### PR TITLE
Add Pi-style built-in coding tools

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -13,21 +13,21 @@ tau_coding   CLI app, resources, skills, extensions, commands, UI integration
 
 ## Phase plan
 
-1. Project foundation and design docs.
-2. Core message, tool, and event types.
-3. Provider interface with fake and real providers.
-4. Pure agent loop.
-5. Reusable `AgentHarness`.
-6. Built-in coding tools.
-7. Non-interactive print-mode CLI.
-8. Append-only session tree persistence.
-9. Coding session wrapper with commands.
-10. Skills, prompt templates, and system prompt assembly.
-11. Rich renderers.
-12. Textual TUI behind an adapter boundary.
-13. Extensions.
-14. Compaction and context management.
-15. Packaging, docs, and examples.
+0. Project foundation and design docs.
+1. Core message, tool, and event types.
+2. Provider interface with fake and real providers.
+3. Pure agent loop.
+4. Reusable `AgentHarness`.
+5. Built-in coding tools.
+6. Non-interactive print-mode CLI.
+7. Append-only session tree persistence.
+8. Coding session wrapper with commands.
+9. Skills, prompt templates, and system prompt assembly.
+10. Rich renderers.
+11. Textual TUI behind an adapter boundary.
+12. Extensions.
+13. Compaction and context management.
+14. Packaging, docs, and examples.
 
 ## Phase 0 deliverables
 

--- a/docs/03-tools.md
+++ b/docs/03-tools.md
@@ -2,26 +2,319 @@
 
 Tools let the assistant inspect and modify the user's environment through structured calls.
 
+Tau separates the idea of a tool from any specific frontend:
+
+- `tau_agent` defines provider-neutral tool types and executes requested tool calls.
+- `tau_coding` provides concrete local coding tools for files and shell commands.
+- CLIs, TUIs, and other frontends decide which tools to expose to a session.
+
 ## Core model
 
-`tau_agent` will define provider-neutral tool definitions and structured tool results.
-The agent loop will receive a list of tools and execute requested calls without depending on any coding-agent UI.
+An `AgentTool` has:
 
-## Initial coding tools
+- a `name`, such as `read` or `bash`
+- a human-readable `description`
+- an `input_schema` describing accepted JSON arguments
+- an async `executor`
+- optional prompt metadata used by clients that assemble tool guidance
 
-`tau_coding` now provides the initial coding tool set:
+A tool returns an `AgentToolResult` with:
+
+- `ok`: whether the tool completed successfully
+- `content`: text that can be sent back to the model
+- optional `data`: structured metadata for UIs, logs, or future integrations
+- optional `error`: a machine-readable or user-readable error message
+
+The agent loop executes tool calls and converts results into `ToolResultMessage` entries in the transcript.
+
+## Built-in coding tools
+
+`tau_coding` provides four built-in local coding tools:
 
 - `read`
 - `write`
 - `edit`
 - `bash`
 
-Use `create_coding_tools()` to register all of them, or create individual tools with `create_read_tool()`, `create_write_tool()`, `create_edit_tool()`, and `create_bash_tool()`.
+Use `create_coding_tools()` to register all of them:
 
-Important behavior preserved from Pi:
+```python
+from tau_coding import create_coding_tools
 
-- exact-text replacement for edits
-- rollback if a multi-edit operation fails
-- output truncation
-- bash timeouts
-- structured success and error results
+tools = create_coding_tools(cwd="/path/to/project")
+```
+
+Or create individual tools:
+
+```python
+from tau_coding import (
+    create_bash_tool,
+    create_edit_tool,
+    create_read_tool,
+    create_write_tool,
+)
+```
+
+Relative paths passed to the tools are resolved against `cwd`. If `cwd` is omitted, Tau uses the process current working directory at the time the factory is called.
+
+## `read`
+
+Reads a file from disk.
+
+Factory functions:
+
+- `create_read_tool_definition()`
+- `create_read_tool()`
+
+### Arguments
+
+```json
+{
+  "path": "README.md",
+  "offset": 1,
+  "limit": 40
+}
+```
+
+| Argument | Required | Type | Description |
+| --- | --- | --- | --- |
+| `path` | yes | string | File path to read. Relative paths are resolved against `cwd`. |
+| `offset` | no | integer | 1-indexed line number to start reading from. |
+| `limit` | no | integer | Maximum number of lines to return. |
+
+`offset` and `limit` must be positive integers when supplied.
+
+### Text behavior
+
+For text files, `read`:
+
+1. opens the file as UTF-8 text
+2. applies `offset` and `limit` if provided
+3. truncates large output to at most 2,000 lines or 50 KB, whichever limit is reached first
+4. appends a continuation hint when more lines remain
+
+Example continuation hint:
+
+```text
+[42 more lines in file. Use offset=101 to continue.]
+```
+
+### Image behavior
+
+Supported image files are detected by MIME type:
+
+- JPEG
+- PNG
+- GIF
+- WebP
+
+For supported images, `read` returns a short text message and stores image metadata in `data`, including:
+
+- resolved path
+- MIME type
+- byte size
+- base64-encoded image bytes
+
+### Errors
+
+`read` fails when:
+
+- `path` is missing or is not a string
+- `offset` or `limit` is not a positive integer
+- the file does not exist
+- the path is a directory
+- `offset` is beyond the end of the file
+- the file cannot be decoded as UTF-8 text and is not a supported image
+
+## `write`
+
+Creates or overwrites a complete UTF-8 text file.
+
+Factory functions:
+
+- `create_write_tool_definition()`
+- `create_write_tool()`
+
+### Arguments
+
+```json
+{
+  "path": "src/example.py",
+  "content": "print('hello')\n"
+}
+```
+
+| Argument | Required | Type | Description |
+| --- | --- | --- | --- |
+| `path` | yes | string | File path to write. Relative paths are resolved against `cwd`. |
+| `content` | yes | string | Complete file contents to write. |
+
+### Behavior
+
+`write`:
+
+1. resolves the target path
+2. creates missing parent directories
+3. writes `content` using UTF-8 encoding
+4. overwrites any existing file at that path
+
+Writes are serialized per resolved path inside the current process. That means concurrent `write` or `edit` operations targeting the same file do not interleave.
+
+### Result metadata
+
+Successful results include:
+
+- resolved path
+- number of characters written
+
+### Errors
+
+`write` fails when:
+
+- `path` is missing or is not a string
+- `content` is missing or is not a string
+- the filesystem rejects the write operation
+
+## `edit`
+
+Applies exact text replacements to one UTF-8 file.
+
+Factory functions:
+
+- `create_edit_tool_definition()`
+- `create_edit_tool()`
+
+### Arguments
+
+```json
+{
+  "path": "src/example.py",
+  "edits": [
+    {
+      "oldText": "print('hello')",
+      "newText": "print('hello, Tau')"
+    }
+  ]
+}
+```
+
+| Argument | Required | Type | Description |
+| --- | --- | --- | --- |
+| `path` | yes | string | File path to edit. Relative paths are resolved against `cwd`. |
+| `edits` | yes | array | One or more replacement objects. |
+| `edits[].oldText` | yes | string | Exact text to replace. Must be non-empty and unique in the original file. |
+| `edits[].newText` | yes | string | Replacement text. |
+
+### Matching rules
+
+Every `oldText` must:
+
+- be non-empty
+- match exactly, including whitespace and newlines
+- appear exactly once in the original file
+- not overlap another edit's matched range
+
+All `oldText` entries are matched against the original file content, not against the result of earlier edits.
+
+### Rollback behavior
+
+`edit` validates every replacement before writing. If any edit fails validation, the file is left unchanged.
+
+### Line endings and BOMs
+
+For matching, Tau normalizes file content and edit text to LF line endings. After applying edits, Tau restores the file's original dominant line ending. UTF-8 byte-order marks are preserved.
+
+### Result metadata
+
+Successful results include:
+
+- resolved path
+- number of edits applied
+- an `ndiff`-style diff
+- a unified patch
+- first changed line number
+
+### Errors
+
+`edit` fails when:
+
+- `path` is missing or is not a string
+- the file does not exist
+- the path is a directory
+- `edits` is missing, empty, or malformed
+- any `oldText` is empty
+- any `oldText` is not found
+- any `oldText` appears more than once
+- edit ranges overlap
+- all replacements would leave the file unchanged
+
+## `bash`
+
+Executes a shell command in the configured working directory.
+
+Factory functions:
+
+- `create_bash_tool_definition()`
+- `create_bash_tool()`
+
+### Arguments
+
+```json
+{
+  "command": "pytest -q",
+  "timeout": 30
+}
+```
+
+| Argument | Required | Type | Description |
+| --- | --- | --- | --- |
+| `command` | yes | string | Shell command to execute. |
+| `timeout` | no | number | Maximum runtime in seconds. Must be greater than zero when supplied. |
+
+There is no default timeout. Callers should provide one when they need bounded execution.
+
+### Behavior
+
+`bash`:
+
+1. runs the command with `cwd` as the subprocess working directory
+2. combines stdout and stderr into a single output stream
+3. decodes output as UTF-8, replacing invalid bytes
+4. returns success when the command exits with code `0`
+5. returns failure when the command exits non-zero or times out
+
+On POSIX systems, commands are started in a new session. If a timeout occurs, Tau kills the whole process group so child processes from pipelines or compound commands are stopped too. On non-POSIX systems, Tau kills the direct subprocess.
+
+### Output truncation
+
+`bash` returns the tail of large output. Output is truncated to at most 2,000 lines or 50 KB, whichever limit is reached first.
+
+When truncation happens, Tau writes the full command output to a temporary `.log` file and includes that path in the result metadata.
+
+### Result metadata
+
+Results include:
+
+- command string
+- exit code
+- whether the command timed out
+- duration in seconds
+- truncation metadata
+- full-output temp file path when output was truncated
+
+### Errors
+
+`bash` fails when:
+
+- `command` is missing or is not a string
+- `timeout` is not a number greater than zero
+- the command exits with a non-zero status
+- the command times out
+- the subprocess cannot be started
+
+## Choosing the right tool
+
+- Use `read` to inspect file contents instead of shelling out to `cat` or `sed`.
+- Use `write` for new files or complete rewrites.
+- Use `edit` for precise changes to an existing file.
+- Use `bash` for commands such as tests, linters, searches, and project inspection.

--- a/docs/03-tools.md
+++ b/docs/03-tools.md
@@ -9,14 +9,16 @@ The agent loop will receive a list of tools and execute requested calls without 
 
 ## Initial coding tools
 
-`tau_coding` will eventually provide:
+`tau_coding` now provides the initial coding tool set:
 
 - `read`
 - `write`
 - `edit`
 - `bash`
 
-Important behavior to preserve:
+Use `create_coding_tools()` to register all of them, or create individual tools with `create_read_tool()`, `create_write_tool()`, `create_edit_tool()`, and `create_bash_tool()`.
+
+Important behavior preserved from Pi:
 
 - exact-text replacement for edits
 - rollback if a multi-edit operation fails

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -24,5 +24,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 2: AI Provider Layer](phase-2-ai-provider-layer.md)
 - [Phase 3: Pure Agent Loop](phase-3-agent-loop.md)
 - [Phase 4: AgentHarness](phase-4-agent-harness.md)
+- [Phase 5: Built-in Coding Tools](phase-5-coding-tools.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-5-coding-tools.md
+++ b/docs/architecture/phase-5-coding-tools.md
@@ -18,7 +18,7 @@ Tau now provides factory functions for these initial tools:
 - `create_bash_tool()`
 - `create_coding_tools()` for the default tool set
 
-Each factory returns a provider-neutral `AgentTool` from `tau_agent.tools`.
+Each factory has a Pi-like `ToolDefinition` counterpart with a description, prompt snippet, prompt guidelines, JSON schema, and executor. The public factory returns a provider-neutral `AgentTool` from `tau_agent.tools`.
 
 ## Why the tools live in `tau_coding`
 
@@ -48,11 +48,11 @@ Arguments:
 - `offset`: optional 1-indexed starting line
 - `limit`: optional number of lines to return
 
-Large output is truncated.
+Large output is truncated with Pi-style truncation metadata and continuation hints. Supported image files (`jpg`, `png`, `gif`, `webp`) are detected and returned as base64 metadata for later UI/provider integration.
 
 ### `write`
 
-Writes a complete UTF-8 text file and creates parent directories when needed.
+Writes a complete UTF-8 text file and creates parent directories when needed. Writes are serialized per path with a file mutation queue so concurrent mutations to the same file do not interleave.
 
 Arguments:
 
@@ -74,6 +74,10 @@ Important Pi-inspired behavior:
 - edits must not overlap
 - validation happens before writing
 - if any edit fails, the file is left unchanged
+- UTF-8 BOMs are preserved
+- existing line endings are preserved
+- results include diff, unified patch, and first-changed-line metadata
+- legacy `oldText`/`newText` arguments and JSON-string `edits` are normalized
 
 ### `bash`
 
@@ -82,9 +86,9 @@ Executes a shell command in the configured working directory.
 Arguments:
 
 - `command`: command string
-- `timeout_seconds`: optional timeout, defaulting to 30 seconds
+- `timeout`: optional timeout in seconds, with no default timeout
 
-The result includes stdout/stderr output, exit code, timeout state, duration, and truncation metadata.
+The result includes combined stdout/stderr output, exit code, timeout state, duration, truncation metadata, and a full-output temp file path when output is truncated.
 
 ## How to use the tools
 

--- a/docs/architecture/phase-5-coding-tools.md
+++ b/docs/architecture/phase-5-coding-tools.md
@@ -1,0 +1,120 @@
+# Phase 5: Built-in Coding Tools
+
+Phase 5 adds Tau's first built-in coding tools in `tau_coding`.
+
+The tools live in:
+
+```text
+src/tau_coding/tools.py
+```
+
+## What was added
+
+Tau now provides factory functions for these initial tools:
+
+- `create_read_tool()`
+- `create_write_tool()`
+- `create_edit_tool()`
+- `create_bash_tool()`
+- `create_coding_tools()` for the default tool set
+
+Each factory returns a provider-neutral `AgentTool` from `tau_agent.tools`.
+
+## Why the tools live in `tau_coding`
+
+`tau_agent` owns the portable agent brain: messages, events, tools as an abstraction, the loop, and the harness.
+
+Filesystem and shell access are coding-agent environment features, so the concrete implementations live in `tau_coding`.
+
+```text
+tau_agent:
+  knows how to execute an AgentTool
+
+tau_coding:
+  provides read/write/edit/bash tools for local coding work
+```
+
+This keeps the core loop reusable and independent of local machine behavior.
+
+## Tool behavior
+
+### `read`
+
+Reads a UTF-8 text file.
+
+Arguments:
+
+- `path`: file path
+- `offset`: optional 1-indexed starting line
+- `limit`: optional number of lines to return
+
+Large output is truncated.
+
+### `write`
+
+Writes a complete UTF-8 text file and creates parent directories when needed.
+
+Arguments:
+
+- `path`: file path
+- `content`: complete file content
+
+### `edit`
+
+Applies exact text replacements to a UTF-8 file.
+
+Arguments:
+
+- `path`: file path
+- `edits`: array of `{ oldText, newText }` objects
+
+Important Pi-inspired behavior:
+
+- every `oldText` must match exactly once
+- edits must not overlap
+- validation happens before writing
+- if any edit fails, the file is left unchanged
+
+### `bash`
+
+Executes a shell command in the configured working directory.
+
+Arguments:
+
+- `command`: command string
+- `timeout_seconds`: optional timeout, defaulting to 30 seconds
+
+The result includes stdout/stderr output, exit code, timeout state, duration, and truncation metadata.
+
+## How to use the tools
+
+```python
+from tau_coding import create_coding_tools
+
+tools = create_coding_tools(cwd="/path/to/project")
+```
+
+Pass those tools into `AgentHarnessConfig` or directly into `run_agent_loop()`.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_coding_tools.py
+```
+
+The tests verify:
+
+- default tool registration
+- file reading with line slicing
+- parent directory creation for writes
+- multi-edit exact replacement
+- rollback on failed edits
+- unique-match validation
+- bash stdout capture
+- bash timeout reporting
+
+## Next phase
+
+The next phase can wire these tools into a non-interactive print-mode CLI so a user can run Tau against a real project from the terminal.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,5 +63,6 @@ nav:
       - "Phase 2: AI Provider Layer": architecture/phase-2-ai-provider-layer.md
       - "Phase 3: Pure Agent Loop": architecture/phase-3-agent-loop.md
       - "Phase 4: AgentHarness": architecture/phase-4-agent-harness.md
+      - "Phase 5: Built-in Coding Tools": architecture/phase-5-coding-tools.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_agent/tools.py
+++ b/src/tau_agent/tools.py
@@ -30,6 +30,7 @@ class AgentToolResult(BaseModel):
     ok: bool
     content: str
     data: dict[str, JSONValue] | None = None
+    details: dict[str, JSONValue] | None = None
     error: str | None = None
 
 
@@ -41,6 +42,8 @@ class AgentTool:
     description: str
     input_schema: Mapping[str, JSONValue]
     executor: ToolExecutor
+    prompt_snippet: str | None = None
+    prompt_guidelines: tuple[str, ...] = ()
 
     async def execute(self, arguments: Mapping[str, JSONValue]) -> AgentToolResult:
         """Execute the tool with provider-neutral JSON-like arguments."""

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -1,20 +1,30 @@
 """Tau coding-agent application package."""
 
 from tau_coding.tools import (
+    ToolDefinition,
     create_bash_tool,
+    create_bash_tool_definition,
     create_coding_tools,
     create_edit_tool,
+    create_edit_tool_definition,
     create_read_tool,
+    create_read_tool_definition,
     create_write_tool,
+    create_write_tool_definition,
 )
 
 __version__ = "0.1.0"
 
 __all__ = [
     "__version__",
+    "ToolDefinition",
     "create_bash_tool",
+    "create_bash_tool_definition",
     "create_coding_tools",
     "create_edit_tool",
+    "create_edit_tool_definition",
     "create_read_tool",
+    "create_read_tool_definition",
     "create_write_tool",
+    "create_write_tool_definition",
 ]

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -1,3 +1,20 @@
 """Tau coding-agent application package."""
 
+from tau_coding.tools import (
+    create_bash_tool,
+    create_coding_tools,
+    create_edit_tool,
+    create_read_tool,
+    create_write_tool,
+)
+
 __version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    "create_bash_tool",
+    "create_coding_tools",
+    "create_edit_tool",
+    "create_read_tool",
+    "create_write_tool",
+]

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -8,6 +8,8 @@ import asyncio
 import difflib
 import json
 import mimetypes
+import os
+import signal
 import tempfile
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
@@ -353,18 +355,27 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
             raise ToolInputError("timeout must be greater than 0")
 
         start = monotonic()
-        process = await asyncio.create_subprocess_shell(
-            command,
-            cwd=root,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
+        if os.name == "posix":
+            process = await asyncio.create_subprocess_shell(
+                command,
+                cwd=root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
+        else:
+            process = await asyncio.create_subprocess_shell(
+                command,
+                cwd=root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
         timed_out = False
         try:
             output_bytes, _stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
         except TimeoutError:
             timed_out = True
-            process.kill()
+            _kill_process_tree(process)
             output_bytes, _stderr = await process.communicate()
 
         output = output_bytes.decode(errors="replace")
@@ -822,6 +833,19 @@ def _base64_text(data: bytes) -> str:
     import base64
 
     return base64.b64encode(data).decode("ascii")
+
+
+def _kill_process_tree(process: asyncio.subprocess.Process) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    else:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
 
 
 def _write_temp_output(output: str) -> str:

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -1,7 +1,16 @@
-"""Built-in coding tools for Tau sessions and CLIs."""
+"""Built-in coding tools for Tau sessions and CLIs.
+
+These tools intentionally follow Pi's coding-tool contracts closely while staying
+inside Tau's simpler Python event/result model.
+"""
 
 import asyncio
+import difflib
+import json
+import mimetypes
+import tempfile
 from collections.abc import Mapping
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from time import monotonic
 
@@ -10,11 +19,57 @@ from tau_agent.types import JSONValue
 
 DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
 DEFAULT_MAX_OUTPUT_LINES = 2_000
-DEFAULT_BASH_TIMEOUT_SECONDS = 30.0
+SUPPORTED_IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+UTF8_BOM = "\ufeff"
 
 
 class ToolInputError(ValueError):
     """Raised when a tool receives invalid structured arguments."""
+
+
+@dataclass(frozen=True, slots=True)
+class TruncationResult:
+    """Pi-style truncation metadata for tool outputs."""
+
+    content: str
+    truncated: bool
+    truncated_by: str | None
+    total_lines: int
+    total_bytes: int
+    output_lines: int
+    output_bytes: int
+    last_line_partial: bool
+    first_line_exceeds_limit: bool
+    max_lines: int
+    max_bytes: int
+
+    def to_json(self) -> dict[str, JSONValue]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDefinition:
+    """Tau equivalent of Pi's coding-agent ToolDefinition."""
+
+    name: str
+    description: str
+    prompt_snippet: str
+    prompt_guidelines: tuple[str, ...]
+    input_schema: Mapping[str, JSONValue]
+    executor: object
+
+    def to_agent_tool(self) -> AgentTool:
+        return AgentTool(
+            name=self.name,
+            description=self.description,
+            input_schema=self.input_schema,
+            executor=self.executor,  # type: ignore[arg-type]
+            prompt_snippet=self.prompt_snippet,
+            prompt_guidelines=self.prompt_guidelines,
+        )
+
+
+_file_locks: dict[Path, asyncio.Lock] = {}
 
 
 def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
@@ -28,11 +83,12 @@ def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
     ]
 
 
-def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
-    """Create a tool that reads text files."""
+def create_read_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
+    """Create the Pi-like read tool definition."""
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        raw_path = _str_arg(arguments, "path")
         path = _path_arg(arguments, "path", cwd=root)
         offset = _optional_int_arg(arguments, "offset")
         limit = _optional_int_arg(arguments, "limit")
@@ -46,36 +102,99 @@ def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
         if path.is_dir():
             raise ToolInputError(f"Path is a directory: {path}")
 
-        text = path.read_text()
-        lines = text.splitlines(keepends=True)
-        start = 0 if offset is None else offset - 1
-        selected = lines[start : None if limit is None else start + limit]
-        content = "".join(selected)
-        truncated = len(selected) < len(lines[start:])
-        content, output_truncated = truncate_text(content)
-        if truncated or output_truncated:
-            content = append_status_line(content, "[truncated]")
+        mime_type = _detect_supported_image_mime_type(path)
+        if mime_type is not None:
+            data = path.read_bytes()
+            return AgentToolResult(
+                tool_call_id="",
+                name="read",
+                ok=True,
+                content=f"Read image file [{mime_type}]",
+                data={
+                    "path": str(path),
+                    "mime_type": mime_type,
+                    "bytes": len(data),
+                    "image_base64": _base64_text(data),
+                },
+            )
+
+        text = path.read_text(encoding="utf-8")
+        all_lines = text.split("\n")
+        start_line = 0 if offset is None else offset - 1
+        if start_line >= len(all_lines):
+            raise ToolInputError(
+                f"Offset {offset} is beyond end of file ({len(all_lines)} lines total)"
+            )
+
+        user_limited_lines: int | None = None
+        if limit is not None:
+            end_line = min(start_line + limit, len(all_lines))
+            selected = "\n".join(all_lines[start_line:end_line])
+            user_limited_lines = end_line - start_line
+        else:
+            selected = "\n".join(all_lines[start_line:])
+
+        truncation = truncate_head(selected)
+        start_display = start_line + 1
+        details: dict[str, JSONValue] = {"path": str(path), "truncation": truncation.to_json()}
+
+        if truncation.first_line_exceeds_limit:
+            first_line_size = format_size(len(all_lines[start_line].encode()))
+            output = (
+                f"[Line {start_display} is {first_line_size}, exceeds "
+                f"{format_size(DEFAULT_MAX_OUTPUT_BYTES)} limit. Use bash: sed -n "
+                f"'{start_display}p' {raw_path} | head -c {DEFAULT_MAX_OUTPUT_BYTES}]"
+            )
+        elif truncation.truncated:
+            end_display = start_display + truncation.output_lines - 1
+            next_offset = end_display + 1
+            output = truncation.content
+            if truncation.truncated_by == "lines":
+                output += (
+                    f"\n\n[Showing lines {start_display}-{end_display} of {len(all_lines)}. "
+                    f"Use offset={next_offset} to continue.]"
+                )
+            else:
+                output += (
+                    f"\n\n[Showing lines {start_display}-{end_display} of {len(all_lines)} "
+                    f"({format_size(DEFAULT_MAX_OUTPUT_BYTES)} limit). "
+                    f"Use offset={next_offset} to continue.]"
+                )
+        elif user_limited_lines is not None and start_line + user_limited_lines < len(all_lines):
+            remaining = len(all_lines) - (start_line + user_limited_lines)
+            next_offset = start_line + user_limited_lines + 1
+            output = (
+                f"{truncation.content}\n\n[{remaining} more lines in file. "
+                f"Use offset={next_offset} to continue.]"
+            )
+        else:
+            output = truncation.content
 
         return AgentToolResult(
             tool_call_id="",
             name="read",
             ok=True,
-            content=content,
-            data={"path": str(path), "truncated": truncated or output_truncated},
+            content=output,
+            data=details,
         )
 
-    return AgentTool(
+    return ToolDefinition(
         name="read",
         description=(
-            "Read a UTF-8 text file. Arguments: path, optional 1-indexed offset, "
-            "optional line limit."
+            "Read the contents of a file. Supports text files and images (jpg, png, gif, webp). "
+            "Images are returned as base64 metadata. For text files, output is truncated to "
+            f"{DEFAULT_MAX_OUTPUT_LINES} lines or {DEFAULT_MAX_OUTPUT_BYTES // 1024}KB "
+            "(whichever is hit first). Use offset/limit for large files. When you need the "
+            "full file, continue with offset until complete."
         ),
+        prompt_snippet="Read file contents",
+        prompt_guidelines=("Use read to examine files instead of cat or sed.",),
         input_schema={
             "type": "object",
             "properties": {
-                "path": {"type": "string"},
-                "offset": {"type": "integer", "minimum": 1},
-                "limit": {"type": "integer", "minimum": 1},
+                "path": {"type": "string", "description": "Path to the file to read"},
+                "offset": {"type": "number", "description": "Line number to start reading from"},
+                "limit": {"type": "number", "description": "Maximum number of lines to read"},
             },
             "required": ["path"],
         },
@@ -83,91 +202,124 @@ def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
     )
 
 
-def create_write_tool(*, cwd: str | Path | None = None) -> AgentTool:
-    """Create a tool that writes complete text files."""
+def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    return create_read_tool_definition(cwd=cwd).to_agent_tool()
+
+
+def create_write_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
+    """Create the Pi-like write tool definition."""
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
         path = _path_arg(arguments, "path", cwd=root)
         content = _str_arg(arguments, "content")
 
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content)
+        async with _file_lock(path):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
 
         return AgentToolResult(
             tool_call_id="",
             name="write",
             ok=True,
-            content=f"Wrote {len(content)} characters to {path}",
+            content=f"Successfully wrote to {path}.",
             data={"path": str(path), "characters": len(content)},
         )
 
-    return AgentTool(
+    return ToolDefinition(
         name="write",
-        description="Write a complete UTF-8 text file, creating parent directories when needed.",
+        description=(
+            "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. "
+            "Automatically creates parent directories."
+        ),
+        prompt_snippet="Create or overwrite files",
+        prompt_guidelines=("Use write only for new files or complete rewrites.",),
         input_schema={
             "type": "object",
-            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to write"},
+                "content": {"type": "string", "description": "Content to write to the file"},
+            },
             "required": ["path", "content"],
         },
         executor=execute,
     )
 
 
-def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
-    """Create a tool that performs exact text replacements with rollback-on-failure."""
+def create_write_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    return create_write_tool_definition(cwd=cwd).to_agent_tool()
+
+
+def create_edit_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
+    """Create the Pi-like edit tool definition."""
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
-        path = _path_arg(arguments, "path", cwd=root)
-        edits = _edits_arg(arguments)
+        prepared = _prepare_edit_arguments(arguments)
+        path = _path_arg(prepared, "path", cwd=root)
+        edits = _edits_arg(prepared)
 
         if not path.exists():
-            raise ToolInputError(f"File not found: {path}")
+            raise ToolInputError(f"Could not edit file: {path}. File not found.")
         if path.is_dir():
-            raise ToolInputError(f"Path is a directory: {path}")
+            raise ToolInputError(f"Could not edit file: {path}. Path is a directory.")
 
-        original = path.read_text()
-        spans: list[tuple[int, int, str]] = []
-        for index, edit in enumerate(edits, start=1):
-            old_text = edit["oldText"]
-            new_text = edit["newText"]
-            if old_text == "":
-                raise ToolInputError(f"Edit {index} oldText must not be empty")
-            first = original.find(old_text)
-            if first < 0:
-                raise ToolInputError(f"Edit {index} oldText was not found")
-            second = original.find(old_text, first + len(old_text))
-            if second >= 0:
-                raise ToolInputError(f"Edit {index} oldText matched more than once")
-            spans.append((first, first + len(old_text), new_text))
+        async with _file_lock(path):
+            raw_content = path.read_text(encoding="utf-8")
+            bom, content = _strip_bom(raw_content)
+            original_ending = detect_line_ending(content)
+            normalized = normalize_to_lf(content)
+            base_content, new_content = apply_edits_to_normalized_content(
+                normalized, edits, str(path)
+            )
+            final_content = bom + restore_line_endings(new_content, original_ending)
+            path.write_text(final_content, encoding="utf-8")
 
-        _validate_non_overlapping(spans)
-        updated = original
-        for start, end, new_text in sorted(spans, reverse=True):
-            updated = f"{updated[:start]}{new_text}{updated[end:]}"
-
-        path.write_text(updated)
+        diff_text, first_changed_line = generate_diff_string(base_content, new_content)
+        patch = generate_unified_patch(str(path), base_content, new_content)
         return AgentToolResult(
             tool_call_id="",
             name="edit",
             ok=True,
-            content=f"Applied {len(edits)} edit(s) to {path}",
-            data={"path": str(path), "edits": len(edits)},
+            content=f"Successfully replaced {len(edits)} block(s) in {path}.",
+            data={
+                "path": str(path),
+                "edits": len(edits),
+                "diff": diff_text,
+                "patch": patch,
+                "first_changed_line": first_changed_line,
+            },
         )
 
-    return AgentTool(
+    return ToolDefinition(
         name="edit",
         description=(
-            "Replace exact text in a UTF-8 file. Every oldText must match exactly once; "
-            "multi-edit failures leave the file unchanged."
+            "Edit a single file using exact text replacement. Every edits[].oldText must match "
+            "a unique, non-overlapping region of the original file. If two changes affect the "
+            "same block or nearby lines, merge them into one edit instead of emitting overlapping "
+            "edits. Do not include large unchanged regions just to connect distant changes."
+        ),
+        prompt_snippet=(
+            "Make precise file edits with exact text replacement, including multiple disjoint "
+            "edits in one call"
+        ),
+        prompt_guidelines=(
+            "Use edit for precise changes (edits[].oldText must match exactly)",
+            "When changing multiple separate locations in one file, use one edit call with "
+            "multiple entries in edits[] instead of multiple edit calls",
+            "Each edits[].oldText is matched against the original file, not after earlier "
+            "edits are applied. Do not emit overlapping or nested edits. Merge nearby "
+            "changes into one edit.",
+            "Keep edits[].oldText as small as possible while still being unique in the file. "
+            "Do not pad with large unchanged regions.",
         ),
         input_schema={
             "type": "object",
             "properties": {
-                "path": {"type": "string"},
+                "path": {"type": "string", "description": "Path to the file to edit"},
                 "edits": {
                     "type": "array",
+                    "description": "One or more targeted replacements.",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -175,82 +327,117 @@ def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
                             "newText": {"type": "string"},
                         },
                         "required": ["oldText", "newText"],
+                        "additionalProperties": False,
                     },
-                    "minItems": 1,
                 },
             },
             "required": ["path", "edits"],
+            "additionalProperties": False,
         },
         executor=execute,
     )
 
 
-def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
-    """Create a tool that executes shell commands with timeout and truncation."""
+def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    return create_edit_tool_definition(cwd=cwd).to_agent_tool()
+
+
+def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
+    """Create the Pi-like bash tool definition."""
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
         command = _str_arg(arguments, "command")
-        timeout_seconds = _optional_float_arg(arguments, "timeout_seconds")
-        if timeout_seconds is None:
-            timeout_seconds = DEFAULT_BASH_TIMEOUT_SECONDS
-        if timeout_seconds <= 0:
-            raise ToolInputError("timeout_seconds must be greater than 0")
+        timeout = _optional_float_arg(arguments, "timeout")
+        if timeout is not None and timeout <= 0:
+            raise ToolInputError("timeout must be greater than 0")
 
         start = monotonic()
         process = await asyncio.create_subprocess_shell(
             command,
             cwd=root,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
         timed_out = False
         try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(), timeout=timeout_seconds
-            )
+            output_bytes, _stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
         except TimeoutError:
             timed_out = True
             process.kill()
-            stdout_bytes, stderr_bytes = await process.communicate()
+            output_bytes, _stderr = await process.communicate()
 
-        stdout = stdout_bytes.decode(errors="replace")
-        stderr = stderr_bytes.decode(errors="replace")
-        output = _format_bash_output(stdout=stdout, stderr=stderr)
-        output, truncated = truncate_text(output)
+        output = output_bytes.decode(errors="replace")
+        truncation = truncate_tail(output)
+        full_output_path: str | None = None
+        output_text = truncation.content or "(no output)"
+        if truncation.truncated:
+            full_output_path = _write_temp_output(output)
+            start_line = truncation.total_lines - truncation.output_lines + 1
+            end_line = truncation.total_lines
+            if truncation.last_line_partial:
+                output_text += (
+                    f"\n\n[Showing last {format_size(truncation.output_bytes)} of line {end_line}. "
+                    f"Full output: {full_output_path}]"
+                )
+            elif truncation.truncated_by == "lines":
+                output_text += (
+                    f"\n\n[Showing lines {start_line}-{end_line} of {truncation.total_lines}. "
+                    f"Full output: {full_output_path}]"
+                )
+            else:
+                output_text += (
+                    f"\n\n[Showing lines {start_line}-{end_line} of {truncation.total_lines} "
+                    f"({format_size(DEFAULT_MAX_OUTPUT_BYTES)} limit). "
+                    f"Full output: {full_output_path}]"
+                )
+
         exit_code = process.returncode
+        status: str | None = None
         if timed_out:
-            output = append_status_line(output, f"Command timed out after {timeout_seconds:g}s")
-        if truncated:
-            output = append_status_line(output, "[truncated]")
+            status = (
+                f"Command timed out after {timeout:g} seconds" if timeout else "Command timed out"
+            )
+        elif exit_code not in (0, None):
+            status = f"Command exited with code {exit_code}"
+        if status:
+            output_text = append_status_block(output_text, status)
 
         ok = exit_code == 0 and not timed_out
         return AgentToolResult(
             tool_call_id="",
             name="bash",
             ok=ok,
-            content=output,
-            error=None if ok else f"Command failed with exit code {exit_code}",
+            content=output_text,
+            error=None if ok else status,
             data={
                 "command": command,
                 "exit_code": exit_code,
                 "timed_out": timed_out,
                 "duration_seconds": round(monotonic() - start, 3),
-                "truncated": truncated,
+                "truncation": truncation.to_json(),
+                "full_output_path": full_output_path,
             },
         )
 
-    return AgentTool(
+    return ToolDefinition(
         name="bash",
         description=(
-            "Execute a shell command in the working directory. Arguments: command, "
-            "optional timeout_seconds."
+            "Execute a bash command in the current working directory. Returns stdout and stderr. "
+            f"Output is truncated to last {DEFAULT_MAX_OUTPUT_LINES} lines or "
+            f"{DEFAULT_MAX_OUTPUT_BYTES // 1024}KB (whichever is hit first). If truncated, "
+            "full output is saved to a temp file. Optionally provide a timeout in seconds."
         ),
+        prompt_snippet="Execute bash commands (ls, grep, find, etc.)",
+        prompt_guidelines=(),
         input_schema={
             "type": "object",
             "properties": {
-                "command": {"type": "string"},
-                "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+                "command": {"type": "string", "description": "Bash command to execute"},
+                "timeout": {
+                    "type": "number",
+                    "description": "Timeout in seconds (optional, no default timeout)",
+                },
             },
             "required": ["command"],
         },
@@ -258,38 +445,233 @@ def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
     )
 
 
-def append_status_line(text: str, status: str) -> str:
-    """Append a status line without introducing an extra blank line."""
-    separator = "" if text.endswith("\n") or not text else "\n"
-    return f"{text}{separator}{status}"
+def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    return create_bash_tool_definition(cwd=cwd).to_agent_tool()
 
 
-def truncate_text(
-    text: str,
+def format_size(bytes_count: int) -> str:
+    if bytes_count < 1024:
+        return f"{bytes_count}B"
+    if bytes_count < 1024 * 1024:
+        return f"{bytes_count / 1024:.1f}KB"
+    return f"{bytes_count / (1024 * 1024):.1f}MB"
+
+
+def append_status_block(text: str, status: str) -> str:
+    """Append a Pi-style status block."""
+    return f"{text}\n\n{status}" if text else status
+
+
+def truncate_head(
+    content: str,
     *,
-    max_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
     max_lines: int = DEFAULT_MAX_OUTPUT_LINES,
-) -> tuple[str, bool]:
-    """Return text truncated by line and UTF-8 byte limits."""
-    lines = text.splitlines(keepends=True)
-    truncated = len(lines) > max_lines
-    limited = "".join(lines[:max_lines])
-    encoded = limited.encode()
+    max_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+) -> TruncationResult:
+    lines = _split_lines_for_counting(content)
+    total_lines = len(lines)
+    total_bytes = len(content.encode())
+    if total_lines <= max_lines and total_bytes <= max_bytes:
+        return _truncation_result(
+            content, False, None, total_lines, total_bytes, total_lines, total_bytes
+        )
+
+    first_line_bytes = len(lines[0].encode()) if lines else 0
+    if first_line_bytes > max_bytes:
+        return _truncation_result(
+            "", True, "bytes", total_lines, total_bytes, 0, 0, first_line=True
+        )
+
+    output_lines: list[str] = []
+    output_bytes = 0
+    truncated_by = "lines"
+    for index, line in enumerate(lines[:max_lines]):
+        line_bytes = len(line.encode()) + (1 if index > 0 else 0)
+        if output_bytes + line_bytes > max_bytes:
+            truncated_by = "bytes"
+            break
+        output_lines.append(line)
+        output_bytes += line_bytes
+
+    output = "\n".join(output_lines)
+    return _truncation_result(
+        output,
+        True,
+        truncated_by,
+        total_lines,
+        total_bytes,
+        len(output_lines),
+        len(output.encode()),
+    )
+
+
+def truncate_tail(
+    content: str,
+    *,
+    max_lines: int = DEFAULT_MAX_OUTPUT_LINES,
+    max_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+) -> TruncationResult:
+    lines = _split_lines_for_counting(content)
+    total_lines = len(lines)
+    total_bytes = len(content.encode())
+    if total_lines <= max_lines and total_bytes <= max_bytes:
+        return _truncation_result(
+            content, False, None, total_lines, total_bytes, total_lines, total_bytes
+        )
+
+    output_lines: list[str] = []
+    output_bytes = 0
+    truncated_by = "lines"
+    last_line_partial = False
+    for line in reversed(lines):
+        line_bytes = len(line.encode()) + (1 if output_lines else 0)
+        if len(output_lines) >= max_lines:
+            truncated_by = "lines"
+            break
+        if output_bytes + line_bytes > max_bytes:
+            truncated_by = "bytes"
+            if not output_lines:
+                clipped = _truncate_string_to_bytes_from_end(line, max_bytes)
+                output_lines.insert(0, clipped)
+                output_bytes = len(clipped.encode())
+                last_line_partial = True
+            break
+        output_lines.insert(0, line)
+        output_bytes += line_bytes
+
+    output = "\n".join(output_lines)
+    return _truncation_result(
+        output,
+        True,
+        truncated_by,
+        total_lines,
+        total_bytes,
+        len(output_lines),
+        len(output.encode()),
+        last_line_partial=last_line_partial,
+    )
+
+
+def detect_line_ending(content: str) -> str:
+    crlf_index = content.find("\r\n")
+    lf_index = content.find("\n")
+    if lf_index == -1 or crlf_index == -1:
+        return "\n"
+    return "\r\n" if crlf_index < lf_index else "\n"
+
+
+def normalize_to_lf(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def restore_line_endings(text: str, ending: str) -> str:
+    return text.replace("\n", "\r\n") if ending == "\r\n" else text
+
+
+def apply_edits_to_normalized_content(
+    normalized_content: str,
+    edits: list[dict[str, str]],
+    path: str,
+) -> tuple[str, str]:
+    normalized_edits = [
+        {"oldText": normalize_to_lf(edit["oldText"]), "newText": normalize_to_lf(edit["newText"])}
+        for edit in edits
+    ]
+    for index, edit in enumerate(normalized_edits):
+        if not edit["oldText"]:
+            raise ToolInputError(_empty_old_text_error(path, index, len(normalized_edits)))
+
+    matches: list[tuple[int, int, str]] = []
+    for index, edit in enumerate(normalized_edits):
+        old_text = edit["oldText"]
+        occurrences = _count_occurrences(normalized_content, old_text)
+        if occurrences == 0:
+            raise ToolInputError(_not_found_error(path, index, len(normalized_edits)))
+        if occurrences > 1:
+            raise ToolInputError(_duplicate_error(path, index, len(normalized_edits), occurrences))
+        start = normalized_content.index(old_text)
+        matches.append((start, start + len(old_text), edit["newText"]))
+
+    _validate_non_overlapping(matches)
+    new_content = normalized_content
+    for start, end, new_text in sorted(matches, reverse=True):
+        new_content = f"{new_content[:start]}{new_text}{new_content[end:]}"
+    if new_content == normalized_content:
+        raise ToolInputError(_no_change_error(path, len(normalized_edits)))
+    return normalized_content, new_content
+
+
+def generate_diff_string(old: str, new: str) -> tuple[str, int | None]:
+    old_lines = old.splitlines()
+    new_lines = new.splitlines()
+    diff = "\n".join(difflib.ndiff(old_lines, new_lines))
+    first_changed_line: int | None = None
+    new_line_number = 0
+    for line in difflib.ndiff(old_lines, new_lines):
+        if line.startswith("  "):
+            new_line_number += 1
+        elif line.startswith("+"):
+            new_line_number += 1
+            if first_changed_line is None:
+                first_changed_line = new_line_number
+        elif line.startswith("-") and first_changed_line is None:
+            first_changed_line = max(new_line_number + 1, 1)
+    return diff, first_changed_line
+
+
+def generate_unified_patch(path: str, old: str, new: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=path,
+            tofile=path,
+        )
+    )
+
+
+def _truncation_result(
+    content: str,
+    truncated: bool,
+    truncated_by: str | None,
+    total_lines: int,
+    total_bytes: int,
+    output_lines: int,
+    output_bytes: int,
+    *,
+    last_line_partial: bool = False,
+    first_line: bool = False,
+) -> TruncationResult:
+    return TruncationResult(
+        content=content,
+        truncated=truncated,
+        truncated_by=truncated_by,
+        total_lines=total_lines,
+        total_bytes=total_bytes,
+        output_lines=output_lines,
+        output_bytes=output_bytes,
+        last_line_partial=last_line_partial,
+        first_line_exceeds_limit=first_line,
+        max_lines=DEFAULT_MAX_OUTPUT_LINES,
+        max_bytes=DEFAULT_MAX_OUTPUT_BYTES,
+    )
+
+
+def _split_lines_for_counting(content: str) -> list[str]:
+    if not content:
+        return []
+    lines = content.split("\n")
+    if content.endswith("\n"):
+        lines.pop()
+    return lines
+
+
+def _truncate_string_to_bytes_from_end(text: str, max_bytes: int) -> str:
+    encoded = text.encode()
     if len(encoded) <= max_bytes:
-        return limited, truncated
-
-    truncated = True
-    clipped = encoded[:max_bytes]
-    return clipped.decode(errors="ignore"), truncated
-
-
-def _format_bash_output(*, stdout: str, stderr: str) -> str:
-    parts: list[str] = []
-    if stdout:
-        parts.append(f"stdout:\n{stdout.rstrip()}")
-    if stderr:
-        parts.append(f"stderr:\n{stderr.rstrip()}")
-    return "\n\n".join(parts) if parts else "Command completed with no output."
+        return text
+    clipped = encoded[-max_bytes:]
+    return clipped.decode(errors="ignore")
 
 
 def _str_arg(arguments: Mapping[str, JSONValue], name: str) -> str:
@@ -325,27 +707,149 @@ def _optional_float_arg(arguments: Mapping[str, JSONValue], name: str) -> float 
     return float(value)
 
 
+def _prepare_edit_arguments(arguments: Mapping[str, JSONValue]) -> Mapping[str, JSONValue]:
+    prepared = dict(arguments)
+    edits_value = prepared.get("edits")
+    if isinstance(edits_value, str):
+        try:
+            parsed = json.loads(edits_value)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            prepared["edits"] = parsed
+
+    old_text = prepared.get("oldText")
+    new_text = prepared.get("newText")
+    if isinstance(old_text, str) and isinstance(new_text, str):
+        edits = prepared.get("edits")
+        edit_list = edits if isinstance(edits, list) else []
+        prepared["edits"] = [*edit_list, {"oldText": old_text, "newText": new_text}]
+        prepared.pop("oldText", None)
+        prepared.pop("newText", None)
+    return prepared
+
+
 def _edits_arg(arguments: Mapping[str, JSONValue]) -> list[dict[str, str]]:
     value = arguments.get("edits")
     if not isinstance(value, list) or not value:
-        raise ToolInputError("edits must be a non-empty array")
+        raise ToolInputError(
+            "Edit tool input is invalid. edits must contain at least one replacement."
+        )
 
     edits: list[dict[str, str]] = []
-    for index, item in enumerate(value, start=1):
+    for index, item in enumerate(value):
         if not isinstance(item, dict):
-            raise ToolInputError(f"Edit {index} must be an object")
+            raise ToolInputError(f"edits[{index}] must be an object")
         old_text = item.get("oldText")
         new_text = item.get("newText")
         if not isinstance(old_text, str) or not isinstance(new_text, str):
-            raise ToolInputError(f"Edit {index} oldText and newText must be strings")
+            raise ToolInputError(
+                f"edits[{index}].oldText and edits[{index}].newText must be strings"
+            )
         edits.append({"oldText": old_text, "newText": new_text})
     return edits
 
 
 def _validate_non_overlapping(spans: list[tuple[int, int, str]]) -> None:
-    sorted_spans = sorted(spans)
     previous_end = -1
-    for start, end, _new_text in sorted_spans:
+    for start, end, _new_text in sorted(spans):
         if start < previous_end:
             raise ToolInputError("Edits must not overlap")
         previous_end = end
+
+
+def _count_occurrences(content: str, text: str) -> int:
+    count = 0
+    start = 0
+    while True:
+        index = content.find(text, start)
+        if index == -1:
+            return count
+        count += 1
+        start = index + len(text)
+
+
+def _strip_bom(content: str) -> tuple[str, str]:
+    return (UTF8_BOM, content[1:]) if content.startswith(UTF8_BOM) else ("", content)
+
+
+def _not_found_error(path: str, edit_index: int, total_edits: int) -> str:
+    if total_edits == 1:
+        return (
+            f"Could not find the exact text in {path}. The old text must match exactly "
+            "including all whitespace and newlines."
+        )
+    return (
+        f"Could not find edits[{edit_index}] in {path}. The oldText must match exactly "
+        "including all whitespace and newlines."
+    )
+
+
+def _duplicate_error(path: str, edit_index: int, total_edits: int, occurrences: int) -> str:
+    if total_edits == 1:
+        return (
+            f"Found {occurrences} occurrences of the text in {path}. The text must be unique. "
+            "Please provide more context to make it unique."
+        )
+    return (
+        f"Found {occurrences} occurrences of edits[{edit_index}] in {path}. "
+        "Each oldText must be unique. Please provide more context to make it unique."
+    )
+
+
+def _empty_old_text_error(path: str, edit_index: int, total_edits: int) -> str:
+    if total_edits == 1:
+        return f"oldText must not be empty in {path}."
+    return f"edits[{edit_index}].oldText must not be empty in {path}."
+
+
+def _no_change_error(path: str, total_edits: int) -> str:
+    if total_edits == 1:
+        return (
+            f"No changes made to {path}. The replacement produced identical content. "
+            "This might indicate an issue with special characters or the text not existing "
+            "as expected."
+        )
+    return f"No changes made to {path}. The replacements produced identical content."
+
+
+def _detect_supported_image_mime_type(path: Path) -> str | None:
+    mime_type, _encoding = mimetypes.guess_type(path)
+    return mime_type if mime_type in SUPPORTED_IMAGE_MIME_TYPES else None
+
+
+def _base64_text(data: bytes) -> str:
+    import base64
+
+    return base64.b64encode(data).decode("ascii")
+
+
+def _write_temp_output(output: str) -> str:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="tau-bash-",
+        suffix=".log",
+        delete=False,
+    ) as handle:
+        handle.write(output)
+        return handle.name
+
+
+class _FileLockContext:
+    def __init__(self, path: Path) -> None:
+        self._path = path.resolve()
+        self._lock: asyncio.Lock | None = None
+
+    async def __aenter__(self) -> None:
+        lock = _file_locks.setdefault(self._path, asyncio.Lock())
+        self._lock = lock
+        await lock.acquire()
+
+    async def __aexit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        if self._lock is not None:
+            self._lock.release()
+
+
+def _file_lock(path: Path) -> _FileLockContext:
+    return _FileLockContext(path)

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -193,8 +193,8 @@ def create_read_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
             "type": "object",
             "properties": {
                 "path": {"type": "string", "description": "Path to the file to read"},
-                "offset": {"type": "number", "description": "Line number to start reading from"},
-                "limit": {"type": "number", "description": "Maximum number of lines to read"},
+                "offset": {"type": "integer", "description": "Line number to start reading from"},
+                "limit": {"type": "integer", "description": "Maximum number of lines to read"},
             },
             "required": ["path"],
         },

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -1,0 +1,351 @@
+"""Built-in coding tools for Tau sessions and CLIs."""
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from time import monotonic
+
+from tau_agent.tools import AgentTool, AgentToolResult
+from tau_agent.types import JSONValue
+
+DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
+DEFAULT_MAX_OUTPUT_LINES = 2_000
+DEFAULT_BASH_TIMEOUT_SECONDS = 30.0
+
+
+class ToolInputError(ValueError):
+    """Raised when a tool receives invalid structured arguments."""
+
+
+def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
+    """Create Tau's default coding tools rooted at `cwd` or the current directory."""
+    root = Path.cwd() if cwd is None else Path(cwd)
+    return [
+        create_read_tool(cwd=root),
+        create_write_tool(cwd=root),
+        create_edit_tool(cwd=root),
+        create_bash_tool(cwd=root),
+    ]
+
+
+def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create a tool that reads text files."""
+    root = Path.cwd() if cwd is None else Path(cwd)
+
+    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        path = _path_arg(arguments, "path", cwd=root)
+        offset = _optional_int_arg(arguments, "offset")
+        limit = _optional_int_arg(arguments, "limit")
+
+        if offset is not None and offset < 1:
+            raise ToolInputError("offset must be at least 1")
+        if limit is not None and limit < 1:
+            raise ToolInputError("limit must be at least 1")
+        if not path.exists():
+            raise ToolInputError(f"File not found: {path}")
+        if path.is_dir():
+            raise ToolInputError(f"Path is a directory: {path}")
+
+        text = path.read_text()
+        lines = text.splitlines(keepends=True)
+        start = 0 if offset is None else offset - 1
+        selected = lines[start : None if limit is None else start + limit]
+        content = "".join(selected)
+        truncated = len(selected) < len(lines[start:])
+        content, output_truncated = truncate_text(content)
+        if truncated or output_truncated:
+            content = append_status_line(content, "[truncated]")
+
+        return AgentToolResult(
+            tool_call_id="",
+            name="read",
+            ok=True,
+            content=content,
+            data={"path": str(path), "truncated": truncated or output_truncated},
+        )
+
+    return AgentTool(
+        name="read",
+        description=(
+            "Read a UTF-8 text file. Arguments: path, optional 1-indexed offset, "
+            "optional line limit."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "offset": {"type": "integer", "minimum": 1},
+                "limit": {"type": "integer", "minimum": 1},
+            },
+            "required": ["path"],
+        },
+        executor=execute,
+    )
+
+
+def create_write_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create a tool that writes complete text files."""
+    root = Path.cwd() if cwd is None else Path(cwd)
+
+    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        path = _path_arg(arguments, "path", cwd=root)
+        content = _str_arg(arguments, "content")
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+        return AgentToolResult(
+            tool_call_id="",
+            name="write",
+            ok=True,
+            content=f"Wrote {len(content)} characters to {path}",
+            data={"path": str(path), "characters": len(content)},
+        )
+
+    return AgentTool(
+        name="write",
+        description="Write a complete UTF-8 text file, creating parent directories when needed.",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+        executor=execute,
+    )
+
+
+def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create a tool that performs exact text replacements with rollback-on-failure."""
+    root = Path.cwd() if cwd is None else Path(cwd)
+
+    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        path = _path_arg(arguments, "path", cwd=root)
+        edits = _edits_arg(arguments)
+
+        if not path.exists():
+            raise ToolInputError(f"File not found: {path}")
+        if path.is_dir():
+            raise ToolInputError(f"Path is a directory: {path}")
+
+        original = path.read_text()
+        spans: list[tuple[int, int, str]] = []
+        for index, edit in enumerate(edits, start=1):
+            old_text = edit["oldText"]
+            new_text = edit["newText"]
+            if old_text == "":
+                raise ToolInputError(f"Edit {index} oldText must not be empty")
+            first = original.find(old_text)
+            if first < 0:
+                raise ToolInputError(f"Edit {index} oldText was not found")
+            second = original.find(old_text, first + len(old_text))
+            if second >= 0:
+                raise ToolInputError(f"Edit {index} oldText matched more than once")
+            spans.append((first, first + len(old_text), new_text))
+
+        _validate_non_overlapping(spans)
+        updated = original
+        for start, end, new_text in sorted(spans, reverse=True):
+            updated = f"{updated[:start]}{new_text}{updated[end:]}"
+
+        path.write_text(updated)
+        return AgentToolResult(
+            tool_call_id="",
+            name="edit",
+            ok=True,
+            content=f"Applied {len(edits)} edit(s) to {path}",
+            data={"path": str(path), "edits": len(edits)},
+        )
+
+    return AgentTool(
+        name="edit",
+        description=(
+            "Replace exact text in a UTF-8 file. Every oldText must match exactly once; "
+            "multi-edit failures leave the file unchanged."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "edits": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "oldText": {"type": "string"},
+                            "newText": {"type": "string"},
+                        },
+                        "required": ["oldText", "newText"],
+                    },
+                    "minItems": 1,
+                },
+            },
+            "required": ["path", "edits"],
+        },
+        executor=execute,
+    )
+
+
+def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create a tool that executes shell commands with timeout and truncation."""
+    root = Path.cwd() if cwd is None else Path(cwd)
+
+    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        command = _str_arg(arguments, "command")
+        timeout_seconds = _optional_float_arg(arguments, "timeout_seconds")
+        if timeout_seconds is None:
+            timeout_seconds = DEFAULT_BASH_TIMEOUT_SECONDS
+        if timeout_seconds <= 0:
+            raise ToolInputError("timeout_seconds must be greater than 0")
+
+        start = monotonic()
+        process = await asyncio.create_subprocess_shell(
+            command,
+            cwd=root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        timed_out = False
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(), timeout=timeout_seconds
+            )
+        except TimeoutError:
+            timed_out = True
+            process.kill()
+            stdout_bytes, stderr_bytes = await process.communicate()
+
+        stdout = stdout_bytes.decode(errors="replace")
+        stderr = stderr_bytes.decode(errors="replace")
+        output = _format_bash_output(stdout=stdout, stderr=stderr)
+        output, truncated = truncate_text(output)
+        exit_code = process.returncode
+        if timed_out:
+            output = append_status_line(output, f"Command timed out after {timeout_seconds:g}s")
+        if truncated:
+            output = append_status_line(output, "[truncated]")
+
+        ok = exit_code == 0 and not timed_out
+        return AgentToolResult(
+            tool_call_id="",
+            name="bash",
+            ok=ok,
+            content=output,
+            error=None if ok else f"Command failed with exit code {exit_code}",
+            data={
+                "command": command,
+                "exit_code": exit_code,
+                "timed_out": timed_out,
+                "duration_seconds": round(monotonic() - start, 3),
+                "truncated": truncated,
+            },
+        )
+
+    return AgentTool(
+        name="bash",
+        description=(
+            "Execute a shell command in the working directory. Arguments: command, "
+            "optional timeout_seconds."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+            },
+            "required": ["command"],
+        },
+        executor=execute,
+    )
+
+
+def append_status_line(text: str, status: str) -> str:
+    """Append a status line without introducing an extra blank line."""
+    separator = "" if text.endswith("\n") or not text else "\n"
+    return f"{text}{separator}{status}"
+
+
+def truncate_text(
+    text: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    max_lines: int = DEFAULT_MAX_OUTPUT_LINES,
+) -> tuple[str, bool]:
+    """Return text truncated by line and UTF-8 byte limits."""
+    lines = text.splitlines(keepends=True)
+    truncated = len(lines) > max_lines
+    limited = "".join(lines[:max_lines])
+    encoded = limited.encode()
+    if len(encoded) <= max_bytes:
+        return limited, truncated
+
+    truncated = True
+    clipped = encoded[:max_bytes]
+    return clipped.decode(errors="ignore"), truncated
+
+
+def _format_bash_output(*, stdout: str, stderr: str) -> str:
+    parts: list[str] = []
+    if stdout:
+        parts.append(f"stdout:\n{stdout.rstrip()}")
+    if stderr:
+        parts.append(f"stderr:\n{stderr.rstrip()}")
+    return "\n\n".join(parts) if parts else "Command completed with no output."
+
+
+def _str_arg(arguments: Mapping[str, JSONValue], name: str) -> str:
+    value = arguments.get(name)
+    if not isinstance(value, str):
+        raise ToolInputError(f"{name} must be a string")
+    return value
+
+
+def _path_arg(arguments: Mapping[str, JSONValue], name: str, *, cwd: Path) -> Path:
+    value = _str_arg(arguments, name)
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = cwd / path
+    return path
+
+
+def _optional_int_arg(arguments: Mapping[str, JSONValue], name: str) -> int | None:
+    value = arguments.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise ToolInputError(f"{name} must be an integer")
+    return value
+
+
+def _optional_float_arg(arguments: Mapping[str, JSONValue], name: str) -> float | None:
+    value = arguments.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, int | float):
+        raise ToolInputError(f"{name} must be a number")
+    return float(value)
+
+
+def _edits_arg(arguments: Mapping[str, JSONValue]) -> list[dict[str, str]]:
+    value = arguments.get("edits")
+    if not isinstance(value, list) or not value:
+        raise ToolInputError("edits must be a non-empty array")
+
+    edits: list[dict[str, str]] = []
+    for index, item in enumerate(value, start=1):
+        if not isinstance(item, dict):
+            raise ToolInputError(f"Edit {index} must be an object")
+        old_text = item.get("oldText")
+        new_text = item.get("newText")
+        if not isinstance(old_text, str) or not isinstance(new_text, str):
+            raise ToolInputError(f"Edit {index} oldText and newText must be strings")
+        edits.append({"oldText": old_text, "newText": new_text})
+    return edits
+
+
+def _validate_non_overlapping(spans: list[tuple[int, int, str]]) -> None:
+    sorted_spans = sorted(spans)
+    previous_end = -1
+    for start, end, _new_text in sorted_spans:
+        if start < previous_end:
+            raise ToolInputError("Edits must not overlap")
+        previous_end = end

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -1,7 +1,10 @@
-"""Built-in coding tools for Tau sessions and CLIs.
+"""Built-in filesystem and shell tools for Tau coding sessions.
 
-These tools intentionally follow Pi's coding-tool contracts closely while staying
-inside Tau's simpler Python event/result model.
+The module exposes factory functions that create provider-neutral `AgentTool`
+objects plus richer `ToolDefinition` objects for callers that need prompt
+metadata and JSON schemas. The tools operate relative to a configurable working
+directory, return structured `AgentToolResult` values, and keep local
+filesystem/shell behavior outside the reusable `tau_agent` package.
 """
 
 import asyncio
@@ -31,7 +34,14 @@ class ToolInputError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class TruncationResult:
-    """Pi-style truncation metadata for tool outputs."""
+    """Metadata describing how a tool output was shortened.
+
+    `content` contains the returned slice. The remaining fields record whether
+    truncation happened, whether the line or byte limit was responsible, the
+    total size of the original output, the size of the returned output, and
+    edge cases such as partial-line output or a first line that is too large to
+    display safely.
+    """
 
     content: str
     truncated: bool
@@ -51,7 +61,13 @@ class TruncationResult:
 
 @dataclass(frozen=True, slots=True)
 class ToolDefinition:
-    """Tau equivalent of Pi's coding-agent ToolDefinition."""
+    """Complete definition for a coding tool before provider conversion.
+
+    A definition contains the tool name, user-facing description, prompt
+    metadata, JSON input schema, and async executor. `to_agent_tool()` converts
+    it into the smaller `AgentTool` type consumed by the provider-neutral agent
+    loop while preserving prompt metadata for clients that render tool guidance.
+    """
 
     name: str
     description: str
@@ -75,7 +91,14 @@ _file_locks: dict[Path, asyncio.Lock] = {}
 
 
 def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
-    """Create Tau's default coding tools rooted at `cwd` or the current directory."""
+    """Create the default coding-tool set for a local project.
+
+    The returned tools are ordered as `read`, `write`, `edit`, and `bash`.
+    Relative paths used with those tools are resolved against `cwd`; when `cwd`
+    is omitted, the process current working directory at factory-call time is
+    used. The tools share per-path write/edit locks within this process so
+    concurrent mutations of the same file do not interleave.
+    """
     root = Path.cwd() if cwd is None else Path(cwd)
     return [
         create_read_tool(cwd=root),
@@ -86,7 +109,20 @@ def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
 
 
 def create_read_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
-    """Create the Pi-like read tool definition."""
+    """Create a definition for the `read` tool.
+
+    The tool reads a file resolved relative to `cwd` unless an absolute path is
+    supplied. Text files are decoded as UTF-8 and may be sliced with optional
+    1-indexed `offset` and positive integer `limit` arguments. Returned text is
+    truncated to `DEFAULT_MAX_OUTPUT_LINES` lines or `DEFAULT_MAX_OUTPUT_BYTES`
+    bytes, whichever comes first, and continuation hints are appended when more
+    lines remain. Supported image paths (`jpg`, `png`, `gif`, and `webp`) are
+    detected by MIME type and returned as base64 metadata instead of text.
+
+    The executor raises `ToolInputError` for invalid arguments, missing files,
+    directories, and offsets beyond the end of the file. Successful results
+    include the resolved path and truncation metadata in `data`.
+    """
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
@@ -205,11 +241,23 @@ def create_read_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
 
 
 def create_read_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create an `AgentTool` for reading UTF-8 text files and supported images."""
     return create_read_tool_definition(cwd=cwd).to_agent_tool()
 
 
 def create_write_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
-    """Create the Pi-like write tool definition."""
+    """Create a definition for the `write` tool.
+
+    The tool writes the supplied string `content` to `path`, resolving relative
+    paths against `cwd`. Parent directories are created automatically and any
+    existing file is overwritten. Writes use UTF-8 text encoding and are guarded
+    by a per-path async lock so multiple writes/edits to the same resolved file
+    are serialized within this process.
+
+    The executor raises `ToolInputError` when `path` or `content` has the wrong
+    type. Successful results include the resolved path and number of characters
+    written in `data`.
+    """
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
@@ -249,11 +297,28 @@ def create_write_tool_definition(*, cwd: str | Path | None = None) -> ToolDefini
 
 
 def create_write_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create an `AgentTool` for creating or overwriting UTF-8 text files."""
     return create_write_tool_definition(cwd=cwd).to_agent_tool()
 
 
 def create_edit_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
-    """Create the Pi-like edit tool definition."""
+    """Create a definition for the `edit` tool.
+
+    The tool applies one or more exact text replacements to a single UTF-8 file
+    resolved relative to `cwd`. Each edit item contains `oldText` and `newText`.
+    Every `oldText` must be non-empty, must occur exactly once in the original
+    file, and must not overlap another edit span. All replacements are validated
+    before writing, so the file is left unchanged if any edit fails.
+
+    File content and edit text are normalized to LF for matching, then the
+    original file's dominant line ending is restored after replacement. UTF-8
+    byte-order marks are preserved. The executor also accepts legacy top-level
+    `oldText`/`newText` arguments and JSON-string `edits` values by normalizing
+    them into the canonical edits list.
+
+    Successful results include the resolved path, edit count, an ndiff-style
+    diff, a unified patch, and the first changed line in `data`.
+    """
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
@@ -341,11 +406,27 @@ def create_edit_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
 
 
 def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create an `AgentTool` for exact, validated text replacement in one file."""
     return create_edit_tool_definition(cwd=cwd).to_agent_tool()
 
 
 def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
-    """Create the Pi-like bash tool definition."""
+    """Create a definition for the `bash` tool.
+
+    The tool runs a shell command with `cwd` as the subprocess working
+    directory and combines stdout and stderr into one UTF-8 decoded output
+    stream. The optional `timeout` argument must be positive when supplied. On
+    timeout, POSIX commands are started in a new session and the entire process
+    group is killed so shell children from pipelines or compound commands do
+    not continue running; non-POSIX platforms fall back to killing the direct
+    subprocess.
+
+    Output is tail-truncated to `DEFAULT_MAX_OUTPUT_LINES` lines or
+    `DEFAULT_MAX_OUTPUT_BYTES` bytes. When truncation occurs, the full output is
+    written to a temporary log file and that path is reported in `data`.
+    Successful and failed command results both include exit code, timeout state,
+    duration, truncation metadata, and full-output path metadata.
+    """
     root = Path.cwd() if cwd is None else Path(cwd)
 
     async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
@@ -457,6 +538,7 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
 
 
 def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
+    """Create an `AgentTool` for executing shell commands with captured output."""
     return create_bash_tool_definition(cwd=cwd).to_agent_tool()
 
 
@@ -469,7 +551,7 @@ def format_size(bytes_count: int) -> str:
 
 
 def append_status_block(text: str, status: str) -> str:
-    """Append a Pi-style status block."""
+    """Append command status text after a blank line when output already exists."""
     return f"{text}\n\n{status}" if text else status
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -219,7 +219,12 @@ async def test_agent_loop_has_no_default_max_turn_limit() -> None:
             ]
             for _ in range(9)
         ]
-        + [[ProviderResponseStartEvent(model="fake"), ProviderResponseEndEvent(message=final_assistant)]]
+        + [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=final_assistant),
+            ]
+        ]
     )
 
     events = await _collect(

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -6,6 +6,7 @@ from tau_coding import (
     create_bash_tool,
     create_coding_tools,
     create_edit_tool,
+    create_edit_tool_definition,
     create_read_tool,
     create_write_tool,
 )
@@ -16,6 +17,16 @@ async def test_create_coding_tools_returns_initial_tool_set(tmp_path: Path) -> N
     tools = create_coding_tools(cwd=tmp_path)
 
     assert [tool.name for tool in tools] == ["read", "write", "edit", "bash"]
+    edit_tool = tools[2]
+    assert edit_tool.prompt_snippet is not None
+    assert "Use edit for precise changes" in edit_tool.prompt_guidelines[0]
+
+
+def test_tool_definitions_expose_pi_style_prompt_metadata(tmp_path: Path) -> None:
+    definition = create_edit_tool_definition(cwd=tmp_path)
+
+    assert definition.prompt_snippet.startswith("Make precise file edits")
+    assert len(definition.prompt_guidelines) == 4
 
 
 @pytest.mark.anyio
@@ -28,8 +39,10 @@ async def test_read_tool_reads_file_with_offset_and_limit(tmp_path: Path) -> Non
 
     assert result.ok is True
     assert result.name == "read"
-    assert result.content == "two\n[truncated]"
-    assert result.data == {"path": str(path), "truncated": True}
+    assert result.content == "two\n\n[2 more lines in file. Use offset=3 to continue.]"
+    assert result.data is not None
+    assert result.data["path"] == str(path)
+    assert isinstance(result.data["truncation"], dict)
 
 
 @pytest.mark.anyio
@@ -69,7 +82,7 @@ async def test_edit_tool_rolls_back_when_any_edit_fails(tmp_path: Path) -> None:
     path.write_text(original)
     tool = create_edit_tool(cwd=tmp_path)
 
-    with pytest.raises(ValueError, match="oldText was not found"):
+    with pytest.raises(ValueError, match="Could not find edits\\[1\\]"):
         await tool.execute(
             {
                 "path": "file.txt",
@@ -89,7 +102,7 @@ async def test_edit_tool_requires_unique_matches(tmp_path: Path) -> None:
     path.write_text("repeat\nrepeat\n")
     tool = create_edit_tool(cwd=tmp_path)
 
-    with pytest.raises(ValueError, match="matched more than once"):
+    with pytest.raises(ValueError, match="Found 2 occurrences"):
         await tool.execute(
             {
                 "path": "file.txt",
@@ -105,7 +118,7 @@ async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
     result = await tool.execute({"command": "printf hello"})
 
     assert result.ok is True
-    assert result.content == "stdout:\nhello"
+    assert result.content == "hello"
     assert result.data is not None
     assert result.data["exit_code"] == 0
     assert result.data["timed_out"] is False
@@ -115,7 +128,7 @@ async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
 async def test_bash_tool_reports_timeout(tmp_path: Path) -> None:
     tool = create_bash_tool(cwd=tmp_path)
 
-    result = await tool.execute({"command": "sleep 1", "timeout_seconds": 0.01})
+    result = await tool.execute({"command": "sleep 1", "timeout": 0.01})
 
     assert result.ok is False
     assert result.data is not None

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from time import monotonic
 
 import pytest
 
@@ -144,3 +145,17 @@ async def test_bash_tool_reports_timeout(tmp_path: Path) -> None:
     assert result.data is not None
     assert result.data["timed_out"] is True
     assert "timed out" in result.content
+
+
+@pytest.mark.anyio
+async def test_bash_tool_timeout_kills_shell_children(tmp_path: Path) -> None:
+    tool = create_bash_tool(cwd=tmp_path)
+
+    start = monotonic()
+    result = await tool.execute({"command": "sleep 1 & wait", "timeout": 0.01})
+    duration = monotonic() - start
+
+    assert result.ok is False
+    assert result.data is not None
+    assert result.data["timed_out"] is True
+    assert duration < 0.5

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -8,6 +8,7 @@ from tau_coding import (
     create_edit_tool,
     create_edit_tool_definition,
     create_read_tool,
+    create_read_tool_definition,
     create_write_tool,
 )
 
@@ -27,6 +28,15 @@ def test_tool_definitions_expose_pi_style_prompt_metadata(tmp_path: Path) -> Non
 
     assert definition.prompt_snippet.startswith("Make precise file edits")
     assert len(definition.prompt_guidelines) == 4
+
+
+def test_read_tool_schema_defines_line_controls_as_integers(tmp_path: Path) -> None:
+    definition = create_read_tool_definition(cwd=tmp_path)
+    properties = definition.input_schema["properties"]
+
+    assert isinstance(properties, dict)
+    assert properties["offset"]["type"] == "integer"
+    assert properties["limit"]["type"] == "integer"
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+import pytest
+
+from tau_coding import (
+    create_bash_tool,
+    create_coding_tools,
+    create_edit_tool,
+    create_read_tool,
+    create_write_tool,
+)
+
+
+@pytest.mark.anyio
+async def test_create_coding_tools_returns_initial_tool_set(tmp_path: Path) -> None:
+    tools = create_coding_tools(cwd=tmp_path)
+
+    assert [tool.name for tool in tools] == ["read", "write", "edit", "bash"]
+
+
+@pytest.mark.anyio
+async def test_read_tool_reads_file_with_offset_and_limit(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("one\ntwo\nthree\n")
+    tool = create_read_tool(cwd=tmp_path)
+
+    result = await tool.execute({"path": "notes.txt", "offset": 2, "limit": 1})
+
+    assert result.ok is True
+    assert result.name == "read"
+    assert result.content == "two\n[truncated]"
+    assert result.data == {"path": str(path), "truncated": True}
+
+
+@pytest.mark.anyio
+async def test_write_tool_creates_parent_directories(tmp_path: Path) -> None:
+    tool = create_write_tool(cwd=tmp_path)
+
+    result = await tool.execute({"path": "nested/file.txt", "content": "hello"})
+
+    assert result.ok is True
+    assert (tmp_path / "nested" / "file.txt").read_text() == "hello"
+
+
+@pytest.mark.anyio
+async def test_edit_tool_applies_multiple_exact_replacements(tmp_path: Path) -> None:
+    path = tmp_path / "file.txt"
+    path.write_text("alpha\nbeta\ngamma\n")
+    tool = create_edit_tool(cwd=tmp_path)
+
+    result = await tool.execute(
+        {
+            "path": "file.txt",
+            "edits": [
+                {"oldText": "alpha", "newText": "one"},
+                {"oldText": "gamma", "newText": "three"},
+            ],
+        }
+    )
+
+    assert result.ok is True
+    assert path.read_text() == "one\nbeta\nthree\n"
+
+
+@pytest.mark.anyio
+async def test_edit_tool_rolls_back_when_any_edit_fails(tmp_path: Path) -> None:
+    path = tmp_path / "file.txt"
+    original = "alpha\nbeta\ngamma\n"
+    path.write_text(original)
+    tool = create_edit_tool(cwd=tmp_path)
+
+    with pytest.raises(ValueError, match="oldText was not found"):
+        await tool.execute(
+            {
+                "path": "file.txt",
+                "edits": [
+                    {"oldText": "alpha", "newText": "one"},
+                    {"oldText": "missing", "newText": "nope"},
+                ],
+            }
+        )
+
+    assert path.read_text() == original
+
+
+@pytest.mark.anyio
+async def test_edit_tool_requires_unique_matches(tmp_path: Path) -> None:
+    path = tmp_path / "file.txt"
+    path.write_text("repeat\nrepeat\n")
+    tool = create_edit_tool(cwd=tmp_path)
+
+    with pytest.raises(ValueError, match="matched more than once"):
+        await tool.execute(
+            {
+                "path": "file.txt",
+                "edits": [{"oldText": "repeat", "newText": "once"}],
+            }
+        )
+
+
+@pytest.mark.anyio
+async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
+    tool = create_bash_tool(cwd=tmp_path)
+
+    result = await tool.execute({"command": "printf hello"})
+
+    assert result.ok is True
+    assert result.content == "stdout:\nhello"
+    assert result.data is not None
+    assert result.data["exit_code"] == 0
+    assert result.data["timed_out"] is False
+
+
+@pytest.mark.anyio
+async def test_bash_tool_reports_timeout(tmp_path: Path) -> None:
+    tool = create_bash_tool(cwd=tmp_path)
+
+    result = await tool.execute({"command": "sleep 1", "timeout_seconds": 0.01})
+
+    assert result.ok is False
+    assert result.data is not None
+    assert result.data["timed_out"] is True
+    assert "timed out" in result.content


### PR DESCRIPTION
## Summary

Adds Phase 5 built-in coding tools for Tau, following Pi's tool contracts more closely:

- Adds read/write/edit/bash coding tools in `tau_coding.tools`
- Adds Pi-like tool definitions with prompt snippets and prompt guidelines
- Extends `AgentTool`/`AgentToolResult` with prompt metadata and details support
- Adds Pi-style truncation metadata and continuation hints
- Adds edit validation, rollback semantics, line-ending/BOM preservation, diff and patch metadata
- Adds bash timeout, tail truncation, and full-output temp file support
- Documents Phase 5 and updates docs navigation/roadmap

Includes the small formatting commit needed for the branch to pass current lint checks.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added built-in coding tools for `read`, `write`, `edit`, and `bash`, including truncation metadata, exact-match edit rollback safeguards, and `bash` timeout handling.
  * Tool results can include optional extra `details`, and tools can carry provider-neutral prompt guidance metadata.
  * Coding tools can be created in one step and configured with a base directory for relative paths.

* **Documentation**
  * Updated roadmap for Phase 0 and added Architecture Notes for Phase 5.
  * Expanded Tau tooling docs with concrete tool contracts and setup guidance.

* **Tests**
  * Strengthened validation for schemas, truncation/footer behavior, and fast bash timeout termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->