### PR TITLE
Add non-interactive print-mode CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 Tau is a Python implementation of Pi's minimalist coding-agent harness architecture.
 
-The project is being built in documented phases. Phase 0 establishes the package layout,
-development tooling, design documents, and a basic `tau --version` command.
+The project is being built in documented phases. Tau currently includes a print-mode CLI
+that can run one prompt against an OpenAI-compatible provider.
 
 ## Development
 
 ```bash
 uv sync --dev --group docs
 uv run tau --version
+OPENAI_API_KEY=... uv run tau "explain this repo"
 uv run pytest
 uv run ruff check .
 uv run ruff format --check .

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -25,5 +25,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 3: Pure Agent Loop](phase-3-agent-loop.md)
 - [Phase 4: AgentHarness](phase-4-agent-harness.md)
 - [Phase 5: Built-in Coding Tools](phase-5-coding-tools.md)
+- [Phase 6: Non-interactive Print-mode CLI](phase-6-print-mode-cli.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-6-print-mode-cli.md
+++ b/docs/architecture/phase-6-print-mode-cli.md
@@ -1,0 +1,90 @@
+# Phase 6: Non-interactive Print-mode CLI
+
+Phase 6 wires Tau's provider layer, agent harness, and built-in coding tools into a usable non-interactive CLI.
+
+The CLI entry point lives in:
+
+```text
+src/tau_coding/cli.py
+```
+
+## What was added
+
+The `tau` command can now run a single prompt in print mode:
+
+```bash
+tau "explain this repo"
+tau -p "write tests for main.py"
+tau --model gpt-4.1-mini "summarize README.md"
+```
+
+The command:
+
+1. loads OpenAI-compatible provider settings from the environment
+2. creates Tau's built-in coding tools
+3. builds a minimal default system prompt
+4. creates an `AgentHarness`
+5. streams assistant text to stdout
+6. prints tool execution summaries to stderr
+
+## Provider configuration
+
+Print mode currently uses the OpenAI-compatible provider.
+
+Required environment:
+
+```bash
+export OPENAI_API_KEY="..."
+```
+
+Optional environment:
+
+```bash
+export OPENAI_BASE_URL="https://api.openai.com/v1"
+```
+
+The default model is currently:
+
+```text
+gpt-4.1-mini
+```
+
+Use `--model` to choose another model supported by the configured endpoint.
+
+## Working directory
+
+Tools are rooted at the current working directory by default.
+
+Use `--cwd` to run tools somewhere else:
+
+```bash
+tau --cwd /path/to/project "inspect the tests"
+```
+
+## Minimal system prompt
+
+Full Pi-style system prompt assembly is planned for a later phase. For now, print mode builds a small prompt containing:
+
+- Tau's identity
+- the list of available tools
+- each tool's `prompt_snippet`
+- each tool's `prompt_guidelines`
+
+This gives the model enough guidance to use the Phase 5 tools while keeping the richer prompt/resource system out of the core harness.
+
+## Boundary
+
+The CLI lives in `tau_coding`. It depends on providers, tools, and the harness, but the reusable `tau_agent` package still has no CLI, Rich, Textual, config-file, or session-storage dependency.
+
+## Tests
+
+The phase is covered by `tests/test_cli.py`, including:
+
+- `tau --version`
+- no-prompt hint output
+- default system prompt contents
+- print-mode streaming with a fake provider
+
+## Next phase
+
+The next roadmap phase is append-only session tree persistence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,5 +64,6 @@ nav:
       - "Phase 3: Pure Agent Loop": architecture/phase-3-agent-loop.md
       - "Phase 4: AgentHarness": architecture/phase-4-agent-harness.md
       - "Phase 5: Built-in Coding Tools": architecture/phase-5-coding-tools.md
+      - "Phase 6: Non-interactive Print-mode CLI": architecture/phase-6-print-mode-cli.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -1,8 +1,25 @@
 """Command-line entry point for Tau."""
 
+from pathlib import Path
+from typing import Annotated
+
+import anyio
 import typer
 
-from tau_coding import __version__
+from tau_agent import (
+    AgentEndEvent,
+    AgentEvent,
+    AgentHarness,
+    AgentHarnessConfig,
+    ErrorEvent,
+    MessageDeltaEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+)
+from tau_ai import ModelProvider, OpenAICompatibleProvider, openai_compatible_config_from_env
+from tau_coding import __version__, create_coding_tools
+
+DEFAULT_MODEL = "gpt-4.1-mini"
 
 app = typer.Typer(
     name="tau",
@@ -13,15 +30,126 @@ app = typer.Typer(
 
 @app.callback(invoke_without_command=True)
 def main(
-    version: bool = typer.Option(
-        False,
-        "--version",
-        help="Show Tau's version and exit.",
-    ),
+    prompt_arg: Annotated[
+        str | None,
+        typer.Argument(help="Prompt to run in non-interactive print mode."),
+    ] = None,
+    prompt_option: Annotated[
+        str | None,
+        typer.Option("--prompt", "-p", help="Prompt to run in non-interactive print mode."),
+    ] = None,
+    model: Annotated[
+        str,
+        typer.Option("--model", "-m", help="Model name to request from the provider."),
+    ] = DEFAULT_MODEL,
+    cwd: Annotated[
+        Path | None,
+        typer.Option("--cwd", help="Working directory for built-in coding tools."),
+    ] = None,
+    version: Annotated[
+        bool,
+        typer.Option("--version", help="Show Tau's version and exit."),
+    ] = False,
 ) -> None:
     """Run the Tau CLI."""
     if version:
         typer.echo(f"tau {__version__}")
         raise typer.Exit()
 
-    typer.echo("Tau phase 0 scaffold is installed. Run `tau --version` to verify the CLI.")
+    prompt = prompt_option or prompt_arg
+    if not prompt:
+        typer.echo("Tau print mode is installed. Pass a prompt or run `tau --version`.")
+        raise typer.Exit()
+
+    try:
+        anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd())
+    except RuntimeError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+async def run_openai_print_mode(prompt: str, model: str, cwd: Path) -> None:
+    """Run print mode with the OpenAI-compatible provider configured from the environment."""
+    provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
+    try:
+        await run_print_mode(prompt=prompt, model=model, cwd=cwd, provider=provider)
+    finally:
+        await provider.aclose()
+
+
+async def run_print_mode(
+    *,
+    prompt: str,
+    model: str,
+    cwd: Path,
+    provider: ModelProvider,
+) -> None:
+    """Run one non-interactive prompt and print streamed events."""
+    tools = create_coding_tools(cwd=cwd)
+    harness = AgentHarness(
+        AgentHarnessConfig(
+            provider=provider,
+            model=model,
+            system=build_default_system_prompt(),
+            tools=tools,
+        )
+    )
+    renderer = PrintModeRenderer()
+    async for event in harness.prompt(prompt):
+        renderer.render(event)
+
+
+class PrintModeRenderer:
+    """Small event renderer for non-interactive CLI output."""
+
+    def __init__(self) -> None:
+        self._assistant_started = False
+        self._assistant_ended = False
+
+    def render(self, event: AgentEvent) -> None:
+        if isinstance(event, MessageDeltaEvent):
+            self._assistant_started = True
+            typer.echo(event.delta, nl=False)
+            return
+
+        if isinstance(event, ToolExecutionStartEvent):
+            self._ensure_assistant_newline()
+            typer.echo(f"→ {event.tool_call.name} {event.tool_call.arguments}", err=True)
+            return
+
+        if isinstance(event, ToolExecutionEndEvent):
+            status = "✓" if event.result.ok else "✗"
+            typer.echo(f"{status} {event.result.name}", err=True)
+            if not event.result.ok and event.result.content:
+                typer.echo(event.result.content, err=True)
+            return
+
+        if isinstance(event, ErrorEvent):
+            self._ensure_assistant_newline()
+            typer.echo(f"Error: {event.message}", err=True)
+            return
+
+        if isinstance(event, AgentEndEvent):
+            self._ensure_assistant_newline(final=True)
+
+    def _ensure_assistant_newline(self, *, final: bool = False) -> None:
+        if self._assistant_started and not self._assistant_ended:
+            typer.echo()
+            self._assistant_ended = True
+        elif final and not self._assistant_started:
+            self._assistant_ended = True
+
+
+def build_default_system_prompt() -> str:
+    """Build the minimal system prompt needed before full prompt assembly exists."""
+    tools = create_coding_tools()
+    snippets = [f"- {tool.name}: {tool.prompt_snippet or tool.description}" for tool in tools]
+    guidelines = [guideline for tool in tools for guideline in tool.prompt_guidelines]
+
+    sections = [
+        "You are Tau, a concise coding agent inspired by Pi.",
+        "Use the available tools to inspect and modify files when needed.",
+        "Available tools:\n" + "\n".join(snippets),
+    ]
+    if guidelines:
+        sections.append("Tool guidelines:\n" + "\n".join(f"- {line}" for line in guidelines))
+    return "\n\n".join(sections)

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -13,6 +13,8 @@ from tau_agent import (
     AgentHarnessConfig,
     ErrorEvent,
     MessageDeltaEvent,
+    MessageEndEvent,
+    MessageStartEvent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
 )
@@ -62,16 +64,18 @@ def main(
         raise typer.Exit()
 
     try:
-        anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd())
+        ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd())
     except RuntimeError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    if not ok:
+        raise typer.Exit(1)
 
 
-async def run_openai_print_mode(prompt: str, model: str, cwd: Path) -> None:
+async def run_openai_print_mode(prompt: str, model: str, cwd: Path) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
     try:
-        await run_print_mode(prompt=prompt, model=model, cwd=cwd, provider=provider)
+        return await run_print_mode(prompt=prompt, model=model, cwd=cwd, provider=provider)
     finally:
         await provider.aclose()
 
@@ -82,8 +86,12 @@ async def run_print_mode(
     model: str,
     cwd: Path,
     provider: ModelProvider,
-) -> None:
-    """Run one non-interactive prompt and print streamed events."""
+) -> bool:
+    """Run one non-interactive prompt and print streamed events.
+
+    Returns False when the agent emits a non-recoverable error so CLI callers
+    can fail non-interactive runs while still rendering the error message.
+    """
     tools = create_coding_tools(cwd=cwd)
     harness = AgentHarness(
         AgentHarnessConfig(
@@ -96,6 +104,7 @@ async def run_print_mode(
     renderer = PrintModeRenderer()
     async for event in harness.prompt(prompt):
         renderer.render(event)
+    return not renderer.failed
 
 
 class PrintModeRenderer:
@@ -104,8 +113,14 @@ class PrintModeRenderer:
     def __init__(self) -> None:
         self._assistant_started = False
         self._assistant_ended = False
+        self.failed = False
 
     def render(self, event: AgentEvent) -> None:
+        if isinstance(event, MessageStartEvent):
+            self._assistant_started = False
+            self._assistant_ended = False
+            return
+
         if isinstance(event, MessageDeltaEvent):
             self._assistant_started = True
             typer.echo(event.delta, nl=False)
@@ -124,11 +139,13 @@ class PrintModeRenderer:
             return
 
         if isinstance(event, ErrorEvent):
+            if not event.recoverable:
+                self.failed = True
             self._ensure_assistant_newline()
             typer.echo(f"Error: {event.message}", err=True)
             return
 
-        if isinstance(event, AgentEndEvent):
+        if isinstance(event, MessageEndEvent | AgentEndEvent):
             self._ensure_assistant_newline(final=True)
 
     def _ensure_assistant_newline(self, *, final: bool = False) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,10 +6,12 @@ from typer.testing import CliRunner
 from tau_agent import AssistantMessage
 from tau_ai import (
     FakeProvider,
+    ProviderErrorEvent,
     ProviderResponseEndEvent,
     ProviderResponseStartEvent,
     ProviderTextDeltaEvent,
 )
+from tau_coding import cli
 from tau_coding.cli import app, build_default_system_prompt, run_print_mode
 
 
@@ -50,11 +52,44 @@ async def test_run_print_mode_streams_assistant_text(
         ]
     )
 
-    await run_print_mode(prompt="Say hello", model="fake", cwd=tmp_path, provider=provider)
+    ok = await run_print_mode(prompt="Say hello", model="fake", cwd=tmp_path, provider=provider)
 
     captured = capsys.readouterr()
+    assert ok is True
     assert captured.out == "Hello\n"
     assert captured.err == ""
     assert provider.calls[0][0] == "fake"
     assert provider.calls[0][1] == build_default_system_prompt()
     assert [tool.name for tool in provider.calls[0][3]] == ["read", "write", "edit", "bash"]
+
+
+@pytest.mark.anyio
+async def test_run_print_mode_fails_on_non_recoverable_error(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderErrorEvent(message="provider failed"),
+            ]
+        ]
+    )
+
+    ok = await run_print_mode(prompt="Say hello", model="fake", cwd=tmp_path, provider=provider)
+
+    captured = capsys.readouterr()
+    assert ok is False
+    assert captured.out == ""
+    assert "Error: provider failed" in captured.err
+
+
+def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_openai_print_mode(prompt: str, model: str, cwd: Path) -> bool:
+        return False
+
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["hello"])
+
+    assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,16 @@
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
 
-from tau_coding.cli import app
+from tau_agent import AssistantMessage
+from tau_ai import (
+    FakeProvider,
+    ProviderResponseEndEvent,
+    ProviderResponseStartEvent,
+    ProviderTextDeltaEvent,
+)
+from tau_coding.cli import app, build_default_system_prompt, run_print_mode
 
 
 def test_version_command() -> None:
@@ -8,3 +18,43 @@ def test_version_command() -> None:
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "tau 0.1.0"
+
+
+def test_cli_without_prompt_prints_print_mode_hint() -> None:
+    result = CliRunner().invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Tau print mode is installed" in result.stdout
+
+
+def test_default_system_prompt_includes_tool_snippets_and_guidelines() -> None:
+    prompt = build_default_system_prompt()
+
+    assert "You are Tau" in prompt
+    assert "- read: Read file contents" in prompt
+    assert "Use read to examine files instead of cat or sed." in prompt
+
+
+@pytest.mark.anyio
+async def test_run_print_mode_streams_assistant_text(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderTextDeltaEvent(delta="Hel"),
+                ProviderTextDeltaEvent(delta="lo"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hello")),
+            ]
+        ]
+    )
+
+    await run_print_mode(prompt="Say hello", model="fake", cwd=tmp_path, provider=provider)
+
+    captured = capsys.readouterr()
+    assert captured.out == "Hello\n"
+    assert captured.err == ""
+    assert provider.calls[0][0] == "fake"
+    assert provider.calls[0][1] == build_default_system_prompt()
+    assert [tool.name for tool in provider.calls[0][3]] == ["read", "write", "edit", "bash"]


### PR DESCRIPTION
## Summary

Adds Phase 6 non-interactive print-mode CLI:

- Runs `tau "prompt"` or `tau -p "prompt"`
- Loads `OpenAICompatibleProvider` from environment
- Supports `--model` and `--cwd`
- Registers built-in coding tools
- Builds a minimal default system prompt from tool snippets/guidelines
- Streams assistant deltas to stdout
- Prints tool summaries/errors to stderr
- Documents Phase 6 and updates README/docs nav

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Print-mode CLI is now fully functional for executing single prompts against OpenAI-compatible providers.
  * Results stream to stdout with tool execution summaries displayed separately.

* **Documentation**
  * Comprehensive architecture documentation added for the print-mode CLI implementation.
  * README updated with CLI usage examples and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->