### PR TITLE
Add session tree primitives

### DIFF
--- a/docs/04-sessions.md
+++ b/docs/04-sessions.md
@@ -2,11 +2,17 @@
 
 Sessions preserve conversations and agent state across runs.
 
-## Design direction
+## Design
 
-Tau will use an append-only session tree. Instead of mutating old state, Tau appends entries and reconstructs state by replaying them.
+Tau uses an append-only session tree. Instead of mutating old state, Tau appends entries and reconstructs state by replaying them.
 
-## Planned entry types
+The low-level implementation lives in:
+
+```text
+src/tau_agent/session/
+```
+
+## Entry types
 
 - `message`
 - `model_change`
@@ -17,6 +23,16 @@ Tau will use an append-only session tree. Instead of mutating old state, Tau app
 - `leaf`
 - `session_info`
 - `custom`
+
+## Current capabilities
+
+Tau can now:
+
+- serialize and deserialize session entries as JSONL
+- append entries to local session files
+- read session files in order
+- reconstruct linear session state
+- reconstruct a root-to-leaf branch path
 
 ## Boundary
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -26,5 +26,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 4: AgentHarness](phase-4-agent-harness.md)
 - [Phase 5: Built-in Coding Tools](phase-5-coding-tools.md)
 - [Phase 6: Non-interactive Print-mode CLI](phase-6-print-mode-cli.md)
+- [Phase 7: Session Tree and JSONL Persistence](phase-7-session-tree.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-7-session-tree.md
+++ b/docs/architecture/phase-7-session-tree.md
@@ -1,0 +1,134 @@
+# Phase 7: Session Tree and JSONL Persistence
+
+Phase 7 adds Tau's first durable session layer.
+
+The session primitives live in:
+
+```text
+src/tau_agent/session/
+```
+
+## What was added
+
+Tau now has:
+
+- typed append-only session entries
+- JSONL serialization helpers
+- local JSONL session storage
+- in-memory session replay
+- branch path traversal helpers
+
+## Why sessions are append-only
+
+Tau follows Pi's core session idea: persisted state is not edited in place. Instead, Tau appends immutable entries and reconstructs the current view by replaying them.
+
+This makes session files:
+
+- easy to inspect
+- easy to append to safely
+- suitable for branching/forking later
+- able to preserve history even after compaction or summaries land
+
+A session file is one JSON object per line:
+
+```jsonl
+{"type":"message","id":"...","message":{"role":"user","content":"Hello"}}
+{"type":"message","id":"...","parent_id":"...","message":{"role":"assistant","content":"Hi"}}
+{"type":"label","id":"...","label":"Greeting"}
+```
+
+## Entry types
+
+Phase 7 defines these entries:
+
+- `message`
+- `model_change`
+- `thinking_level_change`
+- `compaction`
+- `branch_summary`
+- `label`
+- `leaf`
+- `session_info`
+- `custom`
+
+Some entries, such as `compaction` and `branch_summary`, are placeholders for later phases. They are persisted and replay-safe, but they do not yet alter prompt context.
+
+## JSONL storage
+
+`JsonlSessionStorage` provides the first local storage backend:
+
+```python
+from tau_agent.session import JsonlSessionStorage, MessageEntry
+from tau_agent import UserMessage
+
+storage = JsonlSessionStorage("session.jsonl")
+await storage.append(MessageEntry(message=UserMessage(content="Hello")))
+entries = await storage.read_all()
+```
+
+Missing files read as empty sessions. Parent directories are created automatically when appending.
+
+## Replay
+
+`SessionState.from_entries()` reconstructs an in-memory state:
+
+```python
+from tau_agent.session import SessionState
+
+state = SessionState.from_entries(entries)
+```
+
+The reconstructed state includes:
+
+- transcript messages
+- active model
+- thinking level
+- label
+- active leaf id
+- session info
+- custom entries
+
+## Tree paths
+
+Every entry has:
+
+```python
+id: str
+parent_id: str | None
+```
+
+This gives Tau enough structure for branch reconstruction:
+
+```python
+state = SessionState.from_entries(entries, leaf_id="entry-id")
+```
+
+When `leaf_id` is provided, only the root-to-leaf path is replayed. This prevents sibling branches from leaking into the active transcript.
+
+## Boundary
+
+The session layer lives in `tau_agent` because it is part of the reusable agent brain. It does not know about CLI arguments, Textual widgets, Rich rendering, slash commands, or local Tau resource directories.
+
+A later `tau_coding` session wrapper will decide when to append entries, where to store session files, and how commands like `/sessions` or `/fork` should behave.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_session.py
+```
+
+The tests verify:
+
+- entry JSONL round-tripping
+- malformed JSONL errors
+- append/read storage behavior
+- missing-file behavior
+- linear state replay
+- branch path reconstruction
+- missing parent validation
+
+## Next phase
+
+The next roadmap phase is the Tau coding session wrapper. That layer can combine session persistence, slash commands, prompt expansion, resources, and print/interactive frontends on top of this append-only foundation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,5 +65,6 @@ nav:
       - "Phase 4: AgentHarness": architecture/phase-4-agent-harness.md
       - "Phase 5: Built-in Coding Tools": architecture/phase-5-coding-tools.md
       - "Phase 6: Non-interactive Print-mode CLI": architecture/phase-6-print-mode-cli.md
+      - "Phase 7: Session Tree and JSONL Persistence": architecture/phase-7-session-tree.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_agent/__init__.py
+++ b/src/tau_agent/__init__.py
@@ -22,6 +22,20 @@ from tau_agent.harness import (
 )
 from tau_agent.loop import run_agent_loop
 from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
+from tau_agent.session import (
+    BranchSummaryEntry,
+    CompactionEntry,
+    CustomEntry,
+    JsonlSessionStorage,
+    LabelEntry,
+    LeafEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionEntry,
+    SessionInfoEntry,
+    SessionState,
+    ThinkingLevelChangeEntry,
+)
 from tau_agent.tools import AgentTool, AgentToolResult, ToolCall, ToolExecutor
 from tau_agent.types import JSONObject, JSONPrimitive, JSONValue
 
@@ -35,15 +49,27 @@ __all__ = [
     "AgentTool",
     "AgentToolResult",
     "AssistantMessage",
+    "BranchSummaryEntry",
+    "CompactionEntry",
+    "CustomEntry",
     "ErrorEvent",
     "EventListener",
     "JSONObject",
     "JSONPrimitive",
+    "JsonlSessionStorage",
     "JSONValue",
+    "LabelEntry",
+    "LeafEntry",
     "MessageDeltaEvent",
     "MessageEndEvent",
+    "MessageEntry",
     "MessageStartEvent",
+    "ModelChangeEntry",
+    "SessionEntry",
+    "SessionInfoEntry",
+    "SessionState",
     "SimpleCancellationToken",
+    "ThinkingLevelChangeEntry",
     "ToolCall",
     "ToolExecutionEndEvent",
     "ToolExecutionStartEvent",

--- a/src/tau_agent/session/__init__.py
+++ b/src/tau_agent/session/__init__.py
@@ -1,0 +1,48 @@
+"""Append-only session tree primitives for Tau."""
+
+from tau_agent.session.entries import (
+    BaseSessionEntry,
+    BranchSummaryEntry,
+    CompactionEntry,
+    CustomEntry,
+    LabelEntry,
+    LeafEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionEntry,
+    SessionInfoEntry,
+    ThinkingLevelChangeEntry,
+)
+from tau_agent.session.jsonl import (
+    SessionJsonlError,
+    entries_from_json_lines,
+    entry_from_json_line,
+    entry_to_json_line,
+)
+from tau_agent.session.memory import SessionState
+from tau_agent.session.storage import JsonlSessionStorage, SessionStorage
+from tau_agent.session.tree import SessionTreeError, entries_by_id, path_to_entry
+
+__all__ = [
+    "BaseSessionEntry",
+    "BranchSummaryEntry",
+    "CompactionEntry",
+    "CustomEntry",
+    "JsonlSessionStorage",
+    "LabelEntry",
+    "LeafEntry",
+    "MessageEntry",
+    "ModelChangeEntry",
+    "SessionEntry",
+    "SessionInfoEntry",
+    "SessionJsonlError",
+    "SessionState",
+    "SessionStorage",
+    "SessionTreeError",
+    "ThinkingLevelChangeEntry",
+    "entries_by_id",
+    "entries_from_json_lines",
+    "entry_from_json_line",
+    "entry_to_json_line",
+    "path_to_entry",
+]

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -1,0 +1,112 @@
+"""Append-only session entry models."""
+
+from time import time
+from typing import Annotated, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tau_agent.messages import AgentMessage
+from tau_agent.types import JSONValue
+
+
+def new_entry_id() -> str:
+    """Return a unique session entry id."""
+    return uuid4().hex
+
+
+def current_timestamp() -> float:
+    """Return the current Unix timestamp."""
+    return time()
+
+
+class BaseSessionEntry(BaseModel):
+    """Common fields shared by all append-only session entries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=new_entry_id)
+    parent_id: str | None = None
+    timestamp: float = Field(default_factory=current_timestamp)
+
+
+class MessageEntry(BaseSessionEntry):
+    """A transcript message entry."""
+
+    type: Literal["message"] = "message"
+    message: AgentMessage
+
+
+class ModelChangeEntry(BaseSessionEntry):
+    """A model selection change entry."""
+
+    type: Literal["model_change"] = "model_change"
+    model: str
+
+
+class ThinkingLevelChangeEntry(BaseSessionEntry):
+    """A thinking/reasoning level change entry."""
+
+    type: Literal["thinking_level_change"] = "thinking_level_change"
+    thinking_level: str | None = None
+
+
+class CompactionEntry(BaseSessionEntry):
+    """A future context compaction entry."""
+
+    type: Literal["compaction"] = "compaction"
+    summary: str
+    replaces_entry_ids: list[str] = Field(default_factory=list)
+
+
+class BranchSummaryEntry(BaseSessionEntry):
+    """A future branch summary entry."""
+
+    type: Literal["branch_summary"] = "branch_summary"
+    summary: str
+    branch_root_id: str | None = None
+
+
+class LabelEntry(BaseSessionEntry):
+    """A human-readable session label entry."""
+
+    type: Literal["label"] = "label"
+    label: str
+
+
+class LeafEntry(BaseSessionEntry):
+    """The active branch leaf pointer entry."""
+
+    type: Literal["leaf"] = "leaf"
+    entry_id: str | None = None
+
+
+class SessionInfoEntry(BaseSessionEntry):
+    """Basic session metadata entry."""
+
+    type: Literal["session_info"] = "session_info"
+    created_at: float = Field(default_factory=current_timestamp)
+    cwd: str | None = None
+    title: str | None = None
+
+
+class CustomEntry(BaseSessionEntry):
+    """Extension/application-owned session data."""
+
+    type: Literal["custom"] = "custom"
+    namespace: str
+    data: dict[str, JSONValue] = Field(default_factory=dict)
+
+
+type SessionEntry = Annotated[
+    MessageEntry
+    | ModelChangeEntry
+    | ThinkingLevelChangeEntry
+    | CompactionEntry
+    | BranchSummaryEntry
+    | LabelEntry
+    | LeafEntry
+    | SessionInfoEntry
+    | CustomEntry,
+    Field(discriminator="type"),
+]

--- a/src/tau_agent/session/jsonl.py
+++ b/src/tau_agent/session/jsonl.py
@@ -1,0 +1,35 @@
+"""JSONL serialization helpers for session entries."""
+
+from pydantic import TypeAdapter, ValidationError
+
+from tau_agent.session.entries import SessionEntry
+
+_SESSION_ENTRY_ADAPTER: TypeAdapter[SessionEntry] = TypeAdapter(SessionEntry)
+
+
+class SessionJsonlError(ValueError):
+    """Raised when a session JSONL line cannot be decoded."""
+
+
+def entry_to_json_line(entry: SessionEntry) -> str:
+    """Serialize one session entry as a JSONL line."""
+    return _SESSION_ENTRY_ADAPTER.dump_json(entry).decode() + "\n"
+
+
+def entry_from_json_line(line: str, *, line_number: int | None = None) -> SessionEntry:
+    """Deserialize one JSONL line into a typed session entry."""
+    try:
+        return _SESSION_ENTRY_ADAPTER.validate_json(line)
+    except ValidationError as exc:
+        location = f" on line {line_number}" if line_number is not None else ""
+        raise SessionJsonlError(f"Invalid session entry{location}: {exc}") from exc
+
+
+def entries_from_json_lines(lines: list[str]) -> list[SessionEntry]:
+    """Deserialize non-empty JSONL lines in order."""
+    entries: list[SessionEntry] = []
+    for index, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        entries.append(entry_from_json_line(line, line_number=index))
+    return entries

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -1,0 +1,77 @@
+"""In-memory session state reconstruction."""
+
+from dataclasses import dataclass
+
+from tau_agent.messages import AgentMessage
+from tau_agent.session.entries import (
+    CustomEntry,
+    SessionEntry,
+    SessionInfoEntry,
+)
+from tau_agent.session.tree import path_to_entry
+
+
+@dataclass(frozen=True, slots=True)
+class SessionState:
+    """Current session state derived from append-only entries."""
+
+    messages: tuple[AgentMessage, ...]
+    model: str | None
+    thinking_level: str | None
+    label: str | None
+    active_leaf_id: str | None
+    session_info: SessionInfoEntry | None
+    custom_entries: tuple[CustomEntry, ...]
+    entries: tuple[SessionEntry, ...]
+
+    @classmethod
+    def from_entries(
+        cls,
+        entries: list[SessionEntry],
+        *,
+        leaf_id: str | None = None,
+    ) -> SessionState:
+        """Replay entries into state.
+
+        When `leaf_id` is provided, only the root-to-leaf path is replayed. Without
+        it, entries are replayed linearly in storage order.
+        """
+        replay_entries = path_to_entry(entries, leaf_id) if leaf_id is not None else entries
+
+        messages: list[AgentMessage] = []
+        model: str | None = None
+        thinking_level: str | None = None
+        label: str | None = None
+        active_leaf_id: str | None = leaf_id
+        session_info: SessionInfoEntry | None = None
+        custom_entries: list[CustomEntry] = []
+
+        for entry in replay_entries:
+            match entry.type:
+                case "message":
+                    messages.append(entry.message)
+                case "model_change":
+                    model = entry.model
+                case "thinking_level_change":
+                    thinking_level = entry.thinking_level
+                case "label":
+                    label = entry.label
+                case "leaf":
+                    active_leaf_id = entry.entry_id
+                case "session_info":
+                    session_info = entry
+                case "custom":
+                    custom_entries.append(entry)
+                case "compaction" | "branch_summary":
+                    pass
+
+        return cls(
+            messages=tuple(messages),
+            model=model,
+            thinking_level=thinking_level,
+            label=label,
+            active_leaf_id=active_leaf_id,
+            session_info=session_info,
+            custom_entries=tuple(custom_entries),
+            entries=tuple(replay_entries),
+        )

--- a/src/tau_agent/session/storage.py
+++ b/src/tau_agent/session/storage.py
@@ -1,0 +1,38 @@
+"""Session storage protocols and JSONL implementation."""
+
+from pathlib import Path
+from typing import Protocol
+
+from tau_agent.session.entries import SessionEntry
+from tau_agent.session.jsonl import entries_from_json_lines, entry_to_json_line
+
+
+class SessionStorage(Protocol):
+    """Append-only session storage interface."""
+
+    async def append(self, entry: SessionEntry) -> None:
+        """Append one entry to storage."""
+        ...
+
+    async def read_all(self) -> list[SessionEntry]:
+        """Read all entries in storage order."""
+        ...
+
+
+class JsonlSessionStorage:
+    """Local append-only JSONL session storage."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    async def append(self, entry: SessionEntry) -> None:
+        """Append one entry, creating parent directories if needed."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as file:
+            file.write(entry_to_json_line(entry))
+
+    async def read_all(self) -> list[SessionEntry]:
+        """Read all entries in file order. Missing files are empty sessions."""
+        if not self.path.exists():
+            return []
+        return entries_from_json_lines(self.path.read_text(encoding="utf-8").splitlines())

--- a/src/tau_agent/session/tree.py
+++ b/src/tau_agent/session/tree.py
@@ -1,0 +1,38 @@
+"""Session tree traversal helpers."""
+
+from tau_agent.session.entries import SessionEntry
+
+
+class SessionTreeError(ValueError):
+    """Raised when session entries do not form a valid traversable tree."""
+
+
+def entries_by_id(entries: list[SessionEntry]) -> dict[str, SessionEntry]:
+    """Return entries keyed by id, rejecting duplicates."""
+    result: dict[str, SessionEntry] = {}
+    for entry in entries:
+        if entry.id in result:
+            raise SessionTreeError(f"Duplicate session entry id: {entry.id}")
+        result[entry.id] = entry
+    return result
+
+
+def path_to_entry(entries: list[SessionEntry], leaf_id: str) -> list[SessionEntry]:
+    """Return the root-to-leaf path for `leaf_id`."""
+    by_id = entries_by_id(entries)
+    path: list[SessionEntry] = []
+    seen: set[str] = set()
+    current_id: str | None = leaf_id
+
+    while current_id is not None:
+        if current_id in seen:
+            raise SessionTreeError(f"Cycle detected at session entry: {current_id}")
+        seen.add(current_id)
+        entry = by_id.get(current_id)
+        if entry is None:
+            raise SessionTreeError(f"Missing session entry: {current_id}")
+        path.append(entry)
+        current_id = entry.parent_id
+
+    path.reverse()
+    return path

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+
+from tau_agent import AssistantMessage, UserMessage
+from tau_agent.session import (
+    CustomEntry,
+    JsonlSessionStorage,
+    LabelEntry,
+    LeafEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionJsonlError,
+    SessionState,
+    SessionTreeError,
+    entry_from_json_line,
+    entry_to_json_line,
+    path_to_entry,
+)
+
+
+def test_session_entry_round_trips_jsonl() -> None:
+    entry = MessageEntry(id="entry-1", message=UserMessage(content="Hello"))
+
+    line = entry_to_json_line(entry)
+    parsed = entry_from_json_line(line)
+
+    assert parsed == entry
+
+
+def test_invalid_jsonl_line_raises_useful_error() -> None:
+    with pytest.raises(SessionJsonlError, match="Invalid session entry on line 3"):
+        entry_from_json_line('{"type":"unknown"}', line_number=3)
+
+
+@pytest.mark.anyio
+async def test_jsonl_storage_appends_and_reads_entries(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "sessions" / "one.jsonl")
+    first = MessageEntry(id="one", message=UserMessage(content="Hi"))
+    second = LabelEntry(id="two", label="Greeting")
+
+    await storage.append(first)
+    await storage.append(second)
+
+    assert await storage.read_all() == [first, second]
+
+
+@pytest.mark.anyio
+async def test_jsonl_storage_missing_file_is_empty(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "missing.jsonl")
+
+    assert await storage.read_all() == []
+
+
+def test_session_state_replays_linear_entries() -> None:
+    entries = [
+        MessageEntry(id="user", message=UserMessage(content="Hi")),
+        ModelChangeEntry(id="model", model="fake-model"),
+        MessageEntry(id="assistant", message=AssistantMessage(content="Hello")),
+        LabelEntry(id="label", label="Greeting"),
+        CustomEntry(id="custom", namespace="test", data={"ok": True}),
+        LeafEntry(id="leaf", entry_id="assistant"),
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert state.messages == (UserMessage(content="Hi"), AssistantMessage(content="Hello"))
+    assert state.model == "fake-model"
+    assert state.label == "Greeting"
+    assert state.active_leaf_id == "assistant"
+    assert state.custom_entries == (entries[4],)
+
+
+def test_path_to_entry_returns_root_to_leaf_branch() -> None:
+    root = MessageEntry(id="root", message=UserMessage(content="Hi"))
+    left = MessageEntry(id="left", parent_id="root", message=AssistantMessage(content="Left"))
+    right = MessageEntry(id="right", parent_id="root", message=AssistantMessage(content="Right"))
+
+    assert path_to_entry([root, left, right], "right") == [root, right]
+
+
+def test_session_state_can_replay_one_branch() -> None:
+    root = MessageEntry(id="root", message=UserMessage(content="Hi"))
+    left = MessageEntry(id="left", parent_id="root", message=AssistantMessage(content="Left"))
+    right = MessageEntry(id="right", parent_id="root", message=AssistantMessage(content="Right"))
+
+    state = SessionState.from_entries([root, left, right], leaf_id="right")
+
+    assert state.messages == (UserMessage(content="Hi"), AssistantMessage(content="Right"))
+    assert state.active_leaf_id == "right"
+    assert state.entries == (root, right)
+
+
+def test_path_to_entry_rejects_missing_parent() -> None:
+    entry = MessageEntry(id="child", parent_id="missing", message=UserMessage(content="Hi"))
+
+    with pytest.raises(SessionTreeError, match="Missing session entry"):
+        path_to_entry([entry], "child")


### PR DESCRIPTION
## Summary
- add session tree data models and validation helpers
- add JSON session persistence and replay utilities
- document the session tree phase

## Tests
- pytest