### PR TITLE
Add coding session wrapper

### DIFF
--- a/docs/04-sessions.md
+++ b/docs/04-sessions.md
@@ -33,7 +33,10 @@ Tau can now:
 - read session files in order
 - reconstruct linear session state
 - reconstruct a root-to-leaf branch path
+- load a `tau_coding.CodingSession` that restores messages and persists new runs
 
 ## Boundary
 
 Low-level session primitives belong in `tau_agent`. File locations, slash commands, and coding-agent workflows belong in `tau_coding`.
+
+`CodingSession` is the first `tau_coding` layer on top of the low-level primitives. It wires storage, `AgentHarness`, cwd, and coding tools together while leaving richer commands and resource loading for later phases.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -27,5 +27,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 5: Built-in Coding Tools](phase-5-coding-tools.md)
 - [Phase 6: Non-interactive Print-mode CLI](phase-6-print-mode-cli.md)
 - [Phase 7: Session Tree and JSONL Persistence](phase-7-session-tree.md)
+- [Phase 8: Coding Session Wrapper](phase-8-coding-session.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-8-coding-session.md
+++ b/docs/architecture/phase-8-coding-session.md
@@ -1,0 +1,144 @@
+# Phase 8: Coding Session Wrapper
+
+Phase 8 adds Tau's first coding-session environment wrapper.
+
+The implementation lives in:
+
+```text
+src/tau_coding/session.py
+```
+
+## What was added
+
+Tau now has a `CodingSession` that combines:
+
+- `AgentHarness`
+- append-only session storage
+- restored transcript messages
+- built-in coding tools
+- model/session metadata
+- a minimal slash-command seam
+
+This is the first layer that starts to resemble Pi's `AgentSession`, but it remains intentionally small.
+
+## Why this lives in `tau_coding`
+
+`tau_agent` owns reusable primitives:
+
+- messages
+- events
+- tools as an abstraction
+- the pure loop
+- `AgentHarness`
+- low-level session entries/storage/replay
+
+`tau_coding` owns the coding-agent environment around those primitives:
+
+- local cwd
+- built-in coding tools
+- storage choices
+- slash commands
+- prompt/resource loading later
+- print and interactive frontends later
+
+So `CodingSession` belongs in `tau_coding`.
+
+## Loading a session
+
+A session is loaded from a `SessionStorage` implementation:
+
+```python
+from pathlib import Path
+from tau_coding import CodingSession, CodingSessionConfig
+from tau_agent.session import JsonlSessionStorage
+
+session = await CodingSession.load(
+    CodingSessionConfig(
+        provider=provider,
+        model="gpt-4.1-mini",
+        system=system_prompt,
+        storage=JsonlSessionStorage("session.jsonl"),
+        cwd=Path.cwd(),
+    )
+)
+```
+
+Loading performs these steps:
+
+1. read all session entries
+2. initialize metadata for an empty session
+3. replay entries into `SessionState`
+4. create an `AgentHarness` with restored messages
+5. register built-in coding tools unless custom tools are supplied
+
+For a new empty session, Tau appends:
+
+- `SessionInfoEntry`
+- `ModelChangeEntry`
+
+## Prompt and continue
+
+`CodingSession.prompt()` runs a new user prompt through the harness:
+
+```python
+async for event in session.prompt("Read README.md"):
+    ...
+```
+
+After the run completes, all new harness messages are appended as `MessageEntry` records. Tau also appends a `LeafEntry` pointing at the newest message entry.
+
+`CodingSession.continue_()` resumes from restored state without appending a new user message first.
+
+## Persistence model
+
+Phase 8 persists messages after a run completes. This keeps the implementation simple and avoids double-saving messages while `AgentHarness` mutates its in-memory transcript.
+
+Later phases can make persistence more incremental if Tau needs crash recovery during a streaming response.
+
+## Minimal commands
+
+`CodingSession.handle_command()` currently supports only:
+
+- `/help`
+- `/exit`
+
+Unknown slash commands are handled with an explanatory message. Normal prompts return `handled=False`.
+
+This is a small seam for a future command registry. Full commands such as `/model`, `/sessions`, `/fork`, and `/compact` are intentionally deferred.
+
+## Non-goals
+
+Phase 8 does not add:
+
+- automatic print-mode session persistence
+- session directory discovery
+- model switching commands
+- direct bash command prefixes
+- project instruction loading
+- skills or prompt templates
+- Rich rendering
+- Textual UI
+- compaction
+
+Those belong to later phases.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_coding_session.py
+```
+
+The tests verify:
+
+- empty session metadata initialization
+- prompt persistence
+- transcript restore
+- continuation persistence
+- tool result persistence
+- minimal command handling
+
+## Next phase
+
+The next roadmap phase is skills, prompt templates, and system prompt assembly groundwork. The coding-session wrapper created here gives those later systems a stable place to plug in.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,5 +66,6 @@ nav:
       - "Phase 5: Built-in Coding Tools": architecture/phase-5-coding-tools.md
       - "Phase 6: Non-interactive Print-mode CLI": architecture/phase-6-print-mode-cli.md
       - "Phase 7: Session Tree and JSONL Persistence": architecture/phase-7-session-tree.md
+      - "Phase 8: Coding Session Wrapper": architecture/phase-8-coding-session.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -1,5 +1,11 @@
 """Tau coding-agent application package."""
 
+from tau_coding.session import (
+    CodingSession,
+    CodingSessionConfig,
+    CommandResult,
+    jsonl_session_storage,
+)
 from tau_coding.tools import (
     ToolDefinition,
     create_bash_tool,
@@ -17,6 +23,9 @@ __version__ = "0.1.0"
 
 __all__ = [
     "__version__",
+    "CodingSession",
+    "CodingSessionConfig",
+    "CommandResult",
     "ToolDefinition",
     "create_bash_tool",
     "create_bash_tool_definition",
@@ -27,4 +36,5 @@ __all__ = [
     "create_read_tool_definition",
     "create_write_tool",
     "create_write_tool_definition",
+    "jsonl_session_storage",
 ]

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -73,7 +73,12 @@ class CodingSession:
             await config.storage.append(model)
             entries = [info, model]
 
-        state = SessionState.from_entries(entries)
+        linear_state = SessionState.from_entries(entries)
+        state = (
+            SessionState.from_entries(entries, leaf_id=linear_state.active_leaf_id)
+            if linear_state.active_leaf_id is not None
+            else linear_state
+        )
         tools = config.tools if config.tools is not None else create_coding_tools(cwd=config.cwd)
         harness = AgentHarness(
             AgentHarnessConfig(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1,0 +1,172 @@
+"""Persistent coding-session wrapper built on AgentHarness."""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from tau_agent import AgentEvent, AgentHarness, AgentHarnessConfig
+from tau_agent.messages import AgentMessage
+from tau_agent.session import (
+    JsonlSessionStorage,
+    LeafEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionInfoEntry,
+    SessionState,
+    SessionStorage,
+)
+from tau_agent.tools import AgentTool
+from tau_ai import ModelProvider
+from tau_coding.tools import create_coding_tools
+
+
+@dataclass(frozen=True, slots=True)
+class CodingSessionConfig:
+    """Configuration for a persistent coding session."""
+
+    provider: ModelProvider
+    model: str
+    system: str
+    storage: SessionStorage
+    cwd: Path
+    tools: list[AgentTool] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Result of handling a coding-session slash command."""
+
+    handled: bool
+    exit_requested: bool = False
+    message: str | None = None
+
+
+class CodingSession:
+    """Tau's coding-agent environment wrapper.
+
+    `AgentHarness` owns the in-memory agent brain. `CodingSession` owns the
+    coding-session environment around it: durable session entries, default coding
+    tools, and a small command seam for later phases.
+    """
+
+    def __init__(
+        self,
+        config: CodingSessionConfig,
+        *,
+        state: SessionState,
+        harness: AgentHarness,
+        last_parent_id: str | None,
+    ) -> None:
+        self._config = config
+        self._state = state
+        self._harness = harness
+        self._last_parent_id = last_parent_id
+
+    @classmethod
+    async def load(cls, config: CodingSessionConfig) -> CodingSession:
+        """Load a coding session from append-only storage."""
+        entries = await config.storage.read_all()
+        if not entries:
+            info = SessionInfoEntry(cwd=str(config.cwd))
+            model = ModelChangeEntry(parent_id=info.id, model=config.model)
+            await config.storage.append(info)
+            await config.storage.append(model)
+            entries = [info, model]
+
+        state = SessionState.from_entries(entries)
+        tools = config.tools if config.tools is not None else create_coding_tools(cwd=config.cwd)
+        harness = AgentHarness(
+            AgentHarnessConfig(
+                provider=config.provider,
+                model=state.model or config.model,
+                system=config.system,
+                tools=tools,
+            ),
+            messages=state.messages,
+        )
+        return cls(
+            config,
+            state=state,
+            harness=harness,
+            last_parent_id=_last_parent_id_from_state(state),
+        )
+
+    @property
+    def messages(self) -> tuple[AgentMessage, ...]:
+        """Return the restored/current transcript."""
+        return self._harness.messages
+
+    @property
+    def state(self) -> SessionState:
+        """Return the last replayed durable session state."""
+        return self._state
+
+    @property
+    def storage(self) -> SessionStorage:
+        """Return the backing session storage."""
+        return self._config.storage
+
+    def cancel(self) -> None:
+        """Cancel the currently running agent turn, if any."""
+        self._harness.cancel()
+
+    def handle_command(self, text: str) -> CommandResult:
+        """Handle minimal coding-session slash commands.
+
+        This is intentionally tiny. Later phases can replace it with a full Pi-like
+        command registry without changing the persistence boundary.
+        """
+        stripped = text.strip()
+        if not stripped.startswith("/"):
+            return CommandResult(handled=False)
+        if stripped == "/exit":
+            return CommandResult(handled=True, exit_requested=True, message="Exiting session.")
+        if stripped == "/help":
+            return CommandResult(
+                handled=True,
+                message="Available commands: /help, /exit",
+            )
+        return CommandResult(handled=True, message=f"Unknown command: {stripped}")
+
+    async def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
+        """Append a user prompt, run the agent, and persist new messages."""
+        before_count = len(self._harness.messages)
+        async for event in self._harness.prompt(content):
+            yield event
+        await self._persist_new_messages(before_count)
+
+    async def continue_(self) -> AsyncIterator[AgentEvent]:
+        """Continue the agent from restored state and persist new messages."""
+        before_count = len(self._harness.messages)
+        async for event in self._harness.continue_():
+            yield event
+        await self._persist_new_messages(before_count)
+
+    async def _persist_new_messages(self, before_count: int) -> None:
+        new_messages = self._harness.messages[before_count:]
+        last_message_entry_id: str | None = None
+        for message in new_messages:
+            entry = MessageEntry(parent_id=self._last_parent_id, message=message)
+            await self._config.storage.append(entry)
+            self._last_parent_id = entry.id
+            last_message_entry_id = entry.id
+
+        if last_message_entry_id is not None:
+            leaf = LeafEntry(parent_id=last_message_entry_id, entry_id=last_message_entry_id)
+            await self._config.storage.append(leaf)
+
+        entries = await self._config.storage.read_all()
+        self._state = SessionState.from_entries(entries)
+
+
+def _last_parent_id_from_state(state: SessionState) -> str | None:
+    if state.active_leaf_id is not None:
+        return state.active_leaf_id
+    if state.entries:
+        return state.entries[-1].id
+    return None
+
+
+def jsonl_session_storage(path: str | Path) -> JsonlSessionStorage:
+    """Convenience factory for local JSONL coding-session storage."""
+    return JsonlSessionStorage(path)

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -5,6 +5,7 @@ import pytest
 from tau_agent import AssistantMessage, ToolCall, ToolResultMessage, UserMessage
 from tau_agent.session import (
     JsonlSessionStorage,
+    LeafEntry,
     MessageEntry,
     ModelChangeEntry,
     SessionInfoEntry,
@@ -89,6 +90,34 @@ async def test_load_restores_existing_transcript(tmp_path: Path) -> None:
         UserMessage(content="Earlier"),
         AssistantMessage(content="Restored"),
     )
+
+
+@pytest.mark.anyio
+async def test_load_restores_active_leaf_branch(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(id="root", message=UserMessage(content="Root"))
+    left = MessageEntry(
+        id="left",
+        parent_id="root",
+        message=AssistantMessage(content="Inactive branch"),
+    )
+    right = MessageEntry(
+        id="right",
+        parent_id="root",
+        message=AssistantMessage(content="Active branch"),
+    )
+    await storage.append(root)
+    await storage.append(left)
+    await storage.append(right)
+    await storage.append(LeafEntry(entry_id="right"))
+
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    assert session.messages == (
+        UserMessage(content="Root"),
+        AssistantMessage(content="Active branch"),
+    )
+    assert session.state.active_leaf_id == "right"
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import pytest
+
+from tau_agent import AssistantMessage, ToolCall, ToolResultMessage, UserMessage
+from tau_agent.session import (
+    JsonlSessionStorage,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionInfoEntry,
+)
+from tau_ai import FakeProvider, ProviderResponseEndEvent, ProviderResponseStartEvent
+from tau_coding import CodingSession, CodingSessionConfig
+
+
+async def _collect_session_events(session_stream: object) -> list[object]:
+    return [event async for event in session_stream]  # type: ignore[attr-defined]
+
+
+def _config(
+    tmp_path: Path, provider: FakeProvider, storage: JsonlSessionStorage
+) -> CodingSessionConfig:
+    return CodingSessionConfig(
+        provider=provider,
+        model="fake",
+        system="You are Tau.",
+        storage=storage,
+        cwd=tmp_path,
+    )
+
+
+@pytest.mark.anyio
+async def test_load_empty_session_appends_metadata(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    entries = await storage.read_all()
+    assert isinstance(entries[0], SessionInfoEntry)
+    assert entries[0].cwd == str(tmp_path)
+    assert entries[1] == ModelChangeEntry(
+        id=entries[1].id, parent_id=entries[0].id, model="fake", timestamp=entries[1].timestamp
+    )
+    assert session.messages == ()
+    assert session.state.model == "fake"
+
+
+@pytest.mark.anyio
+async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hi")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    _events = await _collect_session_events(session.prompt("Hello"))
+
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Hello"),
+        AssistantMessage(content="Hi"),
+    ]
+    assert entries[-1].type == "leaf"
+    assert entries[-1].entry_id == message_entries[-1].id
+    assert session.messages == (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
+
+
+@pytest.mark.anyio
+async def test_load_restores_existing_transcript(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user_entry = MessageEntry(id="user", message=UserMessage(content="Earlier"))
+    assistant_entry = MessageEntry(
+        id="assistant",
+        parent_id="user",
+        message=AssistantMessage(content="Restored"),
+    )
+    await storage.append(user_entry)
+    await storage.append(assistant_entry)
+
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    assert session.messages == (
+        UserMessage(content="Earlier"),
+        AssistantMessage(content="Restored"),
+    )
+
+
+@pytest.mark.anyio
+async def test_continue_persists_only_new_messages(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(MessageEntry(id="user", message=UserMessage(content="Continue me")))
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Continued")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    _events = await _collect_session_events(session.continue_())
+
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Continue me"),
+        AssistantMessage(content="Continued"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_tool_results_are_persisted(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    tool_call = ToolCall(id="call-1", name="missing", arguments={})
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(
+                    message=AssistantMessage(content="Using tool", tool_calls=[tool_call]),
+                    finish_reason="tool_calls",
+                ),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    _events = await _collect_session_events(session.prompt("Use a tool"))
+
+    messages = [entry.message for entry in await storage.read_all() if entry.type == "message"]
+    assert any(isinstance(message, ToolResultMessage) for message in messages)
+
+
+def test_minimal_commands_are_handled(tmp_path: Path) -> None:
+    session = CodingSession(
+        _config(tmp_path, FakeProvider([]), JsonlSessionStorage(tmp_path / "session.jsonl")),
+        state=object(),  # type: ignore[arg-type]
+        harness=object(),  # type: ignore[arg-type]
+        last_parent_id=None,
+    )
+
+    assert session.handle_command("hello").handled is False
+    assert session.handle_command("/help").message == "Available commands: /help, /exit"
+    assert session.handle_command("/exit").exit_requested is True
+    assert session.handle_command("/unknown").message == "Unknown command: /unknown"


### PR DESCRIPTION
## Summary

Adds Phase 8 coding-session wrapper:

- Adds `tau_coding.session.CodingSession`
- Adds `CodingSessionConfig` and `CommandResult`
- Loads sessions from append-only `SessionStorage`
- Initializes empty sessions with `SessionInfoEntry` and `ModelChangeEntry`
- Restores transcript messages into `AgentHarness`
- Registers default coding tools when custom tools are not supplied
- Persists new prompt/continue messages as `MessageEntry` records
- Updates the active `LeafEntry` after runs
- Adds minimal command handling for `/help` and `/exit`
- Documents Phase 8

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coding session wrapper that loads and persists conversation history, restores prior messages from storage, and supports minimal slash commands (`/help`, `/exit`).

* **Documentation**
  * Added Phase 8 architecture documentation detailing the coding session design and responsibilities.

* **Tests**
  * Added comprehensive test coverage for session persistence, transcript restoration, and command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->