### PR TITLE
Add skills and prompt templates

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -28,5 +28,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 6: Non-interactive Print-mode CLI](phase-6-print-mode-cli.md)
 - [Phase 7: Session Tree and JSONL Persistence](phase-7-session-tree.md)
 - [Phase 8: Coding Session Wrapper](phase-8-coding-session.md)
+- [Phase 9: Skills and Prompt Templates](phase-9-skills-prompts.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-9-skills-prompts.md
+++ b/docs/architecture/phase-9-skills-prompts.md
@@ -1,0 +1,188 @@
+# Phase 9: Skills and Prompt Templates
+
+Phase 9 adds Tau's first markdown resource system.
+
+The implementation lives in:
+
+```text
+src/tau_coding/resources.py
+src/tau_coding/skills.py
+src/tau_coding/prompt_templates.py
+```
+
+## What was added
+
+Tau can now load and use markdown resources from a Tau resource root:
+
+```text
+~/.tau/
+  skills/
+  prompts/
+```
+
+This phase includes:
+
+- resource path helpers
+- minimal markdown frontmatter parsing
+- skill loading
+- `/skill:name` prompt expansion
+- skill index generation
+- prompt template loading
+- `{{ variable }}` template rendering
+- light `CodingSession` integration for skill expansion
+
+## Resource paths
+
+`TauResourcePaths` describes where Tau resources live:
+
+```python
+from tau_coding import TauResourcePaths
+
+paths = TauResourcePaths()  # ~/.tau
+paths.skills_dir            # ~/.tau/skills
+paths.prompts_dir           # ~/.tau/prompts
+```
+
+Tests and callers can provide a custom root:
+
+```python
+paths = TauResourcePaths(root=Path("/tmp/resources"))
+```
+
+## Frontmatter
+
+Skills and prompt templates can include simple frontmatter:
+
+```md
+---
+description: Write and run Python tests.
+---
+
+# Python Testing
+
+Use pytest.
+```
+
+The parser intentionally supports only simple `key: value` pairs. It does not execute code or implement a full YAML parser.
+
+## Skills
+
+Tau supports two skill layouts:
+
+```text
+~/.tau/skills/python-testing/SKILL.md
+~/.tau/skills/git-review.md
+```
+
+Load skills with:
+
+```python
+from tau_coding import TauResourcePaths, load_skills
+
+skills = load_skills(TauResourcePaths())
+```
+
+Duplicate skill names raise `ResourceError`.
+
+## Skill expansion
+
+Skill commands use the roadmap syntax:
+
+```text
+/skill:python-testing add tests for parser.py
+```
+
+Expansion produces prompt text like:
+
+```md
+Use the following skill instructions:
+
+<skill name="python-testing">
+...skill markdown...
+</skill>
+
+User request:
+add tests for parser.py
+```
+
+`CodingSession.prompt()` expands skill commands before sending the prompt to `AgentHarness`. `/skill:name` is not consumed by `handle_command()` because it is a prompt expansion directive, not a command that ends the run.
+
+## Skill index
+
+`build_skill_index()` creates a concise list of available skills for future system prompt assembly:
+
+```md
+Available skills:
+- python-testing: Write and run Python tests.
+- git-review: Review git changes safely.
+```
+
+Phase 10 can use this when building the full system prompt.
+
+## Prompt templates
+
+Prompt templates live in:
+
+```text
+~/.tau/prompts/review.md
+```
+
+Template variables use simple `{{ variable }}` placeholders:
+
+```md
+Review {{ target }} for {{ focus }}.
+```
+
+Render templates with:
+
+```python
+from tau_coding import load_prompt_templates, render_prompt_template
+
+templates = load_prompt_templates(paths)
+text = render_prompt_template(
+    templates[0],
+    {"target": "auth.py", "focus": "security"},
+)
+```
+
+Missing variables raise `ResourceError`; extra variables are ignored.
+
+## Boundary
+
+This phase does not implement full system prompt assembly. It only adds the resource primitives and a minimal skill-expansion hook in `CodingSession`.
+
+Full prompt assembly remains a later phase and will combine:
+
+- base Tau identity
+- tools and tool guidelines
+- project instructions
+- skills index
+- prompt templates
+- extension snippets later
+- environment context
+
+## Tests
+
+This phase is covered by:
+
+```text
+tests/test_resources.py
+tests/test_skills.py
+tests/test_prompt_templates.py
+tests/test_coding_session.py
+```
+
+The tests verify:
+
+- resource paths
+- frontmatter parsing
+- skill loading and duplicate detection
+- skill expansion
+- skill index output
+- prompt template loading
+- template rendering
+- coding-session skill expansion
+
+## Next phase
+
+The next roadmap phase is system prompt assembly. The resource models and loaders added here give that phase the skill and template inputs it needs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,5 +67,6 @@ nav:
       - "Phase 6: Non-interactive Print-mode CLI": architecture/phase-6-print-mode-cli.md
       - "Phase 7: Session Tree and JSONL Persistence": architecture/phase-7-session-tree.md
       - "Phase 8: Coding Session Wrapper": architecture/phase-8-coding-session.md
+      - "Phase 9: Skills and Prompt Templates": architecture/phase-9-skills-prompts.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -1,11 +1,18 @@
 """Tau coding-agent application package."""
 
+from tau_coding.prompt_templates import (
+    PromptTemplate,
+    load_prompt_templates,
+    render_prompt_template,
+)
+from tau_coding.resources import ResourceError, TauResourcePaths
 from tau_coding.session import (
     CodingSession,
     CodingSessionConfig,
     CommandResult,
     jsonl_session_storage,
 )
+from tau_coding.skills import Skill, build_skill_index, expand_skill_command, load_skills
 from tau_coding.tools import (
     ToolDefinition,
     create_bash_tool,
@@ -26,7 +33,12 @@ __all__ = [
     "CodingSession",
     "CodingSessionConfig",
     "CommandResult",
+    "PromptTemplate",
+    "ResourceError",
+    "Skill",
+    "TauResourcePaths",
     "ToolDefinition",
+    "build_skill_index",
     "create_bash_tool",
     "create_bash_tool_definition",
     "create_coding_tools",
@@ -36,5 +48,9 @@ __all__ = [
     "create_read_tool_definition",
     "create_write_tool",
     "create_write_tool_definition",
+    "expand_skill_command",
     "jsonl_session_storage",
+    "load_prompt_templates",
+    "load_skills",
+    "render_prompt_template",
 ]

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -1,0 +1,63 @@
+"""Markdown prompt template loading and rendering."""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from tau_coding.resources import (
+    ResourceError,
+    TauResourcePaths,
+    derive_description,
+    parse_markdown_resource,
+)
+
+_TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
+
+
+@dataclass(frozen=True, slots=True)
+class PromptTemplate:
+    """A markdown prompt template resource."""
+
+    name: str
+    path: Path
+    content: str
+    description: str | None = None
+
+
+def load_prompt_templates(paths: TauResourcePaths | None = None) -> list[PromptTemplate]:
+    """Load markdown prompt templates from `paths.prompts_dir`."""
+    resource_paths = paths or TauResourcePaths()
+    prompts_dir = resource_paths.prompts_dir
+    if not prompts_dir.exists():
+        return []
+
+    templates: list[PromptTemplate] = []
+    seen: set[str] = set()
+    for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
+        name = path.stem
+        if name in seen:
+            raise ResourceError(f"Duplicate prompt template name: {name}")
+        seen.add(name)
+        templates.append(_load_prompt_template(name, path))
+    return templates
+
+
+def render_prompt_template(template: PromptTemplate, variables: Mapping[str, str]) -> str:
+    """Render a prompt template using `{{ variable }}` placeholders."""
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        value = variables.get(name)
+        if value is None:
+            raise ResourceError(f"Missing prompt template variable: {name}")
+        return value
+
+    return _TEMPLATE_VARIABLE_RE.sub(replace, template.content)
+
+
+def _load_prompt_template(name: str, path: Path) -> PromptTemplate:
+    raw = path.read_text(encoding="utf-8")
+    metadata, content = parse_markdown_resource(raw)
+    description = metadata.get("description") or derive_description(content)
+    return PromptTemplate(name=name, path=path, content=content, description=description)

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -1,0 +1,74 @@
+"""Markdown resource path and frontmatter helpers."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tau_agent.types import JSONValue
+
+
+class ResourceError(ValueError):
+    """Raised when Tau resources are invalid or cannot be expanded."""
+
+
+@dataclass(frozen=True, slots=True)
+class TauResourcePaths:
+    """Filesystem locations for Tau markdown resources."""
+
+    root: Path = field(default_factory=lambda: Path.home() / ".tau")
+
+    @property
+    def skills_dir(self) -> Path:
+        """Return the skills directory."""
+        return self.root / "skills"
+
+    @property
+    def prompts_dir(self) -> Path:
+        """Return the prompt templates directory."""
+        return self.root / "prompts"
+
+
+def parse_markdown_resource(text: str) -> tuple[dict[str, str], str]:
+    """Parse minimal YAML-like frontmatter from a markdown resource.
+
+    Only simple `key: value` pairs are supported. This keeps resource parsing
+    dependency-free and avoids evaluating arbitrary code.
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}, text
+
+    raw_frontmatter = text[4:end]
+    body = text[end + len("\n---") :]
+    if body.startswith("\n"):
+        body = body[1:]
+
+    metadata: dict[str, str] = {}
+    for line in raw_frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, separator, value = stripped.partition(":")
+        if not separator:
+            continue
+        metadata[key.strip()] = value.strip().strip("\"'")
+    return metadata, body
+
+
+def derive_description(content: str) -> str | None:
+    """Derive a short description from markdown content."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip() or None
+        return stripped
+    return None
+
+
+def metadata_to_json(metadata: dict[str, str]) -> dict[str, JSONValue]:
+    """Convert string metadata into JSON-like values."""
+    return dict(metadata)

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -33,15 +33,16 @@ def parse_markdown_resource(text: str) -> tuple[dict[str, str], str]:
     Only simple `key: value` pairs are supported. This keeps resource parsing
     dependency-free and avoids evaluating arbitrary code.
     """
-    if not text.startswith("---\n"):
-        return {}, text
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized.startswith("---\n"):
+        return {}, normalized
 
-    end = text.find("\n---", 4)
+    end = normalized.find("\n---", 4)
     if end == -1:
-        return {}, text
+        return {}, normalized
 
-    raw_frontmatter = text[4:end]
-    body = text[end + len("\n---") :]
+    raw_frontmatter = normalized[4:end]
+    body = normalized[end + len("\n---") :]
     if body.startswith("\n"):
         body = body[1:]
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -17,6 +17,9 @@ from tau_agent.session import (
 )
 from tau_agent.tools import AgentTool
 from tau_ai import ModelProvider
+from tau_coding.prompt_templates import PromptTemplate, load_prompt_templates
+from tau_coding.resources import ResourceError, TauResourcePaths
+from tau_coding.skills import Skill, expand_skill_command, load_skills
 from tau_coding.tools import create_coding_tools
 
 
@@ -30,6 +33,7 @@ class CodingSessionConfig:
     storage: SessionStorage
     cwd: Path
     tools: list[AgentTool] | None = None
+    resource_paths: TauResourcePaths | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,11 +60,15 @@ class CodingSession:
         state: SessionState,
         harness: AgentHarness,
         last_parent_id: str | None,
+        skills: tuple[Skill, ...] = (),
+        prompt_templates: tuple[PromptTemplate, ...] = (),
     ) -> None:
         self._config = config
         self._state = state
         self._harness = harness
         self._last_parent_id = last_parent_id
+        self._skills = skills
+        self._prompt_templates = prompt_templates
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -80,6 +88,9 @@ class CodingSession:
             else linear_state
         )
         tools = config.tools if config.tools is not None else create_coding_tools(cwd=config.cwd)
+        resource_paths = config.resource_paths or TauResourcePaths()
+        skills = tuple(load_skills(resource_paths))
+        prompt_templates = tuple(load_prompt_templates(resource_paths))
         harness = AgentHarness(
             AgentHarnessConfig(
                 provider=config.provider,
@@ -94,6 +105,8 @@ class CodingSession:
             state=state,
             harness=harness,
             last_parent_id=_last_parent_id_from_state(state),
+            skills=skills,
+            prompt_templates=prompt_templates,
         )
 
     @property
@@ -111,6 +124,16 @@ class CodingSession:
         """Return the backing session storage."""
         return self._config.storage
 
+    @property
+    def skills(self) -> tuple[Skill, ...]:
+        """Return loaded skills."""
+        return self._skills
+
+    @property
+    def prompt_templates(self) -> tuple[PromptTemplate, ...]:
+        """Return loaded prompt templates."""
+        return self._prompt_templates
+
     def cancel(self) -> None:
         """Cancel the currently running agent turn, if any."""
         self._harness.cancel()
@@ -124,6 +147,8 @@ class CodingSession:
         stripped = text.strip()
         if not stripped.startswith("/"):
             return CommandResult(handled=False)
+        if stripped.startswith("/skill:"):
+            return CommandResult(handled=False)
         if stripped == "/exit":
             return CommandResult(handled=True, exit_requested=True, message="Exiting session.")
         if stripped == "/help":
@@ -133,10 +158,19 @@ class CodingSession:
             )
         return CommandResult(handled=True, message=f"Unknown command: {stripped}")
 
+    def expand_prompt_text(self, text: str) -> str:
+        """Expand prompt text using loaded markdown resources."""
+        expanded_skill = expand_skill_command(text, self._skills)
+        return expanded_skill if expanded_skill is not None else text
+
     async def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
         """Append a user prompt, run the agent, and persist new messages."""
+        try:
+            expanded_content = self.expand_prompt_text(content)
+        except ResourceError:
+            raise
         before_count = len(self._harness.messages)
-        async for event in self._harness.prompt(content):
+        async for event in self._harness.prompt(expanded_content):
             yield event
         await self._persist_new_messages(before_count)
 

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -1,0 +1,96 @@
+"""Markdown skill loading and expansion."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from tau_coding.resources import (
+    ResourceError,
+    TauResourcePaths,
+    derive_description,
+    parse_markdown_resource,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Skill:
+    """A markdown skill resource."""
+
+    name: str
+    path: Path
+    content: str
+    description: str | None = None
+
+
+def load_skills(paths: TauResourcePaths | None = None) -> list[Skill]:
+    """Load markdown skills from `paths.skills_dir` in deterministic order."""
+    resource_paths = paths or TauResourcePaths()
+    skills_dir = resource_paths.skills_dir
+    if not skills_dir.exists():
+        return []
+
+    skills: list[Skill] = []
+    seen: set[str] = set()
+
+    for path in sorted(skills_dir.iterdir(), key=lambda item: item.name):
+        skill_path: Path | None = None
+        name = path.stem
+        if path.is_dir():
+            skill_path = path / "SKILL.md"
+            name = path.name
+            if not skill_path.exists():
+                continue
+        elif path.is_file() and path.suffix.lower() == ".md":
+            skill_path = path
+        else:
+            continue
+
+        if name in seen:
+            raise ResourceError(f"Duplicate skill name: {name}")
+        seen.add(name)
+        skills.append(_load_skill(name, skill_path))
+
+    return sorted(skills, key=lambda skill: skill.name)
+
+
+def expand_skill_command(text: str, skills: Sequence[Skill]) -> str | None:
+    """Expand `/skill:name` prompt text, or return None for non-skill text."""
+    stripped = text.strip()
+    if not stripped.startswith("/skill:"):
+        return None
+
+    command, separator, request = stripped.partition(" ")
+    name = command.removeprefix("/skill:").strip()
+    if not name:
+        raise ResourceError("Skill command must include a skill name")
+
+    skill_by_name = {skill.name: skill for skill in skills}
+    skill = skill_by_name.get(name)
+    if skill is None:
+        raise ResourceError(f"Unknown skill: {name}")
+
+    sections = [
+        "Use the following skill instructions:",
+        f'<skill name="{skill.name}">\n{skill.content.strip()}\n</skill>',
+    ]
+    if separator and request.strip():
+        sections.append(f"User request:\n{request.strip()}")
+    return "\n\n".join(sections)
+
+
+def build_skill_index(skills: Sequence[Skill]) -> str:
+    """Build a concise index of available skills for future system prompt assembly."""
+    if not skills:
+        return "Available skills: none"
+    lines = ["Available skills:"]
+    for skill in sorted(skills, key=lambda item: item.name):
+        description = skill.description or "No description"
+        lines.append(f"- {skill.name}: {description}")
+    return "\n".join(lines)
+
+
+def _load_skill(name: str, path: Path) -> Skill:
+    raw = path.read_text(encoding="utf-8")
+    metadata, content = parse_markdown_resource(raw)
+    description = metadata.get("description") or derive_description(content)
+    return Skill(name=name, path=path, content=content, description=description)

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -11,7 +11,7 @@ from tau_agent.session import (
     SessionInfoEntry,
 )
 from tau_ai import FakeProvider, ProviderResponseEndEvent, ProviderResponseStartEvent
-from tau_coding import CodingSession, CodingSessionConfig
+from tau_coding import CodingSession, CodingSessionConfig, TauResourcePaths
 
 
 async def _collect_session_events(session_stream: object) -> list[object]:
@@ -169,6 +169,39 @@ async def test_tool_results_are_persisted(tmp_path: Path) -> None:
 
     messages = [entry.message for entry in await storage.read_all() if entry.type == "message"]
     assert any(isinstance(message, ToolResultMessage) for message in messages)
+
+
+@pytest.mark.anyio
+async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    skills_dir = resource_root / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ]
+        ]
+    )
+    config = CodingSessionConfig(
+        provider=provider,
+        model="fake",
+        system="You are Tau.",
+        storage=storage,
+        cwd=tmp_path,
+        resource_paths=TauResourcePaths(root=resource_root),
+    )
+    session = await CodingSession.load(config)
+
+    _events = await _collect_session_events(session.prompt("/skill:testing add tests"))
+
+    assert [skill.name for skill in session.skills] == ["testing"]
+    assert '<skill name="testing">' in provider.calls[0][2][0].content
+    assert "User request:\nadd tests" in provider.calls[0][2][0].content
+    assert session.handle_command("/skill:testing").handled is False
 
 
 def test_minimal_commands_are_handled(tmp_path: Path) -> None:

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from tau_coding import (
+    TauResourcePaths,
+    load_prompt_templates,
+    render_prompt_template,
+)
+from tau_coding.prompt_templates import PromptTemplate
+from tau_coding.resources import ResourceError
+
+
+def test_load_prompt_templates_missing_directory_returns_empty(tmp_path: Path) -> None:
+    assert load_prompt_templates(TauResourcePaths(root=tmp_path)) == []
+
+
+def test_load_prompt_templates_from_markdown_files(tmp_path: Path) -> None:
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    (prompts_dir / "review.md").write_text(
+        "---\ndescription: Review code\n---\nReview {{ topic }}.",
+        encoding="utf-8",
+    )
+
+    templates = load_prompt_templates(TauResourcePaths(root=tmp_path))
+
+    assert len(templates) == 1
+    assert templates[0].name == "review"
+    assert templates[0].description == "Review code"
+
+
+def test_render_prompt_template_replaces_variables() -> None:
+    template = PromptTemplate(
+        name="review",
+        path=Path("review.md"),
+        content="Review {{ topic }} for {{ focus }}.",
+    )
+
+    assert render_prompt_template(template, {"topic": "auth", "focus": "security"}) == (
+        "Review auth for security."
+    )
+
+
+def test_render_prompt_template_rejects_missing_variables() -> None:
+    template = PromptTemplate(name="review", path=Path("review.md"), content="Review {{ topic }}.")
+
+    with pytest.raises(ResourceError, match="Missing prompt template variable"):
+        render_prompt_template(template, {})

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -20,6 +20,15 @@ def test_parse_frontmatter_description() -> None:
     assert body == "# Testing\nUse pytest."
 
 
+def test_parse_frontmatter_normalizes_crlf_line_endings() -> None:
+    metadata, body = parse_markdown_resource(
+        "---\r\ndescription: Write tests\r\n---\r\n# Testing\r\nUse pytest."
+    )
+
+    assert metadata == {"description": "Write tests"}
+    assert body == "# Testing\nUse pytest."
+
+
 def test_derive_description_uses_first_heading_or_paragraph() -> None:
     assert derive_description("\n# Title\nBody") == "Title"
     assert derive_description("\nFirst paragraph\nMore") == "First paragraph"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from tau_coding import TauResourcePaths
+from tau_coding.resources import derive_description, parse_markdown_resource
+
+
+def test_resource_paths_use_tau_subdirectories(tmp_path: Path) -> None:
+    paths = TauResourcePaths(root=tmp_path)
+
+    assert paths.skills_dir == tmp_path / "skills"
+    assert paths.prompts_dir == tmp_path / "prompts"
+
+
+def test_parse_frontmatter_description() -> None:
+    metadata, body = parse_markdown_resource(
+        "---\ndescription: Write tests\n---\n# Testing\nUse pytest."
+    )
+
+    assert metadata == {"description": "Write tests"}
+    assert body == "# Testing\nUse pytest."
+
+
+def test_derive_description_uses_first_heading_or_paragraph() -> None:
+    assert derive_description("\n# Title\nBody") == "Title"
+    assert derive_description("\nFirst paragraph\nMore") == "First paragraph"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pytest
+
+from tau_coding import TauResourcePaths, build_skill_index, expand_skill_command, load_skills
+from tau_coding.resources import ResourceError
+
+
+def test_load_skills_missing_directory_returns_empty(tmp_path: Path) -> None:
+    assert load_skills(TauResourcePaths(root=tmp_path)) == []
+
+
+def test_load_skills_from_directory_and_file(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "python-testing").mkdir(parents=True)
+    (skills_dir / "python-testing" / "SKILL.md").write_text(
+        "---\ndescription: Test Python code\n---\n# Python Testing\nUse pytest.",
+        encoding="utf-8",
+    )
+    (skills_dir / "git-review.md").write_text("# Git Review\nReview diffs.", encoding="utf-8")
+
+    skills = load_skills(TauResourcePaths(root=tmp_path))
+
+    assert [skill.name for skill in skills] == ["git-review", "python-testing"]
+    assert skills[0].description == "Git Review"
+    assert skills[1].description == "Test Python code"
+
+
+def test_load_skills_rejects_duplicate_names(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "dup").mkdir(parents=True)
+    (skills_dir / "dup" / "SKILL.md").write_text("# Directory skill", encoding="utf-8")
+    (skills_dir / "dup.md").write_text("# File skill", encoding="utf-8")
+
+    with pytest.raises(ResourceError, match="Duplicate skill name"):
+        load_skills(TauResourcePaths(root=tmp_path))
+
+
+def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
+    skills = load_skills(TauResourcePaths(root=tmp_path))
+
+    expanded = expand_skill_command("/skill:testing add parser tests", skills)
+
+    assert expanded is not None
+    assert '<skill name="testing">' in expanded
+    assert "Run pytest." in expanded
+    assert "User request:\nadd parser tests" in expanded
+
+
+def test_expand_skill_command_returns_none_for_normal_prompt(tmp_path: Path) -> None:
+    assert expand_skill_command("hello", load_skills(TauResourcePaths(root=tmp_path))) is None
+
+
+def test_expand_skill_command_rejects_unknown_skill() -> None:
+    with pytest.raises(ResourceError, match="Unknown skill"):
+        expand_skill_command("/skill:missing", [])
+
+
+def test_build_skill_index(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "testing.md").write_text(
+        "---\ndescription: Test things\n---\nBody",
+        encoding="utf-8",
+    )
+
+    assert build_skill_index(load_skills(TauResourcePaths(root=tmp_path))) == (
+        "Available skills:\n- testing: Test things"
+    )


### PR DESCRIPTION
## Summary

Adds Phase 9 skills and prompt templates:

- Adds `TauResourcePaths` and markdown frontmatter helpers
- Loads skills from `skills/<name>/SKILL.md` and `skills/<name>.md`
- Adds `/skill:name` prompt expansion
- Adds skill index generation for future system prompt assembly
- Loads prompt templates from `prompts/*.md`
- Renders `{{ variable }}` prompt template placeholders
- Integrates loaded skills with `CodingSession.prompt()`
- Documents Phase 9

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`
