### PR TITLE
Add print and event rendering modes

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -22,12 +22,13 @@ tau_coding   CLI app, resources, skills, extensions, commands, UI integration
 6. Non-interactive print-mode CLI.
 7. Append-only session tree persistence.
 8. Coding session wrapper with commands.
-9. Skills, prompt templates, and system prompt assembly.
-10. Rich renderers.
-11. Textual TUI behind an adapter boundary.
-12. Extensions.
-13. Compaction and context management.
-14. Packaging, docs, and examples.
+9. Skills and prompt templates.
+10. System prompt assembly.
+11. Print and event rendering modes.
+12. Textual TUI behind an adapter boundary.
+13. Extensions.
+14. Compaction and context management.
+15. Packaging, docs, and examples.
 
 ## Phase 0 deliverables
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -30,5 +30,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 8: Coding Session Wrapper](phase-8-coding-session.md)
 - [Phase 9: Skills and Prompt Templates](phase-9-skills-prompts.md)
 - [Phase 10: System Prompt Assembly](phase-10-system-prompt.md)
+- [Phase 11: Print and Event Rendering Modes](phase-11-print-event-rendering.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-11-print-event-rendering.md
+++ b/docs/architecture/phase-11-print-event-rendering.md
@@ -1,0 +1,128 @@
+# Phase 11: Print and Event Rendering Modes
+
+Phase 11 adds a small rendering boundary for Tau's non-interactive CLI modes.
+
+The implementation lives in:
+
+```text
+src/tau_coding/rendering/
+```
+
+## What was added
+
+Tau now has event renderers that consume `tau_agent` events outside the portable harness layer:
+
+- `FinalTextRenderer` prints only the final assistant answer.
+- `JsonEventRenderer` writes every agent event as JSON Lines.
+- `TranscriptRenderer` preserves Tau's previous live transcript behavior.
+- `PrintOutputMode` selects `text`, `json`, or `transcript` output.
+
+The CLI exposes this with:
+
+```bash
+tau --output text "summarize this project"
+tau --output json "summarize this project"
+tau --output transcript "summarize this project"
+```
+
+`text` is the default mode.
+
+## Why this exists
+
+Pi keeps terminal output modes outside the reusable agent core:
+
+```text
+agent/session emits events
+print mode consumes events for final text or JSON output
+interactive mode uses a separate TUI layer
+```
+
+Tau now follows the same architectural boundary:
+
+```text
+tau_agent     portable event-producing harness
+tau_coding    CLI mode selection and event rendering
+future TUI    another consumer of the same event stream
+```
+
+This keeps `tau_agent` free of Typer, Rich, Textual, terminal behavior, and UI policy.
+
+## Output modes
+
+### Text mode
+
+Text mode is Pi-style print mode. It consumes the full event stream and prints only the final assistant message after the run finishes.
+
+It ignores tool events for display purposes and returns failure when a non-recoverable `ErrorEvent` appears.
+
+### JSON mode
+
+JSON mode writes one serialized event per line:
+
+```json
+{"type":"message_start","message_role":"assistant"}
+{"type":"message_delta","delta":"Hello"}
+```
+
+This gives scripts and future integrations a stable event stream without depending on human-oriented terminal formatting.
+
+### Transcript mode
+
+Transcript mode preserves Tau's earlier print-mode behavior:
+
+- assistant deltas stream to stdout
+- tool starts and tool results render to stderr
+- errors render to stderr
+
+This is useful while Tau does not yet have a full interactive TUI.
+
+## CLI integration
+
+`run_print_mode()` now accepts:
+
+```python
+output: PrintOutputMode = PrintOutputMode.text
+```
+
+It creates a renderer with:
+
+```python
+create_event_renderer(output)
+```
+
+and sends every event from `AgentHarness.prompt()` to the renderer.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_rendering.py
+tests/test_cli.py
+```
+
+The tests verify:
+
+- transcript streaming behavior
+- final text behavior
+- JSON Lines output
+- non-recoverable error handling
+- CLI output-mode integration
+
+## Non-goals
+
+This phase does not add:
+
+- Rich rendering
+- Textual UI
+- keyboard input
+- session picker
+- diff viewer
+- markdown renderer
+- theme system
+
+Those belong to later frontend phases.
+
+## Next phase
+
+The next phase can build the Textual TUI behind the same event boundary, or first add optional Rich styling inside `tau_coding` without changing `tau_agent`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,5 +69,6 @@ nav:
       - "Phase 8: Coding Session Wrapper": architecture/phase-8-coding-session.md
       - "Phase 9: Skills and Prompt Templates": architecture/phase-9-skills-prompts.md
       - "Phase 10: System Prompt Assembly": architecture/phase-10-system-prompt.md
+      - "Phase 11: Print and Event Rendering Modes": architecture/phase-11-print-event-rendering.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -5,6 +5,14 @@ from tau_coding.prompt_templates import (
     load_prompt_templates,
     render_prompt_template,
 )
+from tau_coding.rendering import (
+    EventRenderer,
+    FinalTextRenderer,
+    JsonEventRenderer,
+    PrintOutputMode,
+    TranscriptRenderer,
+    create_event_renderer,
+)
 from tau_coding.resources import ResourceError, TauResourcePaths
 from tau_coding.session import (
     CodingSession,
@@ -44,12 +52,17 @@ __all__ = [
     "CodingSessionConfig",
     "CommandResult",
     "BuildSystemPromptOptions",
+    "EventRenderer",
+    "FinalTextRenderer",
+    "JsonEventRenderer",
+    "PrintOutputMode",
     "ProjectContextFile",
     "PromptTemplate",
     "ResourceError",
     "Skill",
     "TauResourcePaths",
     "ToolDefinition",
+    "TranscriptRenderer",
     "build_skill_index",
     "build_system_prompt",
     "collect_prompt_guidelines",
@@ -58,6 +71,7 @@ __all__ = [
     "create_coding_tools",
     "create_edit_tool",
     "create_edit_tool_definition",
+    "create_event_renderer",
     "create_read_tool",
     "create_read_tool_definition",
     "create_write_tool",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -6,20 +6,10 @@ from typing import Annotated
 import anyio
 import typer
 
-from tau_agent import (
-    AgentEndEvent,
-    AgentEvent,
-    AgentHarness,
-    AgentHarnessConfig,
-    ErrorEvent,
-    MessageDeltaEvent,
-    MessageEndEvent,
-    MessageStartEvent,
-    ToolExecutionEndEvent,
-    ToolExecutionStartEvent,
-)
+from tau_agent import AgentHarness, AgentHarnessConfig
 from tau_ai import ModelProvider, OpenAICompatibleProvider, openai_compatible_config_from_env
 from tau_coding import __version__, create_coding_tools, load_skills
+from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 
 DEFAULT_MODEL = "gpt-4.1-mini"
@@ -49,6 +39,10 @@ def main(
         Path | None,
         typer.Option("--cwd", help="Working directory for built-in coding tools."),
     ] = None,
+    output: Annotated[
+        PrintOutputMode,
+        typer.Option("--output", "-o", help="Output mode for print mode."),
+    ] = PrintOutputMode.text,
     version: Annotated[
         bool,
         typer.Option("--version", help="Show Tau's version and exit."),
@@ -65,18 +59,22 @@ def main(
         raise typer.Exit()
 
     try:
-        ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd())
+        ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd(), output)
     except RuntimeError as exc:
         raise typer.BadParameter(str(exc)) from exc
     if not ok:
         raise typer.Exit(1)
 
 
-async def run_openai_print_mode(prompt: str, model: str, cwd: Path) -> bool:
+async def run_openai_print_mode(
+    prompt: str, model: str, cwd: Path, output: PrintOutputMode = PrintOutputMode.text
+) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
     try:
-        return await run_print_mode(prompt=prompt, model=model, cwd=cwd, provider=provider)
+        return await run_print_mode(
+            prompt=prompt, model=model, cwd=cwd, provider=provider, output=output
+        )
     finally:
         await provider.aclose()
 
@@ -87,6 +85,7 @@ async def run_print_mode(
     model: str,
     cwd: Path,
     provider: ModelProvider,
+    output: PrintOutputMode = PrintOutputMode.text,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -104,56 +103,7 @@ async def run_print_mode(
             tools=tools,
         )
     )
-    renderer = PrintModeRenderer()
+    renderer = create_event_renderer(output)
     async for event in harness.prompt(prompt):
         renderer.render(event)
-    return not renderer.failed
-
-
-class PrintModeRenderer:
-    """Small event renderer for non-interactive CLI output."""
-
-    def __init__(self) -> None:
-        self._assistant_started = False
-        self._assistant_ended = False
-        self.failed = False
-
-    def render(self, event: AgentEvent) -> None:
-        if isinstance(event, MessageStartEvent):
-            self._assistant_started = False
-            self._assistant_ended = False
-            return
-
-        if isinstance(event, MessageDeltaEvent):
-            self._assistant_started = True
-            typer.echo(event.delta, nl=False)
-            return
-
-        if isinstance(event, ToolExecutionStartEvent):
-            self._ensure_assistant_newline()
-            typer.echo(f"→ {event.tool_call.name} {event.tool_call.arguments}", err=True)
-            return
-
-        if isinstance(event, ToolExecutionEndEvent):
-            status = "✓" if event.result.ok else "✗"
-            typer.echo(f"{status} {event.result.name}", err=True)
-            if not event.result.ok and event.result.content:
-                typer.echo(event.result.content, err=True)
-            return
-
-        if isinstance(event, ErrorEvent):
-            if not event.recoverable:
-                self.failed = True
-            self._ensure_assistant_newline()
-            typer.echo(f"Error: {event.message}", err=True)
-            return
-
-        if isinstance(event, MessageEndEvent | AgentEndEvent):
-            self._ensure_assistant_newline(final=True)
-
-    def _ensure_assistant_newline(self, *, final: bool = False) -> None:
-        if self._assistant_started and not self._assistant_ended:
-            typer.echo()
-            self._assistant_ended = True
-        elif final and not self._assistant_started:
-            self._assistant_ended = True
+    return renderer.finish()

--- a/src/tau_coding/rendering/__init__.py
+++ b/src/tau_coding/rendering/__init__.py
@@ -1,0 +1,25 @@
+"""Event renderers for Tau coding frontends and print modes."""
+
+from tau_coding.rendering.base import EventRenderer, PrintOutputMode
+from tau_coding.rendering.json import JsonEventRenderer
+from tau_coding.rendering.plain import FinalTextRenderer
+from tau_coding.rendering.transcript import TranscriptRenderer
+
+
+def create_event_renderer(mode: PrintOutputMode) -> EventRenderer:
+    """Create a renderer for a print output mode."""
+    if mode is PrintOutputMode.text:
+        return FinalTextRenderer()
+    if mode is PrintOutputMode.json:
+        return JsonEventRenderer()
+    return TranscriptRenderer()
+
+
+__all__ = [
+    "EventRenderer",
+    "FinalTextRenderer",
+    "JsonEventRenderer",
+    "PrintOutputMode",
+    "TranscriptRenderer",
+    "create_event_renderer",
+]

--- a/src/tau_coding/rendering/base.py
+++ b/src/tau_coding/rendering/base.py
@@ -1,0 +1,24 @@
+"""Shared event-rendering primitives for Tau coding modes."""
+
+from enum import StrEnum
+from typing import Protocol
+
+from tau_agent import AgentEvent
+
+
+class PrintOutputMode(StrEnum):
+    """Output modes supported by non-interactive print mode."""
+
+    text = "text"
+    json = "json"
+    transcript = "transcript"
+
+
+class EventRenderer(Protocol):
+    """Consumes agent events and renders them for a frontend or output mode."""
+
+    def render(self, event: AgentEvent) -> None:
+        """Render one event."""
+
+    def finish(self) -> bool:
+        """Finish rendering and return whether the run succeeded."""

--- a/src/tau_coding/rendering/json.py
+++ b/src/tau_coding/rendering/json.py
@@ -1,0 +1,22 @@
+"""JSON event stream renderer."""
+
+import typer
+
+from tau_agent import AgentEvent, ErrorEvent
+
+
+class JsonEventRenderer:
+    """Render every agent event as one JSON object per line."""
+
+    def __init__(self) -> None:
+        self._failed = False
+
+    def render(self, event: AgentEvent) -> None:
+        """Write one event as JSONL."""
+        if isinstance(event, ErrorEvent) and not event.recoverable:
+            self._failed = True
+        typer.echo(event.model_dump_json())
+
+    def finish(self) -> bool:
+        """Return whether the rendered run succeeded."""
+        return not self._failed

--- a/src/tau_coding/rendering/plain.py
+++ b/src/tau_coding/rendering/plain.py
@@ -1,0 +1,36 @@
+"""Pi-style final text renderer for print mode."""
+
+import typer
+
+from tau_agent import AgentEvent, ErrorEvent, MessageEndEvent
+
+
+class FinalTextRenderer:
+    """Render only the final assistant text after the run finishes."""
+
+    def __init__(self) -> None:
+        self._last_assistant_text = ""
+        self._failed = False
+        self._error_messages: list[str] = []
+
+    def render(self, event: AgentEvent) -> None:
+        """Record events needed for final text output."""
+        if isinstance(event, MessageEndEvent):
+            self._last_assistant_text = event.message.content
+            return
+
+        if isinstance(event, ErrorEvent):
+            if not event.recoverable:
+                self._failed = True
+            self._error_messages.append(event.message)
+
+    def finish(self) -> bool:
+        """Print final text or errors and return whether the run succeeded."""
+        if self._failed:
+            for message in self._error_messages:
+                typer.echo(f"Error: {message}", err=True)
+            return False
+
+        if self._last_assistant_text:
+            typer.echo(self._last_assistant_text)
+        return True

--- a/src/tau_coding/rendering/transcript.py
+++ b/src/tau_coding/rendering/transcript.py
@@ -1,0 +1,68 @@
+"""Human-readable streaming transcript renderer."""
+
+import typer
+
+from tau_agent import (
+    AgentEndEvent,
+    AgentEvent,
+    ErrorEvent,
+    MessageDeltaEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+)
+
+
+class TranscriptRenderer:
+    """Render assistant deltas live and tool activity to stderr."""
+
+    def __init__(self) -> None:
+        self._assistant_started = False
+        self._assistant_ended = False
+        self._failed = False
+
+    def render(self, event: AgentEvent) -> None:
+        """Render one agent event."""
+        if isinstance(event, MessageStartEvent):
+            self._assistant_started = False
+            self._assistant_ended = False
+            return
+
+        if isinstance(event, MessageDeltaEvent):
+            self._assistant_started = True
+            typer.echo(event.delta, nl=False)
+            return
+
+        if isinstance(event, ToolExecutionStartEvent):
+            self._ensure_assistant_newline()
+            typer.echo(f"→ {event.tool_call.name} {event.tool_call.arguments}", err=True)
+            return
+
+        if isinstance(event, ToolExecutionEndEvent):
+            status = "✓" if event.result.ok else "✗"
+            typer.echo(f"{status} {event.result.name}", err=True)
+            if not event.result.ok and event.result.content:
+                typer.echo(event.result.content, err=True)
+            return
+
+        if isinstance(event, ErrorEvent):
+            if not event.recoverable:
+                self._failed = True
+            self._ensure_assistant_newline()
+            typer.echo(f"Error: {event.message}", err=True)
+            return
+
+        if isinstance(event, MessageEndEvent | AgentEndEvent):
+            self._ensure_assistant_newline(final=True)
+
+    def finish(self) -> bool:
+        """Return whether the rendered run succeeded."""
+        return not self._failed
+
+    def _ensure_assistant_newline(self, *, final: bool = False) -> None:
+        if self._assistant_started and not self._assistant_ended:
+            typer.echo()
+            self._assistant_ended = True
+        elif final and not self._assistant_started:
+            self._assistant_ended = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from tau_ai import (
 )
 from tau_coding import cli
 from tau_coding.cli import app, run_print_mode
+from tau_coding.rendering import PrintOutputMode
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
 
@@ -32,7 +33,7 @@ def test_cli_without_prompt_prints_print_mode_hint() -> None:
 
 
 @pytest.mark.anyio
-async def test_run_print_mode_streams_assistant_text(
+async def test_run_print_mode_prints_final_assistant_text(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
     provider = FakeProvider(
@@ -80,8 +81,68 @@ async def test_run_print_mode_fails_on_non_recoverable_error(
     assert "Error: provider failed" in captured.err
 
 
+@pytest.mark.anyio
+async def test_run_print_mode_can_emit_json_events(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderTextDeltaEvent(delta="Hello"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hello")),
+            ]
+        ]
+    )
+
+    ok = await run_print_mode(
+        prompt="Say hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        output=PrintOutputMode.json,
+    )
+
+    captured = capsys.readouterr()
+    assert ok is True
+    assert '"type":"agent_start"' in captured.out
+    assert '"type":"message_delta"' in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.anyio
+async def test_run_print_mode_can_emit_live_transcript(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderTextDeltaEvent(delta="Hel"),
+                ProviderTextDeltaEvent(delta="lo"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hello")),
+            ]
+        ]
+    )
+
+    ok = await run_print_mode(
+        prompt="Say hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        output=PrintOutputMode.transcript,
+    )
+
+    captured = capsys.readouterr()
+    assert ok is True
+    assert captured.out == "Hello\n"
+    assert captured.err == ""
+
+
 def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_run_openai_print_mode(prompt: str, model: str, cwd: Path) -> bool:
+    async def fake_run_openai_print_mode(
+        prompt: str, model: str, cwd: Path, output: PrintOutputMode
+    ) -> bool:
         return False
 
     monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,102 @@
+import json
+
+import pytest
+
+from tau_agent import (
+    AgentToolResult,
+    AssistantMessage,
+    ErrorEvent,
+    MessageDeltaEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolCall,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+)
+from tau_coding.rendering import FinalTextRenderer, JsonEventRenderer, TranscriptRenderer
+
+
+def test_transcript_renderer_streams_text_and_tool_events(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    renderer = TranscriptRenderer()
+
+    renderer.render(MessageStartEvent())
+    renderer.render(MessageDeltaEvent(delta="Hel"))
+    renderer.render(MessageDeltaEvent(delta="lo"))
+    renderer.render(
+        ToolExecutionStartEvent(
+            tool_call=ToolCall(id="call-1", name="read", arguments={"path": "a.py"})
+        )
+    )
+    renderer.render(
+        ToolExecutionEndEvent(
+            result=AgentToolResult(tool_call_id="call-1", name="read", ok=True, content="done")
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert renderer.finish() is True
+    assert captured.out == "Hello\n"
+    assert "→ read {'path': 'a.py'}" in captured.err
+    assert "✓ read" in captured.err
+
+
+def test_transcript_renderer_fails_on_non_recoverable_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    renderer = TranscriptRenderer()
+
+    renderer.render(ErrorEvent(message="provider failed", recoverable=False))
+
+    captured = capsys.readouterr()
+    assert renderer.finish() is False
+    assert "Error: provider failed" in captured.err
+
+
+def test_final_text_renderer_prints_only_final_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    renderer = FinalTextRenderer()
+
+    renderer.render(MessageDeltaEvent(delta="ignored"))
+    captured_before_finish = capsys.readouterr()
+    ok = renderer.finish()
+    captured_after_finish = capsys.readouterr()
+
+    assert ok is True
+    assert captured_before_finish.out == ""
+    assert captured_after_finish.out == ""
+
+    renderer.render(MessageEndEvent(message=AssistantMessage(content="Final answer")))
+    ok = renderer.finish()
+    captured = capsys.readouterr()
+
+    assert ok is True
+    assert captured.out == "Final answer\n"
+
+
+def test_final_text_renderer_prints_errors_on_finish(capsys: pytest.CaptureFixture[str]) -> None:
+    renderer = FinalTextRenderer()
+
+    renderer.render(ErrorEvent(message="provider failed", recoverable=False))
+    before_finish = capsys.readouterr()
+    ok = renderer.finish()
+    after_finish = capsys.readouterr()
+
+    assert ok is False
+    assert before_finish.err == ""
+    assert "Error: provider failed" in after_finish.err
+
+
+def test_json_renderer_emits_jsonl(capsys: pytest.CaptureFixture[str]) -> None:
+    renderer = JsonEventRenderer()
+
+    renderer.render(MessageStartEvent())
+    renderer.render(ErrorEvent(message="provider failed", recoverable=False))
+
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert json.loads(lines[0]) == {"type": "message_start", "message_role": "assistant"}
+    assert json.loads(lines[1])["type"] == "error"
+    assert renderer.finish() is False


### PR DESCRIPTION
## Summary

Adds Phase 11 print and event rendering modes, aligned with Pi's separation between agent events, print/json modes, and future UI frontends.

- Adds `tau_coding.rendering` package
- Adds `FinalTextRenderer` for Pi-style final answer output
- Adds `JsonEventRenderer` for JSON Lines event streams
- Adds `TranscriptRenderer` to preserve Tau's previous live output behavior
- Adds `PrintOutputMode` and renderer factory
- Adds CLI `--output text|json|transcript`, with `text` as the default
- Updates roadmap numbering and architecture docs

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--output/-o` flag to CLI print mode with three output formats: `text` (final assistant message), `json` (JSONL event stream), and `transcript` (live streaming output).

* **Documentation**
  * Updated roadmap with refined phase plan separating "Skills and prompt templates" from "System prompt assembly."
  * Added Phase 11 architecture documentation for print and event rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->