### PR TITLE
Add minimal Textual TUI

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -31,5 +31,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 9: Skills and Prompt Templates](phase-9-skills-prompts.md)
 - [Phase 10: System Prompt Assembly](phase-10-system-prompt.md)
 - [Phase 11: Print and Event Rendering Modes](phase-11-print-event-rendering.md)
+- [Phase 12: Textual TUI](phase-12-textual-tui.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-12-textual-tui.md
+++ b/docs/architecture/phase-12-textual-tui.md
@@ -1,0 +1,144 @@
+# Phase 12: Textual TUI
+
+Phase 12 adds Tau's first interactive terminal UI using Textual.
+
+The implementation lives in:
+
+```text
+src/tau_coding/tui/
+```
+
+## What was added
+
+Tau now has a minimal interactive TUI that:
+
+- uses `CodingSession` rather than raw `AgentHarness`
+- accepts user prompts through a Textual input widget
+- streams `AgentEvent` values into TUI display state
+- displays assistant messages, tool events, status messages, and errors
+- supports existing `/help` and `/exit` command handling
+- supports Escape to request cancellation
+- stores the early default TUI session at `.tau/sessions/default.jsonl`
+
+The CLI opens the TUI with:
+
+```bash
+tau tui
+```
+
+Global options can be passed before `tui`:
+
+```bash
+tau --model gpt-4.1-mini --cwd /path/to/project tui
+```
+
+## Why this exists
+
+Pi separates the reusable agent layer from terminal UI concerns:
+
+```text
+agent/session emits events
+terminal frontend consumes events
+TUI components render display state
+```
+
+Tau now follows that same boundary with Python-native Textual:
+
+```text
+CodingSession.prompt()
+  emits AgentEvent
+      ↓
+TuiEventAdapter
+  updates TuiState
+      ↓
+TauTuiApp
+  renders Textual widgets
+```
+
+`tau_agent` still has no dependency on Textual, Rich, Typer, or terminal UI behavior.
+
+## TUI state adapter
+
+The adapter layer is intentionally separate from Textual:
+
+```text
+src/tau_coding/tui/state.py
+src/tau_coding/tui/adapter.py
+```
+
+`TuiState` stores display-only state:
+
+- transcript items
+- current assistant streaming buffer
+- running flag
+- latest error
+
+`TuiEventAdapter` applies portable `AgentEvent` values to that state.
+
+This makes event-to-display behavior testable without launching a terminal app.
+
+## Textual app
+
+The Textual app is intentionally minimal:
+
+```text
+src/tau_coding/tui/app.py
+src/tau_coding/tui/widgets.py
+```
+
+It uses:
+
+- `Header`
+- `Footer`
+- `Static` for status
+- `RichLog` for transcript output
+- `Input` for prompt submission
+
+Prompt execution runs in a Textual worker so the UI can continue updating while events stream.
+
+## Session storage
+
+Phase 12 adds a temporary default local session path helper:
+
+```python
+def default_session_path(cwd: Path) -> Path:
+    return cwd / ".tau" / "sessions" / "default.jsonl"
+```
+
+This is intentionally simple. Later phases can replace it with a richer Pi-style session manager and picker.
+
+## Current limitations
+
+The TUI is a foundation, not a full Pi-level interface yet. It does not include:
+
+- session picker
+- model picker
+- command palette
+- tree navigation
+- diff viewer
+- markdown rendering
+- theme customization
+- keybinding configuration
+- extension UI hooks
+- compaction UI
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_tui_adapter.py
+tests/test_cli.py
+```
+
+Tests focus on the pure adapter and CLI wiring. Full terminal interaction testing is deferred until the TUI surface stabilizes.
+
+## Next phase
+
+The next phase can expand the TUI incrementally with one of:
+
+- session selection and resume support
+- richer transcript rendering
+- command palette and slash-command registry
+- extension hooks
+- compaction/context management UI

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,5 +70,6 @@ nav:
       - "Phase 9: Skills and Prompt Templates": architecture/phase-9-skills-prompts.md
       - "Phase 10: System Prompt Assembly": architecture/phase-10-system-prompt.md
       - "Phase 11: Print and Event Rendering Modes": architecture/phase-11-print-event-rendering.md
+      - "Phase 12: Textual TUI": architecture/phase-12-textual-tui.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.27",
     "pydantic>=2.0",
     "rich>=13.0",
+    "textual>=1.0",
     "typer>=0.12",
 ]
 

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -18,6 +18,7 @@ from tau_coding.session import (
     CodingSession,
     CodingSessionConfig,
     CommandResult,
+    default_session_path,
     jsonl_session_storage,
 )
 from tau_coding.skills import Skill, build_skill_index, expand_skill_command, load_skills
@@ -76,6 +77,7 @@ __all__ = [
     "create_read_tool_definition",
     "create_write_tool",
     "create_write_tool_definition",
+    "default_session_path",
     "expand_skill_command",
     "format_available_tools",
     "format_guidelines",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -11,6 +11,7 @@ from tau_ai import ModelProvider, OpenAICompatibleProvider, openai_compatible_co
 from tau_coding import __version__, create_coding_tools, load_skills
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
+from tau_coding.tui import run_tui_app
 
 DEFAULT_MODEL = "gpt-4.1-mini"
 
@@ -23,6 +24,7 @@ app = typer.Typer(
 
 @app.callback(invoke_without_command=True)
 def main(
+    ctx: typer.Context,
     prompt_arg: Annotated[
         str | None,
         typer.Argument(help="Prompt to run in non-interactive print mode."),
@@ -53,6 +55,16 @@ def main(
         typer.echo(f"tau {__version__}")
         raise typer.Exit()
 
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if prompt_option is None and prompt_arg == "tui":
+        try:
+            anyio.run(run_openai_tui, model, cwd or Path.cwd())
+        except RuntimeError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        raise typer.Exit()
+
     prompt = prompt_option or prompt_arg
     if not prompt:
         typer.echo("Tau print mode is installed. Pass a prompt or run `tau --version`.")
@@ -64,6 +76,11 @@ def main(
         raise typer.BadParameter(str(exc)) from exc
     if not ok:
         raise typer.Exit(1)
+
+
+async def run_openai_tui(model: str, cwd: Path) -> None:
+    """Run the Textual TUI with the default OpenAI-compatible provider."""
+    await run_tui_app(model=model, cwd=cwd)
 
 
 async def run_openai_print_mode(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -228,6 +228,13 @@ def _last_parent_id_from_state(state: SessionState) -> str | None:
     return None
 
 
+def default_session_path(cwd: Path) -> Path:
+    """Return Tau's default project-local session path for early TUI phases."""
+    path = cwd / ".tau" / "sessions" / "default.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def jsonl_session_storage(path: str | Path) -> JsonlSessionStorage:
     """Convenience factory for local JSONL coding-session storage."""
     return JsonlSessionStorage(path)

--- a/src/tau_coding/tui/__init__.py
+++ b/src/tau_coding/tui/__init__.py
@@ -1,0 +1,16 @@
+"""Textual TUI frontend for Tau coding sessions."""
+
+from tau_coding.tui.adapter import TuiEventAdapter
+from tau_coding.tui.app import TauTuiApp, run_tui_app
+from tau_coding.tui.state import ChatItem, TuiState
+from tau_coding.tui.widgets import TranscriptView, render_chat_item
+
+__all__ = [
+    "ChatItem",
+    "TauTuiApp",
+    "TranscriptView",
+    "TuiEventAdapter",
+    "TuiState",
+    "render_chat_item",
+    "run_tui_app",
+]

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -1,0 +1,81 @@
+"""Translate agent events into Textual TUI display state."""
+
+from tau_agent import (
+    AgentEndEvent,
+    AgentEvent,
+    AgentStartEvent,
+    ErrorEvent,
+    MessageDeltaEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    ToolExecutionUpdateEvent,
+)
+from tau_coding.tui.state import TuiState
+
+
+class TuiEventAdapter:
+    """Apply portable agent events to mutable TUI display state."""
+
+    def __init__(self, state: TuiState) -> None:
+        self.state = state
+
+    def apply(self, event: AgentEvent) -> None:
+        """Apply one agent event to the display state."""
+        if isinstance(event, AgentStartEvent):
+            self.state.running = True
+            self.state.error = None
+            return
+
+        if isinstance(event, AgentEndEvent):
+            self._flush_assistant_buffer()
+            self.state.running = False
+            return
+
+        if isinstance(event, MessageStartEvent):
+            self.state.assistant_buffer = ""
+            return
+
+        if isinstance(event, MessageDeltaEvent):
+            self.state.assistant_buffer += event.delta
+            return
+
+        if isinstance(event, MessageEndEvent):
+            text = event.message.content or self.state.assistant_buffer
+            if text:
+                self.state.add_item("assistant", text)
+            self.state.assistant_buffer = ""
+            return
+
+        if isinstance(event, ToolExecutionStartEvent):
+            self._flush_assistant_buffer()
+            self.state.add_item(
+                "tool",
+                f"→ {event.tool_call.name} {event.tool_call.arguments}",
+            )
+            return
+
+        if isinstance(event, ToolExecutionUpdateEvent):
+            self.state.add_item("tool", f"… {event.message}")
+            return
+
+        if isinstance(event, ToolExecutionEndEvent):
+            status = "✓" if event.result.ok else "✗"
+            text = f"{status} {event.result.name}"
+            if not event.result.ok and event.result.content:
+                text = f"{text}\n{event.result.content}"
+            self.state.add_item("tool", text)
+            return
+
+        if isinstance(event, ErrorEvent):
+            self._flush_assistant_buffer()
+            self.state.error = event.message
+            self.state.add_item("error", f"Error: {event.message}")
+            if not event.recoverable:
+                self.state.running = False
+
+    def _flush_assistant_buffer(self) -> None:
+        if self.state.assistant_buffer:
+            self.state.add_item("assistant", self.state.assistant_buffer)
+            self.state.assistant_buffer = ""

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1,0 +1,140 @@
+"""Minimal Textual app for Tau coding sessions."""
+
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Footer, Header, Input, Static
+from textual.worker import Worker
+
+from tau_ai import OpenAICompatibleProvider, openai_compatible_config_from_env
+from tau_coding.session import (
+    CodingSession,
+    CodingSessionConfig,
+    default_session_path,
+    jsonl_session_storage,
+)
+from tau_coding.tui.adapter import TuiEventAdapter
+from tau_coding.tui.state import TuiState
+from tau_coding.tui.widgets import TranscriptView
+
+
+class TauTuiApp(App[None]):
+    """Interactive Textual frontend for a ``CodingSession``."""
+
+    TITLE = "Tau"
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #status {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
+    #transcript {
+        height: 1fr;
+        border: solid $accent;
+    }
+
+    #prompt {
+        dock: bottom;
+    }
+    """
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+        ("ctrl+q", "quit", "Quit"),
+    ]
+
+    def __init__(self, session: CodingSession) -> None:
+        super().__init__()
+        self.session = session
+        self.state = TuiState()
+        self.adapter = TuiEventAdapter(self.state)
+        self._prompt_worker: Worker[None] | None = None
+
+    def compose(self) -> ComposeResult:
+        """Compose the TUI widgets."""
+        yield Header()
+        yield Static("Ready", id="status")
+        with Vertical():
+            yield TranscriptView(id="transcript", wrap=True, highlight=True, markup=False)
+        yield Input(placeholder="Ask Tau…", id="prompt")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        """Focus the prompt when the app starts."""
+        self.query_one(Input).focus()
+        self._refresh()
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle a submitted prompt or slash command."""
+        text = event.value.strip()
+        event.input.value = ""
+        if not text:
+            return
+
+        command = self.session.handle_command(text)
+        if command.handled:
+            if command.message:
+                self.state.add_item("status", command.message)
+            self._refresh()
+            if command.exit_requested:
+                self.exit()
+            return
+
+        if self.state.running:
+            self.state.add_item("status", "Tau is already working. Press Escape to cancel.")
+            self._refresh()
+            return
+
+        self.state.add_item("user", text)
+        self._refresh()
+        self._prompt_worker = self.run_worker(self._run_prompt(text), exclusive=True)
+
+    async def _run_prompt(self, text: str) -> None:
+        """Run one prompt and stream session events into the TUI state."""
+        try:
+            async for event in self.session.prompt(text):
+                self.adapter.apply(event)
+                self.call_from_thread(self._refresh)
+        except Exception as exc:  # noqa: BLE001 - surface unexpected worker errors in the TUI
+            self.state.error = str(exc)
+            self.state.add_item("error", f"Error: {exc}")
+            self.state.running = False
+            self.call_from_thread(self._refresh)
+
+    def action_cancel(self) -> None:
+        """Cancel the active agent turn."""
+        if self.state.running:
+            self.session.cancel()
+            self.state.add_item("status", "Cancellation requested.")
+        else:
+            self.state.add_item("status", "Nothing to cancel.")
+        self._refresh()
+
+    def _refresh(self) -> None:
+        transcript = self.query_one("#transcript", TranscriptView)
+        transcript.update_from_state(self.state)
+        status = self.query_one("#status", Static)
+        status.update("Working…" if self.state.running else "Ready")
+
+
+async def run_tui_app(*, model: str, cwd: Path) -> None:
+    """Create the default provider/session and run the Textual app."""
+    provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
+    try:
+        session = await CodingSession.load(
+            CodingSessionConfig(
+                provider=provider,
+                model=model,
+                cwd=cwd,
+                storage=jsonl_session_storage(default_session_path(cwd)),
+            )
+        )
+        app = TauTuiApp(session)
+        await app.run_async()
+    finally:
+        await provider.aclose()

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -1,0 +1,28 @@
+"""Display state for Tau's Textual TUI."""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+ChatItemRole = Literal["user", "assistant", "tool", "error", "status"]
+
+
+@dataclass(slots=True)
+class ChatItem:
+    """One rendered item in the TUI transcript."""
+
+    role: ChatItemRole
+    text: str
+
+
+@dataclass(slots=True)
+class TuiState:
+    """Mutable display state for the interactive TUI."""
+
+    items: list[ChatItem] = field(default_factory=list)
+    assistant_buffer: str = ""
+    running: bool = False
+    error: str | None = None
+
+    def add_item(self, role: ChatItemRole, text: str) -> None:
+        """Append a transcript item."""
+        self.items.append(ChatItem(role=role, text=text))

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1,0 +1,44 @@
+"""Small Textual widgets for Tau's interactive TUI."""
+
+from rich.text import Text
+from textual.widgets import RichLog
+
+from tau_coding.tui.state import ChatItem, TuiState
+
+_ROLE_LABELS = {
+    "user": "you",
+    "assistant": "assistant",
+    "tool": "tool",
+    "error": "error",
+    "status": "status",
+}
+
+_ROLE_STYLES = {
+    "user": "bold cyan",
+    "assistant": "bold green",
+    "tool": "yellow",
+    "error": "bold red",
+    "status": "dim",
+}
+
+
+class TranscriptView(RichLog):
+    """Scrollable transcript view backed by ``TuiState``."""
+
+    def update_from_state(self, state: TuiState) -> None:
+        """Redraw the transcript from display state."""
+        self.clear()
+        for item in state.items:
+            self.write(render_chat_item(item))
+        if state.assistant_buffer:
+            self.write(render_chat_item(ChatItem(role="assistant", text=state.assistant_buffer)))
+
+
+def render_chat_item(item: ChatItem) -> Text:
+    """Render a chat item as Rich text."""
+    label = _ROLE_LABELS[item.role]
+    style = _ROLE_STYLES[item.role]
+    text = Text()
+    text.append(f"{label}: ", style=style)
+    text.append(item.text)
+    return text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,3 +150,17 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
     result = CliRunner().invoke(app, ["hello"])
 
     assert result.exit_code == 1
+
+
+def test_tui_command_invokes_tui_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, Path]] = []
+
+    async def fake_run_openai_tui(model: str, cwd: Path) -> None:
+        calls.append((model, cwd))
+
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["--cwd", str(tmp_path), "--model", "fake", "tui"])
+
+    assert result.exit_code == 0
+    assert calls == [("fake", tmp_path)]

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -1,0 +1,102 @@
+from tau_agent import (
+    AgentEndEvent,
+    AgentStartEvent,
+    AgentToolResult,
+    AssistantMessage,
+    ErrorEvent,
+    MessageDeltaEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolCall,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    ToolExecutionUpdateEvent,
+)
+from tau_coding.tui import TuiEventAdapter, TuiState
+
+
+def test_tui_adapter_tracks_running_state() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(AgentStartEvent())
+    assert state.running is True
+
+    adapter.apply(AgentEndEvent())
+    assert state.running is False
+
+
+def test_tui_adapter_builds_assistant_items_from_streamed_messages() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(MessageStartEvent())
+    adapter.apply(MessageDeltaEvent(delta="Hel"))
+    adapter.apply(MessageDeltaEvent(delta="lo"))
+    assert state.assistant_buffer == "Hello"
+    assert state.items == []
+
+    adapter.apply(MessageEndEvent(message=AssistantMessage(content="Hello")))
+
+    assert state.assistant_buffer == ""
+    assert [(item.role, item.text) for item in state.items] == [("assistant", "Hello")]
+
+
+def test_tui_adapter_flushes_assistant_buffer_before_tool_events() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(MessageDeltaEvent(delta="Before tool"))
+    adapter.apply(
+        ToolExecutionStartEvent(
+            tool_call=ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+        )
+    )
+
+    assert state.assistant_buffer == ""
+    assert state.items[0].role == "assistant"
+    assert state.items[0].text == "Before tool"
+    assert state.items[1].role == "tool"
+    assert "→ read" in state.items[1].text
+
+
+def test_tui_adapter_records_tool_updates_and_results() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(ToolExecutionUpdateEvent(tool_call_id="call-1", message="reading"))
+    adapter.apply(
+        ToolExecutionEndEvent(
+            result=AgentToolResult(tool_call_id="call-1", name="read", ok=True, content="done")
+        )
+    )
+    adapter.apply(
+        ToolExecutionEndEvent(
+            result=AgentToolResult(
+                tool_call_id="call-2",
+                name="bash",
+                ok=False,
+                content="failed",
+            )
+        )
+    )
+
+    assert [(item.role, item.text) for item in state.items] == [
+        ("tool", "… reading"),
+        ("tool", "✓ read"),
+        ("tool", "✗ bash\nfailed"),
+    ]
+
+
+def test_tui_adapter_records_errors_and_stops_on_non_recoverable_error() -> None:
+    state = TuiState(running=True, assistant_buffer="partial")
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(ErrorEvent(message="provider failed", recoverable=False))
+
+    assert state.running is False
+    assert state.error == "provider failed"
+    assert [(item.role, item.text) for item in state.items] == [
+        ("assistant", "partial"),
+        ("error", "Error: provider failed"),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -283,6 +283,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -301,6 +313,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -331,6 +348,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -728,6 +757,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "rich" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
@@ -748,6 +778,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
@@ -760,6 +791,23 @@ dev = [
 docs = [
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9.5" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
 ]
 
 [[package]]
@@ -796,6 +844,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Phase 12 Textual TUI behind the coding-session/event adapter boundary.

- Adds `tau_coding.tui` package
- Adds pure `TuiState` and `TuiEventAdapter` for testable event-to-display behavior
- Adds a minimal Textual app with transcript, prompt input, status, `/help`, `/exit`, and Escape cancellation
- Runs the TUI through `CodingSession`
- Adds an early default project-local session path at `.tau/sessions/default.jsonl`
- Adds `tau tui` CLI entry behavior
- Adds Textual dependency and docs

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`
