### PR TITLE
Add Tau paths and automatic agents resources

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -26,9 +26,17 @@ tau_coding   CLI app, resources, skills, extensions, commands, UI integration
 10. System prompt assembly.
 11. Print and event rendering modes.
 12. Textual TUI behind an adapter boundary.
-13. Extensions.
-14. Compaction and context management.
-15. Packaging, docs, and examples.
+13. Tau home, paths, and automatic `.agents` resources.
+14. Session manager and resume.
+15. Slash command registry.
+16. Robust skills and prompt discovery.
+17. TUI slash-command autocomplete.
+18. Provider configuration and setup.
+19. Project context discovery and reload.
+20. Packaging and installation polish.
+21. Extensions.
+22. Compaction and context management.
+23. Advanced TUI and product polish.
 
 ## Phase 0 deliverables
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -32,5 +32,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 10: System Prompt Assembly](phase-10-system-prompt.md)
 - [Phase 11: Print and Event Rendering Modes](phase-11-print-event-rendering.md)
 - [Phase 12: Textual TUI](phase-12-textual-tui.md)
+- [Phase 13: Tau Home, Paths, and `.agents` Resources](phase-13-paths-agents-resources.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-13-paths-agents-resources.md
+++ b/docs/architecture/phase-13-paths-agents-resources.md
@@ -1,0 +1,138 @@
+# Phase 13: Tau Home, Paths, and `.agents` Resources
+
+Phase 13 makes Tau's user/project filesystem locations explicit and starts loading `.agents` resources automatically for every normal Tau session.
+
+The implementation lives in:
+
+```text
+src/tau_coding/paths.py
+src/tau_coding/resources.py
+src/tau_coding/skills.py
+src/tau_coding/prompt_templates.py
+```
+
+## What was added
+
+Tau now has a canonical path helper:
+
+```python
+TauPaths
+```
+
+It defines user-level locations such as:
+
+```text
+~/.tau/
+~/.tau/sessions/
+~/.tau/skills/
+~/.tau/prompts/
+~/.agents/
+~/.agents/skills/
+~/.agents/prompts/
+```
+
+and project-level locations such as:
+
+```text
+<project>/.tau/skills/
+<project>/.tau/prompts/
+<project>/.agents/
+<project>/.agents/skills/
+<project>/.agents/prompts/
+```
+
+## Session location
+
+The early TUI default session path moved from project-local storage:
+
+```text
+<project>/.tau/sessions/default.jsonl
+```
+
+to user-home storage keyed by project path:
+
+```text
+~/.tau/sessions/<project-hash>/default.jsonl
+```
+
+This keeps JSONL transcripts in a consistent user-owned location while still separating sessions by project.
+
+## Automatic `.agents` resources
+
+TauResourcePaths now includes `.agents` directories by default.
+
+When no cwd is supplied, Tau loads user resources from:
+
+```text
+~/.tau/skills/
+~/.agents/skills/
+~/.agents/
+~/.tau/prompts/
+~/.agents/prompts/
+```
+
+When a cwd is supplied, Tau also loads project resources from:
+
+```text
+<project>/.tau/skills/
+<project>/.agents/skills/
+<project>/.agents/
+<project>/.tau/prompts/
+<project>/.agents/prompts/
+```
+
+This makes `.agents` part of the normal Tau session environment, not an optional extension mechanism.
+
+## Precedence
+
+Resource directories are loaded in increasing precedence order:
+
+1. user Tau resources
+2. user `.agents` resources
+3. project Tau resources
+4. project `.agents` resources
+
+If two directories define the same skill or prompt template name, the later/higher-precedence resource wins. This lets project resources override user defaults.
+
+Duplicate names within the same directory remain invalid and raise `ResourceError`.
+
+`AGENTS.md` files found directly inside `.agents` directories are not treated as skills. Project instruction discovery is reserved for a later context-discovery phase.
+
+## CodingSession integration
+
+`CodingSession.load()` now builds default resource paths with the session cwd:
+
+```python
+TauResourcePaths(cwd=config.cwd)
+```
+
+That means normal coding sessions automatically see both user and project `.agents` resources.
+
+Print mode also passes cwd-aware resource paths when loading skills for system prompt assembly.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_paths.py
+tests/test_resources.py
+tests/test_skills.py
+tests/test_prompt_templates.py
+tests/test_cli.py
+tests/test_coding_session.py
+```
+
+The tests verify:
+
+- canonical Tau path construction
+- user-home project session paths
+- `.agents` skill discovery
+- `.agents` prompt discovery
+- project resources overriding user resources
+- `AGENTS.md` not being loaded as a skill
+- isolated resource paths for deterministic tests
+
+## Next phase
+
+The next phase should add a real session manager and resume flow on top of these stable user-home session locations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,5 +71,6 @@ nav:
       - "Phase 10: System Prompt Assembly": architecture/phase-10-system-prompt.md
       - "Phase 11: Print and Event Rendering Modes": architecture/phase-11-print-event-rendering.md
       - "Phase 12: Textual TUI": architecture/phase-12-textual-tui.md
+      - "Phase 13: Tau Home, Paths, and .agents Resources": architecture/phase-13-paths-agents-resources.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -1,5 +1,6 @@
 """Tau coding-agent application package."""
 
+from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import (
     PromptTemplate,
     load_prompt_templates,
@@ -61,6 +62,7 @@ __all__ = [
     "PromptTemplate",
     "ResourceError",
     "Skill",
+    "TauPaths",
     "TauResourcePaths",
     "ToolDefinition",
     "TranscriptRenderer",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -10,6 +10,7 @@ from tau_agent import AgentHarness, AgentHarnessConfig
 from tau_ai import ModelProvider, OpenAICompatibleProvider, openai_compatible_config_from_env
 from tau_coding import __version__, create_coding_tools, load_skills
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
+from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tui import run_tui_app
 
@@ -103,6 +104,7 @@ async def run_print_mode(
     cwd: Path,
     provider: ModelProvider,
     output: PrintOutputMode = PrintOutputMode.text,
+    resource_paths: TauResourcePaths | None = None,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -110,7 +112,7 @@ async def run_print_mode(
     can fail non-interactive runs while still rendering the error message.
     """
     tools = create_coding_tools(cwd=cwd)
-    skills = load_skills()
+    skills = load_skills(resource_paths or TauResourcePaths(cwd=cwd))
     system = build_system_prompt(BuildSystemPromptOptions(cwd=cwd, tools=tools, skills=skills))
     harness = AgentHarness(
         AgentHarnessConfig(

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -1,0 +1,77 @@
+"""Canonical filesystem paths for Tau user and project data."""
+
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class TauPaths:
+    """Resolved Tau filesystem locations.
+
+    Tau keeps durable application data under the user's home directory while also
+    loading project-local resources from the active working directory.
+    """
+
+    home: Path = field(default_factory=lambda: Path.home() / ".tau")
+    agents_home: Path = field(default_factory=lambda: Path.home() / ".agents")
+
+    @property
+    def sessions_dir(self) -> Path:
+        """Return the user-level session directory."""
+        return self.home / "sessions"
+
+    @property
+    def user_skills_dir(self) -> Path:
+        """Return Tau's user-level skills directory."""
+        return self.home / "skills"
+
+    @property
+    def user_prompts_dir(self) -> Path:
+        """Return Tau's user-level prompt templates directory."""
+        return self.home / "prompts"
+
+    @property
+    def user_agents_skills_dir(self) -> Path:
+        """Return the user-level `.agents/skills` directory."""
+        return self.agents_home / "skills"
+
+    @property
+    def user_agents_prompts_dir(self) -> Path:
+        """Return the user-level `.agents/prompts` directory."""
+        return self.agents_home / "prompts"
+
+    def project_tau_dir(self, cwd: Path) -> Path:
+        """Return the project-local Tau resource directory."""
+        return cwd / ".tau"
+
+    def project_agents_dir(self, cwd: Path) -> Path:
+        """Return the project-local `.agents` resource directory."""
+        return cwd / ".agents"
+
+    def project_skills_dir(self, cwd: Path) -> Path:
+        """Return the project-local Tau skills directory."""
+        return self.project_tau_dir(cwd) / "skills"
+
+    def project_prompts_dir(self, cwd: Path) -> Path:
+        """Return the project-local Tau prompt templates directory."""
+        return self.project_tau_dir(cwd) / "prompts"
+
+    def project_agents_skills_dir(self, cwd: Path) -> Path:
+        """Return the project-local `.agents/skills` directory."""
+        return self.project_agents_dir(cwd) / "skills"
+
+    def project_agents_prompts_dir(self, cwd: Path) -> Path:
+        """Return the project-local `.agents/prompts` directory."""
+        return self.project_agents_dir(cwd) / "prompts"
+
+    def project_session_dir(self, cwd: Path) -> Path:
+        """Return the user-home session directory for a project cwd."""
+        digest = sha256(str(cwd.resolve()).encode("utf-8")).hexdigest()[:16]
+        return self.sessions_dir / digest
+
+    def default_session_path(self, cwd: Path) -> Path:
+        """Return the default JSONL session path for a project cwd."""
+        path = self.project_session_dir(cwd) / "default.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -26,21 +26,13 @@ class PromptTemplate:
 
 
 def load_prompt_templates(paths: TauResourcePaths | None = None) -> list[PromptTemplate]:
-    """Load markdown prompt templates from `paths.prompts_dir`."""
+    """Load markdown prompt templates from Tau and `.agents` resource directories."""
     resource_paths = paths or TauResourcePaths()
-    prompts_dir = resource_paths.prompts_dir
-    if not prompts_dir.exists():
-        return []
-
-    templates: list[PromptTemplate] = []
-    seen: set[str] = set()
-    for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
-        name = path.stem
-        if name in seen:
-            raise ResourceError(f"Duplicate prompt template name: {name}")
-        seen.add(name)
-        templates.append(_load_prompt_template(name, path))
-    return templates
+    templates_by_name: dict[str, PromptTemplate] = {}
+    for prompts_dir in resource_paths.prompts_dirs:
+        for template in _load_prompt_templates_from_dir(prompts_dir):
+            templates_by_name[template.name] = template
+    return sorted(templates_by_name.values(), key=lambda template: template.name)
 
 
 def render_prompt_template(template: PromptTemplate, variables: Mapping[str, str]) -> str:
@@ -54,6 +46,21 @@ def render_prompt_template(template: PromptTemplate, variables: Mapping[str, str
         return value
 
     return _TEMPLATE_VARIABLE_RE.sub(replace, template.content)
+
+
+def _load_prompt_templates_from_dir(prompts_dir: Path) -> list[PromptTemplate]:
+    if not prompts_dir.exists() or not prompts_dir.is_dir():
+        return []
+
+    templates: list[PromptTemplate] = []
+    seen: set[str] = set()
+    for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
+        name = path.stem
+        if name in seen:
+            raise ResourceError(f"Duplicate prompt template name: {name}")
+        seen.add(name)
+        templates.append(_load_prompt_template(name, path))
+    return templates
 
 
 def _load_prompt_template(name: str, path: Path) -> PromptTemplate:

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from tau_agent.types import JSONValue
+from tau_coding.paths import TauPaths
 
 
 class ResourceError(ValueError):
@@ -12,19 +13,76 @@ class ResourceError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class TauResourcePaths:
-    """Filesystem locations for Tau markdown resources."""
+    """Filesystem locations for Tau markdown resources.
+
+    By default Tau loads both Tau-native resources and `.agents` resources from
+    the user home directory. When a cwd is provided, project-local `.tau` and
+    `.agents` resources are loaded automatically as well.
+    """
 
     root: Path = field(default_factory=lambda: Path.home() / ".tau")
+    cwd: Path | None = None
+    agents_root: Path | None = field(default_factory=lambda: Path.home() / ".agents")
+    paths: TauPaths | None = None
 
     @property
     def skills_dir(self) -> Path:
-        """Return the skills directory."""
+        """Return the primary Tau skills directory."""
         return self.root / "skills"
 
     @property
     def prompts_dir(self) -> Path:
-        """Return the prompt templates directory."""
+        """Return the primary Tau prompt templates directory."""
         return self.root / "prompts"
+
+    @property
+    def skills_dirs(self) -> tuple[Path, ...]:
+        """Return skill directories in increasing precedence order."""
+        paths = self._paths()
+        dirs = [self.skills_dir]
+        if self.agents_root is not None:
+            dirs.extend([self.agents_root / "skills", self.agents_root])
+        if self.cwd is not None:
+            dirs.extend(
+                [
+                    paths.project_skills_dir(self.cwd),
+                    paths.project_agents_skills_dir(self.cwd),
+                    paths.project_agents_dir(self.cwd),
+                ]
+            )
+        return tuple(_dedupe_paths(dirs))
+
+    @property
+    def prompts_dirs(self) -> tuple[Path, ...]:
+        """Return prompt template directories in increasing precedence order."""
+        paths = self._paths()
+        dirs = [self.prompts_dir]
+        if self.agents_root is not None:
+            dirs.append(self.agents_root / "prompts")
+        if self.cwd is not None:
+            dirs.extend(
+                [
+                    paths.project_prompts_dir(self.cwd),
+                    paths.project_agents_prompts_dir(self.cwd),
+                ]
+            )
+        return tuple(_dedupe_paths(dirs))
+
+    def _paths(self) -> TauPaths:
+        agents_home = self.agents_root or Path.home() / ".agents"
+        return self.paths or TauPaths(home=self.root, agents_home=agents_home)
+
+
+def _dedupe_paths(paths: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for path in paths:
+        resolved = path.expanduser()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        deduped.append(resolved)
+    return deduped
 
 
 def parse_markdown_resource(text: str) -> tuple[dict[str, str], str]:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -17,6 +17,7 @@ from tau_agent.session import (
 )
 from tau_agent.tools import AgentTool
 from tau_ai import ModelProvider
+from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import PromptTemplate, load_prompt_templates
 from tau_coding.resources import ResourceError, TauResourcePaths
 from tau_coding.skills import Skill, expand_skill_command, load_skills
@@ -96,7 +97,7 @@ class CodingSession:
             else linear_state
         )
         tools = config.tools if config.tools is not None else create_coding_tools(cwd=config.cwd)
-        resource_paths = config.resource_paths or TauResourcePaths()
+        resource_paths = config.resource_paths or TauResourcePaths(cwd=config.cwd)
         skills = tuple(load_skills(resource_paths))
         prompt_templates = tuple(load_prompt_templates(resource_paths))
         system = (
@@ -244,10 +245,8 @@ def _last_parent_id_from_state(state: SessionState) -> str | None:
 
 
 def default_session_path(cwd: Path) -> Path:
-    """Return Tau's default project-local session path for early TUI phases."""
-    path = cwd / ".tau" / "sessions" / "default.jsonl"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    """Return Tau's default user-home session path for a project cwd."""
+    return TauPaths().default_session_path(cwd)
 
 
 def jsonl_session_storage(path: str | Path) -> JsonlSessionStorage:

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -23,34 +23,20 @@ class Skill:
 
 
 def load_skills(paths: TauResourcePaths | None = None) -> list[Skill]:
-    """Load markdown skills from `paths.skills_dir` in deterministic order."""
+    """Load markdown skills from Tau and `.agents` resource directories.
+
+    Resource directories are loaded in increasing precedence order, so project
+    resources override user resources with the same skill name. Duplicate names
+    within the same directory remain invalid.
+    """
     resource_paths = paths or TauResourcePaths()
-    skills_dir = resource_paths.skills_dir
-    if not skills_dir.exists():
-        return []
+    skills_by_name: dict[str, Skill] = {}
 
-    skills: list[Skill] = []
-    seen: set[str] = set()
+    for skills_dir in resource_paths.skills_dirs:
+        for skill in _load_skills_from_dir(skills_dir):
+            skills_by_name[skill.name] = skill
 
-    for path in sorted(skills_dir.iterdir(), key=lambda item: item.name):
-        skill_path: Path | None = None
-        name = path.stem
-        if path.is_dir():
-            skill_path = path / "SKILL.md"
-            name = path.name
-            if not skill_path.exists():
-                continue
-        elif path.is_file() and path.suffix.lower() == ".md":
-            skill_path = path
-        else:
-            continue
-
-        if name in seen:
-            raise ResourceError(f"Duplicate skill name: {name}")
-        seen.add(name)
-        skills.append(_load_skill(name, skill_path))
-
-    return sorted(skills, key=lambda skill: skill.name)
+    return sorted(skills_by_name.values(), key=lambda skill: skill.name)
 
 
 def expand_skill_command(text: str, skills: Sequence[Skill]) -> str | None:
@@ -87,6 +73,34 @@ def build_skill_index(skills: Sequence[Skill]) -> str:
         description = skill.description or "No description"
         lines.append(f"- {skill.name}: {description}")
     return "\n".join(lines)
+
+
+def _load_skills_from_dir(skills_dir: Path) -> list[Skill]:
+    if not skills_dir.exists() or not skills_dir.is_dir():
+        return []
+
+    skills: list[Skill] = []
+    seen: set[str] = set()
+    for path in sorted(skills_dir.iterdir(), key=lambda item: item.name):
+        skill_path: Path | None = None
+        name = path.stem
+        if path.is_dir():
+            skill_path = path / "SKILL.md"
+            name = path.name
+            if not skill_path.exists():
+                continue
+        elif path.is_file() and path.suffix.lower() == ".md":
+            if path.name.upper() == "AGENTS.MD":
+                continue
+            skill_path = path
+        else:
+            continue
+
+        if name in seen:
+            raise ResourceError(f"Duplicate skill name: {name}")
+        seen.add(name)
+        skills.append(_load_skill(name, skill_path))
+    return skills
 
 
 def _load_skill(name: str, path: Path) -> Skill:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from tau_ai import (
 from tau_coding import cli
 from tau_coding.cli import app, run_print_mode
 from tau_coding.rendering import PrintOutputMode
+from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
 
@@ -47,7 +48,13 @@ async def test_run_print_mode_prints_final_assistant_text(
         ]
     )
 
-    ok = await run_print_mode(prompt="Say hello", model="fake", cwd=tmp_path, provider=provider)
+    ok = await run_print_mode(
+        prompt="Say hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        resource_paths=TauResourcePaths(root=tmp_path / "resources", agents_root=None),
+    )
 
     captured = capsys.readouterr()
     assert ok is True

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -222,7 +222,7 @@ async def test_session_builds_system_prompt_when_system_is_omitted(tmp_path: Pat
         model="fake",
         storage=storage,
         cwd=tmp_path,
-        resource_paths=TauResourcePaths(root=resource_root),
+        resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
     )
     session = await CodingSession.load(config)
 
@@ -254,7 +254,7 @@ async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
         system="You are Tau.",
         storage=storage,
         cwd=tmp_path,
-        resource_paths=TauResourcePaths(root=resource_root),
+        resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
     )
     session = await CodingSession.load(config)
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from tau_coding.paths import TauPaths
+
+
+def test_tau_paths_user_locations(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+
+    assert paths.sessions_dir == tmp_path / ".tau" / "sessions"
+    assert paths.user_skills_dir == tmp_path / ".tau" / "skills"
+    assert paths.user_prompts_dir == tmp_path / ".tau" / "prompts"
+    assert paths.user_agents_skills_dir == tmp_path / ".agents" / "skills"
+    assert paths.user_agents_prompts_dir == tmp_path / ".agents" / "prompts"
+
+
+def test_tau_paths_project_locations(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / "home", agents_home=tmp_path / "agents")
+    cwd = tmp_path / "project"
+
+    assert paths.project_tau_dir(cwd) == cwd / ".tau"
+    assert paths.project_agents_dir(cwd) == cwd / ".agents"
+    assert paths.project_skills_dir(cwd) == cwd / ".tau" / "skills"
+    assert paths.project_prompts_dir(cwd) == cwd / ".tau" / "prompts"
+    assert paths.project_agents_skills_dir(cwd) == cwd / ".agents" / "skills"
+    assert paths.project_agents_prompts_dir(cwd) == cwd / ".agents" / "prompts"
+
+
+def test_default_session_path_uses_home_sessions_and_project_hash(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / "home", agents_home=tmp_path / "agents")
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+
+    session_path = paths.default_session_path(cwd)
+
+    assert session_path.name == "default.jsonl"
+    assert session_path.parent.parent == tmp_path / "home" / "sessions"
+    assert session_path.parent.exists()

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -12,7 +12,7 @@ from tau_coding.resources import ResourceError
 
 
 def test_load_prompt_templates_missing_directory_returns_empty(tmp_path: Path) -> None:
-    assert load_prompt_templates(TauResourcePaths(root=tmp_path)) == []
+    assert load_prompt_templates(TauResourcePaths(root=tmp_path, agents_root=None)) == []
 
 
 def test_load_prompt_templates_from_markdown_files(tmp_path: Path) -> None:
@@ -23,11 +23,45 @@ def test_load_prompt_templates_from_markdown_files(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    templates = load_prompt_templates(TauResourcePaths(root=tmp_path))
+    templates = load_prompt_templates(TauResourcePaths(root=tmp_path, agents_root=None))
 
     assert len(templates) == 1
     assert templates[0].name == "review"
     assert templates[0].description == "Review code"
+
+
+def test_load_prompt_templates_includes_agents_directories(tmp_path: Path) -> None:
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    cwd = tmp_path / "project"
+    (agents_home / "prompts").mkdir(parents=True)
+    (agents_home / "prompts" / "user.md").write_text("User prompt", encoding="utf-8")
+    (cwd / ".agents" / "prompts").mkdir(parents=True)
+    (cwd / ".agents" / "prompts" / "project.md").write_text("Project prompt", encoding="utf-8")
+
+    templates = load_prompt_templates(
+        TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd)
+    )
+
+    assert [template.name for template in templates] == ["project", "user"]
+
+
+def test_project_prompt_template_overrides_user_template(tmp_path: Path) -> None:
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    cwd = tmp_path / "project"
+    (agents_home / "prompts").mkdir(parents=True)
+    (agents_home / "prompts" / "review.md").write_text("User review", encoding="utf-8")
+    (cwd / ".agents" / "prompts").mkdir(parents=True)
+    (cwd / ".agents" / "prompts" / "review.md").write_text("Project review", encoding="utf-8")
+
+    templates = load_prompt_templates(
+        TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd)
+    )
+
+    assert len(templates) == 1
+    assert templates[0].path == cwd / ".agents" / "prompts" / "review.md"
+    assert templates[0].content == "Project review"
 
 
 def test_render_prompt_template_replaces_variables() -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,14 +1,43 @@
 from pathlib import Path
 
-from tau_coding import TauResourcePaths
+from tau_coding import TauPaths, TauResourcePaths
 from tau_coding.resources import derive_description, parse_markdown_resource
 
 
 def test_resource_paths_use_tau_subdirectories(tmp_path: Path) -> None:
-    paths = TauResourcePaths(root=tmp_path)
+    paths = TauResourcePaths(root=tmp_path, agents_root=None)
 
     assert paths.skills_dir == tmp_path / "skills"
     assert paths.prompts_dir == tmp_path / "prompts"
+    assert paths.skills_dirs == (tmp_path / "skills",)
+    assert paths.prompts_dirs == (tmp_path / "prompts",)
+
+
+def test_resource_paths_include_agents_and_project_directories(tmp_path: Path) -> None:
+    cwd = tmp_path / "project"
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    paths = TauResourcePaths(
+        root=tau_home,
+        agents_root=agents_home,
+        cwd=cwd,
+        paths=TauPaths(home=tau_home, agents_home=agents_home),
+    )
+
+    assert paths.skills_dirs == (
+        tau_home / "skills",
+        agents_home / "skills",
+        agents_home,
+        cwd / ".tau" / "skills",
+        cwd / ".agents" / "skills",
+        cwd / ".agents",
+    )
+    assert paths.prompts_dirs == (
+        tau_home / "prompts",
+        agents_home / "prompts",
+        cwd / ".tau" / "prompts",
+        cwd / ".agents" / "prompts",
+    )
 
 
 def test_parse_frontmatter_description() -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,7 +7,7 @@ from tau_coding.resources import ResourceError
 
 
 def test_load_skills_missing_directory_returns_empty(tmp_path: Path) -> None:
-    assert load_skills(TauResourcePaths(root=tmp_path)) == []
+    assert load_skills(TauResourcePaths(root=tmp_path, agents_root=None)) == []
 
 
 def test_load_skills_from_directory_and_file(tmp_path: Path) -> None:
@@ -19,11 +19,56 @@ def test_load_skills_from_directory_and_file(tmp_path: Path) -> None:
     )
     (skills_dir / "git-review.md").write_text("# Git Review\nReview diffs.", encoding="utf-8")
 
-    skills = load_skills(TauResourcePaths(root=tmp_path))
+    skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
     assert [skill.name for skill in skills] == ["git-review", "python-testing"]
     assert skills[0].description == "Git Review"
     assert skills[1].description == "Test Python code"
+
+
+def test_load_skills_includes_user_and_project_agents_directories(tmp_path: Path) -> None:
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    cwd = tmp_path / "project"
+    (agents_home / "skills").mkdir(parents=True)
+    (agents_home / "skills" / "user-skill.md").write_text(
+        "# User Skill\nFrom user agents.", encoding="utf-8"
+    )
+    (cwd / ".agents" / "skills").mkdir(parents=True)
+    (cwd / ".agents" / "skills" / "project-skill.md").write_text(
+        "# Project Skill\nFrom project agents.", encoding="utf-8"
+    )
+
+    skills = load_skills(TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd))
+
+    assert [skill.name for skill in skills] == ["project-skill", "user-skill"]
+
+
+def test_project_agents_skill_overrides_user_agents_skill(tmp_path: Path) -> None:
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    cwd = tmp_path / "project"
+    (agents_home / "skills").mkdir(parents=True)
+    (agents_home / "skills" / "review.md").write_text("# User Review", encoding="utf-8")
+    (cwd / ".agents" / "skills").mkdir(parents=True)
+    (cwd / ".agents" / "skills" / "review.md").write_text("# Project Review", encoding="utf-8")
+
+    skills = load_skills(TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd))
+
+    assert len(skills) == 1
+    assert skills[0].path == cwd / ".agents" / "skills" / "review.md"
+    assert skills[0].description == "Project Review"
+
+
+def test_agents_md_is_not_loaded_as_a_skill(tmp_path: Path) -> None:
+    agents_home = tmp_path / ".agents"
+    agents_home.mkdir()
+    (agents_home / "AGENTS.md").write_text("# Instructions", encoding="utf-8")
+    (agents_home / "review.md").write_text("# Review", encoding="utf-8")
+
+    skills = load_skills(TauResourcePaths(root=tmp_path / ".tau", agents_root=agents_home))
+
+    assert [skill.name for skill in skills] == ["review"]
 
 
 def test_load_skills_rejects_duplicate_names(tmp_path: Path) -> None:
@@ -33,14 +78,14 @@ def test_load_skills_rejects_duplicate_names(tmp_path: Path) -> None:
     (skills_dir / "dup.md").write_text("# File skill", encoding="utf-8")
 
     with pytest.raises(ResourceError, match="Duplicate skill name"):
-        load_skills(TauResourcePaths(root=tmp_path))
+        load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
 
 def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) -> None:
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
-    skills = load_skills(TauResourcePaths(root=tmp_path))
+    skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
     expanded = expand_skill_command("/skill:testing add parser tests", skills)
 
@@ -51,7 +96,12 @@ def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) ->
 
 
 def test_expand_skill_command_returns_none_for_normal_prompt(tmp_path: Path) -> None:
-    assert expand_skill_command("hello", load_skills(TauResourcePaths(root=tmp_path))) is None
+    assert (
+        expand_skill_command(
+            "hello", load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
+        )
+        is None
+    )
 
 
 def test_expand_skill_command_rejects_unknown_skill() -> None:
@@ -67,6 +117,6 @@ def test_build_skill_index(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    assert build_skill_index(load_skills(TauResourcePaths(root=tmp_path))) == (
+    assert build_skill_index(load_skills(TauResourcePaths(root=tmp_path, agents_root=None))) == (
         "Available skills:\n- testing: Test things"
     )


### PR DESCRIPTION
## Summary

Adds Phase 13: Tau home/path foundation and automatic `.agents` resource loading.

- Adds `TauPaths` for canonical Tau user/project locations
- Moves default project session storage to user home under `~/.tau/sessions/<project-hash>/default.jsonl`
- Extends `TauResourcePaths` with user/project Tau and `.agents` resource directories
- Loads `.agents` skills automatically for normal Tau sessions
- Loads `.agents` prompt templates automatically
- Gives project resources precedence over user resources
- Keeps `AGENTS.md` from being treated as a skill
- Updates print mode and `CodingSession` to use cwd-aware resource paths
- Updates roadmap docs and adds Phase 13 architecture docs
- Updated issue #1 with the revised checkbox roadmap

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session transcript storage moved to the user home, with deterministic per-project placement.
  * Automatic loading and override support for reusable skills and prompts from `.agents` resources, following clear precedence rules.
  * Prompt templates and skills now aggregate across configured locations, with project values taking priority.

* **Documentation**
  * Added Phase 13 documentation covering canonical Tau paths and `.agents` resource discovery/override behavior.

* **Tests**
  * Added/updated coverage for paths, resources, prompt templates, skills, and CLI print mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->