### PR TITLE
Polish Textual TUI

### DIFF
--- a/docs/architecture/phase-12-textual-tui.md
+++ b/docs/architecture/phase-12-textual-tui.md
@@ -16,6 +16,8 @@ Tau now has a minimal interactive TUI that:
 - accepts user prompts through a Textual input widget
 - streams `AgentEvent` values into TUI display state
 - displays assistant messages, tool events, status messages, and errors
+- shows a dark-mode session sidebar with model, cwd, tools, skills, and prompt templates
+- restores previous session messages into the visible transcript
 - supports existing `/help` and `/exit` command handling
 - supports Escape to request cancellation
 - stores the early default TUI session at `.tau/sessions/default.jsonl`
@@ -90,7 +92,8 @@ It uses:
 
 - `Header`
 - `Footer`
-- `Static` for status
+- `Static` for status and sidebar content
+- `Horizontal` and `Vertical` containers for the sidebar/main layout
 - `RichLog` for transcript output
 - `Input` for prompt submission
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -132,6 +132,21 @@ class CodingSession:
         )
 
     @property
+    def cwd(self) -> Path:
+        """Return the session working directory."""
+        return self._config.cwd
+
+    @property
+    def model(self) -> str:
+        """Return the active model for this session."""
+        return self._harness.config.model
+
+    @property
+    def tools(self) -> tuple[AgentTool, ...]:
+        """Return the tools available to the agent."""
+        return tuple(self._harness.config.tools)
+
+    @property
     def messages(self) -> tuple[AgentMessage, ...]:
         """Return the restored/current transcript."""
         return self._harness.messages

--- a/src/tau_coding/tui/__init__.py
+++ b/src/tau_coding/tui/__init__.py
@@ -3,14 +3,21 @@
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.app import TauTuiApp, run_tui_app
 from tau_coding.tui.state import ChatItem, TuiState
-from tau_coding.tui.widgets import TranscriptView, render_chat_item
+from tau_coding.tui.widgets import (
+    SessionSidebar,
+    TranscriptView,
+    render_chat_item,
+    render_session_sidebar,
+)
 
 __all__ = [
     "ChatItem",
     "TauTuiApp",
+    "SessionSidebar",
     "TranscriptView",
     "TuiEventAdapter",
     "TuiState",
     "render_chat_item",
+    "render_session_sidebar",
     "run_tui_app",
 ]

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from textual.app import App, ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Footer, Header, Input, Static
 from textual.worker import Worker
 
@@ -16,7 +16,7 @@ from tau_coding.session import (
 )
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.state import TuiState
-from tau_coding.tui.widgets import TranscriptView
+from tau_coding.tui.widgets import SessionSidebar, TranscriptView
 
 
 class TauTuiApp(App[None]):
@@ -26,21 +26,58 @@ class TauTuiApp(App[None]):
     CSS = """
     Screen {
         layout: vertical;
+        background: #0f1117;
+        color: #e6edf3;
+    }
+
+    Header {
+        background: #161b22;
+        color: #f0f6fc;
+        dock: top;
+    }
+
+    Footer {
+        background: #161b22;
+        color: #8b949e;
     }
 
     #status {
         height: 1;
         padding: 0 1;
-        color: $text-muted;
+        background: #0f1117;
+        color: #8b949e;
+    }
+
+    #workspace {
+        height: 1fr;
+    }
+
+    #sidebar {
+        width: 32;
+        min-width: 28;
+        padding: 1;
+        background: #161b22;
+        border-right: solid #30363d;
+    }
+
+    #main-pane {
+        width: 1fr;
+        padding: 1 1 0 1;
     }
 
     #transcript {
         height: 1fr;
-        border: solid $accent;
+        border: round #30363d;
+        background: #0d1117;
+        padding: 0 1;
     }
 
     #prompt {
         dock: bottom;
+        background: #0d1117;
+        color: #f0f6fc;
+        border: round #238636;
+        margin: 0 1 1 1;
     }
     """
     BINDINGS = [
@@ -60,9 +97,11 @@ class TauTuiApp(App[None]):
         """Compose the TUI widgets."""
         yield Header()
         yield Static("Ready", id="status")
-        with Vertical():
-            yield TranscriptView(id="transcript", wrap=True, highlight=True, markup=False)
-        yield Input(placeholder="Ask Tau…", id="prompt")
+        with Horizontal(id="workspace"):
+            yield SessionSidebar(id="sidebar")
+            with Vertical(id="main-pane"):
+                yield TranscriptView(id="transcript", wrap=True, highlight=True, markup=False)
+                yield Input(placeholder="Ask Tau…", id="prompt")
         yield Footer()
 
     async def on_mount(self) -> None:
@@ -117,6 +156,8 @@ class TauTuiApp(App[None]):
         self._refresh()
 
     def _refresh(self) -> None:
+        sidebar = self.query_one("#sidebar", SessionSidebar)
+        sidebar.update_from_session(self.session)
         transcript = self.query_one("#transcript", TranscriptView)
         transcript.update_from_state(self.state)
         status = self.query_one("#status", Static)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -52,6 +52,7 @@ class TauTuiApp(App[None]):
         super().__init__()
         self.session = session
         self.state = TuiState()
+        self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
 
@@ -99,12 +100,12 @@ class TauTuiApp(App[None]):
         try:
             async for event in self.session.prompt(text):
                 self.adapter.apply(event)
-                self.call_from_thread(self._refresh)
+                self._refresh()
         except Exception as exc:  # noqa: BLE001 - surface unexpected worker errors in the TUI
             self.state.error = str(exc)
             self.state.add_item("error", f"Error: {exc}")
             self.state.running = False
-            self.call_from_thread(self._refresh)
+            self._refresh()
 
     def action_cancel(self) -> None:
         """Cancel the active agent turn."""

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -1,7 +1,10 @@
 """Display state for Tau's Textual TUI."""
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Literal
+
+from tau_agent.messages import AgentMessage
 
 ChatItemRole = Literal["user", "assistant", "tool", "error", "status"]
 
@@ -26,3 +29,20 @@ class TuiState:
     def add_item(self, role: ChatItemRole, text: str) -> None:
         """Append a transcript item."""
         self.items.append(ChatItem(role=role, text=text))
+
+    def load_messages(self, messages: Iterable[AgentMessage]) -> None:
+        """Populate the transcript from restored session messages."""
+        for message in messages:
+            if message.role == "user":
+                self.add_item("user", message.content)
+            elif message.role == "assistant":
+                if message.content:
+                    self.add_item("assistant", message.content)
+                for tool_call in message.tool_calls:
+                    self.add_item("tool", f"→ {tool_call.name} {tool_call.arguments}")
+            elif message.role == "tool":
+                status = "✓" if message.ok else "✗"
+                text = f"{status} {message.name}"
+                if message.content:
+                    text = f"{text}\n{message.content}"
+                self.add_item("tool", text)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1,8 +1,18 @@
 """Small Textual widgets for Tau's interactive TUI."""
 
-from rich.text import Text
-from textual.widgets import RichLog
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Protocol
 
+from rich.console import Group, RenderableType
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from textual.widgets import RichLog, Static
+
+from tau_agent.tools import AgentTool
+from tau_coding.prompt_templates import PromptTemplate
+from tau_coding.skills import Skill
 from tau_coding.tui.state import ChatItem, TuiState
 
 _ROLE_LABELS = {
@@ -14,12 +24,39 @@ _ROLE_LABELS = {
 }
 
 _ROLE_STYLES = {
-    "user": "bold cyan",
-    "assistant": "bold green",
-    "tool": "yellow",
-    "error": "bold red",
+    "user": "bold bright_cyan",
+    "assistant": "bold bright_green",
+    "tool": "bright_yellow",
+    "error": "bold bright_red",
     "status": "dim",
 }
+
+
+class SessionSummarySource(Protocol):
+    """Session attributes displayed by the sidebar."""
+
+    @property
+    def cwd(self) -> Path: ...
+
+    @property
+    def model(self) -> str: ...
+
+    @property
+    def tools(self) -> Sequence[AgentTool]: ...
+
+    @property
+    def skills(self) -> Sequence[Skill]: ...
+
+    @property
+    def prompt_templates(self) -> Sequence[PromptTemplate]: ...
+
+
+class SessionSidebar(Static):
+    """Compact sidebar with current session metadata."""
+
+    def update_from_session(self, session: SessionSummarySource) -> None:
+        """Redraw the sidebar from current session metadata."""
+        self.update(render_session_sidebar(session))
 
 
 class TranscriptView(RichLog):
@@ -34,11 +71,58 @@ class TranscriptView(RichLog):
             self.write(render_chat_item(ChatItem(role="assistant", text=state.assistant_buffer)))
 
 
+def render_session_sidebar(session: SessionSummarySource) -> RenderableType:
+    """Render a dark, minimalist summary of the active coding session."""
+    metadata = Table.grid(padding=(0, 1))
+    metadata.add_column(style="bright_black", no_wrap=True)
+    metadata.add_column(style="white")
+    metadata.add_row("model", session.model)
+    metadata.add_row("cwd", _short_path(session.cwd))
+    metadata.add_row("tools", str(len(session.tools)))
+    metadata.add_row("skills", str(len(session.skills)))
+
+    tools = _bullet_list([tool.name for tool in session.tools], empty="No tools")
+    skills = _bullet_list([skill.name for skill in session.skills], empty="No skills loaded yet")
+    prompts = _bullet_list(
+        [template.name for template in session.prompt_templates],
+        empty="No prompt templates",
+    )
+
+    return Group(
+        Panel(metadata, title="session", border_style="bright_black", padding=(0, 1)),
+        Panel(tools, title="tools", border_style="cyan", padding=(0, 1)),
+        Panel(skills, title="skills", border_style="green", padding=(0, 1)),
+        Panel(prompts, title="prompts", border_style="magenta", padding=(0, 1)),
+    )
+
+
 def render_chat_item(item: ChatItem) -> Text:
     """Render a chat item as Rich text."""
     label = _ROLE_LABELS[item.role]
     style = _ROLE_STYLES[item.role]
     text = Text()
     text.append(f"{label}: ", style=style)
-    text.append(item.text)
+    text.append(item.text, style="white")
     return text
+
+
+def _bullet_list(items: Sequence[str], *, empty: str) -> Text:
+    text = Text()
+    if not items:
+        text.append(empty, style="bright_black")
+        return text
+
+    for index, item in enumerate(items):
+        if index:
+            text.append("\n")
+        text.append("• ", style="bright_black")
+        text.append(item, style="white")
+    return text
+
+
+def _short_path(path: Path) -> str:
+    home = Path.home()
+    try:
+        return f"~/{path.relative_to(home)}"
+    except ValueError:
+        return str(path)

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -44,6 +44,9 @@ async def test_load_empty_session_appends_metadata(tmp_path: Path) -> None:
     )
     assert session.messages == ()
     assert session.state.model == "fake"
+    assert session.cwd == tmp_path
+    assert session.model == "fake"
+    assert [tool.name for tool in session.tools] == ["read", "write", "edit", "bash"]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,6 +1,8 @@
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import pytest
+from rich.console import Console
 
 from tau_agent import (
     AgentEndEvent,
@@ -11,17 +13,49 @@ from tau_agent import (
     ToolResultMessage,
     UserMessage,
 )
+from tau_coding.skills import Skill
+from tau_coding.tools import create_coding_tools
 from tau_coding.tui.app import TauTuiApp
+from tau_coding.tui.widgets import render_session_sidebar
 
 
 class FakeSession:
     def __init__(self, messages=(), events=()) -> None:
         self.messages = tuple(messages)
         self.events = tuple(events)
+        self.cwd = Path("/workspace/project")
+        self.model = "fake-model"
+        self.tools = tuple(create_coding_tools(cwd=self.cwd))
+        self.skills = (Skill(name="review", path=self.cwd / "review.md", content="Review code"),)
+        self.prompt_templates = ()
 
     async def prompt(self, text: str) -> AsyncIterator[AgentEvent]:
         for event in self.events:
             yield event
+
+
+def test_session_sidebar_renders_session_metadata() -> None:
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(FakeSession()))
+
+    output = console.export_text()
+    assert "session" in output
+    assert "fake-model" in output
+    assert "tools" in output
+    assert "read" in output
+    assert "skills" in output
+    assert "review" in output
+
+
+@pytest.mark.anyio
+async def test_tui_app_mounts_sidebar_and_transcript() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test():
+        assert app.query_one("#sidebar") is not None
+        assert app.query_one("#transcript") is not None
+        assert app.query_one("#prompt") is not None
 
 
 def test_tui_app_loads_restored_messages_into_display_state() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,70 @@
+from collections.abc import AsyncIterator
+
+import pytest
+
+from tau_agent import (
+    AgentEndEvent,
+    AgentEvent,
+    AgentStartEvent,
+    AssistantMessage,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+from tau_coding.tui.app import TauTuiApp
+
+
+class FakeSession:
+    def __init__(self, messages=(), events=()) -> None:
+        self.messages = tuple(messages)
+        self.events = tuple(events)
+
+    async def prompt(self, text: str) -> AsyncIterator[AgentEvent]:
+        for event in self.events:
+            yield event
+
+
+def test_tui_app_loads_restored_messages_into_display_state() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content="Read the file"),
+                AssistantMessage(
+                    content="I'll inspect it.",
+                    tool_calls=[
+                        ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+                    ],
+                ),
+                ToolResultMessage(
+                    tool_call_id="call-1",
+                    name="read",
+                    content="README contents",
+                    ok=True,
+                ),
+            ]
+        )
+    )
+
+    assert [(item.role, item.text) for item in app.state.items] == [
+        ("user", "Read the file"),
+        ("assistant", "I'll inspect it."),
+        ("tool", "→ read {'path': 'README.md'}"),
+        ("tool", "✓ read\nREADME contents"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_prompt_worker_refreshes_directly() -> None:
+    app = TauTuiApp(FakeSession(events=[AgentStartEvent(), AgentEndEvent()]))
+    refreshes = 0
+
+    def fake_refresh() -> None:
+        nonlocal refreshes
+        refreshes += 1
+
+    app._refresh = fake_refresh  # type: ignore[method-assign]
+
+    await app._run_prompt("hello")
+
+    assert refreshes == 2
+    assert app.state.running is False


### PR DESCRIPTION
## Summary

Adds the recent Textual TUI fixes and UI polish that were made locally after Phase 12 merged.

- Fixes Textual worker refresh behavior
- Restores transcript display for existing session messages
- Polishes the Textual TUI layout

This PR should merge before Phase 13 so the paths/resources branch is based on the latest TUI baseline.

## Validation

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session sidebar now displays model, working directory, tools, skills, and prompt templates at a glance
  * Previous session messages are automatically restored and visible in the chat transcript upon startup
  * Enhanced UI layout with reorganized workspace and improved message rendering with role-specific styling

* **Tests**
  * Added comprehensive tests for TUI app initialization and sidebar rendering
  * Enhanced session tests to verify new session property exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->