### PR TITLE
Add session manager and resume support

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -33,5 +33,6 @@ The most important boundary is that `tau_agent` should stay portable. It can def
 - [Phase 11: Print and Event Rendering Modes](phase-11-print-event-rendering.md)
 - [Phase 12: Textual TUI](phase-12-textual-tui.md)
 - [Phase 13: Tau Home, Paths, and `.agents` Resources](phase-13-paths-agents-resources.md)
+- [Phase 14: Session Manager and Resume](phase-14-session-manager-resume.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/phase-14-session-manager-resume.md
+++ b/docs/architecture/phase-14-session-manager-resume.md
@@ -1,0 +1,148 @@
+# Phase 14: Session Manager and Resume
+
+Phase 14 makes Tau sessions first-class records stored under Tau home.
+
+The implementation lives in:
+
+```text
+src/tau_coding/session_manager.py
+```
+
+## What was added
+
+Tau now has a `SessionManager` that can:
+
+- create new sessions
+- index sessions in user-home metadata
+- list sessions newest-first
+- look up sessions by id
+- touch sessions after new messages are persisted
+- return a default project session for existing TUI behavior
+
+Session metadata is represented by:
+
+```python
+CodingSessionRecord
+```
+
+with:
+
+- `id`
+- `path`
+- `cwd`
+- `model`
+- `title`
+- `created_at`
+- `updated_at`
+
+## Storage layout
+
+Session transcripts remain append-only JSONL files.
+
+Session metadata is stored at:
+
+```text
+~/.tau/sessions/index.jsonl
+```
+
+Project-specific transcript files live under:
+
+```text
+~/.tau/sessions/<project-hash>/
+```
+
+The default project session remains:
+
+```text
+~/.tau/sessions/<project-hash>/default.jsonl
+```
+
+but it is now indexed with a stable id:
+
+```text
+default-<project-hash>
+```
+
+New sessions are stored as:
+
+```text
+~/.tau/sessions/<project-hash>/<session-id>.jsonl
+```
+
+## CodingSession integration
+
+`CodingSessionConfig` now accepts:
+
+```python
+session_id: str | None
+session_manager: SessionManager | None
+```
+
+When a session persists new messages, it touches the session manager record so `updated_at` stays current.
+
+This keeps the session transcript and session index loosely coupled: `tau_agent` still only knows about append-only session storage, while `tau_coding` owns user-facing session metadata.
+
+## TUI integration
+
+The TUI now creates sessions through `SessionManager`.
+
+Default behavior:
+
+```bash
+tau tui
+```
+
+opens or creates the default project session.
+
+Create a new session:
+
+```bash
+tau --new-session tui
+```
+
+Resume an indexed session:
+
+```bash
+tau --resume <session-id> tui
+```
+
+If the session id is unknown, Tau exits with a clear error.
+
+## CLI session listing
+
+Tau can list indexed sessions:
+
+```bash
+tau sessions
+```
+
+The first implementation prints tab-separated rows:
+
+```text
+<id>    <title>    <model>    <cwd>
+```
+
+A richer session picker belongs in a later TUI polish phase.
+
+## Tests
+
+The phase is covered by:
+
+```text
+tests/test_session_manager.py
+tests/test_coding_session.py
+tests/test_cli.py
+```
+
+The tests verify:
+
+- session creation and indexing
+- default session records
+- newest-first listing
+- metadata updates after prompt persistence
+- TUI resume/new-session CLI wiring
+- session listing CLI output
+
+## Next phase
+
+The next phase should replace hardcoded slash-command handling with a command registry. That registry can then power TUI autocomplete and session commands such as `/sessions`, `/resume`, and `/new`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,5 +72,6 @@ nav:
       - "Phase 11: Print and Event Rendering Modes": architecture/phase-11-print-event-rendering.md
       - "Phase 12: Textual TUI": architecture/phase-12-textual-tui.md
       - "Phase 13: Tau Home, Paths, and .agents Resources": architecture/phase-13-paths-agents-resources.md
+      - "Phase 14: Session Manager and Resume": architecture/phase-14-session-manager-resume.md
   - ADRs:
       - Use Textual for TUI: adr/0001-use-textual-for-tui.md

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -22,6 +22,7 @@ from tau_coding.session import (
     default_session_path,
     jsonl_session_storage,
 )
+from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.skills import Skill, build_skill_index, expand_skill_command, load_skills
 from tau_coding.system_prompt import (
     BuildSystemPromptOptions,
@@ -52,6 +53,7 @@ __all__ = [
     "__version__",
     "CodingSession",
     "CodingSessionConfig",
+    "CodingSessionRecord",
     "CommandResult",
     "BuildSystemPromptOptions",
     "EventRenderer",
@@ -61,6 +63,7 @@ __all__ = [
     "ProjectContextFile",
     "PromptTemplate",
     "ResourceError",
+    "SessionManager",
     "Skill",
     "TauPaths",
     "TauResourcePaths",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -11,6 +11,7 @@ from tau_ai import ModelProvider, OpenAICompatibleProvider, openai_compatible_co
 from tau_coding import __version__, create_coding_tools, load_skills
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.resources import TauResourcePaths
+from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tui import run_tui_app
 
@@ -46,6 +47,14 @@ def main(
         PrintOutputMode,
         typer.Option("--output", "-o", help="Output mode for print mode."),
     ] = PrintOutputMode.text,
+    resume: Annotated[
+        str | None,
+        typer.Option("--resume", help="Resume a session id in TUI mode."),
+    ] = None,
+    new_session: Annotated[
+        bool,
+        typer.Option("--new-session", help="Create a new session in TUI mode."),
+    ] = False,
     version: Annotated[
         bool,
         typer.Option("--version", help="Show Tau's version and exit."),
@@ -59,9 +68,13 @@ def main(
     if ctx.invoked_subcommand is not None:
         return
 
+    if prompt_option is None and prompt_arg == "sessions":
+        render_session_list(SessionManager().list_sessions())
+        raise typer.Exit()
+
     if prompt_option is None and prompt_arg == "tui":
         try:
-            anyio.run(run_openai_tui, model, cwd or Path.cwd())
+            anyio.run(run_openai_tui, model, cwd or Path.cwd(), resume, new_session)
         except RuntimeError as exc:
             raise typer.BadParameter(str(exc)) from exc
         raise typer.Exit()
@@ -79,9 +92,22 @@ def main(
         raise typer.Exit(1)
 
 
-async def run_openai_tui(model: str, cwd: Path) -> None:
+async def run_openai_tui(
+    model: str, cwd: Path, session_id: str | None = None, new_session: bool = False
+) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
-    await run_tui_app(model=model, cwd=cwd)
+    await run_tui_app(model=model, cwd=cwd, session_id=session_id, new_session=new_session)
+
+
+def render_session_list(records: list[CodingSessionRecord]) -> None:
+    """Render indexed sessions for the CLI."""
+    if not records:
+        typer.echo("No sessions found.")
+        return
+
+    for record in records:
+        title = record.title or "Untitled"
+        typer.echo(f"{record.id}\t{title}\t{record.model}\t{record.cwd}")
 
 
 async def run_openai_print_mode(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -20,6 +20,7 @@ from tau_ai import ModelProvider
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import PromptTemplate, load_prompt_templates
 from tau_coding.resources import ResourceError, TauResourcePaths
+from tau_coding.session_manager import SessionManager
 from tau_coding.skills import Skill, expand_skill_command, load_skills
 from tau_coding.system_prompt import (
     BuildSystemPromptOptions,
@@ -43,6 +44,8 @@ class CodingSessionConfig:
     context_files: tuple[ProjectContextFile, ...] = ()
     tools: list[AgentTool] | None = None
     resource_paths: TauResourcePaths | None = None
+    session_id: str | None = None
+    session_manager: SessionManager | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -234,6 +237,8 @@ class CodingSession:
 
         entries = await self._config.storage.read_all()
         self._state = SessionState.from_entries(entries)
+        if self._config.session_id is not None and self._config.session_manager is not None:
+            self._config.session_manager.touch_session(self._config.session_id, model=self.model)
 
 
 def _last_parent_id_from_state(state: SessionState) -> str | None:

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -1,0 +1,183 @@
+"""User-home session management for Tau coding sessions."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from time import time
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict
+
+from tau_coding.paths import TauPaths
+
+
+class SessionRecordModel(BaseModel):
+    """JSON-serializable coding-session metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    path: str
+    cwd: str
+    model: str
+    title: str | None = None
+    created_at: float
+    updated_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class CodingSessionRecord:
+    """Metadata for one durable coding session."""
+
+    id: str
+    path: Path
+    cwd: Path
+    model: str
+    title: str | None
+    created_at: float
+    updated_at: float
+
+    @classmethod
+    def from_model(cls, model: SessionRecordModel) -> CodingSessionRecord:
+        """Convert a JSON model to a record."""
+        return cls(
+            id=model.id,
+            path=Path(model.path),
+            cwd=Path(model.cwd),
+            model=model.model,
+            title=model.title,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    def to_model(self) -> SessionRecordModel:
+        """Convert this record to a JSON model."""
+        return SessionRecordModel(
+            id=self.id,
+            path=str(self.path),
+            cwd=str(self.cwd),
+            model=self.model,
+            title=self.title,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+class SessionManager:
+    """Create, index, list, and resume user-home coding sessions."""
+
+    def __init__(self, paths: TauPaths | None = None) -> None:
+        self.paths = paths or TauPaths()
+
+    @property
+    def index_path(self) -> Path:
+        """Return the session metadata index path."""
+        return self.paths.sessions_dir / "index.jsonl"
+
+    def list_sessions(self) -> list[CodingSessionRecord]:
+        """Return all indexed sessions, newest updated first."""
+        records = self._read_index()
+        return sorted(records, key=lambda record: record.updated_at, reverse=True)
+
+    def get_session(self, session_id: str) -> CodingSessionRecord | None:
+        """Return a session record by id, if present."""
+        for record in self._read_index():
+            if record.id == session_id:
+                return record
+        return None
+
+    def create_session(
+        self,
+        *,
+        cwd: Path,
+        model: str,
+        title: str | None = None,
+        session_id: str | None = None,
+    ) -> CodingSessionRecord:
+        """Create and index a new session record."""
+        now = time()
+        resolved_cwd = cwd.resolve()
+        record_id = session_id or uuid4().hex
+        path = self.paths.project_session_dir(resolved_cwd) / f"{record_id}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = CodingSessionRecord(
+            id=record_id,
+            path=path,
+            cwd=resolved_cwd,
+            model=model,
+            title=title,
+            created_at=now,
+            updated_at=now,
+        )
+        self._upsert(record)
+        return record
+
+    def get_or_create_default_session(self, *, cwd: Path, model: str) -> CodingSessionRecord:
+        """Return the default project session, creating an index record when needed."""
+        resolved_cwd = cwd.resolve()
+        project_hash = self.paths.project_session_dir(resolved_cwd).name
+        session_id = f"default-{project_hash}"
+        existing = self.get_session(session_id)
+        if existing is not None:
+            return existing
+
+        now = time()
+        path = self.paths.default_session_path(resolved_cwd)
+        record = CodingSessionRecord(
+            id=session_id,
+            path=path,
+            cwd=resolved_cwd,
+            model=model,
+            title="Default session",
+            created_at=now,
+            updated_at=now,
+        )
+        self._upsert(record)
+        return record
+
+    def touch_session(
+        self,
+        session_id: str,
+        *,
+        model: str | None = None,
+        title: str | None = None,
+    ) -> CodingSessionRecord | None:
+        """Update a session's last-used metadata."""
+        existing = self.get_session(session_id)
+        if existing is None:
+            return None
+        updated = CodingSessionRecord(
+            id=existing.id,
+            path=existing.path,
+            cwd=existing.cwd,
+            model=model or existing.model,
+            title=title if title is not None else existing.title,
+            created_at=existing.created_at,
+            updated_at=time(),
+        )
+        self._upsert(updated)
+        return updated
+
+    def _read_index(self) -> list[CodingSessionRecord]:
+        if not self.index_path.exists():
+            return []
+
+        records: list[CodingSessionRecord] = []
+        for line in self.index_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            model = SessionRecordModel.model_validate_json(stripped)
+            records.append(CodingSessionRecord.from_model(model))
+        return records
+
+    def _write_index(self, records: list[CodingSessionRecord]) -> None:
+        self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        content = "\n".join(record.to_model().model_dump_json() for record in records)
+        if content:
+            content += "\n"
+        self.index_path.write_text(content, encoding="utf-8")
+
+    def _upsert(self, record: CodingSessionRecord) -> None:
+        records = [item for item in self._read_index() if item.id != record.id]
+        records.append(record)
+        self._write_index(records)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -8,12 +8,8 @@ from textual.widgets import Footer, Header, Input, Static
 from textual.worker import Worker
 
 from tau_ai import OpenAICompatibleProvider, openai_compatible_config_from_env
-from tau_coding.session import (
-    CodingSession,
-    CodingSessionConfig,
-    default_session_path,
-    jsonl_session_storage,
-)
+from tau_coding.session import CodingSession, CodingSessionConfig, jsonl_session_storage
+from tau_coding.session_manager import SessionManager
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.state import TuiState
 from tau_coding.tui.widgets import SessionSidebar, TranscriptView
@@ -164,16 +160,36 @@ class TauTuiApp(App[None]):
         status.update("Working…" if self.state.running else "Ready")
 
 
-async def run_tui_app(*, model: str, cwd: Path) -> None:
+async def run_tui_app(
+    *,
+    model: str,
+    cwd: Path,
+    session_id: str | None = None,
+    new_session: bool = False,
+    session_manager: SessionManager | None = None,
+) -> None:
     """Create the default provider/session and run the Textual app."""
     provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
+    manager = session_manager or SessionManager()
     try:
+        if new_session:
+            record = manager.create_session(cwd=cwd, model=model)
+        elif session_id is not None:
+            existing_record = manager.get_session(session_id)
+            if existing_record is None:
+                raise RuntimeError(f"Unknown session: {session_id}")
+            record = existing_record
+        else:
+            record = manager.get_or_create_default_session(cwd=cwd, model=model)
+
         session = await CodingSession.load(
             CodingSessionConfig(
                 provider=provider,
-                model=model,
-                cwd=cwd,
-                storage=jsonl_session_storage(default_session_path(cwd)),
+                model=record.model or model,
+                cwd=record.cwd,
+                storage=jsonl_session_storage(record.path),
+                session_id=record.id,
+                session_manager=manager,
             )
         )
         app = TauTuiApp(session)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -169,6 +169,9 @@ async def run_tui_app(
     session_manager: SessionManager | None = None,
 ) -> None:
     """Create the default provider/session and run the Textual app."""
+    if new_session and session_id is not None:
+        raise RuntimeError("--resume and --new-session cannot be used together")
+
     provider = OpenAICompatibleProvider(openai_compatible_config_from_env())
     manager = session_manager or SessionManager()
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from tau_ai import (
     ProviderResponseStartEvent,
     ProviderTextDeltaEvent,
 )
-from tau_coding import cli
+from tau_coding import CodingSessionRecord, cli
 from tau_coding.cli import app, run_print_mode
 from tau_coding.rendering import PrintOutputMode
 from tau_coding.resources import TauResourcePaths
@@ -160,14 +160,67 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
 
 
 def test_tui_command_invokes_tui_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    calls: list[tuple[str, Path]] = []
+    calls: list[tuple[str, Path, str | None, bool]] = []
 
-    async def fake_run_openai_tui(model: str, cwd: Path) -> None:
-        calls.append((model, cwd))
+    async def fake_run_openai_tui(
+        model: str, cwd: Path, session_id: str | None, new_session: bool
+    ) -> None:
+        calls.append((model, cwd, session_id, new_session))
 
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
 
-    result = CliRunner().invoke(app, ["--cwd", str(tmp_path), "--model", "fake", "tui"])
+    result = CliRunner().invoke(
+        app,
+        [
+            "--cwd",
+            str(tmp_path),
+            "--model",
+            "fake",
+            "--resume",
+            "session-1",
+            "--new-session",
+            "tui",
+        ],
+    )
 
     assert result.exit_code == 0
-    assert calls == [("fake", tmp_path)]
+    assert calls == [("fake", tmp_path, "session-1", True)]
+
+
+def test_sessions_command_lists_indexed_sessions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    record = CodingSessionRecord(
+        id="session-1",
+        path=tmp_path / "session.jsonl",
+        cwd=tmp_path,
+        model="fake",
+        title="Test session",
+        created_at=1.0,
+        updated_at=2.0,
+    )
+
+    class FakeSessionManager:
+        def list_sessions(self) -> list[CodingSessionRecord]:
+            return [record]
+
+    monkeypatch.setattr(cli, "SessionManager", FakeSessionManager)
+
+    result = CliRunner().invoke(app, ["sessions"])
+
+    assert result.exit_code == 0
+    assert "session-1" in result.stdout
+    assert "Test session" in result.stdout
+
+
+def test_sessions_command_handles_empty_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSessionManager:
+        def list_sessions(self) -> list[CodingSessionRecord]:
+            return []
+
+    monkeypatch.setattr(cli, "SessionManager", FakeSessionManager)
+
+    result = CliRunner().invoke(app, ["sessions"])
+
+    assert result.exit_code == 0
+    assert "No sessions found." in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,13 +178,38 @@ def test_tui_command_invokes_tui_runner(monkeypatch: pytest.MonkeyPatch, tmp_pat
             "fake",
             "--resume",
             "session-1",
-            "--new-session",
             "tui",
         ],
     )
 
     assert result.exit_code == 0
-    assert calls == [("fake", tmp_path, "session-1", True)]
+    assert calls == [("fake", tmp_path, "session-1", False)]
+
+
+def test_tui_command_rejects_resume_with_new_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_run_openai_tui(
+        model: str, cwd: Path, session_id: str | None, new_session: bool
+    ) -> None:
+        raise RuntimeError("--resume and --new-session cannot be used together")
+
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--cwd",
+            str(tmp_path),
+            "--resume",
+            "session-1",
+            "--new-session",
+            "tui",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--resume and --new-session cannot be used together" in result.output
 
 
 def test_sessions_command_lists_indexed_sessions(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -11,7 +11,13 @@ from tau_agent.session import (
     SessionInfoEntry,
 )
 from tau_ai import FakeProvider, ProviderResponseEndEvent, ProviderResponseStartEvent
-from tau_coding import CodingSession, CodingSessionConfig, TauResourcePaths
+from tau_coding import (
+    CodingSession,
+    CodingSessionConfig,
+    SessionManager,
+    TauPaths,
+    TauResourcePaths,
+)
 
 
 async def _collect_session_events(session_stream: object) -> list[object]:
@@ -231,6 +237,38 @@ async def test_session_builds_system_prompt_when_system_is_omitted(tmp_path: Pat
     assert "Available tools:\n- read: Read file contents" in provider.calls[0][1]
     assert "<available_skills>" in provider.calls[0][1]
     assert "<name>testing</name>" in provider.calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_session_touches_session_manager_after_persisting_messages(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ]
+        ]
+    )
+    config = CodingSessionConfig(
+        provider=provider,
+        model="fake",
+        system="You are Tau.",
+        storage=storage,
+        cwd=tmp_path,
+        session_id=record.id,
+        session_manager=manager,
+        resource_paths=TauResourcePaths(root=tmp_path / "resources", agents_root=None),
+    )
+    session = await CodingSession.load(config)
+
+    _events = await _collect_session_events(session.prompt("Hello"))
+
+    updated = manager.get_session(record.id)
+    assert updated is not None
+    assert updated.updated_at >= record.updated_at
 
 
 @pytest.mark.anyio

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from tau_coding.paths import TauPaths
+from tau_coding.session_manager import SessionManager
+
+
+def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+
+    record = manager.create_session(cwd=cwd, model="fake", title="Test session")
+
+    assert record.path.parent.parent == tmp_path / ".tau" / "sessions"
+    assert record.path.name == f"{record.id}.jsonl"
+    assert manager.get_session(record.id) == record
+    assert manager.list_sessions() == [record]
+
+
+def test_session_manager_gets_or_creates_default_session(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+
+    first = manager.get_or_create_default_session(cwd=cwd, model="fake")
+    second = manager.get_or_create_default_session(cwd=cwd, model="other")
+
+    assert first == second
+    assert first.id.startswith("default-")
+    assert first.path.name == "default.jsonl"
+    assert first.path.parent.exists()
+
+
+def test_session_manager_touch_updates_metadata(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    record = manager.create_session(cwd=cwd, model="fake")
+
+    updated = manager.touch_session(record.id, model="new-model", title="Updated")
+
+    assert updated is not None
+    assert updated.id == record.id
+    assert updated.model == "new-model"
+    assert updated.title == "Updated"
+    assert updated.updated_at >= record.updated_at
+    assert manager.get_session(record.id) == updated
+
+
+def test_session_manager_sorts_newest_updated_first(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    older = manager.create_session(cwd=cwd, model="fake", session_id="older")
+    newer = manager.create_session(cwd=cwd, model="fake", session_id="newer")
+    manager.touch_session(older.id)
+
+    sessions = manager.list_sessions()
+
+    assert [session.id for session in sessions] == ["older", "newer"]
+    assert newer in sessions


### PR DESCRIPTION
## Summary

Adds Phase 14 session manager and resume support.

- Adds `SessionManager` and `CodingSessionRecord`
- Stores session metadata under `~/.tau/sessions/index.jsonl`
- Creates/list/resumes user-home sessions
- Keeps default project sessions indexed as `default-<project-hash>`
- Touches session metadata after `CodingSession` persists new messages
- Adds `tau sessions` listing
- Adds TUI session options:
  - `tau --new-session tui`
  - `tau --resume <session-id> tui`
- Documents Phase 14

Also updated issue #1 to mark Phase 13 complete.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session management: Create new sessions with `--new-session` or resume previous sessions with `--resume <session-id>`.
  * Added `tau sessions` command to list all saved coding sessions with details (id, title, model, and working directory).
  * Sessions are automatically tracked and persisted between runs, ordered by most recent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->