### PR TITLE
Add OpenAI Codex subscription OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ uv run tau --version
 tau
 ```
 
-Inside the TUI, run `/login` to save a provider API key.
+Inside the TUI, run `/login` to save a provider API key, or
+`/login openai-codex` to authenticate with a Codex subscription account.
 
 Run one prompt without opening the TUI:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,15 +62,21 @@ Example:
 }
 ```
 
-API keys are not written to this file. Built-in providers added through
-`/login` read their key from `~/.tau/credentials.json` using `credential_name`.
-Providers without a `credential_name`, such as custom local providers, read the
-environment variable named by `api_key_env`. `timeout_seconds` is optional and
-defaults to `60`; when present, it must be greater than zero. `max_retries`
-defaults to `0`, and `max_retry_delay_seconds` defaults to `1`; both must be
-zero or greater. `headers` is optional and must be an object with string keys
-and string values. Tau sends these headers with provider requests, while keeping
-its own authentication headers under runtime control.
+API keys and OAuth refresh credentials are not written to this file. Built-in
+providers added through `/login` read their credential from
+`~/.tau/credentials.json` using `credential_name`. Providers without a
+`credential_name`, such as custom local providers, read the environment variable
+named by `api_key_env`. `timeout_seconds` is optional and defaults to `60`; when
+present, it must be greater than zero. `max_retries` defaults to `0`, and
+`max_retry_delay_seconds` defaults to `1`; both must be zero or greater.
+`headers` is optional and must be an object with string keys and string values.
+Tau sends these headers with provider requests, while keeping its own
+authentication headers under runtime control.
+
+OAuth-backed providers, such as `openai-codex`, store a structured credential
+object in `~/.tau/credentials.json` and refresh expired access tokens before a
+model request. Use `/login openai-codex` to authenticate with a Codex
+subscription account.
 
 For example, Hugging Face organization billing can be configured with:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,15 +47,17 @@ tau 0.1.0
 
 ## Configure a Provider
 
-Tau includes built-in provider entries for OpenAI, Anthropic, OpenRouter, and
-Hugging Face Inference Providers. In the TUI, run `/login` to see the list and
-`/login openai` to save an API key for a provider.
+Tau includes built-in provider entries for OpenAI, OpenAI Codex subscription,
+Anthropic, OpenRouter, and Hugging Face Inference Providers. In the TUI, run
+`/login` to see the list, `/login openai` to save an API key, or
+`/login openai-codex` to authenticate with a Codex subscription account.
 
-Provider metadata is written to `~/.tau/providers.json`. API keys saved with
-`/login` are written to `~/.tau/credentials.json` with private file permissions.
-For built-in providers added with `/login`, Tau uses the key saved in
-`credentials.json`. The `api_key_env` field in `providers.json` is metadata for
-custom/env-based providers and does not override a saved Tau login.
+Provider metadata is written to `~/.tau/providers.json`. API keys and OAuth
+refresh credentials saved with `/login` are written to `~/.tau/credentials.json`
+with private file permissions. For built-in providers added with `/login`, Tau
+uses the credential saved in `credentials.json`. The `api_key_env` field in
+`providers.json` is metadata for custom/env-based providers and does not
+override a saved Tau login.
 
 To add a custom OpenAI-compatible provider:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,14 +52,16 @@ tau -p "explain this repository"
 Print-mode prompts create indexed session entries under `~/.tau/sessions/` while
 keeping stdout/stderr script-friendly.
 
-Tau includes built-in provider entries for OpenAI, Anthropic, OpenRouter, and
-Hugging Face Inference Providers. In the TUI, run `/login` to see them and
-`/login openai` to save an API key.
+Tau includes built-in provider entries for OpenAI, OpenAI Codex subscription,
+Anthropic, OpenRouter, and Hugging Face Inference Providers. In the TUI, run
+`/login` to see them, `/login openai` to save an API key, or
+`/login openai-codex` to authenticate with a Codex subscription account.
 
-Saved API keys live in `~/.tau/credentials.json` with private file permissions.
-For built-in providers added with `/login`, Tau uses the key saved in
-`credentials.json`. The `api_key_env` field in `providers.json` is metadata for
-custom/env-based providers and does not override a saved Tau login.
+Saved API keys and OAuth refresh credentials live in `~/.tau/credentials.json`
+with private file permissions. For built-in providers added with `/login`, Tau
+uses the credential saved in `credentials.json`. The `api_key_env` field in
+`providers.json` is metadata for custom/env-based providers and does not
+override a saved Tau login.
 
 Optionally configure a custom provider:
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,6 +35,26 @@ export OPENAI_MAX_RETRY_DELAY_SECONDS="0.5"
 
 The provider uses `/chat/completions` with streaming enabled.
 
+## OpenAI Codex Subscription Provider
+
+Tau also includes an `openai-codex` provider for Codex / ChatGPT subscription
+accounts. This is separate from the `openai` API-key provider.
+
+In the TUI, run:
+
+```text
+/login openai-codex
+```
+
+Tau opens the OpenAI OAuth URL, listens for the local callback at
+`http://localhost:1455/auth/callback`, and also accepts a pasted redirect URL or
+authorization code as a fallback. Refreshable OAuth credentials are saved in
+`~/.tau/credentials.json` with private file permissions.
+
+The provider sends requests to the ChatGPT backend Codex Responses endpoint and
+uses the OAuth access token plus the ChatGPT account id required by that API.
+Expired access tokens are refreshed automatically before a model request.
+
 ## Durable Provider Config
 
 Tau stores provider metadata in:
@@ -106,8 +126,9 @@ Inside the TUI:
 
 `/model` opens the interactive model picker. The picker includes models from
 configured providers, so selecting a model can also switch the active runtime
-provider. `/login` adds or refreshes a built-in provider, and `/reload`
-refreshes provider settings for future command use.
+provider. `/login` adds or refreshes a built-in provider, including
+OAuth-backed providers such as `openai-codex`, and `/reload` refreshes provider
+settings for future command use.
 
 When Tau loads `~/.tau/providers.json`, it merges the current built-in model
 catalog into built-in provider entries such as Hugging Face. Custom models and

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -19,6 +19,12 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.fake import FakeProvider
+from tau_ai.openai_codex import (
+    DEFAULT_OPENAI_CODEX_BASE_URL,
+    OpenAICodexConfig,
+    OpenAICodexCredentials,
+    OpenAICodexProvider,
+)
 from tau_ai.openai_compatible import OpenAICompatibleProvider
 from tau_ai.provider import CancellationToken, ModelProvider
 
@@ -30,8 +36,12 @@ __all__ = [
     "DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES",
     "DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS",
     "DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS",
+    "DEFAULT_OPENAI_CODEX_BASE_URL",
     "FakeProvider",
     "ModelProvider",
+    "OpenAICodexConfig",
+    "OpenAICodexCredentials",
+    "OpenAICodexProvider",
     "OpenAICompatibleConfig",
     "OpenAICompatibleProvider",
     "ProviderErrorEvent",

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -194,6 +194,18 @@ class _ToolCallBuilder:
         """Replace streamed tool arguments with final provider arguments."""
         self.arguments_parts = [arguments]
 
+    def update_from_item(self, item: Mapping[str, Any]) -> None:
+        """Fill in metadata from a completed function-call item."""
+        call_id = item.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            self.call_id = call_id
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id:
+            self.item_id = item_id
+        name = item.get("name")
+        if isinstance(name, str):
+            self.name = name
+
     def build(self) -> ToolCall:
         """Build a complete Tau tool call."""
         arguments_text = "".join(self.arguments_parts)
@@ -300,7 +312,10 @@ async def _codex_provider_events(
 ) -> AsyncIterator[ProviderEvent]:
     content_parts: list[str] = []
     tool_calls: list[ToolCall] = []
-    current_tool: _ToolCallBuilder | None = None
+    active_tools: list[_ToolCallBuilder] = []
+    tools_by_item_id: dict[str, _ToolCallBuilder] = {}
+    tools_by_call_id: dict[str, _ToolCallBuilder] = {}
+    tools_by_output_index: dict[int, _ToolCallBuilder] = {}
     finish_reason: str | None = None
 
     async for event in _iter_sse_objects(response):
@@ -327,17 +342,38 @@ async def _codex_provider_events(
         if event_type == "response.output_item.added":
             item = event.get("item")
             if isinstance(item, Mapping) and item.get("type") == "function_call":
-                current_tool = _tool_builder_from_item(item)
+                _track_tool_builder(
+                    _tool_builder_from_item(item),
+                    event,
+                    active_tools=active_tools,
+                    by_item_id=tools_by_item_id,
+                    by_call_id=tools_by_call_id,
+                    by_output_index=tools_by_output_index,
+                )
 
         elif event_type == "response.function_call_arguments.delta":
             delta = event.get("delta")
-            if current_tool is not None and isinstance(delta, str):
-                current_tool.add_delta(delta)
+            tool_builder = _tool_builder_for_event(
+                event,
+                active_tools=active_tools,
+                by_item_id=tools_by_item_id,
+                by_call_id=tools_by_call_id,
+                by_output_index=tools_by_output_index,
+            )
+            if tool_builder is not None and isinstance(delta, str):
+                tool_builder.add_delta(delta)
 
         elif event_type == "response.function_call_arguments.done":
             arguments = event.get("arguments")
-            if current_tool is not None and isinstance(arguments, str):
-                current_tool.set_arguments(arguments)
+            tool_builder = _tool_builder_for_event(
+                event,
+                active_tools=active_tools,
+                by_item_id=tools_by_item_id,
+                by_call_id=tools_by_call_id,
+                by_output_index=tools_by_output_index,
+            )
+            if tool_builder is not None and isinstance(arguments, str):
+                tool_builder.set_arguments(arguments)
 
         elif event_type == "response.output_text.delta":
             delta = event.get("delta")
@@ -351,13 +387,37 @@ async def _codex_provider_events(
         }:
             item = event.get("item")
             if isinstance(item, Mapping) and item.get("type") == "function_call":
-                tool_builder = current_tool or _tool_builder_from_item(item)
+                tool_builder = _tool_builder_for_event(
+                    event,
+                    active_tools=active_tools,
+                    by_item_id=tools_by_item_id,
+                    by_call_id=tools_by_call_id,
+                    by_output_index=tools_by_output_index,
+                )
+                if tool_builder is None:
+                    tool_builder = _tool_builder_from_item(item)
+                    _track_tool_builder(
+                        tool_builder,
+                        event,
+                        active_tools=active_tools,
+                        by_item_id=tools_by_item_id,
+                        by_call_id=tools_by_call_id,
+                        by_output_index=tools_by_output_index,
+                    )
+                else:
+                    tool_builder.update_from_item(item)
                 arguments = item.get("arguments")
                 if isinstance(arguments, str):
                     tool_builder.set_arguments(arguments)
                 tool_call = tool_builder.build()
                 tool_calls.append(tool_call)
-                current_tool = None
+                _untrack_tool_builder(
+                    tool_builder,
+                    active_tools=active_tools,
+                    by_item_id=tools_by_item_id,
+                    by_call_id=tools_by_call_id,
+                    by_output_index=tools_by_output_index,
+                )
                 yield ProviderToolCallEvent(tool_call=tool_call)
             elif isinstance(item, Mapping) and item.get("type") == "message" and not content_parts:
                 text = _text_from_done_message(item)
@@ -413,6 +473,98 @@ def _tool_builder_from_item(item: Mapping[str, Any]) -> _ToolCallBuilder:
         item_id=item_id if isinstance(item_id, str) and item_id else None,
         name=name if isinstance(name, str) else "",
     )
+
+
+def _track_tool_builder(
+    builder: _ToolCallBuilder,
+    event: Mapping[str, Any],
+    *,
+    active_tools: list[_ToolCallBuilder],
+    by_item_id: dict[str, _ToolCallBuilder],
+    by_call_id: dict[str, _ToolCallBuilder],
+    by_output_index: dict[int, _ToolCallBuilder],
+) -> None:
+    if builder not in active_tools:
+        active_tools.append(builder)
+    if builder.item_id:
+        by_item_id[builder.item_id] = builder
+    if builder.call_id:
+        by_call_id[builder.call_id] = builder
+    output_index = _event_output_index(event)
+    if output_index is not None:
+        by_output_index[output_index] = builder
+
+
+def _untrack_tool_builder(
+    builder: _ToolCallBuilder,
+    *,
+    active_tools: list[_ToolCallBuilder],
+    by_item_id: dict[str, _ToolCallBuilder],
+    by_call_id: dict[str, _ToolCallBuilder],
+    by_output_index: dict[int, _ToolCallBuilder],
+) -> None:
+    if builder in active_tools:
+        active_tools.remove(builder)
+    if builder.item_id and by_item_id.get(builder.item_id) is builder:
+        del by_item_id[builder.item_id]
+    if builder.call_id and by_call_id.get(builder.call_id) is builder:
+        del by_call_id[builder.call_id]
+    for output_index, tracked_builder in tuple(by_output_index.items()):
+        if tracked_builder is builder:
+            del by_output_index[output_index]
+
+
+def _tool_builder_for_event(
+    event: Mapping[str, Any],
+    *,
+    active_tools: list[_ToolCallBuilder],
+    by_item_id: dict[str, _ToolCallBuilder],
+    by_call_id: dict[str, _ToolCallBuilder],
+    by_output_index: dict[int, _ToolCallBuilder],
+) -> _ToolCallBuilder | None:
+    item_id = _event_item_id(event)
+    if item_id is not None and item_id in by_item_id:
+        return by_item_id[item_id]
+    call_id = _event_call_id(event)
+    if call_id is not None and call_id in by_call_id:
+        return by_call_id[call_id]
+    output_index = _event_output_index(event)
+    if output_index is not None and output_index in by_output_index:
+        return by_output_index[output_index]
+    if len(active_tools) == 1:
+        return active_tools[0]
+    return None
+
+
+def _event_item_id(event: Mapping[str, Any]) -> str | None:
+    item_id = event.get("item_id")
+    if isinstance(item_id, str) and item_id:
+        return item_id
+    item = event.get("item")
+    if isinstance(item, Mapping):
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id:
+            return item_id
+    return None
+
+
+def _event_call_id(event: Mapping[str, Any]) -> str | None:
+    call_id = event.get("call_id")
+    if isinstance(call_id, str) and call_id:
+        return call_id
+    item = event.get("item")
+    if isinstance(item, Mapping):
+        call_id = item.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            return call_id
+    return None
+
+
+def _event_output_index(event: Mapping[str, Any]) -> int | None:
+    output_index = event.get("output_index")
+    if isinstance(output_index, int) and not isinstance(output_index, bool):
+        return output_index
+    return None
 
 
 def _text_from_done_message(item: Mapping[str, Any]) -> str:

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -1,0 +1,535 @@
+"""OpenAI Codex subscription Responses provider."""
+
+from asyncio import sleep
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from json import JSONDecodeError, dumps, loads
+from platform import machine, release, system
+from typing import Any
+
+import httpx
+
+from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
+from tau_agent.tools import AgentTool, ToolCall
+from tau_agent.types import JSONValue
+from tau_ai.env import (
+    DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES,
+    DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS,
+    DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
+)
+from tau_ai.events import (
+    ProviderErrorEvent,
+    ProviderEvent,
+    ProviderResponseEndEvent,
+    ProviderResponseStartEvent,
+    ProviderTextDeltaEvent,
+    ProviderToolCallEvent,
+)
+from tau_ai.provider import CancellationToken
+
+DEFAULT_OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api"
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAICodexCredentials:
+    """Bearer token and account id required by ChatGPT Codex Responses."""
+
+    access_token: str
+    account_id: str
+
+
+type OpenAICodexCredentialResolver = Callable[[], Awaitable[OpenAICodexCredentials]]
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAICodexConfig:
+    """Configuration for the OpenAI Codex subscription Responses endpoint."""
+
+    credential_resolver: OpenAICodexCredentialResolver
+    base_url: str = DEFAULT_OPENAI_CODEX_BASE_URL
+    headers: Mapping[str, str] | None = None
+    timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
+    max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
+    max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
+    originator: str = "tau"
+
+
+class OpenAICodexProvider:
+    """Provider adapter for ChatGPT subscription Codex Responses over SSE."""
+
+    def __init__(
+        self,
+        config: OpenAICodexConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this provider created it."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Stream one Codex Responses request as provider-neutral events."""
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            client = self._get_client()
+            payload = _build_codex_payload(
+                model=model,
+                system=system,
+                messages=messages,
+                tools=tools,
+            )
+            url = _resolve_codex_url(self._config.base_url)
+
+            yield ProviderResponseStartEvent(model=model)
+
+            attempt = 0
+            while True:
+                emitted_content = False
+                try:
+                    credentials = await self._config.credential_resolver()
+                    headers = _build_codex_headers(
+                        self._config.headers,
+                        access_token=credentials.access_token,
+                        account_id=credentials.account_id,
+                        originator=self._config.originator,
+                    )
+                    async with client.stream(
+                        "POST",
+                        url,
+                        json=payload,
+                        headers=headers,
+                    ) as response:
+                        if response.status_code >= 400:
+                            body = await response.aread()
+                            body_text = body.decode(errors="replace")
+                            if await self._should_retry(
+                                attempt,
+                                status_code=response.status_code,
+                                body=body_text,
+                            ):
+                                attempt += 1
+                                continue
+                            yield ProviderErrorEvent(
+                                message=(
+                                    "OpenAI Codex request failed with status "
+                                    f"{response.status_code}"
+                                ),
+                                data={
+                                    "body": body_text,
+                                    "attempts": attempt + 1,
+                                },
+                            )
+                            return
+
+                        async for event in _codex_provider_events(response, signal=signal):
+                            if isinstance(
+                                event,
+                                ProviderTextDeltaEvent | ProviderToolCallEvent,
+                            ):
+                                emitted_content = True
+                            yield event
+                        return
+                except httpx.HTTPError as exc:
+                    if not emitted_content and await self._should_retry(attempt):
+                        attempt += 1
+                        continue
+                    yield ProviderErrorEvent(
+                        message=str(exc),
+                        data={"attempts": attempt + 1},
+                    )
+                    return
+                except Exception as exc:  # noqa: BLE001 - provider errors are surfaced as events
+                    yield ProviderErrorEvent(message=str(exc), data={"attempts": attempt + 1})
+                    return
+
+        return iterator()
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+        return self._client
+
+    async def _should_retry(
+        self,
+        attempt: int,
+        *,
+        status_code: int | None = None,
+        body: str = "",
+    ) -> bool:
+        if attempt >= self._config.max_retries:
+            return False
+        if status_code is not None and not _is_retryable_status(status_code, body):
+            return False
+        if self._config.max_retry_delay_seconds:
+            await sleep(self._config.max_retry_delay_seconds)
+        return True
+
+
+class _ToolCallBuilder:
+    def __init__(self, *, call_id: str, item_id: str | None, name: str) -> None:
+        self.call_id = call_id
+        self.item_id = item_id
+        self.name = name
+        self.arguments_parts: list[str] = []
+
+    def add_delta(self, delta: str) -> None:
+        """Append a streamed tool-argument fragment."""
+        self.arguments_parts.append(delta)
+
+    def set_arguments(self, arguments: str) -> None:
+        """Replace streamed tool arguments with final provider arguments."""
+        self.arguments_parts = [arguments]
+
+    def build(self) -> ToolCall:
+        """Build a complete Tau tool call."""
+        arguments_text = "".join(self.arguments_parts)
+        arguments = _loads_object(arguments_text) if arguments_text else {}
+        if arguments is None:
+            arguments = {"_raw_arguments": arguments_text}
+        item_id = self.item_id or f"fc_{self.call_id}"
+        return ToolCall(
+            id=f"{self.call_id}|{item_id}",
+            name=self.name,
+            arguments=arguments,
+        )
+
+
+def _build_codex_payload(
+    *,
+    model: str,
+    system: str,
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "model": model,
+        "store": False,
+        "stream": True,
+        "instructions": system or "You are a helpful assistant.",
+        "input": _messages_to_responses_input(messages),
+        "text": {"verbosity": "low"},
+        "include": ["reasoning.encrypted_content"],
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+    }
+    if tools:
+        payload["tools"] = [_tool_to_codex(tool) for tool in tools]
+    return payload
+
+
+def _messages_to_responses_input(messages: list[AgentMessage]) -> list[JSONValue]:
+    items: list[JSONValue] = []
+    assistant_index = 0
+    for message in messages:
+        if isinstance(message, UserMessage):
+            items.append(
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": message.content}],
+                }
+            )
+        elif isinstance(message, AssistantMessage):
+            if message.content:
+                items.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": message.content,
+                                "annotations": [],
+                            }
+                        ],
+                        "status": "completed",
+                        "id": f"msg_{assistant_index}",
+                    }
+                )
+                assistant_index += 1
+            for tool_call in message.tool_calls:
+                call_id, item_id = _split_tool_call_id(tool_call.id)
+                item: dict[str, JSONValue] = {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": tool_call.name,
+                    "arguments": dumps(tool_call.arguments),
+                }
+                if item_id:
+                    item["id"] = item_id
+                items.append(item)
+        elif isinstance(message, ToolResultMessage):
+            call_id, _item_id = _split_tool_call_id(message.tool_call_id)
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": message.content,
+                }
+            )
+    return items
+
+
+def _tool_to_codex(tool: AgentTool) -> dict[str, JSONValue]:
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": dict(tool.input_schema),
+        "strict": None,
+    }
+
+
+async def _codex_provider_events(
+    response: httpx.Response,
+    *,
+    signal: CancellationToken | None,
+) -> AsyncIterator[ProviderEvent]:
+    content_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+    current_tool: _ToolCallBuilder | None = None
+    finish_reason: str | None = None
+
+    async for event in _iter_sse_objects(response):
+        if signal is not None and signal.is_cancelled():
+            return
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            continue
+
+        if event_type == "error":
+            yield ProviderErrorEvent(
+                message=_error_message(event, fallback="OpenAI Codex returned an error"),
+                data={"event": event},
+            )
+            return
+
+        if event_type == "response.failed":
+            yield ProviderErrorEvent(
+                message=_response_error_message(event),
+                data={"event": event},
+            )
+            return
+
+        if event_type == "response.output_item.added":
+            item = event.get("item")
+            if isinstance(item, Mapping) and item.get("type") == "function_call":
+                current_tool = _tool_builder_from_item(item)
+
+        elif event_type == "response.function_call_arguments.delta":
+            delta = event.get("delta")
+            if current_tool is not None and isinstance(delta, str):
+                current_tool.add_delta(delta)
+
+        elif event_type == "response.function_call_arguments.done":
+            arguments = event.get("arguments")
+            if current_tool is not None and isinstance(arguments, str):
+                current_tool.set_arguments(arguments)
+
+        elif event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str) and delta:
+                content_parts.append(delta)
+                yield ProviderTextDeltaEvent(delta=delta)
+
+        elif event_type in {
+            "response.output_item.done",
+            "response.output_item.completed",
+        }:
+            item = event.get("item")
+            if isinstance(item, Mapping) and item.get("type") == "function_call":
+                tool_builder = current_tool or _tool_builder_from_item(item)
+                arguments = item.get("arguments")
+                if isinstance(arguments, str):
+                    tool_builder.set_arguments(arguments)
+                tool_call = tool_builder.build()
+                tool_calls.append(tool_call)
+                current_tool = None
+                yield ProviderToolCallEvent(tool_call=tool_call)
+            elif isinstance(item, Mapping) and item.get("type") == "message" and not content_parts:
+                text = _text_from_done_message(item)
+                if text:
+                    content_parts.append(text)
+                    yield ProviderTextDeltaEvent(delta=text)
+
+        elif event_type in {
+            "response.done",
+            "response.completed",
+            "response.incomplete",
+        }:
+            finish_reason = _finish_reason_from_response(event)
+            break
+
+    yield ProviderResponseEndEvent(
+        message=AssistantMessage(content="".join(content_parts), tool_calls=tool_calls),
+        finish_reason=finish_reason,
+    )
+
+
+async def _iter_sse_objects(response: httpx.Response) -> AsyncIterator[dict[str, JSONValue]]:
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        stripped = line.strip()
+        if not stripped:
+            if data_lines:
+                data = "\n".join(data_lines).strip()
+                data_lines = []
+                parsed = _loads_object(data)
+                if parsed is not None:
+                    yield parsed
+            continue
+        if not stripped.startswith("data:"):
+            continue
+        value = stripped.removeprefix("data:").strip()
+        if value == "[DONE]":
+            break
+        data_lines.append(value)
+
+    if data_lines:
+        parsed = _loads_object("\n".join(data_lines).strip())
+        if parsed is not None:
+            yield parsed
+
+
+def _tool_builder_from_item(item: Mapping[str, Any]) -> _ToolCallBuilder:
+    call_id = item.get("call_id")
+    name = item.get("name")
+    item_id = item.get("id")
+    return _ToolCallBuilder(
+        call_id=call_id if isinstance(call_id, str) and call_id else "call_0",
+        item_id=item_id if isinstance(item_id, str) and item_id else None,
+        name=name if isinstance(name, str) else "",
+    )
+
+
+def _text_from_done_message(item: Mapping[str, Any]) -> str:
+    content = item.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for part in content:
+        if not isinstance(part, Mapping):
+            continue
+        if part.get("type") == "output_text":
+            text = part.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        elif part.get("type") == "refusal":
+            refusal = part.get("refusal")
+            if isinstance(refusal, str):
+                parts.append(refusal)
+    return "".join(parts)
+
+
+def _finish_reason_from_response(event: Mapping[str, Any]) -> str | None:
+    response = event.get("response")
+    if not isinstance(response, Mapping):
+        return None
+    status = response.get("status")
+    if isinstance(status, str):
+        return status
+    return None
+
+
+def _response_error_message(event: Mapping[str, Any]) -> str:
+    response = event.get("response")
+    if isinstance(response, Mapping):
+        error = response.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            code = error.get("code")
+            if isinstance(message, str) and message:
+                return message
+            if isinstance(code, str) and code:
+                return f"OpenAI Codex response failed: {code}"
+    return "OpenAI Codex response failed"
+
+
+def _error_message(event: Mapping[str, Any], *, fallback: str) -> str:
+    message = event.get("message")
+    if isinstance(message, str) and message:
+        return message
+    code = event.get("code")
+    if isinstance(code, str) and code:
+        return code
+    return fallback
+
+
+def _build_codex_headers(
+    configured_headers: Mapping[str, str] | None,
+    *,
+    access_token: str,
+    account_id: str,
+    originator: str,
+) -> dict[str, str]:
+    headers = {
+        **dict(configured_headers or {}),
+        "Authorization": f"Bearer {access_token}",
+        "chatgpt-account-id": account_id,
+        "originator": originator,
+        "User-Agent": f"tau ({system()} {release()}; {machine()})",
+        "OpenAI-Beta": "responses=experimental",
+        "accept": "text/event-stream",
+        "content-type": "application/json",
+    }
+    return headers
+
+
+def _resolve_codex_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/codex/responses"):
+        return normalized
+    if normalized.endswith("/codex"):
+        return f"{normalized}/responses"
+    return f"{normalized}/codex/responses"
+
+
+def _split_tool_call_id(value: str) -> tuple[str, str | None]:
+    if "|" not in value:
+        return value, None
+    call_id, item_id = value.split("|", 1)
+    return call_id, item_id or None
+
+
+def _loads_object(value: str) -> dict[str, JSONValue] | None:
+    try:
+        loaded = loads(value)
+    except JSONDecodeError:
+        return None
+    if isinstance(loaded, dict):
+        return loaded
+    return None
+
+
+def _is_retryable_status(status_code: int, body: str) -> bool:
+    if status_code == 429 and _is_terminal_rate_limit(body):
+        return False
+    return status_code in {408, 409, 425, 429} or status_code >= 500
+
+
+def _is_terminal_rate_limit(body: str) -> bool:
+    normalized = body.lower()
+    markers = (
+        "gousagelimiterror",
+        "freeusagelimiterror",
+        "monthly usage limit reached",
+        "available balance",
+        "insufficient_quota",
+        "out of budget",
+        "quota exceeded",
+        "billing",
+    )
+    return any(marker in normalized for marker in markers)

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -17,7 +17,12 @@ from tau_coding.context_window import (
     estimate_tool_tokens,
     summarize_messages_for_compaction,
 )
-from tau_coding.credentials import CredentialStoreError, FileCredentialStore, credentials_path
+from tau_coding.credentials import (
+    CredentialStoreError,
+    FileCredentialStore,
+    OAuthCredential,
+    credentials_path,
+)
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import (
     PromptTemplate,
@@ -34,6 +39,7 @@ from tau_coding.provider_config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER_NAME,
     AnthropicProviderConfig,
+    OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfig,
     ProviderConfigError,
@@ -127,6 +133,8 @@ __all__ = [
     "ModelChoice",
     "AnthropicProviderConfig",
     "OpenAICompatibleProviderConfig",
+    "OpenAICodexProviderConfig",
+    "OAuthCredential",
     "PrintOutputMode",
     "ProjectContextFile",
     "PromptTemplate",

--- a/src/tau_coding/credentials.py
+++ b/src/tau_coding/credentials.py
@@ -1,7 +1,9 @@
-"""Local credential storage for Tau provider API keys."""
+"""Local credential storage for Tau provider credentials."""
 
+from dataclasses import dataclass
 from json import dumps, loads
 from pathlib import Path
+from typing import Any, Literal
 
 from tau_coding.paths import TauPaths
 
@@ -10,24 +12,83 @@ class CredentialStoreError(ValueError):
     """Raised when Tau credential storage cannot be read or written."""
 
 
+@dataclass(frozen=True, slots=True)
+class OAuthCredential:
+    """Refreshable OAuth credential persisted under Tau home."""
+
+    access: str
+    refresh: str
+    expires: int
+    account_id: str
+
+    def to_json(self) -> dict[str, str | int]:
+        """Serialize this OAuth credential to JSON-compatible data."""
+        return {
+            "type": "oauth",
+            "access": self.access,
+            "refresh": self.refresh,
+            "expires": self.expires,
+            "account_id": self.account_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyCredential:
+    """API-key credential persisted under Tau home."""
+
+    key: str
+
+    def to_json(self) -> dict[str, str | int]:
+        """Serialize this API key credential to JSON-compatible data."""
+        return {"type": "api_key", "key": self.key}
+
+
+type StoredCredential = str | ApiKeyCredential | OAuthCredential
+type StoredCredentialKind = Literal["api_key", "oauth"]
+
+
 class FileCredentialStore:
-    """Small JSON-backed API key store under Tau home."""
+    """Small JSON-backed provider credential store under Tau home."""
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or credentials_path()
 
     def get(self, name: str) -> str | None:
-        """Return a stored credential value by name."""
-        return self._load().get(name)
+        """Return a stored API-key credential value by name."""
+        credential = self._load().get(name)
+        if isinstance(credential, str):
+            return credential
+        if isinstance(credential, ApiKeyCredential):
+            return credential.key
+        return None
 
     def set(self, name: str, value: str) -> None:
-        """Store a credential value by name."""
-        if not name.strip():
-            raise CredentialStoreError("Credential name must not be empty")
-        if not value.strip():
+        """Store an API-key credential value by name."""
+        name = _validate_credential_name(name)
+        value = value.strip()
+        if not value:
             raise CredentialStoreError("Credential value must not be empty")
         data = self._load()
-        data[name.strip()] = value.strip()
+        data[name] = value
+        self._save(data)
+
+    def set_api_key(self, name: str, value: str) -> None:
+        """Store an API-key credential value by name."""
+        self.set(name, value)
+
+    def get_oauth(self, name: str) -> OAuthCredential | None:
+        """Return a stored OAuth credential by name."""
+        credential = self._load().get(name)
+        if isinstance(credential, OAuthCredential):
+            return credential
+        return None
+
+    def set_oauth(self, name: str, credential: OAuthCredential) -> None:
+        """Store a refreshable OAuth credential by name."""
+        name = _validate_credential_name(name)
+        _validate_oauth_credential(credential)
+        data = self._load()
+        data[name] = credential
         self._save(data)
 
     def delete(self, name: str) -> None:
@@ -36,25 +97,87 @@ class FileCredentialStore:
         data.pop(name, None)
         self._save(data)
 
-    def _load(self) -> dict[str, str]:
+    def _load(self) -> dict[str, StoredCredential]:
         if not self.path.exists():
             return {}
         raw = loads(self.path.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise CredentialStoreError("Tau credentials must be a JSON object")
-        credentials: dict[str, str] = {}
+        credentials: dict[str, StoredCredential] = {}
         for key, value in raw.items():
-            if not isinstance(key, str) or not isinstance(value, str):
-                raise CredentialStoreError("Tau credential names and values must be strings")
-            credentials[key] = value
+            if not isinstance(key, str):
+                raise CredentialStoreError("Tau credential names must be strings")
+            credentials[key] = _credential_from_json(value)
         return credentials
 
-    def _save(self, data: dict[str, str]) -> None:
+    def _save(self, data: dict[str, StoredCredential]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        raw = {key: _credential_to_json(value) for key, value in data.items()}
+        self.path.write_text(dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         self.path.chmod(0o600)
 
 
 def credentials_path(paths: TauPaths | None = None) -> Path:
     """Return Tau's local provider credential path."""
     return (paths or TauPaths()).home / "credentials.json"
+
+
+def _validate_credential_name(name: str) -> str:
+    normalized = name.strip()
+    if not normalized:
+        raise CredentialStoreError("Credential name must not be empty")
+    return normalized
+
+
+def _validate_oauth_credential(credential: OAuthCredential) -> None:
+    if not credential.access.strip():
+        raise CredentialStoreError("OAuth access token must not be empty")
+    if not credential.refresh.strip():
+        raise CredentialStoreError("OAuth refresh token must not be empty")
+    if not credential.account_id.strip():
+        raise CredentialStoreError("OAuth account id must not be empty")
+    if credential.expires <= 0:
+        raise CredentialStoreError("OAuth expiry must be greater than 0")
+
+
+def _credential_from_json(value: object) -> StoredCredential:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        raise CredentialStoreError("Tau credential values must be strings or objects")
+
+    credential_type = value.get("type")
+    if credential_type not in {"api_key", "oauth"}:
+        raise CredentialStoreError("Tau credential object type must be api_key or oauth")
+    if credential_type == "api_key":
+        key = _string_field(value, "key", credential_type)
+        return ApiKeyCredential(key=key)
+
+    expires = value.get("expires")
+    if not isinstance(expires, int) or isinstance(expires, bool) or expires <= 0:
+        raise CredentialStoreError("Tau oauth credential expires must be a positive integer")
+    return OAuthCredential(
+        access=_string_field(value, "access", credential_type),
+        refresh=_string_field(value, "refresh", credential_type),
+        expires=expires,
+        account_id=_string_field(value, "account_id", credential_type),
+    )
+
+
+def _credential_to_json(value: StoredCredential) -> str | dict[str, str | int]:
+    if isinstance(value, str):
+        return value
+    return value.to_json()
+
+
+def _string_field(
+    value: dict[Any, Any],
+    field_name: str,
+    credential_type: StoredCredentialKind,
+) -> str:
+    field = value.get(field_name)
+    if not isinstance(field, str) or not field.strip():
+        raise CredentialStoreError(
+            f"Tau {credential_type} credential field must be a non-empty string: {field_name}"
+        )
+    return field.strip()

--- a/src/tau_coding/oauth.py
+++ b/src/tau_coding/oauth.py
@@ -240,7 +240,7 @@ async def exchange_openai_codex_authorization_code(
     client: httpx.AsyncClient | None = None,
 ) -> TokenResponse:
     """Exchange an OpenAI Codex authorization code for OAuth tokens."""
-    return await _post_openai_codex_token(
+    raw = await _post_openai_codex_token(
         {
             "grant_type": "authorization_code",
             "client_id": OPENAI_CODEX_CLIENT_ID,
@@ -251,6 +251,13 @@ async def exchange_openai_codex_authorization_code(
         client=client,
         action="exchange",
     )
+    access_token = _required_token_field(raw, "access_token", action="exchange")
+    refresh_token = _required_token_field(raw, "refresh_token", action="exchange")
+    return TokenResponse(
+        access=access_token,
+        refresh=refresh_token,
+        expires=_token_expiry(raw, access_token, action="exchange"),
+    )
 
 
 async def refresh_openai_codex_token(
@@ -259,7 +266,7 @@ async def refresh_openai_codex_token(
     client: httpx.AsyncClient | None = None,
 ) -> OAuthCredential:
     """Refresh OpenAI Codex OAuth credentials."""
-    token = await _post_openai_codex_token(
+    raw = await _post_openai_codex_token(
         {
             "grant_type": "refresh_token",
             "client_id": OPENAI_CODEX_CLIENT_ID,
@@ -268,27 +275,23 @@ async def refresh_openai_codex_token(
         client=client,
         action="refresh",
     )
-    account_id = account_id_from_access_token(token.access)
+    access_token = _required_token_field(raw, "access_token", action="refresh")
+    next_refresh_token = _optional_token_field(raw, "refresh_token") or refresh_token
+    account_id = account_id_from_access_token(access_token)
     if account_id is None:
         raise OAuthError("Failed to extract OpenAI account id from refreshed access token")
     return OAuthCredential(
-        access=token.access,
-        refresh=token.refresh,
-        expires=token.expires,
+        access=access_token,
+        refresh=next_refresh_token,
+        expires=_token_expiry(raw, access_token, action="refresh"),
         account_id=account_id,
     )
 
 
 def account_id_from_access_token(access_token: str) -> str | None:
     """Extract the ChatGPT account id from an OpenAI Codex access JWT."""
-    try:
-        parts = access_token.split(".")
-        if len(parts) != 3:
-            return None
-        payload = loads(_base64url_decode(parts[1]).decode("utf-8"))
-    except Exception:
-        return None
-    if not isinstance(payload, dict):
+    payload = _access_token_payload(access_token)
+    if payload is None:
         return None
     auth = payload.get(OPENAI_CODEX_ACCOUNT_CLAIM)
     if not isinstance(auth, dict):
@@ -299,12 +302,35 @@ def account_id_from_access_token(access_token: str) -> str | None:
     return account_id.strip()
 
 
+def _access_token_expiry(access_token: str) -> int | None:
+    payload = _access_token_payload(access_token)
+    if payload is None:
+        return None
+    exp = payload.get("exp")
+    if isinstance(exp, int | float) and not isinstance(exp, bool) and exp > 0:
+        return int(exp * 1000)
+    return None
+
+
+def _access_token_payload(access_token: str) -> dict[str, Any] | None:
+    try:
+        parts = access_token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = loads(_base64url_decode(parts[1]).decode("utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 async def _post_openai_codex_token(
     data: dict[str, str],
     *,
     client: httpx.AsyncClient | None,
     action: str,
-) -> TokenResponse:
+) -> dict[str, Any]:
     owns_client = client is None
     active_client = client or httpx.AsyncClient(timeout=60)
     try:
@@ -325,24 +351,39 @@ async def _post_openai_codex_token(
     raw = response.json()
     if not isinstance(raw, dict):
         raise OAuthError(f"OpenAI Codex token {action} response must be a JSON object")
-    access_token = raw.get("access_token")
-    refresh_token = raw.get("refresh_token")
-    expires_in = raw.get("expires_in")
-    if (
-        not isinstance(access_token, str)
-        or not access_token
-        or not isinstance(refresh_token, str)
-        or not refresh_token
-        or not isinstance(expires_in, int | float)
-        or isinstance(expires_in, bool)
-    ):
+    return raw
+
+
+def _required_token_field(raw: dict[str, Any], field: str, *, action: str) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value:
         raise OAuthError(
-            f"OpenAI Codex token {action} response missing fields: {dumps(raw, sort_keys=True)}"
+            f"OpenAI Codex token {action} response missing {field}: {dumps(raw, sort_keys=True)}"
         )
-    return TokenResponse(
-        access=access_token,
-        refresh=refresh_token,
-        expires=int(time.time() * 1000) + int(expires_in * 1000),
+    return value
+
+
+def _optional_token_field(raw: dict[str, Any], field: str) -> str | None:
+    value = raw.get(field)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _token_expiry(raw: dict[str, Any], access_token: str, *, action: str) -> int:
+    expires_in = raw.get("expires_in")
+    if isinstance(expires_in, int | float) and not isinstance(expires_in, bool):
+        return int(time.time() * 1000) + int(expires_in * 1000)
+    if expires_in is not None:
+        raise OAuthError(
+            f"OpenAI Codex token {action} response has invalid expires_in: "
+            f"{dumps(raw, sort_keys=True)}"
+        )
+    expires = _access_token_expiry(access_token)
+    if expires is not None:
+        return expires
+    raise OAuthError(
+        f"OpenAI Codex token {action} response missing expiry: {dumps(raw, sort_keys=True)}"
     )
 
 

--- a/src/tau_coding/oauth.py
+++ b/src/tau_coding/oauth.py
@@ -1,0 +1,460 @@
+"""OAuth helpers for subscription-backed coding providers."""
+
+import asyncio
+import base64
+import hashlib
+import secrets
+import threading
+import time
+import webbrowser
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from json import dumps, loads
+from os import environ
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from tau_coding.credentials import OAuthCredential
+
+OPENAI_CODEX_OAUTH_PROVIDER = "openai-codex"
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+OPENAI_CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+OPENAI_CODEX_REDIRECT_URI = "http://localhost:1455/auth/callback"
+OPENAI_CODEX_SCOPE = "openid profile email offline_access"
+OPENAI_CODEX_ACCOUNT_CLAIM = "https://api.openai.com/auth"
+OPENAI_CODEX_CALLBACK_PORT = 1455
+TOKEN_REFRESH_SKEW_MS = 60_000
+
+type AuthCallback = Callable[["OAuthAuthInfo"], None]
+type PromptCallback = Callable[["OAuthPrompt"], Awaitable[str]]
+type ManualCodeCallback = Callable[[], Awaitable[str]]
+type ProgressCallback = Callable[[str], None]
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthAuthInfo:
+    """Authorization URL and optional user instructions."""
+
+    url: str
+    instructions: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthPrompt:
+    """Text prompt used for manual OAuth fallback input."""
+
+    message: str
+    placeholder: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationCode:
+    """Parsed OAuth authorization callback data."""
+
+    code: str | None = None
+    state: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationFlow:
+    """OpenAI Codex OAuth authorization flow state."""
+
+    verifier: str
+    state: str
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class TokenResponse:
+    """Successful OAuth token response."""
+
+    access: str
+    refresh: str
+    expires: int
+
+
+class OAuthError(RuntimeError):
+    """Raised when an OAuth flow cannot complete."""
+
+
+class _LocalOAuthServer:
+    def __init__(
+        self,
+        server: ThreadingHTTPServer,
+        thread: threading.Thread,
+        future: asyncio.Future[str | None],
+    ) -> None:
+        self._server = server
+        self._thread = thread
+        self._future = future
+
+    async def wait_for_code(self) -> str | None:
+        """Wait for the local callback server to receive a code."""
+        return await self._future
+
+    def cancel_wait(self) -> None:
+        """Resolve the pending wait without an authorization code."""
+        if not self._future.done():
+            self._future.set_result(None)
+
+    def close(self) -> None:
+        """Stop the local callback server."""
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=1)
+
+
+def create_pkce_pair() -> tuple[str, str]:
+    """Return a PKCE verifier and S256 challenge."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = _base64url(digest)
+    return verifier, challenge
+
+
+def create_openai_codex_authorization_flow(
+    *,
+    originator: str = "tau",
+) -> AuthorizationFlow:
+    """Create an OpenAI Codex OAuth authorization URL."""
+    verifier, challenge = create_pkce_pair()
+    state = secrets.token_hex(16)
+    params = {
+        "response_type": "code",
+        "client_id": OPENAI_CODEX_CLIENT_ID,
+        "redirect_uri": OPENAI_CODEX_REDIRECT_URI,
+        "scope": OPENAI_CODEX_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "originator": originator,
+    }
+    return AuthorizationFlow(
+        verifier=verifier,
+        state=state,
+        url=f"{OPENAI_CODEX_AUTHORIZE_URL}?{urlencode(params)}",
+    )
+
+
+def parse_authorization_input(value: str) -> AuthorizationCode:
+    """Parse a pasted redirect URL, query string, code#state pair, or raw code."""
+    stripped = value.strip()
+    if not stripped:
+        return AuthorizationCode()
+
+    parsed_url = urlparse(stripped)
+    if parsed_url.scheme and parsed_url.netloc:
+        params = parse_qs(parsed_url.query)
+        return AuthorizationCode(
+            code=_first_query_value(params, "code"),
+            state=_first_query_value(params, "state"),
+        )
+
+    if "#" in stripped:
+        code, state = stripped.split("#", 1)
+        return AuthorizationCode(code=code or None, state=state or None)
+
+    if "code=" in stripped:
+        params = parse_qs(stripped)
+        return AuthorizationCode(
+            code=_first_query_value(params, "code"),
+            state=_first_query_value(params, "state"),
+        )
+
+    return AuthorizationCode(code=stripped)
+
+
+def oauth_credential_is_expired(credential: OAuthCredential) -> bool:
+    """Return whether an OAuth credential should be refreshed before use."""
+    return int(time.time() * 1000) >= credential.expires - TOKEN_REFRESH_SKEW_MS
+
+
+async def login_openai_codex(
+    *,
+    on_auth: AuthCallback,
+    on_prompt: PromptCallback,
+    on_manual_code_input: ManualCodeCallback | None = None,
+    on_progress: ProgressCallback | None = None,
+    open_browser: bool = True,
+    originator: str = "tau",
+    client: httpx.AsyncClient | None = None,
+) -> OAuthCredential:
+    """Run OpenAI Codex OAuth and return refreshable credentials."""
+    flow = create_openai_codex_authorization_flow(originator=originator)
+    server = await _start_local_oauth_server(flow.state)
+
+    on_auth(
+        OAuthAuthInfo(
+            url=flow.url,
+            instructions="A browser window should open. Complete login to finish.",
+        )
+    )
+    if open_browser:
+        webbrowser.open(flow.url)
+
+    try:
+        code = await _wait_for_authorization_code(
+            flow=flow,
+            server=server,
+            on_manual_code_input=on_manual_code_input,
+        )
+        if code is None:
+            manual_input = await on_prompt(
+                OAuthPrompt(message="Paste the authorization code or full redirect URL:")
+            )
+            parsed = parse_authorization_input(manual_input)
+            _validate_state(parsed.state, flow.state)
+            code = parsed.code
+        if not code:
+            raise OAuthError("Missing authorization code")
+        on_progress and on_progress("Exchanging authorization code...")
+        token = await exchange_openai_codex_authorization_code(
+            code,
+            flow.verifier,
+            client=client,
+        )
+        account_id = account_id_from_access_token(token.access)
+        if account_id is None:
+            raise OAuthError("Failed to extract OpenAI account id from access token")
+        return OAuthCredential(
+            access=token.access,
+            refresh=token.refresh,
+            expires=token.expires,
+            account_id=account_id,
+        )
+    finally:
+        if server is not None:
+            server.close()
+
+
+async def exchange_openai_codex_authorization_code(
+    code: str,
+    verifier: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> TokenResponse:
+    """Exchange an OpenAI Codex authorization code for OAuth tokens."""
+    return await _post_openai_codex_token(
+        {
+            "grant_type": "authorization_code",
+            "client_id": OPENAI_CODEX_CLIENT_ID,
+            "code": code,
+            "code_verifier": verifier,
+            "redirect_uri": OPENAI_CODEX_REDIRECT_URI,
+        },
+        client=client,
+        action="exchange",
+    )
+
+
+async def refresh_openai_codex_token(
+    refresh_token: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> OAuthCredential:
+    """Refresh OpenAI Codex OAuth credentials."""
+    token = await _post_openai_codex_token(
+        {
+            "grant_type": "refresh_token",
+            "client_id": OPENAI_CODEX_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        client=client,
+        action="refresh",
+    )
+    account_id = account_id_from_access_token(token.access)
+    if account_id is None:
+        raise OAuthError("Failed to extract OpenAI account id from refreshed access token")
+    return OAuthCredential(
+        access=token.access,
+        refresh=token.refresh,
+        expires=token.expires,
+        account_id=account_id,
+    )
+
+
+def account_id_from_access_token(access_token: str) -> str | None:
+    """Extract the ChatGPT account id from an OpenAI Codex access JWT."""
+    try:
+        parts = access_token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = loads(_base64url_decode(parts[1]).decode("utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    auth = payload.get(OPENAI_CODEX_ACCOUNT_CLAIM)
+    if not isinstance(auth, dict):
+        return None
+    account_id = auth.get("chatgpt_account_id")
+    if not isinstance(account_id, str) or not account_id.strip():
+        return None
+    return account_id.strip()
+
+
+async def _post_openai_codex_token(
+    data: dict[str, str],
+    *,
+    client: httpx.AsyncClient | None,
+    action: str,
+) -> TokenResponse:
+    owns_client = client is None
+    active_client = client or httpx.AsyncClient(timeout=60)
+    try:
+        response = await active_client.post(
+            OPENAI_CODEX_TOKEN_URL,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    finally:
+        if owns_client:
+            await active_client.aclose()
+
+    if response.status_code >= 400:
+        raise OAuthError(
+            f"OpenAI Codex token {action} failed ({response.status_code}): {response.text}"
+        )
+
+    raw = response.json()
+    if not isinstance(raw, dict):
+        raise OAuthError(f"OpenAI Codex token {action} response must be a JSON object")
+    access_token = raw.get("access_token")
+    refresh_token = raw.get("refresh_token")
+    expires_in = raw.get("expires_in")
+    if (
+        not isinstance(access_token, str)
+        or not access_token
+        or not isinstance(refresh_token, str)
+        or not refresh_token
+        or not isinstance(expires_in, int | float)
+        or isinstance(expires_in, bool)
+    ):
+        raise OAuthError(
+            f"OpenAI Codex token {action} response missing fields: {dumps(raw, sort_keys=True)}"
+        )
+    return TokenResponse(
+        access=access_token,
+        refresh=refresh_token,
+        expires=int(time.time() * 1000) + int(expires_in * 1000),
+    )
+
+
+async def _wait_for_authorization_code(
+    *,
+    flow: AuthorizationFlow,
+    server: _LocalOAuthServer | None,
+    on_manual_code_input: ManualCodeCallback | None,
+) -> str | None:
+    tasks: list[asyncio.Task[str | None]] = []
+    if server is not None:
+        tasks.append(asyncio.create_task(server.wait_for_code()))
+    if on_manual_code_input is not None:
+        tasks.append(asyncio.create_task(_await_manual_code(on_manual_code_input)))
+    if not tasks:
+        return None
+
+    try:
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+        result = next(iter(done)).result()
+    finally:
+        if server is not None:
+            server.cancel_wait()
+
+    if result is None:
+        return None
+    parsed = parse_authorization_input(result)
+    _validate_state(parsed.state, flow.state)
+    return parsed.code
+
+
+async def _await_manual_code(callback: ManualCodeCallback) -> str | None:
+    return await callback()
+
+
+def _validate_state(state: str | None, expected_state: str) -> None:
+    if state is not None and state != expected_state:
+        raise OAuthError("OAuth state mismatch")
+
+
+async def _start_local_oauth_server(state: str) -> _LocalOAuthServer | None:
+    host = environ.get("TAU_OAUTH_CALLBACK_HOST", "127.0.0.1")
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str | None] = loop.create_future()
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            try:
+                parsed = urlparse(self.path)
+                if parsed.path != "/auth/callback":
+                    self._finish(404, _oauth_html("Callback route not found."))
+                    return
+                params = parse_qs(parsed.query)
+                if _first_query_value(params, "state") != state:
+                    self._finish(400, _oauth_html("OAuth state mismatch."))
+                    return
+                code = _first_query_value(params, "code")
+                if not code:
+                    self._finish(400, _oauth_html("Missing authorization code."))
+                    return
+                self._finish(
+                    200,
+                    _oauth_html("OpenAI authentication completed. You can close this window."),
+                )
+                if not future.done():
+                    loop.call_soon_threadsafe(future.set_result, code)
+            except Exception:
+                self._finish(500, _oauth_html("Internal error while processing OAuth callback."))
+
+        def log_message(self, _format: str, *_args: Any) -> None:
+            return
+
+        def _finish(self, status: int, body: str) -> None:
+            encoded = body.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    try:
+        server = ThreadingHTTPServer((host, OPENAI_CODEX_CALLBACK_PORT), CallbackHandler)
+    except OSError:
+        return None
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return _LocalOAuthServer(server, thread, future)
+
+
+def _first_query_value(params: dict[str, list[str]], key: str) -> str | None:
+    values = params.get(key)
+    if not values:
+        return None
+    return values[0] or None
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _oauth_html(message: str) -> str:
+    escaped = (
+        message.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+    return f'<!doctype html><meta charset="utf-8"><title>Tau OAuth</title><p>{escaped}</p>'

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Literal
 
-ProviderKind = Literal["openai-compatible", "anthropic"]
+ProviderKind = Literal["openai-compatible", "anthropic", "openai-codex"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +44,24 @@ BUILTIN_PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
         ),
         default_model="gpt-5.5",
         docs_url="https://platform.openai.com/docs",
+    ),
+    ProviderCatalogEntry(
+        name="openai-codex",
+        display_name="OpenAI Codex subscription",
+        kind="openai-codex",
+        base_url="https://chatgpt.com/backend-api",
+        api_key_env="OPENAI_CODEX_ACCESS_TOKEN",
+        credential_name="openai-codex",
+        models=(
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex",
+            "gpt-5.3-codex-spark",
+            "gpt-5.2",
+        ),
+        default_model="gpt-5.5",
+        docs_url="https://chatgpt.com/codex",
     ),
     ProviderCatalogEntry(
         name="anthropic",

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 
 from tau_ai import (
     DEFAULT_ANTHROPIC_BASE_URL,
+    DEFAULT_OPENAI_CODEX_BASE_URL,
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES,
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS,
     DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
@@ -110,7 +111,55 @@ class AnthropicProviderConfig:
         }
 
 
-type ProviderConfig = OpenAICompatibleProviderConfig | AnthropicProviderConfig
+@dataclass(frozen=True, slots=True)
+class OpenAICodexProviderConfig:
+    """Durable settings for OpenAI Codex subscription OAuth."""
+
+    name: str = "openai-codex"
+    base_url: str = DEFAULT_OPENAI_CODEX_BASE_URL
+    api_key_env: str = "OPENAI_CODEX_ACCESS_TOKEN"
+    credential_name: str | None = "openai-codex"
+    models: tuple[str, ...] = (
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+    )
+    default_model: str = "gpt-5.5"
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
+    max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
+    max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
+
+    def __post_init__(self) -> None:
+        _validate_provider_numbers(
+            timeout_seconds=self.timeout_seconds,
+            max_retries=self.max_retries,
+            max_retry_delay_seconds=self.max_retry_delay_seconds,
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        """Serialize this provider config to JSON-compatible data."""
+        return {
+            "name": self.name,
+            "type": "openai-codex",
+            "base_url": self.base_url,
+            "api_key_env": self.api_key_env,
+            "credential_name": self.credential_name,
+            "models": list(self.models),
+            "default_model": self.default_model,
+            "headers": dict(self.headers),
+            "timeout_seconds": self.timeout_seconds,
+            "max_retries": self.max_retries,
+            "max_retry_delay_seconds": self.max_retry_delay_seconds,
+        }
+
+
+type ProviderConfig = (
+    OpenAICompatibleProviderConfig | AnthropicProviderConfig | OpenAICodexProviderConfig
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,8 +198,7 @@ class ProviderSelection:
 def builtin_provider_configs() -> tuple[ProviderConfig, ...]:
     """Return Tau's built-in provider configs."""
     return tuple(
-        provider_config_from_catalog_entry(entry.name)
-        for entry in BUILTIN_PROVIDER_CATALOG
+        provider_config_from_catalog_entry(entry.name) for entry in BUILTIN_PROVIDER_CATALOG
     )
 
 
@@ -161,6 +209,15 @@ def provider_config_from_catalog_entry(name: str) -> ProviderConfig:
             continue
         if entry.kind == "anthropic":
             return AnthropicProviderConfig(
+                name=entry.name,
+                base_url=entry.base_url,
+                api_key_env=entry.api_key_env,
+                credential_name=entry.credential_name,
+                models=entry.models,
+                default_model=entry.default_model,
+            )
+        if entry.kind == "openai-codex":
+            return OpenAICodexProviderConfig(
                 name=entry.name,
                 base_url=entry.base_url,
                 api_key_env=entry.api_key_env,
@@ -203,9 +260,7 @@ def load_provider_settings(paths: TauPaths | None = None) -> ProviderSettings:
     return _with_builtin_catalog_models(provider_settings_from_json(raw))
 
 
-def save_provider_settings(
-    settings: ProviderSettings, paths: TauPaths | None = None
-) -> Path:
+def save_provider_settings(settings: ProviderSettings, paths: TauPaths | None = None) -> Path:
     """Write durable provider settings and return the path."""
     path = provider_settings_path(paths)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -346,6 +401,8 @@ def provider_kind(provider: ProviderConfig) -> ProviderKind:
     """Return the durable provider kind."""
     if isinstance(provider, AnthropicProviderConfig):
         return "anthropic"
+    if isinstance(provider, OpenAICodexProviderConfig):
+        return "openai-codex"
     return "openai-compatible"
 
 
@@ -353,7 +410,7 @@ def _provider_from_json(data: object) -> ProviderConfig:
     if not isinstance(data, dict):
         raise ProviderConfigError("Provider entries must be JSON objects")
     provider_type = _string(data.get("type"), "providers[].type")
-    if provider_type not in {"openai-compatible", "anthropic"}:
+    if provider_type not in {"openai-compatible", "anthropic", "openai-codex"}:
         raise ProviderConfigError(f"Unsupported provider type: {provider_type}")
     name = _string(data.get("name"), "providers[].name")
     base_url = _string(data.get("base_url"), f"providers[{name}].base_url").rstrip("/")
@@ -394,6 +451,19 @@ def _provider_from_json(data: object) -> ProviderConfig:
             max_retries=max_retries,
             max_retry_delay_seconds=max_retry_delay_seconds,
         )
+    if provider_type == "openai-codex":
+        return OpenAICodexProviderConfig(
+            name=name,
+            base_url=base_url,
+            api_key_env=api_key_env,
+            credential_name=credential_name,
+            models=models,
+            default_model=default_model,
+            headers=headers,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+            max_retry_delay_seconds=max_retry_delay_seconds,
+        )
     return OpenAICompatibleProviderConfig(
         name=name,
         base_url=base_url,
@@ -423,9 +493,7 @@ def _api_key_from_provider(
     if api_key:
         return api_key
     credential_hint = f" or run /login {provider.name}" if provider.credential_name else ""
-    raise RuntimeError(
-        f"Missing provider API key. Set {provider.api_key_env}{credential_hint}."
-    )
+    raise RuntimeError(f"Missing provider API key. Set {provider.api_key_env}{credential_hint}.")
 
 
 def _validate_provider_numbers(

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -1,11 +1,25 @@
 """Runtime provider construction for Tau coding sessions."""
 
+from os import environ
 from typing import Protocol
 
-from tau_ai import AnthropicProvider, ModelProvider, OpenAICompatibleProvider
-from tau_coding.credentials import FileCredentialStore
+from tau_ai import (
+    AnthropicProvider,
+    ModelProvider,
+    OpenAICodexConfig,
+    OpenAICodexCredentials,
+    OpenAICodexProvider,
+    OpenAICompatibleProvider,
+)
+from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.oauth import (
+    account_id_from_access_token,
+    oauth_credential_is_expired,
+    refresh_openai_codex_token,
+)
 from tau_coding.provider_config import (
     AnthropicProviderConfig,
+    OpenAICodexProviderConfig,
     ProviderConfig,
     anthropic_config_from_provider,
     openai_compatible_config_from_provider,
@@ -31,6 +45,68 @@ def create_model_provider(
         return AnthropicProvider(
             anthropic_config_from_provider(provider, credential_reader=credentials)
         )
+    if isinstance(provider, OpenAICodexProviderConfig):
+        return OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=OpenAICodexCredentialResolver(
+                    provider,
+                    credential_store=credentials,
+                ),
+                base_url=provider.base_url,
+                headers=provider.headers,
+                timeout_seconds=provider.timeout_seconds,
+                max_retries=provider.max_retries,
+                max_retry_delay_seconds=provider.max_retry_delay_seconds,
+            )
+        )
     return OpenAICompatibleProvider(
         openai_compatible_config_from_provider(provider, credential_reader=credentials)
     )
+
+
+class OpenAICodexCredentialResolver:
+    """Resolve and refresh OpenAI Codex OAuth credentials for one request."""
+
+    def __init__(
+        self,
+        provider: OpenAICodexProviderConfig,
+        *,
+        credential_store: FileCredentialStore,
+    ) -> None:
+        self._provider = provider
+        self._credential_store = credential_store
+
+    async def __call__(self) -> OpenAICodexCredentials:
+        """Return a valid Codex access token and account id."""
+        credential_name = self._provider.credential_name
+        if credential_name:
+            credential = self._credential_store.get_oauth(credential_name)
+            if credential is not None:
+                credential = await self._refresh_if_needed(credential_name, credential)
+                return OpenAICodexCredentials(
+                    access_token=credential.access,
+                    account_id=credential.account_id,
+                )
+
+        access_token = environ.get(self._provider.api_key_env)
+        if access_token:
+            account_id = account_id_from_access_token(access_token)
+            if account_id is None:
+                raise RuntimeError(
+                    f"{self._provider.api_key_env} must contain an OpenAI Codex access JWT"
+                )
+            return OpenAICodexCredentials(access_token=access_token, account_id=account_id)
+
+        credential_hint = f"Run /login {self._provider.name}."
+        raise RuntimeError(f"Missing OpenAI Codex OAuth credentials. {credential_hint}")
+
+    async def _refresh_if_needed(
+        self,
+        credential_name: str,
+        credential: OAuthCredential,
+    ) -> OAuthCredential:
+        if not oauth_credential_is_expired(credential):
+            return credential
+        refreshed = await refresh_openai_codex_token(credential.refresh)
+        self._credential_store.set_oauth(credential_name, refreshed)
+        return refreshed

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1,5 +1,6 @@
 """Minimal Textual app for Tau coding sessions."""
 
+import asyncio
 from collections.abc import AsyncIterator, Sequence
 from inspect import isawaitable
 from pathlib import Path
@@ -18,7 +19,8 @@ from tau_agent.tools import AgentTool
 from tau_ai import ProviderErrorEvent, ProviderEvent
 from tau_ai.provider import CancellationToken
 from tau_coding.commands import CommandRegistry, create_default_command_registry
-from tau_coding.credentials import FileCredentialStore
+from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.oauth import OAuthAuthInfo, OAuthPrompt, login_openai_codex
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ProviderCatalogEntry,
@@ -406,9 +408,7 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
         )
         self._reset_model_list_index()
         help_text = (
-            "No matching models"
-            if not self.visible_choices
-            else "Enter selects - Escape closes"
+            "No matching models" if not self.visible_choices else "Enter selects - Escape closes"
         )
         self.query_one("#model-picker-help", Static).update(help_text)
 
@@ -500,6 +500,87 @@ class LoginScreen(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         """Close without saving."""
+        self.dismiss(None)
+
+
+class OAuthLoginScreen(ModalScreen[OAuthCredential | None]):
+    """OAuth login flow for providers backed by subscription auth."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, provider: ProviderCatalogEntry, *, theme: TuiTheme) -> None:
+        super().__init__()
+        self.provider = provider
+        self.theme = theme
+        self._manual_code_future: asyncio.Future[str] | None = None
+        self._manual_code_value: str | None = None
+
+    def compose(self) -> ComposeResult:
+        """Compose the OAuth login prompt."""
+        with Vertical(id="login-screen"):
+            yield Static(f"Login: {self.provider.display_name}", id="login-title")
+            yield Static("Complete the browser login, or paste the redirect URL.", id="login-help")
+            yield Static("", id="login-oauth-url")
+            yield Input(
+                placeholder="Paste redirect URL or authorization code",
+                id="login-oauth-code",
+            )
+            yield Static("Enter submits - Escape closes", id="login-footer")
+
+    def on_mount(self) -> None:
+        """Focus the manual-code field and start OAuth."""
+        self.query_one("#login-oauth-code", Input).focus()
+        self.run_worker(self._run_login(), exclusive=True)
+
+    async def _run_login(self) -> None:
+        try:
+            credential = await login_openai_codex(
+                on_auth=self._show_auth,
+                on_prompt=self._prompt_for_code,
+                on_manual_code_input=self._manual_code_input,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface OAuth failures in the TUI
+            self.query_one("#login-help", Static).update(f"OAuth failed: {exc}")
+            return
+        self.dismiss(credential)
+
+    def _show_auth(self, info: OAuthAuthInfo) -> None:
+        self.query_one("#login-oauth-url", Static).update(info.url)
+        if info.instructions:
+            self.query_one("#login-help", Static).update(info.instructions)
+
+    async def _prompt_for_code(self, prompt: OAuthPrompt) -> str:
+        self.query_one("#login-help", Static).update(prompt.message)
+        return await self._manual_code_input()
+
+    async def _manual_code_input(self) -> str:
+        if self._manual_code_value is not None:
+            return self._manual_code_value
+        loop = asyncio.get_running_loop()
+        self._manual_code_future = loop.create_future()
+        try:
+            return await self._manual_code_future
+        finally:
+            self._manual_code_future = None
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Resolve the manual OAuth code fallback."""
+        if event.input.id != "login-oauth-code":
+            return
+        event.stop()
+        value = event.value.strip()
+        if not value:
+            return
+        self._manual_code_value = value
+        if self._manual_code_future is not None and not self._manual_code_future.done():
+            self._manual_code_future.set_result(value)
+
+    def action_cancel(self) -> None:
+        """Close without saving OAuth credentials."""
+        if self._manual_code_future is not None and not self._manual_code_future.done():
+            self._manual_code_future.cancel()
         self.dismiss(None)
 
 
@@ -710,7 +791,8 @@ class TauTuiApp(App[None]):
         color: $tau-muted-text;
     }
 
-    LoginScreen {
+    LoginScreen,
+    OAuthLoginScreen {
         align: center middle;
     }
 
@@ -736,10 +818,18 @@ class TauTuiApp(App[None]):
         margin-bottom: 1;
     }
 
-    #login-api-key {
+    #login-api-key,
+    #login-oauth-code {
         background: $tau-prompt-background;
         color: $tau-prompt-text;
         border: tall $tau-prompt-border;
+        margin-bottom: 1;
+    }
+
+    #login-oauth-url {
+        min-height: 1;
+        max-height: 4;
+        color: $tau-chrome-text;
         margin-bottom: 1;
     }
 
@@ -1032,6 +1122,12 @@ class TauTuiApp(App[None]):
         if entry is None:
             self._notify(f"Unknown provider: {provider_name}", severity="error")
             return
+        if entry.kind == "openai-codex":
+            self.push_screen(
+                OAuthLoginScreen(entry, theme=self.tui_settings.resolved_theme),
+                callback=lambda credential: self._handle_oauth_login_result(entry, credential),
+            )
+            return
         self.push_screen(
             LoginScreen(entry, theme=self.tui_settings.resolved_theme),
             callback=lambda api_key: self._handle_login_result(entry, api_key),
@@ -1042,6 +1138,26 @@ class TauTuiApp(App[None]):
             return
         try:
             FileCredentialStore().set(entry.credential_name, api_key)
+            settings = load_provider_settings()
+            provider = provider_config_from_catalog_entry(entry.name)
+            save_provider_settings(upsert_provider(settings, provider, set_default=True))
+            self.session.reload()
+            self.session.set_provider(entry.name)
+        except Exception as exc:  # noqa: BLE001 - surface login failures in the TUI
+            self._notify(f"Could not save login: {exc}", severity="error")
+            return
+        self._notify(f"Saved login for {entry.display_name}.")
+        self._refresh()
+
+    def _handle_oauth_login_result(
+        self,
+        entry: ProviderCatalogEntry,
+        credential: OAuthCredential | None,
+    ) -> None:
+        if credential is None:
+            return
+        try:
+            FileCredentialStore().set_oauth(entry.credential_name, credential)
             settings = load_provider_settings()
             provider = provider_config_from_catalog_entry(entry.name)
             save_provider_settings(upsert_provider(settings, provider, set_default=True))
@@ -1212,18 +1328,16 @@ def _login_provider_label(provider: ProviderCatalogEntry) -> str:
     return f"{provider.display_name}\n  {provider.name}"
 
 
-def _model_picker_label(
-    choice: ModelChoice, *, current_model: str, current_provider: str
-) -> str:
-    marker = "* " if (
-        choice.provider_name == current_provider and choice.model == current_model
-    ) else "  "
+def _model_picker_label(choice: ModelChoice, *, current_model: str, current_provider: str) -> str:
+    marker = (
+        "* "
+        if (choice.provider_name == current_provider and choice.model == current_model)
+        else "  "
+    )
     return f"{marker}{choice.provider_name}:{choice.model}"
 
 
-def _filter_model_choices(
-    choices: Sequence[ModelChoice], query: str
-) -> tuple[ModelChoice, ...]:
+def _filter_model_choices(choices: Sequence[ModelChoice], query: str) -> tuple[ModelChoice, ...]:
     normalized = query.strip().lower()
     if not normalized:
         return tuple(choices)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,9 +32,7 @@ def test_version_command() -> None:
 def test_cli_without_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[
-        tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]
-    ] = []
+    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -69,9 +67,7 @@ def test_cli_without_prompt_invokes_tui_runner(
 def test_cli_positional_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[
-        tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]
-    ] = []
+    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -330,9 +326,7 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
 def test_default_tui_invokes_tui_runner_with_flags(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[
-        tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]
-    ] = []
+    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -523,6 +517,7 @@ def test_providers_command_lists_default_provider(
 
     assert result.exit_code == 0
     assert "*\topenai\topenai-compatible\tgpt-5.5" in result.stdout
+    assert " \topenai-codex\topenai-codex\tgpt-5.5" in result.stdout
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
     assert " \topenrouter\topenai-compatible\topenai/gpt-5.5" in result.stdout
     assert " \thuggingface\topenai-compatible\topenai/gpt-oss-120b" in result.stdout

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2,7 +2,7 @@ from stat import S_IMODE
 
 import pytest
 
-from tau_coding.credentials import CredentialStoreError, FileCredentialStore
+from tau_coding.credentials import CredentialStoreError, FileCredentialStore, OAuthCredential
 
 
 def test_file_credential_store_round_trips_and_sets_private_permissions(tmp_path) -> None:
@@ -29,3 +29,20 @@ def test_file_credential_store_rejects_empty_values(tmp_path) -> None:
 
     with pytest.raises(CredentialStoreError, match="must not be empty"):
         store.set("openai", "")
+
+
+def test_file_credential_store_round_trips_oauth_credentials(tmp_path) -> None:
+    path = tmp_path / "credentials.json"
+    store = FileCredentialStore(path)
+    credential = OAuthCredential(
+        access="access-token",
+        refresh="refresh-token",
+        expires=123456,
+        account_id="account-1",
+    )
+
+    store.set_oauth("openai-codex", credential)
+
+    assert store.get("openai-codex") is None
+    assert store.get_oauth("openai-codex") == credential
+    assert '"type": "oauth"' in path.read_text(encoding="utf-8")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,5 +1,6 @@
 import base64
 from json import dumps
+from time import time
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -73,8 +74,29 @@ async def test_refresh_openai_codex_token_returns_oauth_credential() -> None:
     assert credential.expires > 0
 
 
-def _jwt(account_id: str) -> str:
+@pytest.mark.anyio
+async def test_refresh_openai_codex_token_preserves_refresh_and_reads_jwt_expiry() -> None:
+    expires = int(time()) + 3600
+    access_token = _jwt("account-3", expires=expires)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.content.decode()
+        assert "grant_type=refresh_token" in body
+        return httpx.Response(200, json={"access_token": access_token})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        credential = await refresh_openai_codex_token("old-refresh", client=client)
+
+    assert credential.access == access_token
+    assert credential.refresh == "old-refresh"
+    assert credential.account_id == "account-3"
+    assert credential.expires == expires * 1000
+
+
+def _jwt(account_id: str, *, expires: int | None = None) -> str:
     payload = {OPENAI_CODEX_ACCOUNT_CLAIM: {"chatgpt_account_id": account_id}}
+    if expires is not None:
+        payload["exp"] = expires
     return ".".join(
         [
             _base64url(dumps({"alg": "none"}).encode()),

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,88 @@
+import base64
+from json import dumps
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from tau_coding.oauth import (
+    OPENAI_CODEX_ACCOUNT_CLAIM,
+    OPENAI_CODEX_CLIENT_ID,
+    account_id_from_access_token,
+    create_openai_codex_authorization_flow,
+    parse_authorization_input,
+    refresh_openai_codex_token,
+)
+
+
+def test_create_openai_codex_authorization_flow_includes_pkce_and_codex_params() -> None:
+    flow = create_openai_codex_authorization_flow(originator="tau-test")
+
+    url = urlparse(flow.url)
+    params = parse_qs(url.query)
+
+    assert url.geturl().startswith("https://auth.openai.com/oauth/authorize?")
+    assert params["response_type"] == ["code"]
+    assert params["client_id"] == [OPENAI_CODEX_CLIENT_ID]
+    assert params["redirect_uri"] == ["http://localhost:1455/auth/callback"]
+    assert params["scope"] == ["openid profile email offline_access"]
+    assert params["code_challenge_method"] == ["S256"]
+    assert params["codex_cli_simplified_flow"] == ["true"]
+    assert params["originator"] == ["tau-test"]
+    assert params["state"] == [flow.state]
+    assert params["code_challenge"][0]
+    assert flow.verifier
+
+
+def test_parse_authorization_input_accepts_redirect_url_query_and_raw_code() -> None:
+    assert (
+        parse_authorization_input("http://localhost:1455/auth/callback?code=abc&state=state-1").code
+        == "abc"
+    )
+    assert parse_authorization_input("code=abc&state=state-1").state == "state-1"
+    assert parse_authorization_input("abc#state-1").state == "state-1"
+    assert parse_authorization_input("abc").code == "abc"
+
+
+def test_account_id_from_access_token_reads_openai_auth_claim() -> None:
+    assert account_id_from_access_token(_jwt("account-1")) == "account-1"
+    assert account_id_from_access_token("not-a-jwt") is None
+
+
+@pytest.mark.anyio
+async def test_refresh_openai_codex_token_returns_oauth_credential() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.content.decode()
+        assert "grant_type=refresh_token" in body
+        assert "client_id=" in body
+        return httpx.Response(
+            200,
+            json={
+                "access_token": _jwt("account-2"),
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        credential = await refresh_openai_codex_token("old-refresh", client=client)
+
+    assert credential.access == _jwt("account-2")
+    assert credential.refresh == "new-refresh"
+    assert credential.account_id == "account-2"
+    assert credential.expires > 0
+
+
+def _jwt(account_id: str) -> str:
+    payload = {OPENAI_CODEX_ACCOUNT_CLAIM: {"chatgpt_account_id": account_id}}
+    return ".".join(
+        [
+            _base64url(dumps({"alg": "none"}).encode()),
+            _base64url(dumps(payload).encode()),
+            "signature",
+        ]
+    )
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -6,6 +6,7 @@ from tau_coding.paths import TauPaths
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     AnthropicProviderConfig,
+    OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfigError,
     ProviderSettings,
@@ -25,6 +26,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
     assert settings.default_provider == "openai"
     assert [provider.name for provider in settings.providers] == [
         "openai",
+        "openai-codex",
         "anthropic",
         "openrouter",
         "huggingface",
@@ -90,6 +92,7 @@ def test_upsert_openai_compatible_provider_replaces_and_sets_default() -> None:
         "huggingface",
         "local",
         "openai",
+        "openai-codex",
         "openrouter",
     ]
     assert replaced.get_provider("local").default_model == "llama"
@@ -285,6 +288,32 @@ def test_provider_settings_from_json_loads_headers() -> None:
 
     assert isinstance(provider, OpenAICompatibleProviderConfig)
     assert provider.headers == {"X-HF-Bill-To": "my-org"}
+
+
+def test_provider_settings_from_json_loads_openai_codex_provider() -> None:
+    settings = provider_settings_from_json(
+        {
+            "default_provider": "openai-codex",
+            "providers": [
+                {
+                    "type": "openai-codex",
+                    "name": "openai-codex",
+                    "base_url": "https://chatgpt.com/backend-api",
+                    "api_key_env": "OPENAI_CODEX_ACCESS_TOKEN",
+                    "credential_name": "openai-codex",
+                    "models": ["gpt-5.5", "gpt-5.4"],
+                    "default_model": "gpt-5.5",
+                    "headers": {"X-Test": "enabled"},
+                }
+            ],
+        }
+    )
+
+    provider = settings.get_provider("openai-codex")
+
+    assert isinstance(provider, OpenAICodexProviderConfig)
+    assert provider.default_model == "gpt-5.5"
+    assert provider.headers == {"X-Test": "enabled"}
 
 
 def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> None:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1,0 +1,62 @@
+import pytest
+
+from tau_ai import OpenAICodexProvider
+from tau_coding import provider_runtime
+from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.provider_config import OpenAICodexProviderConfig
+from tau_coding.provider_runtime import OpenAICodexCredentialResolver, create_model_provider
+
+
+def test_create_model_provider_returns_openai_codex_provider(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+
+    provider = create_model_provider(
+        OpenAICodexProviderConfig(),
+        credential_store=store,
+    )
+
+    assert isinstance(provider, OpenAICodexProvider)
+
+
+@pytest.mark.anyio
+async def test_openai_codex_credential_resolver_refreshes_expired_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="old-access",
+            refresh="old-refresh",
+            expires=1,
+            account_id="old-account",
+        ),
+    )
+
+    async def fake_refresh(refresh_token: str) -> OAuthCredential:
+        assert refresh_token == "old-refresh"
+        return OAuthCredential(
+            access="new-access",
+            refresh="new-refresh",
+            expires=9999999999999,
+            account_id="new-account",
+        )
+
+    monkeypatch.setattr(provider_runtime, "refresh_openai_codex_token", fake_refresh)
+
+    resolver = OpenAICodexCredentialResolver(
+        OpenAICodexProviderConfig(),
+        credential_store=store,
+    )
+
+    credentials = await resolver()
+
+    assert credentials.access_token == "new-access"
+    assert credentials.account_id == "new-account"
+    assert store.get_oauth("openai-codex") == OAuthCredential(
+        access="new-access",
+        refresh="new-refresh",
+        expires=9999999999999,
+        account_id="new-account",
+    )

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -459,6 +459,71 @@ async def test_openai_codex_provider_streams_tool_calls() -> None:
 
 
 @pytest.mark.anyio
+async def test_openai_codex_provider_routes_parallel_tool_argument_streams() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_item.added","output_index":0,'
+                '"item":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"read"}}\n\n'
+                'data: {"type":"response.output_item.added","output_index":1,'
+                '"item":{"type":"function_call","id":"fc-2","call_id":"call-2","name":"run"}}\n\n'
+                'data: {"type":"response.function_call_arguments.delta",'
+                '"item_id":"fc-1","delta":"{\\"path\\":"}\n\n'
+                'data: {"type":"response.function_call_arguments.delta",'
+                '"item_id":"fc-2","delta":"{\\"cmd\\":"}\n\n'
+                'data: {"type":"response.function_call_arguments.done",'
+                '"item_id":"fc-1","arguments":"{\\"path\\":\\"README.md\\"}"}\n\n'
+                'data: {"type":"response.output_item.done","output_index":0,'
+                '"item":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"read"}}\n\n'
+                'data: {"type":"response.function_call_arguments.done",'
+                '"item_id":"fc-2","arguments":"{\\"cmd\\":\\"pwd\\"}"}\n\n'
+                'data: {"type":"response.output_item.done","output_index":1,'
+                '"item":{"type":"function_call","id":"fc-2","call_id":"call-2","name":"run"}}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Use two tools")],
+                tools=[],
+            )
+        )
+
+    tool_call_events = [event for event in events if isinstance(event, ProviderToolCallEvent)]
+
+    assert tool_call_events == [
+        ProviderToolCallEvent(
+            tool_call=ToolCall(id="call-1|fc-1", name="read", arguments={"path": "README.md"})
+        ),
+        ProviderToolCallEvent(
+            tool_call=ToolCall(id="call-2|fc-2", name="run", arguments={"cmd": "pwd"})
+        ),
+    ]
+    assert isinstance(events[-1], ProviderResponseEndEvent)
+    assert events[-1].message.tool_calls == [
+        ToolCall(id="call-1|fc-1", name="read", arguments={"path": "README.md"}),
+        ToolCall(id="call-2|fc-2", name="run", arguments={"cmd": "pwd"}),
+    ]
+
+
+@pytest.mark.anyio
 async def test_anthropic_provider_formats_request_and_streams_text() -> None:
     requests: list[httpx.Request] = []
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -10,6 +10,9 @@ from tau_ai import (
     AnthropicConfig,
     AnthropicProvider,
     FakeProvider,
+    OpenAICodexConfig,
+    OpenAICodexCredentials,
+    OpenAICodexProvider,
     OpenAICompatibleConfig,
     OpenAICompatibleProvider,
     ProviderErrorEvent,
@@ -307,6 +310,152 @@ async def test_openai_compatible_provider_does_not_retry_non_transient_status() 
     assert len(requests) == 1
     assert isinstance(events[-1], ProviderErrorEvent)
     assert events[-1].data == {"body": "bad request", "attempts": 1}
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_formats_request_and_streams_text() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = loads(request.content)
+        assert payload["model"] == "gpt-5.5"
+        assert payload["store"] is False
+        assert payload["stream"] is True
+        assert payload["instructions"] == "You are Tau."
+        assert payload["input"] == [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Say hello"}],
+            }
+        ]
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_text.delta","delta":"Hel"}\n\n'
+                'data: {"type":"response.output_text.delta","delta":"lo"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                headers={"X-Test": "enabled"},
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert [event.type for event in events] == [
+        "response_start",
+        "text_delta",
+        "text_delta",
+        "response_end",
+    ]
+    assert isinstance(events[-1], ProviderResponseEndEvent)
+    assert events[-1].message.content == "Hello"
+    assert events[-1].finish_reason == "completed"
+
+    request = requests[0]
+    assert request.url == "https://chatgpt.test/backend-api/codex/responses"
+    assert request.headers["authorization"] == "Bearer access-token"
+    assert request.headers["chatgpt-account-id"] == "account-1"
+    assert request.headers["originator"] == "tau"
+    assert request.headers["openai-beta"] == "responses=experimental"
+    assert request.headers["x-test"] == "enabled"
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_streams_tool_calls() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        return AgentToolResult(
+            tool_call_id="call-1|fc-1",
+            name="read",
+            ok=True,
+            content=str(arguments),
+        )
+
+    tool = AgentTool(
+        name="read",
+        description="Read a file.",
+        input_schema={"type": "object", "properties": {"path": {"type": "string"}}},
+        executor=executor,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = loads(request.content)
+        assert payload["tools"] == [
+            {
+                "type": "function",
+                "name": "read",
+                "description": "Read a file.",
+                "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+                "strict": None,
+            }
+        ]
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_item.added",'
+                '"item":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"read"}}\n\n'
+                'data: {"type":"response.function_call_arguments.delta","delta":"{\\"path\\":"}\n\n'
+                'data: {"type":"response.function_call_arguments.done",'
+                '"arguments":"{\\"path\\":\\"README.md\\"}"}\n\n'
+                'data: {"type":"response.output_item.done",'
+                '"item":{"type":"function_call","id":"fc-1","call_id":"call-1",'
+                '"name":"read","arguments":"{\\"path\\":\\"README.md\\"}"}}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Read README.md")],
+                tools=[tool],
+            )
+        )
+
+    tool_call_events = [event for event in events if isinstance(event, ProviderToolCallEvent)]
+
+    assert tool_call_events == [
+        ProviderToolCallEvent(
+            tool_call=ToolCall(id="call-1|fc-1", name="read", arguments={"path": "README.md"})
+        )
+    ]
+    assert isinstance(events[-1], ProviderResponseEndEvent)
+    assert events[-1].message.tool_calls == [
+        ToolCall(id="call-1|fc-1", name="read", arguments={"path": "README.md"})
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from tau_agent import (
     UserMessage,
 )
 from tau_coding.commands import CommandResult
+from tau_coding.credentials import OAuthCredential
 from tau_coding.provider_config import OpenAICompatibleProviderConfig, ProviderSettings
 from tau_coding.session import ModelChoice
 from tau_coding.session_manager import CodingSessionRecord
@@ -33,6 +35,7 @@ from tau_coding.tui.app import (
     LoginProviderPickerScreen,
     LoginScreen,
     ModelPickerScreen,
+    OAuthLoginScreen,
     SessionPickerScreen,
     TauTuiApp,
 )
@@ -98,8 +101,8 @@ class FakeSession:
             return CommandResult(handled=True, resume_picker_requested=True)
         if text == "/login":
             return CommandResult(handled=True, login_picker_requested=True)
-        if text == "/login openai":
-            return CommandResult(handled=True, login_provider="openai")
+        if text.startswith("/login "):
+            return CommandResult(handled=True, login_provider=text.removeprefix("/login "))
         if text == "/model":
             return CommandResult(handled=True, model_picker_requested=True)
         if text.startswith("/thinking "):
@@ -804,9 +807,7 @@ async def test_tui_app_quits_from_focused_prompt_with_default_keybinding() -> No
     async with app.run_test() as pilot:
         prompt = app.query_one("#prompt")
         visible_bindings = [
-            binding
-            for binding in prompt._bindings.get_bindings_for_key("ctrl+d")
-            if binding.show
+            binding for binding in prompt._bindings.get_bindings_for_key("ctrl+d") if binding.show
         ]
 
         assert any(
@@ -870,6 +871,46 @@ async def test_tui_login_saves_provider_key(
 
 
 @pytest.mark.anyio
+async def test_tui_login_openai_codex_saves_oauth_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    credential_future = asyncio.get_running_loop().create_future()
+
+    async def fake_login_openai_codex(**_kwargs: object) -> OAuthCredential:
+        return await credential_future
+
+    monkeypatch.setattr(tui_app, "login_openai_codex", fake_login_openai_codex)
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login openai-codex"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, OAuthLoginScreen)
+        credential_future.set_result(
+            OAuthCredential(
+                access="access-token",
+                refresh="refresh-token",
+                expires=123456,
+                account_id="account-1",
+            )
+        )
+        await pilot.pause()
+
+    assert session.reload_count == 1
+    assert session.provider_name == "openai-codex"
+    assert all("access-token" not in item.text for item in app.state.items)
+    credentials = (tmp_path / ".tau" / "credentials.json").read_text(encoding="utf-8")
+    assert '"type": "oauth"' in credentials
+    assert "refresh-token" in credentials
+
+
+@pytest.mark.anyio
 async def test_tui_login_opens_provider_picker() -> None:
     app = TauTuiApp(FakeSession())
 
@@ -883,8 +924,10 @@ async def test_tui_login_opens_provider_picker() -> None:
         provider_list = app.screen.query_one("#login-provider-list", ListView)
         labels = [str(item.query_one(Label).render()) for item in provider_list.children]
         assert labels[0] == "OpenAI\n  openai"
+        assert labels[1] == "OpenAI Codex subscription\n  openai-codex"
         assert "gpt-5.5" not in "\n".join(labels)
 
+        await pilot.press("down")
         await pilot.press("down")
         await pilot.press("enter")
         await pilot.pause()


### PR DESCRIPTION
Closes #23.

## Summary
- Adds an OpenAI Codex subscription OAuth flow modeled after Pi's implementation, including PKCE, local callback, manual-code fallback, token refresh, and structured OAuth credential storage.
- Adds the `openai-codex` provider path across catalog/config/runtime plus a Tau AI adapter for the ChatGPT Codex Responses SSE endpoint.
- Wires `/login openai-codex` into the Textual UI and updates provider docs/getting-started material.
- Adds deterministic tests for OAuth URL/code parsing, credential storage, provider config/runtime, SSE streaming, TUI login routing, CLI provider listing, parallel Codex tool-call streams, and refresh responses with omitted optional fields.

## Review Fixes
- Routes streamed Codex tool-call argument events by `item_id`, `call_id`, or `output_index` so `parallel_tool_calls` cannot corrupt overlapping function calls.
- Allows refresh token responses to omit `refresh_token` and `expires_in`, preserving the existing refresh token and falling back to JWT `exp` for expiry when needed.

## Validation
- `uv run pytest tests/test_tau_ai.py::test_openai_codex_provider_routes_parallel_tool_argument_streams tests/test_oauth.py::test_refresh_openai_codex_token_preserves_refresh_and_reads_jwt_expiry -q`
- `uv run ruff check src tests`
- `uv run mypy`
- `uv run pytest tests/test_tau_ai.py tests/test_oauth.py tests/test_provider_runtime.py -q`
- `uv run ruff format --check src/tau_ai/openai_codex.py src/tau_coding/oauth.py tests/test_tau_ai.py tests/test_oauth.py`
- `uv run pytest` (290 passed)
- Previous full docs validation: `uv run --group docs mkdocs build --strict`

Note: repo-wide `uv run ruff format --check .` still reports pre-existing formatting drift in unrelated files; the changed Python files are format-checked above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an OpenAI Codex subscription built-in provider with OAuth-based authentication via `/login openai-codex`, including manual redirect/code fallback.
  * Added streaming Codex Responses (SSE) with assistant text streaming and tool-call aggregation, plus configurable retry handling.
* **Documentation**
  * Updated installation, getting-started, configuration, provider, and first-run login instructions for the new provider and OAuth credential storage/refresh behavior.
* **Tests**
  * Expanded coverage for OAuth helpers, credential store OAuth round-trips, provider runtime selection/refresh, TUI OAuth login, and Codex streaming/tool-call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->