### PR TITLE
Add expandable TUI tool results

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,11 +119,12 @@ Example:
   "keybindings": {
     "cancel": "escape",
     "command_palette": "ctrl+j",
-    "session_picker": "ctrl+o",
+    "session_picker": "ctrl+r",
     "accept_completion": "f2",
     "completion_next": "down",
     "completion_previous": "up",
     "thinking_cycle": "shift+tab",
+    "toggle_tool_results": "ctrl+o",
     "quit": "ctrl+d"
   }
 }

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -12,7 +12,7 @@ from tau_agent import (
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
 )
-from tau_coding.tui.state import TuiState, format_tool_result_block
+from tau_coding.tui.state import TuiState
 
 
 class TuiEventAdapter:
@@ -47,15 +47,6 @@ class TuiEventAdapter:
                 self.state.add_item("user", event.message.content)
                 return
             if event.message.role == "tool":
-                self.state.add_item(
-                    "tool",
-                    format_tool_result_block(
-                        name=event.message.name,
-                        ok=event.message.ok,
-                        content=event.message.content,
-                        data=event.message.data,
-                    ),
-                )
                 return
             text = event.message.content or self.state.assistant_buffer
             if text:
@@ -65,10 +56,7 @@ class TuiEventAdapter:
 
         if isinstance(event, ToolExecutionStartEvent):
             self._flush_assistant_buffer()
-            self.state.add_item(
-                "tool",
-                f"→ {event.tool_call.name} {event.tool_call.arguments}",
-            )
+            self.state.add_tool_call(event.tool_call)
             return
 
         if isinstance(event, ToolExecutionUpdateEvent):
@@ -76,15 +64,7 @@ class TuiEventAdapter:
             return
 
         if isinstance(event, ToolExecutionEndEvent):
-            self.state.add_item(
-                "tool",
-                format_tool_result_block(
-                    name=event.result.name,
-                    ok=event.result.ok,
-                    content=event.result.content,
-                    data=event.result.data,
-                ),
-            )
+            self.state.record_tool_result(event.result)
             return
 
         if isinstance(event, ErrorEvent):

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -99,6 +99,8 @@ class CompletionActionTarget(Protocol):
 
     def action_cycle_thinking(self) -> None: ...
 
+    def action_toggle_tool_results(self) -> None: ...
+
 
 class SessionCompletionRecord(Protocol):
     """Session metadata needed to render resume picker completions."""
@@ -150,6 +152,10 @@ class PromptInput(Input):
         """Cycle the app-level thinking mode."""
         self._completion_target().action_cycle_thinking()
 
+    def action_toggle_tool_results(self) -> None:
+        """Toggle app-level tool result display."""
+        self._completion_target().action_toggle_tool_results()
+
     async def action_quit(self) -> None:
         """Quit the app through the app-level action."""
         await self.app.action_quit()
@@ -177,6 +183,9 @@ class PromptInput(Input):
         elif _is_thinking_cycle_key(event.key, keybindings.thinking_cycle):
             event.stop()
             self._completion_target().action_cycle_thinking()
+        elif event.key == keybindings.toggle_tool_results:
+            event.stop()
+            self._completion_target().action_toggle_tool_results()
         elif event.key == keybindings.completion_next:
             event.stop()
             self._completion_target().action_completion_next()
@@ -1055,6 +1064,12 @@ class TauTuiApp(App[None]):
             return
         self.run_worker(self._cycle_thinking_level(), exclusive=False)
 
+    def action_toggle_tool_results(self) -> None:
+        """Toggle inline tool result details in the transcript."""
+        expanded = self.state.toggle_tool_results()
+        self._refresh()
+        self._notify("Tool results expanded." if expanded else "Tool results collapsed.")
+
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:
             return
@@ -1399,6 +1414,7 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
             "Previous completion",
             priority=True,
         ),
+        Binding(keybindings.toggle_tool_results, "toggle_tool_results", "Tool results"),
         Binding(keybindings.quit, "quit", "Quit"),
     ]
 
@@ -1408,6 +1424,12 @@ def _prompt_bindings(keybindings: TuiKeybindings) -> list[Binding]:
         Binding(keybindings.command_palette, "open_command_palette", show=False, priority=True),
         Binding(keybindings.session_picker, "open_session_picker", show=False, priority=True),
         Binding(keybindings.thinking_cycle, "cycle_thinking", show=False, priority=True),
+        Binding(
+            keybindings.toggle_tool_results,
+            "toggle_tool_results",
+            show=False,
+            priority=True,
+        ),
         Binding(keybindings.accept_completion, "accept_completion", show=False, priority=True),
         Binding(keybindings.completion_next, "completion_next", show=False, priority=True),
         Binding(keybindings.completion_previous, "completion_previous", show=False, priority=True),

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -11,7 +11,7 @@ from textual.binding import Binding, BindingsMap
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Static
+from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
 
 from tau_agent.messages import AgentMessage
@@ -99,6 +99,8 @@ class CompletionActionTarget(Protocol):
 
     def action_cycle_thinking(self) -> None: ...
 
+    async def action_submit_prompt(self) -> None: ...
+
 
 class SessionCompletionRecord(Protocol):
     """Session metadata needed to render resume picker completions."""
@@ -109,8 +111,8 @@ class SessionCompletionRecord(Protocol):
     cwd: Path
 
 
-class PromptInput(Input):
-    """Prompt input with completion key bindings."""
+class PromptInput(TextArea):
+    """Multiline prompt input with completion key bindings."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = []
 
@@ -125,6 +127,29 @@ class PromptInput(Input):
         self._bindings = BindingsMap.merge(
             [self._bindings, BindingsMap(_prompt_bindings(self.tui_keybindings))]
         )
+
+    @property
+    def value(self) -> str:
+        """Compatibility alias for tests and code that previously used Input.value."""
+        return self.text
+
+    @value.setter
+    def value(self, text: str) -> None:
+        self.text = text
+
+    @property
+    def cursor_position(self) -> int:
+        """Return a flat cursor offset for Input compatibility."""
+        row, column = self.cursor_location
+        lines = self.text.split("\n")
+        return sum(len(line) + 1 for line in lines[:row]) + column
+
+    @cursor_position.setter
+    def cursor_position(self, offset: int) -> None:
+        text = self.text
+        bounded = max(0, min(offset, len(text)))
+        before = text[:bounded]
+        self.move_cursor((before.count("\n"), len(before.rsplit("\n", 1)[-1])))
 
     def action_accept_completion(self) -> None:
         """Accept the selected app-level completion."""
@@ -163,9 +188,17 @@ class PromptInput(Input):
         self._completion_target().action_completion_previous()
 
     async def on_key(self, event: Key) -> None:
-        """Route completion keys before default input handling."""
+        """Route completion and submission keys before default input handling."""
         keybindings = self.tui_keybindings
-        if event.key == keybindings.accept_completion:
+        if event.key == "enter":
+            event.stop()
+            event.prevent_default()
+            await self._completion_target().action_submit_prompt()
+        elif event.key == "shift+enter":
+            event.stop()
+            event.prevent_default()
+            self.insert("\n")
+        elif event.key == keybindings.accept_completion:
             event.stop()
             self._completion_target().action_accept_completion()
         elif event.key == keybindings.command_palette:
@@ -652,6 +685,8 @@ class TauTuiApp(App[None]):
         border: tall transparent;
         margin: 0 1 1 1;
         padding: 0 1;
+        min-height: 3;
+        max-height: 8;
     }
 
     #prompt:focus {
@@ -880,7 +915,7 @@ class TauTuiApp(App[None]):
                     markup=False,
                 )
                 yield PromptInput(
-                    placeholder="Ask Tau…",
+                    placeholder="Ask Tau…  Enter submits, Shift+Enter inserts a newline",
                     id="prompt",
                     tui_keybindings=self.tui_settings.keybindings,
                 )
@@ -890,7 +925,7 @@ class TauTuiApp(App[None]):
 
     async def on_mount(self) -> None:
         """Focus the prompt when the app starts."""
-        self.query_one(Input).focus()
+        self.query_one(PromptInput).focus()
         self._update_responsive_layout(self.size.width, self.size.height)
         self._refresh()
         self._refresh_completions()
@@ -903,28 +938,27 @@ class TauTuiApp(App[None]):
         """Update responsive chrome when the terminal changes size."""
         self._update_responsive_layout(event.size.width, event.size.height)
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        """Update prompt autocomplete when the input value changes."""
-        if event.input.id != "prompt":
+    def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        """Update prompt autocomplete when the prompt text changes."""
+        if event.text_area.id != "prompt":
             return
-        self._completion_state = self._build_completion_state(event.value)
+        self._completion_state = self._build_completion_state(event.text_area.text)
         self._refresh_completions()
 
-    async def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Handle a submitted prompt or slash command."""
-        if event.input.id != "prompt":
-            return
-        raw_text = event.value
+    async def action_submit_prompt(self) -> None:
+        """Submit the current prompt text or slash command."""
+        prompt = self.query_one("#prompt", PromptInput)
+        raw_text = prompt.text
         applied_completion = self._apply_selected_completion(raw_text)
         if applied_completion is not None and applied_completion != raw_text:
-            event.input.value = applied_completion
-            event.input.cursor_position = len(applied_completion)
+            prompt.text = applied_completion
+            prompt.move_cursor(_text_end_location(applied_completion))
             self._completion_state = self._build_completion_state(applied_completion)
             self._refresh_completions()
             return
 
         text = raw_text.strip()
-        event.input.value = ""
+        prompt.text = ""
         self._completion_state = CompletionState()
         self._refresh_completions()
         if not text:
@@ -996,13 +1030,13 @@ class TauTuiApp(App[None]):
         if isinstance(self.screen, LoginProviderPickerScreen | ModelPickerScreen):
             self.screen.action_select_cursor()
             return
-        prompt = self.query_one("#prompt", Input)
-        applied = self._apply_selected_completion(prompt.value)
+        prompt = self.query_one("#prompt", PromptInput)
+        applied = self._apply_selected_completion(prompt.text)
         if applied is None:
             return
-        prompt.value = applied
-        prompt.cursor_position = len(prompt.value)
-        self._completion_state = self._build_completion_state(prompt.value)
+        prompt.text = applied
+        prompt.move_cursor(_text_end_location(applied))
+        self._completion_state = self._build_completion_state(prompt.text)
         self._refresh_completions()
 
     def action_completion_next(self) -> None:
@@ -1027,11 +1061,11 @@ class TauTuiApp(App[None]):
 
     def action_open_command_palette(self) -> None:
         """Open the slash-command palette in the prompt."""
-        prompt = self.query_one("#prompt", Input)
+        prompt = self.query_one("#prompt", PromptInput)
         prompt.focus()
-        prompt.value = "/"
-        prompt.cursor_position = len(prompt.value)
-        self._completion_state = self._build_completion_state(prompt.value)
+        prompt.text = "/"
+        prompt.move_cursor((0, 1))
+        self._completion_state = self._build_completion_state(prompt.text)
         self._refresh_completions()
 
     def action_open_session_picker(self) -> None:
@@ -1413,6 +1447,12 @@ def _prompt_bindings(keybindings: TuiKeybindings) -> list[Binding]:
         Binding(keybindings.completion_previous, "completion_previous", show=False, priority=True),
         Binding(keybindings.quit, "quit", "Quit", priority=True),
     ]
+
+
+def _text_end_location(text: str) -> tuple[int, int]:
+    """Return the TextArea cursor location at the end of text."""
+    line, _, column_text = text.rpartition("\n")
+    return (line.count("\n") + 1 if line else 0, len(column_text))
 
 
 def _format_prompt_error(exc: BaseException, session: CodingSession) -> str:

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -23,6 +23,7 @@ class TuiKeybindings:
     completion_next: str = "down"
     completion_previous: str = "up"
     thinking_cycle: str = "shift+tab"
+    toggle_tool_results: str = "ctrl+o"
     quit: str = "ctrl+d"
 
     def to_json(self) -> dict[str, str]:
@@ -35,6 +36,7 @@ class TuiKeybindings:
             "completion_next": self.completion_next,
             "completion_previous": self.completion_previous,
             "thinking_cycle": self.thinking_cycle,
+            "toggle_tool_results": self.toggle_tool_results,
             "quit": self.quit,
         }
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from tau_agent.messages import AgentMessage
+from tau_agent.tools import AgentToolResult, ToolCall
 from tau_agent.types import JSONValue
 
 ChatItemRole = Literal["user", "assistant", "tool", "error", "status"]
@@ -19,6 +20,8 @@ class ChatItem:
 
     role: ChatItemRole
     text: str
+    tool_call_id: str | None = None
+    tool_result_text: str | None = None
 
 
 @dataclass(slots=True)
@@ -29,10 +32,57 @@ class TuiState:
     assistant_buffer: str = ""
     running: bool = False
     error: str | None = None
+    show_tool_results: bool = False
 
-    def add_item(self, role: ChatItemRole, text: str) -> None:
+    def add_item(
+        self,
+        role: ChatItemRole,
+        text: str,
+        *,
+        tool_call_id: str | None = None,
+        tool_result_text: str | None = None,
+    ) -> None:
         """Append a transcript item."""
-        self.items.append(ChatItem(role=role, text=text))
+        self.items.append(
+            ChatItem(
+                role=role,
+                text=text,
+                tool_call_id=tool_call_id,
+                tool_result_text=tool_result_text,
+            )
+        )
+
+    def add_tool_call(self, tool_call: ToolCall) -> None:
+        """Append a collapsed tool-call item."""
+        self.add_item(
+            "tool",
+            format_tool_call_block(tool_call),
+            tool_call_id=tool_call.id,
+        )
+
+    def record_tool_result(self, result: AgentToolResult) -> None:
+        """Attach a tool result to its matching call, or append an orphan result."""
+        result_text = format_tool_result_block(
+            name=result.name,
+            ok=result.ok,
+            content=result.content,
+            data=result.data,
+        )
+        for item in reversed(self.items):
+            if item.role == "tool" and item.tool_call_id == result.tool_call_id:
+                item.tool_result_text = result_text
+                return
+        self.add_item(
+            "tool",
+            format_tool_result_summary(name=result.name, ok=result.ok),
+            tool_call_id=result.tool_call_id,
+            tool_result_text=result_text,
+        )
+
+    def toggle_tool_results(self) -> bool:
+        """Toggle expanded display for tool results and return the new state."""
+        self.show_tool_results = not self.show_tool_results
+        return self.show_tool_results
 
     def clear(self) -> None:
         """Clear visible transcript state without modifying durable session history."""
@@ -49,17 +99,30 @@ class TuiState:
                 if message.content:
                     self.add_item("assistant", message.content)
                 for tool_call in message.tool_calls:
-                    self.add_item("tool", f"→ {tool_call.name} {tool_call.arguments}")
+                    self.add_tool_call(tool_call)
             elif message.role == "tool":
-                self.add_item(
-                    "tool",
-                    format_tool_result_block(
+                self.record_tool_result(
+                    AgentToolResult(
+                        tool_call_id=message.tool_call_id,
                         name=message.name,
                         ok=message.ok,
                         content=message.content,
                         data=message.data,
-                    ),
+                        details=message.details,
+                        error=message.error,
+                    )
                 )
+
+
+def format_tool_call_block(tool_call: ToolCall) -> str:
+    """Format a collapsed tool call for live and restored transcript blocks."""
+    return f"→ {tool_call.name} {tool_call.arguments}"
+
+
+def format_tool_result_summary(*, name: str, ok: bool) -> str:
+    """Format a terse tool result line for orphaned results."""
+    status = "✓" if ok else "✗"
+    return f"{status} {name}"
 
 
 def format_tool_result_block(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -131,7 +131,11 @@ class TranscriptView(RichLog):
         self.clear()
         for item in state.items:
             self.write(
-                render_chat_item(item, theme=theme),
+                render_chat_item(
+                    item,
+                    theme=theme,
+                    show_tool_results=state.show_tool_results,
+                ),
                 expand=True,
                 shrink=True,
                 scroll_end=scroll_end,
@@ -141,6 +145,7 @@ class TranscriptView(RichLog):
                 render_chat_item(
                     ChatItem(role="assistant", text=state.assistant_buffer),
                     theme=theme,
+                    show_tool_results=state.show_tool_results,
                 ),
                 expand=True,
                 shrink=True,
@@ -240,11 +245,12 @@ def render_chat_item(
     item: ChatItem,
     *,
     theme: TuiTheme = TAU_DARK_THEME,
+    show_tool_results: bool = False,
 ) -> RenderableType:
     """Render a chat item as a standalone Toad-inspired transcript block."""
     role_style = theme.role_styles[item.role]
     body = _render_chat_body(
-        item.text,
+        _visible_chat_text(item, show_tool_results=show_tool_results),
         role=item.role,
         body_style=role_style.body,
         syntax_theme=theme.syntax_theme,
@@ -257,6 +263,12 @@ def render_chat_item(
         Padding(body, (0, 1, 0, 1), style=role_style.body),
     )
     return Padding(table, (1, 1, 1, 0), style=role_style.body)
+
+
+def _visible_chat_text(item: ChatItem, *, show_tool_results: bool) -> str:
+    if item.role != "tool" or not show_tool_results or not item.tool_result_text:
+        return item.text
+    return f"{item.text}\n\n{item.tool_result_text}"
 
 
 def _render_chat_body(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -94,10 +94,10 @@ def test_tui_adapter_records_tool_updates_and_results() -> None:
         )
     )
 
-    assert [(item.role, item.text) for item in state.items] == [
-        ("tool", "… reading"),
-        ("tool", "✓ read\ndone"),
-        ("tool", "✗ bash\nfailed"),
+    assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
+        ("tool", "… reading", None),
+        ("tool", "✓ read", "✓ read\ndone"),
+        ("tool", "✗ bash", "✗ bash\nfailed"),
     ]
 
 
@@ -128,9 +128,10 @@ def test_tui_adapter_renders_live_edit_patch() -> None:
         )
     )
 
-    assert [(item.role, item.text) for item in state.items] == [
+    assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
         (
             "tool",
+            "✓ edit",
             "✓ edit\n"
             "Successfully replaced 1 block.\n"
             "\n"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -18,6 +18,7 @@ from tau_agent import (
     MessageEndEvent,
     ToolCall,
     ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
     ToolResultMessage,
     UserMessage,
 )
@@ -283,6 +284,27 @@ def test_chat_items_render_fenced_code_without_markers() -> None:
     assert "python" not in output
 
 
+def test_tool_chat_items_hide_and_show_result_text() -> None:
+    item = ChatItem(
+        role="tool",
+        text="→ read {'path': 'README.md'}",
+        tool_result_text="✓ read\nfull file contents",
+    )
+
+    collapsed_console = Console(record=True, width=80)
+    collapsed_console.print(render_chat_item(item))
+    collapsed = collapsed_console.export_text()
+
+    expanded_console = Console(record=True, width=80)
+    expanded_console.print(render_chat_item(item, show_tool_results=True))
+    expanded = expanded_console.export_text()
+
+    assert "→ read" in collapsed
+    assert "full file contents" not in collapsed
+    assert "→ read" in expanded
+    assert "full file contents" in expanded
+
+
 def test_assistant_chat_items_render_markdown_lists() -> None:
     console = Console(record=True, width=60)
     item = ChatItem(role="assistant", text="Plan:\n\n- inspect\n- patch")
@@ -478,12 +500,12 @@ def test_tui_app_loads_restored_messages_into_display_state() -> None:
         )
     )
 
-    assert [(item.role, item.text) for item in app.state.items] == [
-        ("user", "Read the file"),
-        ("assistant", "I'll inspect it."),
-        ("tool", "→ edit {'path': 'README.md'}"),
+    assert [(item.role, item.text, item.tool_result_text) for item in app.state.items] == [
+        ("user", "Read the file", None),
+        ("assistant", "I'll inspect it.", None),
         (
             "tool",
+            "→ edit {'path': 'README.md'}",
             "✓ edit\n"
             "Successfully replaced 1 block.\n"
             "\n"
@@ -1004,6 +1026,29 @@ async def test_tui_app_thinking_command_updates_session() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
+    app = TauTuiApp(FakeSession())
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        assert app.state.show_tool_results is False
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.show_tool_results is True
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+
+    assert app.state.show_tool_results is False
+    assert notifications == ["Tool results expanded.", "Tool results collapsed."]
+
+
+@pytest.mark.anyio
 async def test_tui_app_cycles_thinking_from_keybinding() -> None:
     session = FakeSession()
     app = TauTuiApp(session)
@@ -1101,6 +1146,9 @@ async def test_tui_prompt_worker_refreshes_context_after_message_changes() -> No
             self.context_token_estimate = 30
             yield MessageEndEvent(message=AssistantMessage(content="Using a tool."))
             self.context_token_estimate = 40
+            yield ToolExecutionStartEvent(
+                tool_call=ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+            )
             yield ToolExecutionEndEvent(
                 result=AgentToolResult(
                     tool_call_id="call-1",
@@ -1123,11 +1171,11 @@ async def test_tui_prompt_worker_refreshes_context_after_message_changes() -> No
 
     await app._run_prompt("read README")
 
-    assert observed_context == [10, 20, 30, 40, 50]
-    assert [(item.role, item.text) for item in app.state.items] == [
-        ("user", "read README"),
-        ("assistant", "Using a tool."),
-        ("tool", "✓ read\ncontents"),
+    assert observed_context == [10, 20, 30, 40, 40, 50]
+    assert [(item.role, item.text, item.tool_result_text) for item in app.state.items] == [
+        ("user", "read README", None),
+        ("assistant", "Using a tool.", None),
+        ("tool", "→ read {'path': 'README.md'}", "✓ read\ncontents"),
     ]
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7,7 +7,7 @@ from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from textual.containers import VerticalScroll
-from textual.widgets import Input, Label, ListView
+from textual.widgets import Input, Label, ListView, TextArea
 
 from tau_agent import (
     AgentEndEvent,
@@ -344,7 +344,9 @@ async def test_tui_app_mounts_sidebar_and_transcript() -> None:
         transcript = app.query_one("#transcript")
         assert transcript is not None
         assert transcript.min_width == 1
-        assert app.query_one("#prompt") is not None
+        prompt = app.query_one("#prompt")
+        assert isinstance(prompt, TextArea)
+        assert prompt.soft_wrap is True
 
 
 @pytest.mark.anyio
@@ -562,6 +564,30 @@ async def test_tui_app_resume_command_opens_session_picker() -> None:
 
         assert isinstance(app.screen, SessionPickerScreen)
         assert [(item.role, item.text) for item in app.state.items] == [("user", "Earlier")]
+
+
+@pytest.mark.anyio
+async def test_tui_app_submits_multiline_prompt_with_enter() -> None:
+    session = FakeSession(
+        events=[
+            AgentStartEvent(),
+            MessageEndEvent(message=UserMessage(content="first\nsecond")),
+            AgentEndEvent(),
+        ]
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "first"
+        prompt.cursor_position = len(prompt.value)
+        await pilot.press("shift+enter")
+        prompt.value += "second"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.prompt_texts == ["first\nsecond"]
+    assert prompt.value == ""
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -37,7 +37,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
         {
           "keybindings": {
             "command_palette": "ctrl+j",
-            "session_picker": "ctrl+o",
+            "session_picker": "ctrl+y",
             "accept_completion": "f2",
             "thinking_cycle": "f3"
           },
@@ -50,7 +50,8 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     settings = load_tui_settings(paths)
 
     assert settings.keybindings.command_palette == "ctrl+j"
-    assert settings.keybindings.session_picker == "ctrl+o"
+    assert settings.keybindings.session_picker == "ctrl+y"
+    assert settings.keybindings.toggle_tool_results == "ctrl+o"
     assert settings.keybindings.accept_completion == "f2"
     assert settings.keybindings.thinking_cycle == "f3"
     assert settings.keybindings.cancel == "escape"
@@ -84,7 +85,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
     settings = TuiSettings(
         keybindings=TuiKeybindings(
             command_palette="ctrl+j",
-            session_picker="ctrl+o",
+            session_picker="ctrl+y",
             accept_completion="f2",
             thinking_cycle="f3",
         ),
@@ -92,7 +93,8 @@ def test_tui_keybindings_serialize_to_json() -> None:
     )
 
     assert settings.to_json()["keybindings"]["command_palette"] == "ctrl+j"
-    assert settings.to_json()["keybindings"]["session_picker"] == "ctrl+o"
+    assert settings.to_json()["keybindings"]["session_picker"] == "ctrl+y"
+    assert settings.to_json()["keybindings"]["toggle_tool_results"] == "ctrl+o"
     assert settings.to_json()["keybindings"]["accept_completion"] == "f2"
     assert settings.to_json()["keybindings"]["thinking_cycle"] == "f3"
     assert settings.to_json()["theme"] == "high-contrast"


### PR DESCRIPTION
Closes #18\n\n## Summary\n- render tool calls as collapsed transcript items by default\n- attach live and restored tool results to matching tool calls\n- add configurable ctrl+o toggle for expanding/collapsing inline tool result contents\n\n## Tests\n- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the default TUI keybindings example: `session_picker` now uses `ctrl+r`.

* **New Features**
  * Added `ctrl+o` to toggle inline tool result visibility (expanded/collapsed) in the TUI.
  * Enhanced tool execution tracking and how tool calls/results are displayed.

* **Tests**
  * Expanded coverage for tool result rendering, visibility toggling, and multiline prompt submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->