### PR TITLE
Surface diagnostic log paths for TUI agent errors

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -11,9 +11,20 @@ from textual.binding import Binding, BindingsMap
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
-from textual.widgets import Button, Footer, Header, Input, Label, ListItem, ListView, Static, TextArea
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    Label,
+    ListItem,
+    ListView,
+    Static,
+    TextArea,
+)
 from textual.worker import Worker
 
+from tau_agent import ErrorEvent
 from tau_agent.messages import AgentMessage
 from tau_agent.tools import AgentTool
 from tau_ai import ProviderErrorEvent, ProviderEvent
@@ -1108,6 +1119,8 @@ class TauTuiApp(App[None]):
         try:
             async for event in self.session.prompt(text):
                 self.adapter.apply(event)
+                if isinstance(event, ErrorEvent) and not event.recoverable:
+                    _attach_diagnostic_log_path_to_error(self.state, self.session)
                 self._refresh()
         except Exception as exc:  # noqa: BLE001 - surface unexpected worker errors in the TUI
             message = _format_prompt_error(exc, self.session)
@@ -1607,6 +1620,19 @@ def _format_prompt_error(exc: BaseException, session: CodingSession) -> str:
     if isinstance(log_path, Path):
         return f"{message}\nLog: {log_path}"
     return message
+
+
+def _attach_diagnostic_log_path_to_error(state: TuiState, session: CodingSession) -> None:
+    log_path = getattr(session, "last_diagnostic_log_path", None)
+    if not isinstance(log_path, Path) or state.error is None:
+        return
+    message = f"Error: {state.error}\nLog: {log_path}"
+    state.error = message
+    for item in reversed(state.items):
+        if item.role == "error":
+            item.text = message
+            return
+    state.add_item("error", message)
 
 
 async def run_tui_app(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -11,9 +11,9 @@ from rich.console import Console, Group, RenderableType
 from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.panel import Panel
+from rich.style import Style
 from rich.syntax import Syntax
 from rich.table import Table
-from rich.style import Style
 from rich.text import Text
 from rich.theme import Theme
 from textual.events import Resize

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -15,6 +15,7 @@ from tau_agent import (
     AgentStartEvent,
     AgentToolResult,
     AssistantMessage,
+    ErrorEvent,
     MessageEndEvent,
     ToolCall,
     ToolExecutionEndEvent,
@@ -1248,6 +1249,25 @@ async def test_tui_prompt_worker_refreshes_directly() -> None:
     await app._run_prompt("hello")
 
     assert refreshes == 2
+    assert app.state.running is False
+
+
+@pytest.mark.anyio
+async def test_tui_prompt_worker_shows_diagnostic_log_path_for_error_event(tmp_path: Path) -> None:
+    class ErrorSession(FakeSession):
+        def __init__(self) -> None:
+            super().__init__(events=[AgentStartEvent(), ErrorEvent(message="provider failed")])
+            self.last_diagnostic_log_path = tmp_path / "tau-home" / "logs" / "agent-calls.jsonl"
+
+    session = ErrorSession()
+    app = TauTuiApp(session)
+    app._refresh = lambda: None  # type: ignore[method-assign]
+
+    await app._run_prompt("break")
+
+    assert app.state.error == f"Error: provider failed\nLog: {session.last_diagnostic_log_path}"
+    assert app.state.items[-1].role == "error"
+    assert app.state.items[-1].text == app.state.error
     assert app.state.running is False
 
 


### PR DESCRIPTION
## Summary
- attach the coding-session diagnostic log path to non-recoverable TUI error events
- keep the existing exception failure display behavior
- add regression coverage for provider/error-event failures in the TUI prompt worker

Closes #20

## Tests
- uv run ruff check src tests
- uv run mypy
- uv run pytest tests/test_tui_app.py::test_tui_prompt_worker_shows_diagnostic_log_path_for_error_event
- uv run pytest tests/test_coding_session.py tests/test_tui_app.py
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Error messages now display diagnostic log paths when prompt execution fails, making it easier to locate detailed diagnostic information for troubleshooting.

* **Tests**
  * Added test coverage for diagnostic log path visibility during error events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->