### PR TITLE
[codex] Compact TUI context count

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -164,7 +164,6 @@ def render_session_sidebar(
     metadata = Table.grid(padding=(0, 1))
     metadata.add_column(style=theme.completion_description, no_wrap=True)
     metadata.add_column(style=theme.prompt_text)
-    metadata.add_row("context", _context_percentage(session))
     metadata.add_row("provider", session.provider_name)
     metadata.add_row("model", session.model)
     metadata.add_row("thinking", _thinking_level(session))
@@ -500,19 +499,22 @@ def _plain_text(text: str, *, body_style: str) -> Text:
     return Text(text, style=body_style, overflow="fold", no_wrap=False)
 
 
-def _context_percentage(session: SessionSummarySource) -> str:
-    threshold = session.auto_compact_token_threshold
-    if threshold is None or threshold <= 0:
-        return "--"
-    percentage = min(round((session.context_token_estimate / threshold) * 100), 999)
-    return f"{percentage}%"
-
-
 def _context_usage(session: SessionSummarySource) -> str:
     threshold = session.auto_compact_token_threshold
     if threshold is None or threshold <= 0:
-        return f"{session.context_token_estimate} context"
-    return f"{session.context_token_estimate}/{threshold} context"
+        return f"{_compact_token_count(session.context_token_estimate)} context"
+    return (
+        f"{_compact_token_count(session.context_token_estimate)}"
+        f"/{_compact_token_count(threshold)} context"
+    )
+
+
+def _compact_token_count(value: int) -> str:
+    if value <= 0:
+        return "0k"
+    if value < 1000:
+        return "<1k"
+    return f"{(value + 500) // 1000}k"
 
 
 def _thinking_level(session: SessionSummarySource) -> str:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -45,6 +45,7 @@ from tau_coding.tui.app import (
 from tau_coding.tui.config import HIGH_CONTRAST_THEME, TuiKeybindings, TuiSettings
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
+    _compact_token_count,
     render_chat_item,
     render_compact_session_info,
     render_session_sidebar,
@@ -75,8 +76,8 @@ class FakeSession:
         self.context_files = (
             ProjectContextFile(path=str(self.cwd / "AGENTS.md"), content="Follow rules."),
         )
-        self.context_token_estimate = 123
-        self.auto_compact_token_threshold = 1000
+        self.context_token_estimate = 12034
+        self.auto_compact_token_threshold = 200000
         self.thinking_level = "medium"
         self.available_thinking_levels = ("off", "minimal", "low", "medium", "high", "xhigh")
         self.state = FakeSessionState()
@@ -167,8 +168,8 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "████████" in output
     assert "τ = 2π" in output
     assert "session" in output
-    assert "context" in output
-    assert "12%" in output
+    assert "context" not in output
+    assert "12k" not in output
     assert "provider" in output
     assert "openai" in output
     assert "fake-model" in output
@@ -198,9 +199,16 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
 
     output = console.export_text()
     assert "/workspace/project (--)" in output
-    assert "123/1000 context" in output
+    assert "12k/200k context" in output
     assert "openai:fake-model" in output
     assert "(medium)" in output
+
+
+def test_compact_token_count_uses_thousands_suffix() -> None:
+    assert _compact_token_count(0) == "0k"
+    assert _compact_token_count(499) == "<1k"
+    assert _compact_token_count(12034) == "12k"
+    assert _compact_token_count(12500) == "13k"
 
 
 def test_compact_session_info_wraps_to_available_width() -> None:


### PR DESCRIPTION
## Summary

- Remove the redundant context count from the TUI sidebar session panel.
- Keep context usage under the prompt and format token counts in compact thousands form, for example `12k`.
- Update TUI render tests for the new sidebar and prompt metadata behavior.

Closes #30.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Context token usage in the TUI now renders in a more compact, readable format (e.g., `12k/200k`), including special handling for values under 1k.

* **Bug Fixes**
  * Session sidebar metadata no longer includes the previously shown context percentage row.

* **Tests**
  * Updated TUI rendering expectations and added coverage for compact token count formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->