### PR TITLE
[codex] Show TUI context files in sidebar

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,8 @@ The built-in themes are:
 
 The built-in sidebar is responsive: Tau shows it on medium or larger terminal
 windows and hides it automatically when the terminal is narrow or short.
+When visible, it includes the active provider/model, thinking mode, loaded tools,
+skills, prompt templates, and context files such as `AGENTS.md`.
 
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -22,6 +22,7 @@ from textual.widgets import RichLog, Static
 from tau_agent.tools import AgentTool
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.skills import Skill
+from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import ChatItem, TuiState
@@ -55,6 +56,9 @@ class SessionSummarySource(Protocol):
 
     @property
     def prompt_templates(self) -> Sequence[PromptTemplate]: ...
+
+    @property
+    def context_files(self) -> Sequence[ProjectContextFile]: ...
 
     @property
     def context_token_estimate(self) -> int: ...
@@ -181,6 +185,11 @@ def render_session_sidebar(
         empty="No prompt templates",
         theme=theme,
     )
+    context = _bullet_list(
+        _context_file_labels(session.context_files, cwd=session.cwd),
+        empty="No context files",
+        theme=theme,
+    )
     logo = Text(TAU_SIDEBAR_LOGO, style=f"bold {theme.prompt_text}")
 
     return Group(
@@ -188,6 +197,13 @@ def render_session_sidebar(
         Panel(
             metadata,
             title="session",
+            box=box.SQUARE,
+            border_style=theme.border,
+            padding=(0, 1),
+        ),
+        Panel(
+            context,
+            title="context",
             box=box.SQUARE,
             border_style=theme.border,
             padding=(0, 1),
@@ -515,6 +531,24 @@ def _compact_token_count(value: int) -> str:
     if value < 1000:
         return "<1k"
     return f"{(value + 500) // 1000}k"
+
+
+def _context_file_labels(
+    context_files: Sequence[ProjectContextFile],
+    *,
+    cwd: Path,
+) -> list[str]:
+    return [_context_file_label(Path(context_file.path), cwd=cwd) for context_file in context_files]
+
+
+def _context_file_label(path: Path, *, cwd: Path) -> str:
+    expanded_path = path.expanduser()
+    if not expanded_path.is_absolute():
+        expanded_path = cwd / expanded_path
+    try:
+        return str(expanded_path.resolve().relative_to(cwd.expanduser().resolve()))
+    except (OSError, ValueError):
+        return _short_path(expanded_path)
 
 
 def _thinking_level(session: SessionSummarySource) -> str:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -168,7 +168,8 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "████████" in output
     assert "τ = 2π" in output
     assert "session" in output
-    assert "context" not in output
+    assert "context" in output
+    assert "AGENTS.md" in output
     assert "12k" not in output
     assert "provider" in output
     assert "openai" in output
@@ -187,9 +188,29 @@ def test_session_sidebar_uses_square_muted_panels() -> None:
     sidebar = render_session_sidebar(FakeSession())
     panels = [renderable for renderable in sidebar.renderables if isinstance(renderable, Panel)]
 
-    assert len(panels) == 4
+    assert len(panels) == 5
     assert all(renderable.box == box.SQUARE for renderable in panels)
     assert {str(renderable.border_style) for renderable in panels} == {"#141922"}
+
+
+def test_session_sidebar_lists_multiple_context_files() -> None:
+    session = FakeSession()
+    session.context_files = (
+        ProjectContextFile(path=str(session.cwd / "AGENTS.md"), content="Root rules."),
+        ProjectContextFile(
+            path=str(session.cwd / ".agents" / "AGENTS.md"),
+            content="Agent rules.",
+        ),
+        ProjectContextFile(path="docs/AGENTS.md", content="Docs rules."),
+    )
+    console = Console(record=True, width=100)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "AGENTS.md" in output
+    assert ".agents/AGENTS.md" in output
+    assert "docs/AGENTS.md" in output
 
 
 def test_compact_session_info_renders_sidebar_facts() -> None:


### PR DESCRIPTION
## Summary

- Add loaded context files to the TUI sidebar using readable paths relative to the session cwd when possible.
- Keep the context display separate from the compact token count under the prompt.
- Document the sidebar contents and add render coverage for multiple context files.

Closes #29.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI sidebar now displays context files (such as AGENTS.md) in a dedicated panel alongside provider/model, thinking mode, tools, skills, and prompt templates.

* **Documentation**
  * Updated configuration documentation to clarify that the built-in responsive sidebar includes context files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->