### PR TITLE
[codex] Enable transcript text selection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,10 @@ windows and hides it automatically when the terminal is narrow or short.
 When visible, it includes the active provider/model, thinking mode, loaded tools,
 skills, prompt templates, and context files such as `AGENTS.md`.
 
+Transcript text supports Textual selection for visible user, assistant, tool, and
+error output. Copy shortcuts are terminal-emulator dependent, and selecting the
+full visible row can include Tau's left accent marker.
+
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown
 themes, unknown keybinding names, empty keys, and duplicate assignments so

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 from textual.events import Resize
+from textual.selection import Selection
 from textual.widgets import RichLog, Static
 
 from tau_agent.tools import AgentTool
@@ -157,6 +158,13 @@ class TranscriptView(RichLog):
                 shrink=True,
                 scroll_end=scroll_end,
             )
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """Return selected transcript text from RichLog's rendered line buffer."""
+        if not self.lines:
+            return None
+        text = "\n".join(line.text.rstrip() for line in self.lines)
+        return selection.extract(text), "\n"
 
 
 def render_session_sidebar(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -45,6 +45,7 @@ from tau_coding.tui.app import (
 from tau_coding.tui.config import HIGH_CONTRAST_THEME, TuiKeybindings, TuiSettings
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
+    TranscriptView,
     _compact_token_count,
     render_chat_item,
     render_compact_session_info,
@@ -369,6 +370,47 @@ def test_tool_chat_items_color_status_metadata_not_tool_name_or_results() -> Non
     assert f"{white};48;2;0;0;0m✗ bash" in error_output
     assert f"{red};48;2;0;0;0m✗ bash" not in error_output
     assert f"{red};48;2;0;0;0mfailed" not in error_output
+
+
+@pytest.mark.anyio
+async def test_transcript_view_exposes_visible_text_selection() -> None:
+    tool_call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": "printf hello", "timeout": 5},
+    )
+    app = TauTuiApp(
+        FakeSession(
+            messages=(
+                UserMessage(content="Run the command"),
+                AssistantMessage(content="I will run it.", tool_calls=(tool_call,)),
+                ToolResultMessage(
+                    tool_call_id="call-1",
+                    name="bash",
+                    ok=True,
+                    content="hello\nworld",
+                ),
+            )
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        app.state.show_tool_results = True
+        app.state.add_item("error", "Error: provider failed")
+        app._refresh()
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.text_select_all()
+
+        selected = app.screen.get_selected_text()
+        assert selected is not None
+        assert "Run the command" in selected
+        assert "I will run it." in selected
+        assert "$ printf hello" in selected
+        assert "hello" in selected
+        assert "world" in selected
+        assert "Error: provider failed" in selected
 
 
 def test_assistant_chat_items_render_markdown_lists() -> None:


### PR DESCRIPTION
## Summary

- Implement `TranscriptView.get_selection()` so Textual can extract selected text from the rendered transcript buffer.
- Cover selection for visible user, assistant, tool, and error output through the TUI test harness.
- Document terminal-dependent copy behavior and the visible accent-marker limitation.

Closes #19.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`