### PR TITLE
[codex] Copy selected TUI messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,9 @@ Example:
     "completion_previous": "up",
     "thinking_cycle": "shift+tab",
     "toggle_tool_results": "ctrl+o",
+    "message_previous": "alt+up",
+    "message_next": "alt+down",
+    "copy_message": "ctrl+c",
     "quit": "ctrl+d"
   }
 }
@@ -144,6 +147,8 @@ skills, prompt templates, and context files such as `AGENTS.md`.
 Transcript text supports Textual selection for visible user, assistant, tool, and
 error output. Copy shortcuts are terminal-emulator dependent, and selecting the
 full visible row can include Tau's left accent marker.
+Use `Alt+Up` / `Alt+Down` to select transcript messages and `Ctrl+C` to copy the
+selected message text through Textual's terminal clipboard integration.
 
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -112,6 +112,12 @@ class CompletionActionTarget(Protocol):
 
     def action_toggle_tool_results(self) -> None: ...
 
+    def action_select_previous_message(self) -> None: ...
+
+    def action_select_next_message(self) -> None: ...
+
+    def action_copy_selected_message(self) -> None: ...
+
     async def action_submit_prompt(self) -> None: ...
 
 
@@ -198,6 +204,18 @@ class PromptInput(TextArea):
         """Toggle app-level tool result display."""
         self._completion_target().action_toggle_tool_results()
 
+    def action_select_previous_message(self) -> None:
+        """Select the previous transcript message."""
+        self._completion_target().action_select_previous_message()
+
+    def action_select_next_message(self) -> None:
+        """Select the next transcript message."""
+        self._completion_target().action_select_next_message()
+
+    def action_copy_selected_message(self) -> None:
+        """Copy the selected transcript message."""
+        self._completion_target().action_copy_selected_message()
+
     async def action_quit(self) -> None:
         """Quit the app through the app-level action."""
         await self.app.action_quit()
@@ -236,6 +254,17 @@ class PromptInput(TextArea):
         elif event.key == keybindings.toggle_tool_results:
             event.stop()
             self._completion_target().action_toggle_tool_results()
+        elif event.key == keybindings.message_previous:
+            event.stop()
+            self._completion_target().action_select_previous_message()
+        elif event.key == keybindings.message_next:
+            event.stop()
+            self._completion_target().action_select_next_message()
+        elif event.key == keybindings.copy_message:
+            if self.selected_text:
+                return
+            event.stop()
+            self._completion_target().action_copy_selected_message()
         elif event.key == keybindings.completion_next:
             event.stop()
             if self._has_completion_options():
@@ -1207,6 +1236,41 @@ class TauTuiApp(App[None]):
         self._refresh()
         self._notify("Tool results expanded." if expanded else "Tool results collapsed.")
 
+    def action_select_previous_message(self) -> None:
+        """Select the previous transcript message for copy operations."""
+        item = self.state.select_previous_item()
+        self._refresh()
+        if item is None:
+            self._notify("No transcript messages.")
+
+    def action_select_next_message(self) -> None:
+        """Select the next transcript message for copy operations."""
+        item = self.state.select_next_item()
+        self._refresh()
+        if item is None:
+            self._notify("No transcript messages.")
+
+    def action_copy_selected_message(self) -> None:
+        """Copy the selected transcript message to the terminal clipboard."""
+        text = self._selected_message_text()
+        if text is None:
+            self._notify("Select a transcript message first.", severity="warning")
+            return
+        try:
+            self.copy_to_clipboard(text)
+        except Exception as exc:  # noqa: BLE001 - terminal clipboard support varies
+            self._notify(f"Could not copy message: {exc}", severity="error")
+            return
+        self._notify("Copied selected message.")
+
+    def _selected_message_text(self) -> str | None:
+        item = self.state.selected_item()
+        if item is None:
+            return None
+        if item.role == "tool" and self.state.show_tool_results and item.tool_result_text:
+            return f"{item.text}\n\n{item.tool_result_text}"
+        return item.text
+
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:
             return
@@ -1588,6 +1652,9 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
             priority=True,
         ),
         Binding(keybindings.toggle_tool_results, "toggle_tool_results", "Tool results"),
+        Binding(keybindings.message_previous, "select_previous_message", "Prev msg"),
+        Binding(keybindings.message_next, "select_next_message", "Next msg"),
+        Binding(keybindings.copy_message, "copy_selected_message", "Copy msg"),
         Binding(keybindings.quit, "quit", "Quit"),
     ]
 
@@ -1600,6 +1667,24 @@ def _prompt_bindings(keybindings: TuiKeybindings) -> list[Binding]:
         Binding(
             keybindings.toggle_tool_results,
             "toggle_tool_results",
+            show=False,
+            priority=True,
+        ),
+        Binding(
+            keybindings.message_previous,
+            "select_previous_message",
+            show=False,
+            priority=True,
+        ),
+        Binding(
+            keybindings.message_next,
+            "select_next_message",
+            show=False,
+            priority=True,
+        ),
+        Binding(
+            keybindings.copy_message,
+            "copy_selected_message",
             show=False,
             priority=True,
         ),

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -24,6 +24,9 @@ class TuiKeybindings:
     completion_previous: str = "up"
     thinking_cycle: str = "shift+tab"
     toggle_tool_results: str = "ctrl+o"
+    message_previous: str = "alt+up"
+    message_next: str = "alt+down"
+    copy_message: str = "ctrl+c"
     quit: str = "ctrl+d"
 
     def to_json(self) -> dict[str, str]:
@@ -37,6 +40,9 @@ class TuiKeybindings:
             "completion_previous": self.completion_previous,
             "thinking_cycle": self.thinking_cycle,
             "toggle_tool_results": self.toggle_tool_results,
+            "message_previous": self.message_previous,
+            "message_next": self.message_next,
+            "copy_message": self.copy_message,
             "quit": self.quit,
         }
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -33,6 +33,7 @@ class TuiState:
     running: bool = False
     error: str | None = None
     show_tool_results: bool = False
+    selected_item_index: int | None = None
 
     def add_item(
         self,
@@ -51,6 +52,8 @@ class TuiState:
                 tool_result_text=tool_result_text,
             )
         )
+        if self.selected_item_index is not None:
+            self.selected_item_index = min(self.selected_item_index, len(self.items) - 1)
 
     def add_tool_call(self, tool_call: ToolCall) -> None:
         """Append a collapsed tool-call item."""
@@ -89,6 +92,7 @@ class TuiState:
         self.items.clear()
         self.assistant_buffer = ""
         self.error = None
+        self.selected_item_index = None
 
     def load_messages(self, messages: Iterable[AgentMessage]) -> None:
         """Populate the transcript from restored session messages."""
@@ -112,6 +116,37 @@ class TuiState:
                         error=message.error,
                     )
                 )
+
+    def selected_item(self) -> ChatItem | None:
+        """Return the currently selected transcript item."""
+        if self.selected_item_index is None:
+            return None
+        if not 0 <= self.selected_item_index < len(self.items):
+            self.selected_item_index = None
+            return None
+        return self.items[self.selected_item_index]
+
+    def select_next_item(self) -> ChatItem | None:
+        """Move selection toward newer transcript items."""
+        if not self.items:
+            self.selected_item_index = None
+            return None
+        if self.selected_item_index is None:
+            self.selected_item_index = len(self.items) - 1
+        else:
+            self.selected_item_index = min(self.selected_item_index + 1, len(self.items) - 1)
+        return self.items[self.selected_item_index]
+
+    def select_previous_item(self) -> ChatItem | None:
+        """Move selection toward older transcript items."""
+        if not self.items:
+            self.selected_item_index = None
+            return None
+        if self.selected_item_index is None:
+            self.selected_item_index = len(self.items) - 1
+        else:
+            self.selected_item_index = max(self.selected_item_index - 1, 0)
+        return self.items[self.selected_item_index]
 
 
 def format_tool_call_block(tool_call: ToolCall) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -115,7 +115,7 @@ class TranscriptView(RichLog):
         """Redraw the transcript from display state."""
         self._render_state = state
         self._render_theme = theme
-        self._redraw(scroll_end=True)
+        self._redraw(scroll_end=state.selected_item_index is None)
 
     def on_resize(self, event: Resize) -> None:
         """Re-render transcript entries when the terminal width changes."""
@@ -136,12 +136,13 @@ class TranscriptView(RichLog):
         theme = self._render_theme
         self._last_render_width = self.scrollable_content_region.width
         self.clear()
-        for item in state.items:
+        for index, item in enumerate(state.items):
             self.write(
                 render_chat_item(
                     item,
                     theme=theme,
                     show_tool_results=state.show_tool_results,
+                    selected=index == state.selected_item_index,
                 ),
                 expand=True,
                 shrink=True,
@@ -271,9 +272,12 @@ def render_chat_item(
     *,
     theme: TuiTheme = TAU_DARK_THEME,
     show_tool_results: bool = False,
+    selected: bool = False,
 ) -> RenderableType:
     """Render a chat item as a standalone Toad-inspired transcript block."""
     role_style = _chat_item_role_style(item, theme)
+    if selected:
+        role_style = TuiRoleStyle(border=theme.accent, body=role_style.body)
     body = (
         _render_tool_chat_body(
             item,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -301,6 +301,15 @@ def test_chat_items_use_configured_theme_accent() -> None:
     assert "38;2;0;255;102" in output
 
 
+def test_selected_chat_item_uses_accent_border() -> None:
+    console = Console(record=True, width=40)
+
+    console.print(render_chat_item(ChatItem(role="assistant", text="Done."), selected=True))
+
+    output = console.export_text(styles=True)
+    assert "38;2;244;162;97" in output
+
+
 def test_chat_items_render_fenced_code_without_markers() -> None:
     console = Console(record=True, width=60)
     item = ChatItem(
@@ -1289,6 +1298,92 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
 
     assert app.state.show_tool_results is False
     assert notifications == ["Tool results expanded.", "Tool results collapsed."]
+
+
+@pytest.mark.anyio
+async def test_tui_app_copies_selected_transcript_messages() -> None:
+    tool_call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": "printf hello", "timeout": 5},
+    )
+    app = TauTuiApp(
+        FakeSession(
+            messages=(
+                UserMessage(content="User prompt"),
+                AssistantMessage(content="Assistant response", tool_calls=(tool_call,)),
+                ToolResultMessage(
+                    tool_call_id="call-1",
+                    name="bash",
+                    ok=True,
+                    content="tool output",
+                ),
+            )
+        )
+    )
+    copied: list[str] = []
+    notifications: list[str] = []
+
+    def fake_copy(text: str) -> None:
+        copied.append(text)
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app.copy_to_clipboard = fake_copy  # type: ignore[method-assign]
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.state.show_tool_results = True
+        app.state.add_item("error", "Error: failed")
+        app._refresh()
+
+        for _ in range(4):
+            await pilot.press("alt+up")
+            await pilot.press("ctrl+c")
+            await pilot.pause()
+
+    assert copied == [
+        "Error: failed",
+        "$ printf hello (timeout 5s)\n\n✓ bash\ntool output",
+        "Assistant response",
+        "User prompt",
+    ]
+    assert notifications == [
+        "Copied selected message.",
+        "Copied selected message.",
+        "Copied selected message.",
+        "Copied selected message.",
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_copy_selected_message_reports_failures() -> None:
+    app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))
+    notifications: list[tuple[str, str | None]] = []
+
+    def fake_copy(text: str) -> None:
+        del text
+        raise RuntimeError("clipboard unavailable")
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity")
+        notifications.append((message, severity if isinstance(severity, str) else None))
+
+    app.copy_to_clipboard = fake_copy  # type: ignore[method-assign]
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+c")
+        await pilot.press("alt+up")
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+    assert notifications == [
+        ("Select a transcript message first.", "warning"),
+        ("Could not copy message: clipboard unavailable", "error"),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -39,7 +39,8 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
             "command_palette": "ctrl+j",
             "session_picker": "ctrl+y",
             "accept_completion": "f2",
-            "thinking_cycle": "f3"
+            "thinking_cycle": "f3",
+            "copy_message": "ctrl+b"
           },
           "theme": "high-contrast"
         }
@@ -54,6 +55,9 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     assert settings.keybindings.toggle_tool_results == "ctrl+o"
     assert settings.keybindings.accept_completion == "f2"
     assert settings.keybindings.thinking_cycle == "f3"
+    assert settings.keybindings.message_previous == "alt+up"
+    assert settings.keybindings.message_next == "alt+down"
+    assert settings.keybindings.copy_message == "ctrl+b"
     assert settings.keybindings.cancel == "escape"
     assert settings.theme == "high-contrast"
     assert settings.resolved_theme == HIGH_CONTRAST_THEME
@@ -88,6 +92,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
             session_picker="ctrl+y",
             accept_completion="f2",
             thinking_cycle="f3",
+            copy_message="ctrl+b",
         ),
         theme="high-contrast",
     )
@@ -97,6 +102,9 @@ def test_tui_keybindings_serialize_to_json() -> None:
     assert settings.to_json()["keybindings"]["toggle_tool_results"] == "ctrl+o"
     assert settings.to_json()["keybindings"]["accept_completion"] == "f2"
     assert settings.to_json()["keybindings"]["thinking_cycle"] == "f3"
+    assert settings.to_json()["keybindings"]["message_previous"] == "alt+up"
+    assert settings.to_json()["keybindings"]["message_next"] == "alt+down"
+    assert settings.to_json()["keybindings"]["copy_message"] == "ctrl+b"
     assert settings.to_json()["theme"] == "high-contrast"
 
 


### PR DESCRIPTION
## Summary

- Add TUI message selection with `Alt+Up` / `Alt+Down` and a visible selected-message accent.
- Add `Ctrl+C` copy for the selected transcript message using Textual's terminal clipboard integration, with success and failure feedback.
- Keep prompt text copying intact when the prompt itself has selected text.
- Add configurable keybindings, docs, and coverage for user, assistant, tool, and error messages.

Closes #32.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`