### PR TITLE
[codex] Clarify provider credential precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,13 +62,15 @@ Example:
 }
 ```
 
-API keys and OAuth refresh credentials are not written to this file. Built-in
-providers added through `/login` read their credential from
-`~/.tau/credentials.json` using `credential_name`. Providers without a
-`credential_name`, such as custom local providers, read the environment variable
-named by `api_key_env`. `timeout_seconds` is optional and defaults to `60`; when
-present, it must be greater than zero. `max_retries` defaults to `0`, and
-`max_retry_delay_seconds` defaults to `1`; both must be zero or greater.
+API keys and OAuth refresh credentials are not written to this file. Tau resolves
+credentials in this order: stored API key or OAuth credential from
+`~/.tau/credentials.json`, then the provider-specific environment variable named
+by `api_key_env`. Built-in providers added through `/login` read their saved
+credential using `credential_name`. Providers without a `credential_name`, such
+as custom local providers, read the environment variable named by `api_key_env`.
+`timeout_seconds` is optional and defaults to `60`; when present, it must be
+greater than zero. `max_retries` defaults to `0`, and `max_retry_delay_seconds`
+defaults to `1`; both must be zero or greater.
 `headers` is optional and must be an object with string keys and string values.
 Tau sends these headers with provider requests, while keeping its own
 authentication headers under runtime control.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -69,6 +69,11 @@ List configured providers:
 tau providers
 ```
 
+`tau providers` shows whether each provider will use a stored Tau credential,
+an environment-variable fallback, or has missing credentials. Stored API keys
+and OAuth credentials in `~/.tau/credentials.json` take precedence over
+provider-specific environment variables such as `OPENAI_API_KEY`.
+
 Create or update a provider:
 
 ```bash

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -16,10 +16,13 @@ from tau_ai import (
 )
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
 from tau_coding import __version__
+from tau_coding.credentials import FileCredentialStore
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER_NAME,
+    CredentialReader,
     OpenAICompatibleProviderConfig,
+    ProviderConfig,
     ProviderSettings,
     load_provider_settings,
     provider_kind,
@@ -45,7 +48,7 @@ app = typer.Typer(
 
 def providers_command() -> None:
     """List configured model providers."""
-    render_provider_settings(load_provider_settings())
+    render_provider_settings(load_provider_settings(), credential_reader=FileCredentialStore())
 
 
 def setup_command(
@@ -295,7 +298,11 @@ def _resolve_export_source(
     return record.path, title
 
 
-def render_provider_settings(settings: ProviderSettings) -> None:
+def render_provider_settings(
+    settings: ProviderSettings,
+    *,
+    credential_reader: CredentialReader | None = None,
+) -> None:
     """Render configured providers for the CLI."""
     for provider in settings.providers:
         marker = "*" if provider.name == settings.default_provider else " "
@@ -303,10 +310,28 @@ def render_provider_settings(settings: ProviderSettings) -> None:
         typer.echo(
             f"{marker}\t{provider.name}\t{provider_kind(provider)}\t"
             f"{provider.default_model}\t{models}\t{provider.api_key_env}\t"
+            f"{_provider_credential_status(provider, credential_reader=credential_reader)}\t"
             f"{provider.base_url}\t{provider.timeout_seconds:g}s\t"
             f"retries={provider.max_retries}\t"
             f"retry_delay={provider.max_retry_delay_seconds:g}s"
         )
+
+
+def _provider_credential_status(
+    provider: ProviderConfig,
+    *,
+    credential_reader: CredentialReader | None,
+) -> str:
+    if provider.credential_name and credential_reader is not None:
+        if provider_kind(provider) == "openai-codex":
+            get_oauth = getattr(credential_reader, "get_oauth", None)
+            if get_oauth is not None and get_oauth(provider.credential_name) is not None:
+                return f"stored:{provider.credential_name}"
+        elif credential_reader.get(provider.credential_name):
+            return f"stored:{provider.credential_name}"
+    if environ.get(provider.api_key_env):
+        return f"env:{provider.api_key_env}"
+    return "missing"
 
 
 async def run_openai_print_mode(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,11 @@ from tau_ai import (
 from tau_coding import CodingSessionRecord, SessionManager, cli
 from tau_coding.cli import app, run_print_mode
 from tau_coding.paths import TauPaths
-from tau_coding.provider_config import load_provider_settings
+from tau_coding.provider_config import (
+    OpenAICompatibleProviderConfig,
+    ProviderSettings,
+    load_provider_settings,
+)
 from tau_coding.rendering import PrintOutputMode
 from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
@@ -521,6 +525,47 @@ def test_providers_command_lists_default_provider(
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
     assert " \topenrouter\topenai-compatible\topenai/gpt-5.5" in result.stdout
     assert " \thuggingface\topenai-compatible\topenai/gpt-oss-120b" in result.stdout
+
+
+def test_render_provider_settings_shows_credential_source(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("STORED_API_KEY", raising=False)
+    monkeypatch.setenv("ENV_API_KEY", "env-key")
+    monkeypatch.delenv("MISSING_API_KEY", raising=False)
+    settings = ProviderSettings(
+        default_provider="stored",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="stored",
+                api_key_env="STORED_API_KEY",
+                credential_name="stored",
+            ),
+            OpenAICompatibleProviderConfig(
+                name="env",
+                api_key_env="ENV_API_KEY",
+                credential_name=None,
+            ),
+            OpenAICompatibleProviderConfig(
+                name="missing",
+                api_key_env="MISSING_API_KEY",
+                credential_name="missing",
+            ),
+        ),
+    )
+
+    class FakeCredentials:
+        def get(self, name: str) -> str | None:
+            return "stored-key" if name == "stored" else None
+
+    cli.render_provider_settings(settings, credential_reader=FakeCredentials())
+
+    output = capsys.readouterr().out
+    assert "*\tstored\topenai-compatible\tgpt-5.5" in output
+    assert "\tSTORED_API_KEY\tstored:stored\t" in output
+    assert "\tENV_API_KEY\tenv:ENV_API_KEY\t" in output
+    assert "\tMISSING_API_KEY\tmissing\t" in output
 
 
 def test_setup_command_writes_provider_settings(

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -379,6 +379,49 @@ def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> 
     assert "custom/coder" in provider.models
 
 
+def test_load_provider_settings_restores_builtin_credential_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-key")
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        """
+{
+  "default_provider": "openrouter",
+  "providers": [
+    {
+      "type": "openai-compatible",
+      "name": "openrouter",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "credential_name": null,
+      "models": ["openai/gpt-5.5"],
+      "default_model": "openai/gpt-5.5"
+    }
+  ]
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    class FakeCredentials:
+        def get(self, name: str) -> str | None:
+            return "stored-key" if name == "openrouter" else None
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+    provider = settings.get_provider("openrouter")
+
+    assert isinstance(provider, OpenAICompatibleProviderConfig)
+    assert provider.credential_name == "openrouter"
+    config = openai_compatible_config_from_provider(
+        provider,
+        credential_reader=FakeCredentials(),
+    )
+    assert config.api_key == "stored-key"
+
+
 def test_provider_settings_from_json_rejects_invalid_headers() -> None:
     with pytest.raises(ProviderConfigError, match="string object"):
         provider_settings_from_json(


### PR DESCRIPTION
## Summary

- Show explicit credential source in `tau providers`: stored credential, env fallback, or missing.
- Document Tau's credential precedence: stored API key/OAuth first, provider env var second.
- Add regression coverage that stale built-in provider entries regain catalog `credential_name` metadata and therefore prefer saved credentials over env vars.

Closes #16.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`