### PR TITLE
[codex] Add TUI activity indicator

### DIFF
--- a/docs/custom-tui.md
+++ b/docs/custom-tui.md
@@ -184,6 +184,15 @@ A custom picker UI can also read the same data directly:
 - `session.available_thinking_levels`
 - `session.session_manager`
 
+## Activity State
+
+Frontends should treat `AgentStartEvent`/`AgentEndEvent` and non-recoverable
+`ErrorEvent` values as the source of truth for whether the agent is working.
+The built-in Textual app renders a subtle animated status indicator while the
+session is running and resets it to `Ready` when the run completes, is cancelled,
+or fails. Custom TUIs can use the same event-driven state instead of checking
+provider-specific streaming details.
+
 ## Keybindings
 
 Keybindings and themes are frontend policy. The built-in Textual app reads optional

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -11,6 +11,7 @@ from textual.binding import Binding, BindingsMap
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import (
     Button,
     Footer,
@@ -68,6 +69,7 @@ from tau_coding.tui.widgets import (
 type BindingEntry = Binding | tuple[str, str] | tuple[str, str, str]
 SIDEBAR_MIN_WIDTH = 96
 SIDEBAR_MIN_HEIGHT = 24
+ACTIVITY_FRAMES = ("Working |", "Working /", "Working -", "Working \\")
 
 
 class LoginRequiredProvider:
@@ -1033,6 +1035,8 @@ class TauTuiApp(App[None]):
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
         self._completion_state = CompletionState()
+        self._activity_frame = 0
+        self._activity_timer: Timer | None = None
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Return Tau-specific CSS variables for the selected TUI theme."""
@@ -1072,6 +1076,12 @@ class TauTuiApp(App[None]):
             self._notify(self.startup_message, severity="warning")
         if self.initial_prompt and self.initial_prompt.strip():
             self._submit_prompt(self.initial_prompt.strip())
+
+    def on_unmount(self) -> None:
+        """Stop the activity timer when the app is torn down."""
+        if self._activity_timer is not None:
+            self._activity_timer.stop()
+            self._activity_timer = None
 
     def on_resize(self, event: Resize) -> None:
         """Update responsive chrome when the terminal changes size."""
@@ -1489,8 +1499,36 @@ class TauTuiApp(App[None]):
         compact_info.update_from_session(self.session, theme=theme)
         transcript = self.query_one("#transcript", TranscriptView)
         transcript.update_from_state(self.state, theme=theme)
+        self._sync_activity_indicator()
         status = self.query_one("#status", Static)
-        status.update("Working…" if self.state.running else "Ready")
+        status.update(self._status_text())
+
+    def _sync_activity_indicator(self) -> None:
+        if self.state.running:
+            if self._activity_timer is None:
+                self._activity_timer = self.set_interval(
+                    0.2,
+                    self._tick_activity,
+                    name="activity-indicator",
+                )
+            else:
+                self._activity_timer.resume()
+            return
+        self._activity_frame = 0
+        if self._activity_timer is not None:
+            self._activity_timer.pause()
+
+    def _tick_activity(self) -> None:
+        if not self.state.running:
+            return
+        self._activity_frame = (self._activity_frame + 1) % len(ACTIVITY_FRAMES)
+        status = self.query_one("#status", Static)
+        status.update(self._status_text())
+
+    def _status_text(self) -> str:
+        if not self.state.running:
+            return "Ready"
+        return ACTIVITY_FRAMES[self._activity_frame]
 
     def _refresh_completions(self) -> None:
         suggestions = self.query_one("#autocomplete", Static)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -668,6 +668,45 @@ def test_tui_app_loads_restored_messages_into_display_state() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_animates_activity_status_while_running() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test():
+        status = app.query_one("#status")
+
+        assert str(status.render()) == "Ready"
+
+        app.adapter.apply(AgentStartEvent())
+        app._refresh()
+
+        assert str(status.render()) == "Working |"
+
+        app._tick_activity()
+
+        assert str(status.render()) == "Working /"
+
+        app.adapter.apply(AgentEndEvent())
+        app._refresh()
+
+        assert str(status.render()) == "Ready"
+
+
+@pytest.mark.anyio
+async def test_tui_app_clears_activity_status_on_error() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test():
+        status = app.query_one("#status")
+
+        app.adapter.apply(AgentStartEvent())
+        app._refresh()
+        app.adapter.apply(ErrorEvent(message="provider failed", recoverable=False))
+        app._refresh()
+
+        assert str(status.render()) == "Ready"
+
+
+@pytest.mark.anyio
 async def test_tui_app_new_command_starts_new_visible_state() -> None:
     app = TauTuiApp(FakeSession(messages=[UserMessage(content="Earlier")]))
 


### PR DESCRIPTION
## Summary
- replace the static running status with a subtle animated TUI activity indicator
- start/stop the indicator from event-driven running state and clean up the timer on unmount
- document activity-state guidance for custom TUIs

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`

Closes #35