### PR TITLE
Add queued steering and follow-up prompts

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -49,6 +49,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Phase 20.2: Thinking Mode Controls](phase-20-2-thinking-controls.md)
 - [Phase 20.3: Skill Invocation Reliability](phase-20-3-skill-invocation.md)
 - [Phase 20.4: Session Export and Visualization](phase-20-4-session-export.md)
+- [Queued Steering and Follow-ups](queued-steering-follow-ups.md)
 - [Phase 22: Compaction Replay Foundation](phase-22-compaction-foundation.md)
 
 More pages will be added here as each phase lands.

--- a/docs/architecture/queued-steering-follow-ups.md
+++ b/docs/architecture/queued-steering-follow-ups.md
@@ -1,0 +1,68 @@
+# Queued Steering And Follow-ups
+
+This slice adds Pi-style message queueing while an agent run is active.
+
+## What Was Added
+
+`tau_agent.AgentHarness` now owns two prompt queues:
+
+- steering messages, injected after the current assistant turn and any tool batch
+- follow-up messages, injected only when the run would otherwise stop
+
+The harness exposes `steer()`, `follow_up()`, `clear_queues()`,
+`queued_messages`, `pending_message_count`, and `is_running`. Direct overlapping
+`prompt()` and `continue_()` calls are rejected so callers cannot mutate one
+transcript from two active runs.
+
+`run_agent_loop()` accepts provider-neutral queue-drain callbacks. When a queue
+drains, the loop appends the queued user message to the same message list used
+for normal prompts and emits ordinary user `MessageStartEvent` and
+`MessageEndEvent` values before the next provider call.
+
+`QueueUpdateEvent` reports pending steering and follow-up text for frontends.
+The Textual TUI uses it for status-line queue counts.
+
+## Coding Session Boundary
+
+`CodingSession.prompt()` keeps ordinary non-running prompts unchanged. While the
+harness is running, callers must pass one of:
+
+```python
+session.prompt(text, streaming_behavior="steer")
+session.prompt(text, streaming_behavior="follow_up")
+```
+
+The session expands `/skill:<name>` prompt text before queueing. It does not
+persist a queued message at queue time. Persistence still happens after the
+active run finishes, when the harness has injected queued user messages into the
+transcript.
+
+## TUI Behavior
+
+The built-in Textual frontend maps:
+
+- `Enter` while running to steering queueing
+- `Alt-Enter` while running to follow-up queueing
+
+Pending queues are visible in the status line while the run continues. Once a
+queued message is injected, it appears in the transcript as a normal user
+message and the pending count updates.
+
+## Boundary
+
+Queue ownership lives in `tau_agent`, prompt expansion and persistence stay in
+`tau_coding`, and Textual only decides keybindings and presentation. Provider
+adapters do not know about queued messages; they receive the updated transcript
+on the next provider call.
+
+## Tests
+
+The behavior is covered by:
+
+```text
+tests/test_agent_loop.py
+tests/test_agent_harness.py
+tests/test_coding_session.py
+tests/test_tui_adapter.py
+tests/test_tui_app.py
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,7 @@ Example:
     "cancel": "escape",
     "command_palette": "ctrl+j",
     "session_picker": "ctrl+r",
+    "queue_follow_up": "alt+enter",
     "accept_completion": "f2",
     "completion_next": "down",
     "completion_previous": "up",
@@ -274,6 +275,11 @@ emits them. Thinking tokens are hidden by default and can be remapped in
 `~/.tau/tui.json` with the `toggle_thinking` keybinding.
 
 Remap the thinking-mode cycle shortcut with the `thinking_cycle` keybinding.
+
+While the agent is running in the TUI, `Enter` queues the prompt as steering for
+the active run. `Alt-Enter` queues the prompt as a follow-up that waits until the
+active run would otherwise stop. Remap the follow-up shortcut with
+`queue_follow_up`.
 
 Thinking controls are model-aware. Tau enables them only when the active
 provider configuration declares supported levels for the active model. Custom

--- a/docs/custom-tui.md
+++ b/docs/custom-tui.md
@@ -55,6 +55,7 @@ The event stream contains provider-neutral `AgentEvent` values from
 
 - `AgentStartEvent` and `AgentEndEvent`
 - `MessageStartEvent`, `MessageDeltaEvent`, and `MessageEndEvent`
+- `QueueUpdateEvent`
 - `ThinkingDeltaEvent`
 - `ToolExecutionStartEvent`, `ToolExecutionUpdateEvent`, and `ToolExecutionEndEvent`
 - `ErrorEvent`
@@ -67,6 +68,28 @@ that expose it. Keep it separate from assistant message text, hide it by
 default, and let the user opt in from the frontend. The built-in Textual app
 uses `Ctrl+T` for this toggle and renders thinking content with a distinct
 transcript style.
+
+`QueueUpdateEvent` carries the current pending steering and follow-up prompt
+text. Use it for pending-message badges or status text. Queued prompts are not
+durable conversation messages until the harness injects them and emits normal
+`MessageStartEvent`/`MessageEndEvent` user-message events.
+
+## Queued Steering And Follow-ups
+
+If a user submits more text while `AgentStartEvent` has marked the session as
+running, queue it instead of starting a second prompt worker:
+
+```python
+async for event in session.prompt(user_text, streaming_behavior="steer"):
+    adapter.apply(event)
+    redraw(state)
+```
+
+Use `streaming_behavior="follow_up"` for a follow-up shortcut that should wait
+until the active run would otherwise stop. The built-in Textual frontend maps
+normal `Enter` while running to steering and `Alt-Enter` to follow-up queueing.
+Direct overlapping `session.prompt(...)` calls without `streaming_behavior` are
+rejected so callers do not mutate the same transcript from concurrent runs.
 
 ## Restoring Visible State
 
@@ -212,6 +235,7 @@ The built-in configurable action names are:
 - `cancel`
 - `command_palette`
 - `session_picker`
+- `queue_follow_up`
 - `accept_completion`
 - `completion_next`
 - `completion_previous`

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -35,9 +35,29 @@ The harness:
 - calls `run_agent_loop()`
 - streams `AgentEvent` objects
 - exposes `continue_()` for running without a new user prompt
+- rejects overlapping `prompt()` / `continue_()` runs
+- queues steering and follow-up messages for an active run
 - supports event listeners
 - supports basic cancellation
 
 The harness does not know about CLI arguments, Textual, Rich rendering, slash commands, or session files.
+
+## Queues
+
+Use queue APIs while a run is active:
+
+```python
+harness.steer("Adjust the current plan.")
+harness.follow_up("When that is done, summarize the result.")
+```
+
+Steering messages are injected after the current assistant turn and tool batch,
+before the next provider call. Follow-up messages are injected only when the run
+would otherwise stop. `AgentHarnessConfig.queue_mode` defaults to
+`"one_at_a_time"`; set it to `"all"` to drain each queue as a full batch.
+
+The harness emits `QueueUpdateEvent` values as queues change and as messages are
+drained. Queued messages become durable transcript messages only when they are
+injected into the loop.
 
 For a detailed architecture walkthrough, read [Phase 4: AgentHarness](architecture/phase-4-agent-harness.md).

--- a/src/tau_agent/__init__.py
+++ b/src/tau_agent/__init__.py
@@ -8,6 +8,7 @@ from tau_agent.events import (
     MessageDeltaEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolExecutionEndEvent,
@@ -20,6 +21,7 @@ from tau_agent.harness import (
     AgentHarness,
     AgentHarnessConfig,
     EventListener,
+    QueuedMessages,
     SimpleCancellationToken,
 )
 from tau_agent.loop import run_agent_loop
@@ -67,6 +69,8 @@ __all__ = [
     "MessageEntry",
     "MessageStartEvent",
     "ModelChangeEntry",
+    "QueuedMessages",
+    "QueueUpdateEvent",
     "RetryEvent",
     "SessionEntry",
     "SessionInfoEntry",

--- a/src/tau_agent/events.py
+++ b/src/tau_agent/events.py
@@ -46,6 +46,14 @@ class RetryEvent(BaseModel):
     data: dict[str, JSONValue] | None = None
 
 
+class QueueUpdateEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["queue_update"] = "queue_update"
+    steering: tuple[str, ...] = ()
+    follow_up: tuple[str, ...] = ()
+
+
 class MessageStartEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -111,6 +119,7 @@ type AgentEvent = (
     | AgentEndEvent
     | TurnStartEvent
     | TurnEndEvent
+    | QueueUpdateEvent
     | RetryEvent
     | MessageStartEvent
     | MessageDeltaEvent

--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -1,17 +1,33 @@
 """Stateful reusable agent harness built on the pure loop."""
 
+from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from inspect import isawaitable
+from typing import Literal
 
-from tau_agent.events import AgentEvent, MessageEndEvent, MessageStartEvent
+from tau_agent.events import AgentEvent, MessageEndEvent, MessageStartEvent, QueueUpdateEvent
 from tau_agent.loop import run_agent_loop
 from tau_agent.messages import AgentMessage, UserMessage
 from tau_agent.tools import AgentTool
 from tau_ai.provider import ModelProvider
 
 EventListener = Callable[[AgentEvent], Awaitable[None] | None]
+QueueMode = Literal["one_at_a_time", "all"]
+
+
+@dataclass(frozen=True, slots=True)
+class QueuedMessages:
+    """Snapshot of harness-owned queued user messages."""
+
+    steering: tuple[AgentMessage, ...] = ()
+    follow_up: tuple[AgentMessage, ...] = ()
+
+    @property
+    def count(self) -> int:
+        """Return the total queued message count."""
+        return len(self.steering) + len(self.follow_up)
 
 
 @dataclass(slots=True)
@@ -23,6 +39,7 @@ class AgentHarnessConfig:
     system: str
     tools: list[AgentTool] = field(default_factory=list)
     max_turns: int | None = None
+    queue_mode: QueueMode = "one_at_a_time"
 
 
 class SimpleCancellationToken:
@@ -58,6 +75,9 @@ class AgentHarness:
         self._messages = list(messages)
         self._listeners: list[EventListener] = []
         self._current_signal: SimpleCancellationToken | None = None
+        self._running = False
+        self._steering_queue: deque[AgentMessage] = deque()
+        self._follow_up_queue: deque[AgentMessage] = deque()
 
     @property
     def messages(self) -> tuple[AgentMessage, ...]:
@@ -68,6 +88,28 @@ class AgentHarness:
     def config(self) -> AgentHarnessConfig:
         """Return the harness configuration."""
         return self._config
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether a prompt or continuation is currently active."""
+        return self._running
+
+    @property
+    def queued_messages(self) -> QueuedMessages:
+        """Return a snapshot of queued steering and follow-up messages."""
+        return QueuedMessages(
+            steering=tuple(self._steering_queue),
+            follow_up=tuple(self._follow_up_queue),
+        )
+
+    @property
+    def pending_message_count(self) -> int:
+        """Return the total queued message count."""
+        return self.queued_messages.count
+
+    def has_queued_messages(self) -> bool:
+        """Return whether either queue has pending messages."""
+        return bool(self._steering_queue or self._follow_up_queue)
 
     def append_message(self, message: AgentMessage) -> None:
         """Append an existing message, useful for restoring session state."""
@@ -92,14 +134,50 @@ class AgentHarness:
         if self._current_signal is not None:
             self._current_signal.cancel()
 
+    def steer(self, content: str) -> QueueUpdateEvent:
+        """Queue a steering message for the active or next run."""
+        return self.steer_message(UserMessage(content=content))
+
+    def steer_message(self, message: AgentMessage) -> QueueUpdateEvent:
+        """Queue a message to inject after the current turn/tool batch."""
+        self._steering_queue.append(message)
+        return self.queue_update_event()
+
+    def follow_up(self, content: str) -> QueueUpdateEvent:
+        """Queue a follow-up message for when the active run would stop."""
+        return self.follow_up_message(UserMessage(content=content))
+
+    def follow_up_message(self, message: AgentMessage) -> QueueUpdateEvent:
+        """Queue a message to inject when the current run would otherwise stop."""
+        self._follow_up_queue.append(message)
+        return self.queue_update_event()
+
+    def clear_queues(self) -> QueuedMessages:
+        """Clear all queued messages and return the cleared snapshot."""
+        snapshot = self.queued_messages
+        self._steering_queue.clear()
+        self._follow_up_queue.clear()
+        return snapshot
+
+    def queue_update_event(self) -> QueueUpdateEvent:
+        """Return the current queue state as a portable agent event."""
+        return QueueUpdateEvent(
+            steering=tuple(message.content for message in self._steering_queue),
+            follow_up=tuple(message.content for message in self._follow_up_queue),
+        )
+
     def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
         """Append a user message and run the agent loop."""
+        self._ensure_not_running()
+        self._running = True
         message = UserMessage(content=content)
         self._messages.append(message)
         return self._run(prompt_message=message)
 
     def continue_(self) -> AsyncIterator[AgentEvent]:
         """Continue the agent loop without appending a new user message."""
+        self._ensure_not_running()
+        self._running = True
         return self._run()
 
     async def _run(self, *, prompt_message: UserMessage | None = None) -> AsyncIterator[AgentEvent]:
@@ -115,6 +193,9 @@ class AgentHarness:
                 tools=self._config.tools,
                 max_turns=self._config.max_turns,
                 signal=signal,
+                get_steering_messages=self._drain_steering_messages,
+                get_follow_up_messages=self._drain_follow_up_messages,
+                get_queue_update=self.queue_update_event,
             ):
                 await self._notify(event)
                 yield event
@@ -128,9 +209,31 @@ class AgentHarness:
         finally:
             if self._current_signal is signal:
                 self._current_signal = None
+            self._running = False
 
     async def _notify(self, event: AgentEvent) -> None:
         for listener in list(self._listeners):
             result = listener(event)
             if isawaitable(result):
                 await result
+
+    def _ensure_not_running(self) -> None:
+        if self._running:
+            raise RuntimeError(
+                "AgentHarness is already running; use steer() or follow_up() to queue messages."
+            )
+
+    def _drain_steering_messages(self) -> tuple[AgentMessage, ...]:
+        return self._drain_queue(self._steering_queue)
+
+    def _drain_follow_up_messages(self) -> tuple[AgentMessage, ...]:
+        return self._drain_queue(self._follow_up_queue)
+
+    def _drain_queue(self, queue: deque[AgentMessage]) -> tuple[AgentMessage, ...]:
+        if not queue:
+            return ()
+        if self._config.queue_mode == "all":
+            messages = tuple(queue)
+            queue.clear()
+            return messages
+        return (queue.popleft(),)

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -1,6 +1,6 @@
 """Pure provider/tool agent loop."""
 
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 
 from tau_agent.events import (
     AgentEndEvent,
@@ -10,6 +10,7 @@ from tau_agent.events import (
     MessageDeltaEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolExecutionEndEvent,
@@ -40,6 +41,9 @@ async def run_agent_loop(
     tools: list[AgentTool],
     max_turns: int | None = None,
     signal: CancellationToken | None = None,
+    get_steering_messages: Callable[[], Sequence[AgentMessage]] | None = None,
+    get_follow_up_messages: Callable[[], Sequence[AgentMessage]] | None = None,
+    get_queue_update: Callable[[], QueueUpdateEvent] | None = None,
 ) -> AsyncIterator[AgentEvent]:
     """Run the pure agent loop and stream provider-neutral agent events.
 
@@ -113,6 +117,26 @@ async def run_agent_loop(
 
         if not assistant_message.tool_calls:
             yield TurnEndEvent(turn=turn)
+            queue_events = _drain_queued_messages(
+                messages,
+                get_steering_messages,
+                get_queue_update,
+            )
+            if queue_events:
+                for queue_event in queue_events:
+                    yield queue_event
+                turn += 1
+                continue
+            queue_events = _drain_queued_messages(
+                messages,
+                get_follow_up_messages,
+                get_queue_update,
+            )
+            if queue_events:
+                for queue_event in queue_events:
+                    yield queue_event
+                turn += 1
+                continue
             break
 
         async for tool_event in _execute_tool_calls(
@@ -123,6 +147,12 @@ async def run_agent_loop(
             yield tool_event
 
         yield TurnEndEvent(turn=turn)
+        for queue_event in _drain_queued_messages(
+            messages,
+            get_steering_messages,
+            get_queue_update,
+        ):
+            yield queue_event
         turn += 1
     else:
         yield ErrorEvent(
@@ -131,6 +161,27 @@ async def run_agent_loop(
         )
 
     yield AgentEndEvent()
+
+
+def _drain_queued_messages(
+    messages: list[AgentMessage],
+    get_messages: Callable[[], Sequence[AgentMessage]] | None,
+    get_queue_update: Callable[[], QueueUpdateEvent] | None,
+) -> tuple[AgentEvent, ...]:
+    if get_messages is None:
+        return ()
+    queued_messages = tuple(get_messages())
+    if not queued_messages:
+        return ()
+
+    messages.extend(queued_messages)
+    events: list[AgentEvent] = []
+    for message in queued_messages:
+        events.append(MessageStartEvent(message_role=message.role))
+        events.append(MessageEndEvent(message=message))
+    if get_queue_update is not None:
+        events.append(get_queue_update())
+    return tuple(events)
 
 
 async def _execute_tool_calls(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -3,8 +3,16 @@
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import Literal
 
-from tau_agent import AgentEvent, AgentHarness, AgentHarnessConfig, ErrorEvent
+from tau_agent import (
+    AgentEvent,
+    AgentHarness,
+    AgentHarnessConfig,
+    ErrorEvent,
+    QueuedMessages,
+    QueueUpdateEvent,
+)
 from tau_agent.messages import AgentMessage
 from tau_agent.session import (
     CompactionEntry,
@@ -68,6 +76,8 @@ from tau_coding.thinking import (
     normalize_thinking_level,
 )
 from tau_coding.tools import create_coding_tools
+
+StreamingBehavior = Literal["steer", "follow_up"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -354,6 +364,26 @@ class CodingSession:
         return self._config.session_manager
 
     @property
+    def is_running(self) -> bool:
+        """Return whether this session currently has an active agent run."""
+        return self._harness.is_running
+
+    @property
+    def queued_messages(self) -> QueuedMessages:
+        """Return queued steering and follow-up messages."""
+        return self._harness.queued_messages
+
+    @property
+    def queued_steering_messages(self) -> tuple[str, ...]:
+        """Return queued steering message text for UI display."""
+        return tuple(message.content for message in self._harness.queued_messages.steering)
+
+    @property
+    def queued_follow_up_messages(self) -> tuple[str, ...]:
+        """Return queued follow-up message text for UI display."""
+        return tuple(message.content for message in self._harness.queued_messages.follow_up)
+
+    @property
     def last_diagnostic_log_path(self) -> Path | None:
         """Return the last diagnostic log path written by this session."""
         return self._last_diagnostic_log_path
@@ -361,6 +391,14 @@ class CodingSession:
     def cancel(self) -> None:
         """Cancel the currently running agent turn, if any."""
         self._harness.cancel()
+
+    def queue_update_event(self) -> QueueUpdateEvent:
+        """Return the current queue state as an agent event."""
+        return self._harness.queue_update_event()
+
+    def clear_queued_messages(self) -> QueuedMessages:
+        """Clear queued steering and follow-up messages."""
+        return self._harness.clear_queues()
 
     def set_model(self, model: str) -> None:
         """Switch the active model for future turns in this process."""
@@ -619,18 +657,14 @@ class CodingSession:
         expanded_skill = expand_skill_command(text, self._skills)
         return expanded_skill if expanded_skill is not None else text
 
-    async def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
+    async def prompt(
+        self,
+        content: str,
+        *,
+        streaming_behavior: StreamingBehavior | None = None,
+    ) -> AsyncIterator[AgentEvent]:
         """Append a user prompt, run the agent, and persist new messages."""
         context = self._diagnostic_context()
-        try:
-            await self._maybe_auto_compact()
-        except Exception as exc:
-            self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
-                context=context,
-                phase="auto_compact",
-                exc=exc,
-            )
-            raise
         try:
             expanded_content = self.expand_prompt_text(content)
         except ResourceError:
@@ -639,6 +673,27 @@ class CodingSession:
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
                 context=context,
                 phase="expand_prompt",
+                exc=exc,
+            )
+            raise
+
+        if self._harness.is_running:
+            if streaming_behavior == "steer":
+                yield self._harness.steer(expanded_content)
+                return
+            if streaming_behavior == "follow_up":
+                yield self._harness.follow_up(expanded_content)
+                return
+            raise RuntimeError(
+                "CodingSession is already running; pass streaming_behavior to queue a message."
+            )
+
+        try:
+            await self._maybe_auto_compact()
+        except Exception as exc:
+            self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
+                context=context,
+                phase="auto_compact",
                 exc=exc,
             )
             raise

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -8,6 +8,7 @@ from tau_agent import (
     MessageDeltaEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolExecutionEndEvent,
@@ -46,6 +47,10 @@ class TuiEventAdapter:
 
         if isinstance(event, ThinkingDeltaEvent):
             self.state.add_thinking_delta(event.delta)
+            return
+
+        if isinstance(event, QueueUpdateEvent):
+            self.state.update_queue(steering=event.steering, follow_up=event.follow_up)
             return
 
         if isinstance(event, MessageEndEvent):

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -126,6 +126,8 @@ class CompletionActionTarget(Protocol):
 
     async def action_submit_prompt(self) -> None: ...
 
+    async def action_submit_follow_up(self) -> None: ...
+
 
 class SessionCompletionRecord(Protocol):
     """Session metadata needed to render resume picker completions."""
@@ -226,6 +228,10 @@ class PromptInput(TextArea):
         """Copy the selected transcript message."""
         self._completion_target().action_copy_selected_message()
 
+    async def action_submit_follow_up(self) -> None:
+        """Submit the prompt as an app-level follow-up."""
+        await self._completion_target().action_submit_follow_up()
+
     async def action_quit(self) -> None:
         """Quit the app through the app-level action."""
         await self.app.action_quit()
@@ -241,7 +247,11 @@ class PromptInput(TextArea):
     async def on_key(self, event: Key) -> None:
         """Route completion and submission keys before default input handling."""
         keybindings = self.tui_keybindings
-        if event.key == "enter":
+        if event.key == keybindings.queue_follow_up:
+            event.stop()
+            event.prevent_default()
+            await self._completion_target().action_submit_follow_up()
+        elif event.key == "enter":
             event.stop()
             event.prevent_default()
             await self._completion_target().action_submit_prompt()
@@ -1105,6 +1115,17 @@ class TauTuiApp(App[None]):
 
     async def action_submit_prompt(self) -> None:
         """Submit the current prompt text or slash command."""
+        await self._submit_prompt_from_editor(streaming_behavior="steer")
+
+    async def action_submit_follow_up(self) -> None:
+        """Submit the current prompt as a queued follow-up while running."""
+        await self._submit_prompt_from_editor(streaming_behavior="follow_up")
+
+    async def _submit_prompt_from_editor(
+        self,
+        *,
+        streaming_behavior: Literal["steer", "follow_up"],
+    ) -> None:
         prompt = self.query_one("#prompt", PromptInput)
         raw_text = prompt.text
         applied_completion = self._apply_selected_completion(raw_text)
@@ -1154,7 +1175,7 @@ class TauTuiApp(App[None]):
             return
 
         if self.state.running:
-            self._notify("Tau is already working. Press Escape to cancel.")
+            await self._queue_prompt(text, streaming_behavior=streaming_behavior)
             return
 
         self._submit_prompt(text)
@@ -1163,6 +1184,25 @@ class TauTuiApp(App[None]):
         """Add a prompt to the transcript and start the agent worker."""
         self._refresh()
         self._prompt_worker = self.run_worker(self._run_prompt(text), exclusive=True)
+
+    async def _queue_prompt(
+        self,
+        text: str,
+        *,
+        streaming_behavior: Literal["steer", "follow_up"],
+    ) -> None:
+        """Queue a prompt for the active agent worker."""
+        try:
+            async for event in self.session.prompt(text, streaming_behavior=streaming_behavior):
+                self.adapter.apply(event)
+        except Exception as exc:  # noqa: BLE001 - surface queueing failures in the TUI
+            self._notify(f"Could not queue message: {exc}", severity="error")
+            return
+        self._refresh()
+        if streaming_behavior == "follow_up":
+            self._notify("Queued follow-up message.")
+        else:
+            self._notify("Queued steering message.")
 
     async def _run_prompt(self, text: str) -> None:
         """Run one prompt and stream session events into the TUI state."""
@@ -1508,6 +1548,7 @@ class TauTuiApp(App[None]):
 
     def _refresh(self) -> None:
         theme = self.tui_settings.resolved_theme
+        self._sync_queue_state()
         sidebar = self.query_one("#sidebar", SessionSidebar)
         sidebar.update_from_session(self.session, theme=theme)
         compact_info = self.query_one("#compact-session-info", CompactSessionInfo)
@@ -1517,6 +1558,12 @@ class TauTuiApp(App[None]):
         self._sync_activity_indicator()
         status = self.query_one("#status", Static)
         status.update(self._status_text())
+
+    def _sync_queue_state(self) -> None:
+        queue_event = getattr(self.session, "queue_update_event", None)
+        if not callable(queue_event):
+            return
+        self.adapter.apply(queue_event())
 
     def _sync_activity_indicator(self) -> None:
         if self.state.running:
@@ -1541,9 +1588,11 @@ class TauTuiApp(App[None]):
         status.update(self._status_text())
 
     def _status_text(self) -> str:
+        queue_text = _queue_status_text(self.state)
         if not self.state.running:
-            return "Ready"
-        return ACTIVITY_FRAMES[self._activity_frame]
+            return f"Ready | queued: {queue_text}" if queue_text else "Ready"
+        status = ACTIVITY_FRAMES[self._activity_frame]
+        return f"{status} | queued: {queue_text}" if queue_text else status
 
     def _refresh_completions(self) -> None:
         suggestions = self.query_one("#autocomplete", Static)
@@ -1682,6 +1731,19 @@ def _theme_css_variables(theme: TuiTheme) -> dict[str, str]:
     }
 
 
+def _queue_status_text(state: TuiState) -> str:
+    parts: list[str] = []
+    steering_count = len(state.queued_steering)
+    follow_up_count = len(state.queued_follow_up)
+    if steering_count:
+        suffix = "" if steering_count == 1 else "s"
+        parts.append(f"{steering_count} steering message{suffix}")
+    if follow_up_count:
+        suffix = "" if follow_up_count == 1 else "s"
+        parts.append(f"{follow_up_count} follow-up message{suffix}")
+    return ", ".join(parts)
+
+
 def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
     return [
         Binding(keybindings.cancel, "cancel", "Cancel"),
@@ -1692,6 +1754,12 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
             keybindings.accept_completion,
             "accept_completion",
             "Complete",
+            priority=True,
+        ),
+        Binding(
+            keybindings.queue_follow_up,
+            "submit_follow_up",
+            "Follow-up",
             priority=True,
         ),
         Binding(
@@ -1719,6 +1787,7 @@ def _prompt_bindings(keybindings: TuiKeybindings) -> list[Binding]:
     return [
         Binding(keybindings.command_palette, "open_command_palette", show=False, priority=True),
         Binding(keybindings.session_picker, "open_session_picker", show=False, priority=True),
+        Binding(keybindings.queue_follow_up, "submit_follow_up", show=False, priority=True),
         Binding(keybindings.thinking_cycle, "cycle_thinking", show=False, priority=True),
         Binding(
             keybindings.toggle_tool_results,

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -19,6 +19,7 @@ class TuiKeybindings:
     cancel: str = "escape"
     command_palette: str = "ctrl+k"
     session_picker: str = "ctrl+r"
+    queue_follow_up: str = "alt+enter"
     accept_completion: str = "tab"
     completion_next: str = "down"
     completion_previous: str = "up"
@@ -36,6 +37,7 @@ class TuiKeybindings:
             "cancel": self.cancel,
             "command_palette": self.command_palette,
             "session_picker": self.session_picker,
+            "queue_follow_up": self.queue_follow_up,
             "accept_completion": self.accept_completion,
             "completion_next": self.completion_next,
             "completion_previous": self.completion_previous,

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -34,6 +34,8 @@ class TuiState:
     error: str | None = None
     show_tool_results: bool = False
     show_thinking: bool = False
+    queued_steering: tuple[str, ...] = ()
+    queued_follow_up: tuple[str, ...] = ()
     selected_item_index: int | None = None
 
     def add_item(
@@ -108,6 +110,16 @@ class TuiState:
         ):
             self.selected_item_index = None
         return self.show_thinking
+
+    def update_queue(self, *, steering: tuple[str, ...], follow_up: tuple[str, ...]) -> None:
+        """Replace visible queued-message state."""
+        self.queued_steering = steering
+        self.queued_follow_up = follow_up
+
+    @property
+    def queued_message_count(self) -> int:
+        """Return the total number of pending queued messages."""
+        return len(self.queued_steering) + len(self.queued_follow_up)
 
     def clear(self) -> None:
         """Clear visible transcript state without modifying durable session history."""

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -2,7 +2,14 @@ from collections.abc import Mapping
 
 import pytest
 
-from tau_agent import AgentTool, AgentToolResult, AssistantMessage, UserMessage
+from tau_agent import (
+    AgentTool,
+    AgentToolResult,
+    AssistantMessage,
+    MessageEndEvent,
+    MessageStartEvent,
+    UserMessage,
+)
 from tau_agent.harness import AgentHarness, AgentHarnessConfig
 from tau_agent.types import JSONValue
 from tau_ai import (
@@ -82,6 +89,22 @@ def test_harness_can_replace_messages() -> None:
     assert harness.messages == (UserMessage(content="Summary"),)
 
 
+def test_harness_can_clear_queued_messages() -> None:
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=FakeProvider([]), model="fake", system="You are Tau.")
+    )
+
+    harness.steer("Adjust")
+    harness.follow_up("Later")
+    cleared = harness.clear_queues()
+
+    assert cleared.steering == (UserMessage(content="Adjust"),)
+    assert cleared.follow_up == (UserMessage(content="Later"),)
+    assert harness.pending_message_count == 0
+    assert harness.queue_update_event().steering == ()
+    assert harness.queue_update_event().follow_up == ()
+
+
 @pytest.mark.anyio
 async def test_subscribed_listeners_receive_events_and_can_unsubscribe() -> None:
     assistant = AssistantMessage(content="Hello")
@@ -156,6 +179,130 @@ async def test_cancel_requests_cancellation_for_current_run() -> None:
         "agent_end",
     ]
     assert harness.messages == (UserMessage(content="Hi"),)
+
+
+@pytest.mark.anyio
+async def test_harness_rejects_overlapping_prompt_runs() -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hello")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Queued answer")),
+            ],
+        ]
+    )
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=provider, model="fake", system="You are Tau.")
+    )
+
+    events = []
+    queued = False
+    async for event in harness.prompt("Hi"):
+        events.append(event)
+        if (
+            isinstance(event, MessageStartEvent)
+            and event.message_role == "assistant"
+            and not queued
+        ):
+            with pytest.raises(RuntimeError, match="already running"):
+                harness.prompt("Overlapping")
+            queue_event = harness.steer("Queued instead")
+            assert queue_event.steering == ("Queued instead",)
+            queued = True
+
+    assert harness.is_running is False
+    assert harness.pending_message_count == 0
+    assert harness.messages == (
+        UserMessage(content="Hi"),
+        AssistantMessage(content="Hello"),
+        UserMessage(content="Queued instead"),
+        AssistantMessage(content="Queued answer"),
+    )
+
+
+@pytest.mark.anyio
+async def test_harness_drains_follow_up_messages_one_at_a_time_by_default() -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="First")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Second")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Third")),
+            ],
+        ]
+    )
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=provider, model="fake", system="You are Tau.")
+    )
+
+    events = []
+    async for event in harness.prompt("Hi"):
+        events.append(event)
+        if isinstance(event, MessageEndEvent) and event.message.content == "First":
+            harness.follow_up("Second prompt")
+            harness.follow_up("Third prompt")
+
+    assert [event.type for event in events].count("queue_update") == 2
+    assert harness.messages == (
+        UserMessage(content="Hi"),
+        AssistantMessage(content="First"),
+        UserMessage(content="Second prompt"),
+        AssistantMessage(content="Second"),
+        UserMessage(content="Third prompt"),
+        AssistantMessage(content="Third"),
+    )
+    assert provider.calls[1][2] == list(harness.messages[:3])
+    assert provider.calls[2][2] == list(harness.messages[:5])
+    assert harness.pending_message_count == 0
+
+
+@pytest.mark.anyio
+async def test_harness_can_drain_all_queued_messages_together() -> None:
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="First")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Second")),
+            ],
+        ]
+    )
+    harness = AgentHarness(
+        AgentHarnessConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            queue_mode="all",
+        )
+    )
+
+    async for event in harness.prompt("Hi"):
+        if isinstance(event, MessageEndEvent) and event.message.content == "First":
+            harness.follow_up("Second prompt")
+            harness.follow_up("Third prompt")
+
+    assert harness.messages == (
+        UserMessage(content="Hi"),
+        AssistantMessage(content="First"),
+        UserMessage(content="Second prompt"),
+        UserMessage(content="Third prompt"),
+        AssistantMessage(content="Second"),
+    )
+    assert provider.calls[1][2] == list(harness.messages[:4])
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8,6 +8,7 @@ from tau_agent import (
     AgentToolResult,
     AssistantMessage,
     ErrorEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolCall,
@@ -188,6 +189,150 @@ async def test_agent_loop_executes_tools_and_continues_until_no_tool_calls() -> 
     ]
     assert len(provider.calls) == 2
     assert provider.calls[1][2] == messages[:3]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_injects_steering_after_tool_batch() -> None:
+    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+        return AgentToolResult(
+            tool_call_id="call-1",
+            name="read",
+            ok=True,
+            content=f"contents of {arguments['path']}",
+        )
+
+    tool = AgentTool(
+        name="read",
+        description="Read a file.",
+        input_schema={"type": "object"},
+        executor=executor,
+    )
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    first_assistant = AssistantMessage(content="I'll read it.", tool_calls=[tool_call])
+    final_assistant = AssistantMessage(content="Updated plan.")
+    messages = [UserMessage(content="Read README.md")]
+    steering_queue = [UserMessage(content="Also summarize it")]
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=first_assistant, finish_reason="tool_calls"),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=final_assistant, finish_reason="stop"),
+            ],
+        ]
+    )
+
+    def get_steering_messages() -> tuple[UserMessage, ...]:
+        if not steering_queue:
+            return ()
+        return (steering_queue.pop(0),)
+
+    events = await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[tool],
+            get_steering_messages=get_steering_messages,
+            get_queue_update=lambda: QueueUpdateEvent(),
+        )
+    )
+
+    assert [event.type for event in events] == [
+        "agent_start",
+        "turn_start",
+        "message_start",
+        "message_end",
+        "tool_execution_start",
+        "tool_execution_end",
+        "turn_end",
+        "message_start",
+        "message_end",
+        "queue_update",
+        "turn_start",
+        "message_start",
+        "message_end",
+        "turn_end",
+        "agent_end",
+    ]
+    assert provider.calls[1][2] == messages[:4]
+    assert messages == [
+        UserMessage(content="Read README.md"),
+        first_assistant,
+        ToolResultMessage(
+            tool_call_id="call-1",
+            name="read",
+            content="contents of README.md",
+            ok=True,
+        ),
+        UserMessage(content="Also summarize it"),
+        final_assistant,
+    ]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_injects_follow_up_only_when_run_would_stop() -> None:
+    first_assistant = AssistantMessage(content="Initial answer.")
+    final_assistant = AssistantMessage(content="Follow-up answer.")
+    messages = [UserMessage(content="Start")]
+    follow_up_queue = [UserMessage(content="One more thing")]
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=first_assistant, finish_reason="stop"),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=final_assistant, finish_reason="stop"),
+            ],
+        ]
+    )
+
+    def get_follow_up_messages() -> tuple[UserMessage, ...]:
+        if not follow_up_queue:
+            return ()
+        return (follow_up_queue.pop(0),)
+
+    events = await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[],
+            get_follow_up_messages=get_follow_up_messages,
+            get_queue_update=lambda: QueueUpdateEvent(),
+        )
+    )
+
+    assert [event.type for event in events] == [
+        "agent_start",
+        "turn_start",
+        "message_start",
+        "message_end",
+        "turn_end",
+        "message_start",
+        "message_end",
+        "queue_update",
+        "turn_start",
+        "message_start",
+        "message_end",
+        "turn_end",
+        "agent_end",
+    ]
+    assert len(provider.calls) == 2
+    assert provider.calls[1][2] == messages[:3]
+    assert messages == [
+        UserMessage(content="Start"),
+        first_assistant,
+        UserMessage(content="One more thing"),
+        final_assistant,
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -10,6 +10,7 @@ from tau_agent import (
     ErrorEvent,
     MessageDeltaEvent,
     MessageEndEvent,
+    QueueUpdateEvent,
     ThinkingDeltaEvent,
     ToolCall,
     ToolExecutionEndEvent,
@@ -87,6 +88,7 @@ def test_events_have_stable_type_names() -> None:
 
     events = [
         MessageDeltaEvent(delta="hello"),
+        QueueUpdateEvent(steering=("adjust",), follow_up=()),
         ThinkingDeltaEvent(delta="reasoning"),
         MessageEndEvent(message=message),
         ToolExecutionStartEvent(tool_call=tool_call),
@@ -96,6 +98,7 @@ def test_events_have_stable_type_names() -> None:
 
     assert [event.type for event in events] == [
         "message_delta",
+        "queue_update",
         "thinking_delta",
         "message_end",
         "tool_execution_start",

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -8,6 +9,7 @@ from tau_agent import (
     AgentMessage,
     AgentTool,
     AssistantMessage,
+    QueueUpdateEvent,
     ToolCall,
     ToolResultMessage,
     UserMessage,
@@ -24,6 +26,7 @@ from tau_agent.session import (
 from tau_ai import (
     CancellationToken,
     FakeProvider,
+    ModelProvider,
     ProviderEvent,
     ProviderResponseEndEvent,
     ProviderResponseStartEvent,
@@ -46,7 +49,7 @@ async def _collect_session_events(session_stream: object) -> list[object]:
 
 
 def _config(
-    tmp_path: Path, provider: FakeProvider, storage: JsonlSessionStorage
+    tmp_path: Path, provider: ModelProvider, storage: JsonlSessionStorage
 ) -> CodingSessionConfig:
     return CodingSessionConfig(
         provider=provider,
@@ -81,6 +84,40 @@ class RaisingProvider:
         async def iterator() -> AsyncIterator[ProviderEvent]:
             raise RuntimeError("provider exploded")
             yield  # pragma: no cover
+
+        return iterator()
+
+
+class WaitingProvider:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.calls: list[list[AgentMessage]] = []
+        self.call_count = 0
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        del model, system, tools, signal
+        call_index = self.call_count
+        self.call_count += 1
+        self.calls.append(list(messages))
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            if call_index == 0:
+                yield ProviderResponseStartEvent(model="fake")
+                self.started.set()
+                await self.release.wait()
+                yield ProviderResponseEndEvent(message=AssistantMessage(content="First"))
+                return
+            yield ProviderResponseStartEvent(model="fake")
+            yield ProviderResponseEndEvent(message=AssistantMessage(content="Second"))
 
         return iterator()
 
@@ -171,6 +208,50 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
     assert entries[-1].type == "leaf"
     assert entries[-1].entry_id == message_entries[-1].id
     assert session.messages == (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
+
+
+@pytest.mark.anyio
+async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = WaitingProvider()
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+    run_events: list[object] = []
+
+    async def run_prompt() -> None:
+        async for event in session.prompt("Hello"):
+            run_events.append(event)
+
+    task = asyncio.create_task(run_prompt())
+    await provider.started.wait()
+
+    with pytest.raises(RuntimeError, match="already running"):
+        await _collect_session_events(session.prompt("Dropped overlap"))
+
+    queue_events = await _collect_session_events(
+        session.prompt("Queued steering", streaming_behavior="steer")
+    )
+    entries_before_release = await storage.read_all()
+
+    provider.release.set()
+    await task
+
+    assert queue_events == [QueueUpdateEvent(steering=("Queued steering",))]
+    assert [entry.type for entry in entries_before_release] == [
+        "session_info",
+        "model_change",
+        "thinking_level_change",
+    ]
+    assert session.messages == (
+        UserMessage(content="Hello"),
+        AssistantMessage(content="First"),
+        UserMessage(content="Queued steering"),
+        AssistantMessage(content="Second"),
+    )
+    assert provider.calls[1] == list(session.messages[:3])
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == list(session.messages)
+    assert any(isinstance(event, QueueUpdateEvent) for event in run_events)
 
 
 @pytest.mark.anyio

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -9,6 +9,7 @@ from tau_agent import (
     MessageDeltaEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolCall,
@@ -113,12 +114,18 @@ def test_json_renderer_emits_jsonl(capsys: pytest.CaptureFixture[str]) -> None:
     renderer = JsonEventRenderer()
 
     renderer.render(MessageStartEvent())
+    renderer.render(QueueUpdateEvent(steering=("adjust",), follow_up=("after",)))
     renderer.render(ThinkingDeltaEvent(delta="hidden reasoning"))
     renderer.render(ErrorEvent(message="provider failed", recoverable=False))
 
     captured = capsys.readouterr()
     lines = captured.out.splitlines()
     assert json.loads(lines[0]) == {"type": "message_start", "message_role": "assistant"}
-    assert json.loads(lines[1]) == {"type": "thinking_delta", "delta": "hidden reasoning"}
-    assert json.loads(lines[2])["type"] == "error"
+    assert json.loads(lines[1]) == {
+        "type": "queue_update",
+        "steering": ["adjust"],
+        "follow_up": ["after"],
+    }
+    assert json.loads(lines[2]) == {"type": "thinking_delta", "delta": "hidden reasoning"}
+    assert json.loads(lines[3])["type"] == "error"
     assert renderer.finish() is False

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -7,6 +7,7 @@ from tau_agent import (
     MessageDeltaEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueueUpdateEvent,
     RetryEvent,
     ThinkingDeltaEvent,
     ToolCall,
@@ -184,6 +185,17 @@ def test_tui_adapter_records_retry_status() -> None:
     assert [(item.role, item.text) for item in state.items] == [
         ("status", "… Retrying provider request 2/3 after HTTP 503.")
     ]
+
+
+def test_tui_adapter_records_queue_updates() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(QueueUpdateEvent(steering=("adjust",), follow_up=("after",)))
+
+    assert state.queued_steering == ("adjust",)
+    assert state.queued_follow_up == ("after",)
+    assert state.queued_message_count == 2
 
 
 def test_tool_result_blocks_preview_long_content() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -17,6 +17,7 @@ from tau_agent import (
     AssistantMessage,
     ErrorEvent,
     MessageEndEvent,
+    QueueUpdateEvent,
     ToolCall,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
@@ -89,6 +90,9 @@ class FakeSession:
         self.new_session_count = 0
         self.prompt_texts: list[str] = []
         self.reload_count = 0
+        self.queued_steering_messages: tuple[str, ...] = ()
+        self.queued_follow_up_messages: tuple[str, ...] = ()
+        self.streaming_behaviors: list[str | None] = []
 
     def handle_command(self, text: str) -> CommandResult:
         if text == "/help":
@@ -154,8 +158,28 @@ class FakeSession:
         self.context_token_estimate = 0
         return "Started new session: new-session"
 
-    async def prompt(self, text: str) -> AsyncIterator[AgentEvent]:
+    def queue_update_event(self) -> QueueUpdateEvent:
+        return QueueUpdateEvent(
+            steering=self.queued_steering_messages,
+            follow_up=self.queued_follow_up_messages,
+        )
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        streaming_behavior: str | None = None,
+    ) -> AsyncIterator[AgentEvent]:
         self.prompt_texts.append(text)
+        self.streaming_behaviors.append(streaming_behavior)
+        if streaming_behavior == "steer":
+            self.queued_steering_messages = (*self.queued_steering_messages, text)
+            yield self.queue_update_event()
+            return
+        if streaming_behavior == "follow_up":
+            self.queued_follow_up_messages = (*self.queued_follow_up_messages, text)
+            yield self.queue_update_event()
+            return
         for event in self.events:
             yield event
 
@@ -1347,6 +1371,68 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
 
     assert app.state.show_tool_results is False
     assert notifications == ["Tool results expanded.", "Tool results collapsed."]
+
+
+@pytest.mark.anyio
+async def test_tui_app_queues_steering_prompt_while_running() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.text = "adjust course"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        status = app.query_one("#status")
+        assert prompt.text == ""
+        assert session.prompt_texts == ["adjust course"]
+        assert session.streaming_behaviors == ["steer"]
+        assert app.state.queued_steering == ("adjust course",)
+        assert app.state.queued_follow_up == ()
+        assert "queued: 1 steering message" in str(status.render())
+
+    assert notifications == ["Queued steering message."]
+
+
+@pytest.mark.anyio
+async def test_tui_app_queues_follow_up_prompt_from_keybinding() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.text = "after this"
+
+        await pilot.press("alt+enter")
+        await pilot.pause()
+
+        status = app.query_one("#status")
+        assert prompt.text == ""
+        assert session.prompt_texts == ["after this"]
+        assert session.streaming_behaviors == ["follow_up"]
+        assert app.state.queued_steering == ()
+        assert app.state.queued_follow_up == ("after this",)
+        assert "queued: 1 follow-up message" in str(status.render())
+
+    assert notifications == ["Queued follow-up message."]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -38,6 +38,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
           "keybindings": {
             "command_palette": "ctrl+j",
             "session_picker": "ctrl+y",
+            "queue_follow_up": "f5",
             "accept_completion": "f2",
             "thinking_cycle": "f3",
             "toggle_thinking": "f4",
@@ -53,6 +54,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
 
     assert settings.keybindings.command_palette == "ctrl+j"
     assert settings.keybindings.session_picker == "ctrl+y"
+    assert settings.keybindings.queue_follow_up == "f5"
     assert settings.keybindings.toggle_tool_results == "ctrl+o"
     assert settings.keybindings.toggle_thinking == "f4"
     assert settings.keybindings.accept_completion == "f2"
@@ -92,6 +94,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
         keybindings=TuiKeybindings(
             command_palette="ctrl+j",
             session_picker="ctrl+y",
+            queue_follow_up="f5",
             accept_completion="f2",
             thinking_cycle="f3",
             toggle_thinking="f4",
@@ -102,6 +105,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
 
     assert settings.to_json()["keybindings"]["command_palette"] == "ctrl+j"
     assert settings.to_json()["keybindings"]["session_picker"] == "ctrl+y"
+    assert settings.to_json()["keybindings"]["queue_follow_up"] == "f5"
     assert settings.to_json()["keybindings"]["toggle_tool_results"] == "ctrl+o"
     assert settings.to_json()["keybindings"]["toggle_thinking"] == "f4"
     assert settings.to_json()["keybindings"]["accept_completion"] == "f2"


### PR DESCRIPTION
## Summary
- add harness-owned steering and follow-up queues with active-run guards
- drain steering after turns/tool batches and follow-ups when a run would otherwise stop
- expose queue updates through provider-neutral events and coding-session prompt behavior
- map TUI Enter-while-running to steering and Alt+Enter to follow-up queueing with pending status text
- document the queueing architecture and TUI/custom frontend contract

Closes #28.

## Verification
- uv run pytest
- uv run ruff check .
- uv run mypy