### PR TITLE
Fix TUI agent cancellation

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -104,6 +104,8 @@ class CompletionActionTarget(Protocol):
 
     def action_accept_completion(self) -> None: ...
 
+    def action_cancel(self) -> None: ...
+
     def action_completion_next(self) -> None: ...
 
     def action_completion_previous(self) -> None: ...
@@ -262,6 +264,9 @@ class PromptInput(TextArea):
         elif event.key == keybindings.accept_completion:
             event.stop()
             self._completion_target().action_accept_completion()
+        elif event.key == keybindings.cancel:
+            event.stop()
+            self._completion_target().action_cancel()
         elif event.key == keybindings.command_palette:
             event.stop()
             self._completion_target().action_open_command_palette()
@@ -1053,6 +1058,7 @@ class TauTuiApp(App[None]):
         self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
+        self._prompt_run_id = 0
         self._completion_state = CompletionState()
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
@@ -1182,8 +1188,10 @@ class TauTuiApp(App[None]):
 
     def _submit_prompt(self, text: str) -> None:
         """Add a prompt to the transcript and start the agent worker."""
+        self._prompt_run_id += 1
+        run_id = self._prompt_run_id
         self._refresh()
-        self._prompt_worker = self.run_worker(self._run_prompt(text), exclusive=True)
+        self._prompt_worker = self.run_worker(self._run_prompt(text, run_id), exclusive=True)
 
     async def _queue_prompt(
         self,
@@ -1204,25 +1212,52 @@ class TauTuiApp(App[None]):
         else:
             self._notify("Queued steering message.")
 
-    async def _run_prompt(self, text: str) -> None:
+    async def _run_prompt(self, text: str, run_id: int | None = None) -> None:
         """Run one prompt and stream session events into the TUI state."""
+        active_run_id = self._prompt_run_id if run_id is None else run_id
         try:
             async for event in self.session.prompt(text):
+                if active_run_id != self._prompt_run_id:
+                    return
                 self.adapter.apply(event)
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     _attach_diagnostic_log_path_to_error(self.state, self.session)
                 self._refresh()
         except Exception as exc:  # noqa: BLE001 - surface unexpected worker errors in the TUI
+            if active_run_id != self._prompt_run_id:
+                return
             message = _format_prompt_error(exc, self.session)
             self.state.error = message
             self.state.add_item("error", message)
             self.state.running = False
             self._refresh()
+        finally:
+            if active_run_id == self._prompt_run_id:
+                self._prompt_worker = None
 
     def action_cancel(self) -> None:
         """Cancel the active agent turn."""
-        if self.state.running:
-            self.session.cancel()
+        self._cancel_active_prompt(notify=True)
+
+    def _cancel_active_prompt(self, *, notify: bool) -> None:
+        """Cancel the active prompt worker and ignore any late events from it."""
+        worker = self._prompt_worker
+        is_worker_active = worker is not None and not worker.is_cancelled
+        is_session_running = bool(getattr(self.session, "is_running", False))
+        if not (self.state.running or is_session_running or is_worker_active):
+            return
+
+        self._prompt_run_id += 1
+        cancel = getattr(self.session, "cancel", None)
+        if callable(cancel):
+            cancel()
+        if worker is not None and not worker.is_cancelled:
+            worker.cancel()
+        self._prompt_worker = None
+        self.state.running = False
+        self.state.assistant_buffer = ""
+        self._refresh()
+        if notify:
             self._notify("Cancellation requested.")
 
     def action_accept_completion(self) -> None:
@@ -1354,6 +1389,7 @@ class TauTuiApp(App[None]):
         self._refresh()
 
     async def _new_session(self) -> None:
+        self._cancel_active_prompt(notify=False)
         new_session = getattr(self.session, "new_session", None)
         if new_session is None:
             self._notify("Session manager is not available.")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -93,6 +93,7 @@ class FakeSession:
         self.queued_steering_messages: tuple[str, ...] = ()
         self.queued_follow_up_messages: tuple[str, ...] = ()
         self.streaming_behaviors: list[str | None] = []
+        self.cancel_count = 0
 
     def handle_command(self, text: str) -> CommandResult:
         if text == "/help":
@@ -157,6 +158,9 @@ class FakeSession:
         self.messages = ()
         self.context_token_estimate = 0
         return "Started new session: new-session"
+
+    def cancel(self) -> None:
+        self.cancel_count += 1
 
     def queue_update_event(self) -> QueueUpdateEvent:
         return QueueUpdateEvent(
@@ -1074,6 +1078,60 @@ async def test_tui_app_command_modal_renders_literal_markup_text() -> None:
         assert isinstance(app.screen, CommandOutputScreen)
         body = app.screen.query_one("#command-output-body")
         assert str(body.render()) == "Available [commands]\n/help"
+
+
+@pytest.mark.anyio
+async def test_tui_app_escape_cancels_running_session_from_prompt() -> None:
+    class RunningSession(FakeSession):
+        @property
+        def is_running(self) -> bool:
+            return True
+
+    session = RunningSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.adapter.apply(AgentStartEvent())
+        app._refresh()
+
+        await pilot.press("escape")
+
+        assert session.cancel_count == 1
+        assert app.state.running is False
+        assert notifications == ["Cancellation requested."]
+
+
+@pytest.mark.anyio
+async def test_tui_app_new_command_cancels_active_run_and_ignores_late_events() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        app.adapter.apply(AgentStartEvent())
+        app._refresh()
+        old_run_id = app._prompt_run_id
+        prompt = app.query_one("#prompt")
+        prompt.value = "/new"
+
+        await pilot.press("enter")
+
+        assert session.cancel_count == 1
+        assert session.new_session_count == 1
+        assert app._prompt_run_id == old_run_id + 1
+        assert app.state.items == []
+        assert app.state.running is False
+
+        session.events = (MessageEndEvent(message=AssistantMessage(content="late old output")),)
+        await app._run_prompt("old prompt", old_run_id)
+
+        assert app.state.items == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- route Escape from the focused prompt input to app-level cancellation
- cancel active prompt workers and session runs before starting /new
- ignore stale events from cancelled/old prompt runs

## Tests
- uv run pytest tests/test_tui_app.py tests/test_coding_session.py tests/test_agent_harness.py tests/test_agent_loop.py tests/test_tui_adapter.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to cancel active prompts mid-execution using the escape key
  * Starting a new session now automatically cancels any previously running prompt
  * Cancellation confirmation notification displayed when a prompt is interrupted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->