### PR TITLE
[codex] Add session rename command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,8 +201,12 @@ Inside the TUI:
 
 ```text
 /resume
+/name <new name>
 /status
 ```
+
+`/name <new name>` renames the current indexed session. The new name is shown
+in the `/resume` picker and in session-id completions.
 
 ## Skills and Prompt Templates
 

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -263,6 +263,15 @@ def create_default_command_registry() -> CommandRegistry:
     )
     registry.register(
         SlashCommand(
+            name="name",
+            usage="/name <new name>",
+            description="Rename the current session.",
+            handler=_name_command,
+            search_terms=("rename", "title"),
+        )
+    )
+    registry.register(
+        SlashCommand(
             name="model",
             usage="/model",
             description="Choose the active model.",
@@ -438,6 +447,34 @@ def _resume_command(context: CommandContext) -> CommandResult:
     )
 
 
+def _name_command(context: CommandContext) -> CommandResult:
+    manager = context.session.session_manager
+    session_id = context.session.session_id
+    if manager is None or session_id is None:
+        return CommandResult(handled=True, message="Session manager is not available.")
+
+    record = manager.get_session(session_id)
+    if record is None:
+        return CommandResult(handled=True, message=f"Unknown current session: {session_id}")
+
+    if not context.args:
+        title = record.title or "Untitled session"
+        return CommandResult(
+            handled=True,
+            message=f"Current session name: {title}\nUsage: /name <new name>",
+        )
+
+    try:
+        name = _validated_session_name(context.args)
+    except ValueError as exc:
+        return CommandResult(handled=True, message=str(exc))
+
+    updated = manager.touch_session(session_id, model=context.session.model, title=name)
+    if updated is None:
+        return CommandResult(handled=True, message=f"Unknown current session: {session_id}")
+    return CommandResult(handled=True, message=f"Session renamed: {updated.title}")
+
+
 def _format_sessions(context: CommandContext) -> str:
     manager = context.session.session_manager
     if manager is None:
@@ -492,8 +529,7 @@ def _thinking_command(context: CommandContext) -> CommandResult:
         return CommandResult(
             handled=True,
             message=(
-                "Thinking controls are unavailable for "
-                f"{session.provider_name}:{session.model}"
+                f"Thinking controls are unavailable for {session.provider_name}:{session.model}"
             ),
         )
     try:
@@ -522,8 +558,7 @@ def _login_command(context: CommandContext) -> CommandResult:
             return CommandResult(
                 handled=True,
                 message=(
-                    f"Unknown login provider: {provider_name}\n"
-                    f"Available providers: {providers}"
+                    f"Unknown login provider: {provider_name}\nAvailable providers: {providers}"
                 ),
             )
         return CommandResult(handled=True, login_provider=entry.name)
@@ -550,6 +585,15 @@ def _format_diagnostics(
 def _parse_command(text: str) -> tuple[str, str]:
     command, separator, args = text[1:].partition(" ")
     return _normalize_name(command), args.strip() if separator else ""
+
+
+def _validated_session_name(value: str) -> str:
+    name = value.strip()
+    if not name:
+        raise ValueError("Usage: /name <new name>")
+    if any(char in name for char in "\r\n\t"):
+        raise ValueError("Session name must be a single line.")
+    return name
 
 
 def _normalize_name(name: str) -> str:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -70,6 +70,7 @@ def test_help_lists_registered_commands(tmp_path: Path) -> None:
     assert result.handled is True
     assert result.message is not None
     assert "/help" in result.message
+    assert "/name <new name>" in result.message
     assert "/new" in result.message
     assert "/clear" not in result.message
     assert "/skills" in result.message
@@ -279,6 +280,51 @@ def test_resume_command_rejects_missing_or_unknown_session(tmp_path: Path) -> No
     unknown = create_default_command_registry().execute(session, "/resume missing")
 
     assert unknown.message == "Unknown session: missing"
+
+
+def test_name_command_shows_current_name_and_usage(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake-model", title="Test session")
+    session = FakeSession(tmp_path, manager=manager)
+    session.session_id = record.id
+
+    result = create_default_command_registry().execute(session, "/name")
+
+    assert result.message == "Current session name: Test session\nUsage: /name <new name>"
+
+
+def test_name_command_renames_current_session(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake-model", title="Old name")
+    session = FakeSession(tmp_path, manager=manager)
+    session.session_id = record.id
+
+    result = create_default_command_registry().execute(session, "/name Customer bugfix")
+
+    assert result.message == "Session renamed: Customer bugfix"
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Customer bugfix"
+    assert renamed.model == "fake-model"
+    assert renamed.updated_at >= record.updated_at
+
+
+def test_name_command_reports_missing_session_manager(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/name Work")
+
+    assert result.message == "Session manager is not available."
+
+
+def test_name_command_rejects_multiline_name(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake-model")
+    session = FakeSession(tmp_path, manager=manager)
+    session.session_id = record.id
+
+    result = create_default_command_registry().execute(session, "/name Bad\nName")
+
+    assert result.message == "Session name must be a single line."
+    assert manager.get_session(record.id) == record
 
 
 def test_unknown_command_returns_message(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add `/name <new name>` to rename the current indexed session
- show the current session name and usage when `/name` is run without arguments
- document that renamed sessions appear in `/resume` and completion flows

Fixes #56.

## Validation

- `uv run pytest tests/test_commands.py tests/test_session_manager.py -q`
- `uv run ruff check src/tau_coding/commands.py tests/test_commands.py`
- `uv run ruff format --check src/tau_coding/commands.py tests/test_commands.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/name <new name>` command to rename the current session
  * Renamed sessions appear in the session resume picker and completions

* **Documentation**
  * Updated Sessions TUI commands documentation to include `/name` command details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->