### PR TITLE
[codex] Move working spinner above prompt

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -69,7 +69,7 @@ from tau_coding.tui.widgets import (
 type BindingEntry = Binding | tuple[str, str] | tuple[str, str, str]
 SIDEBAR_MIN_WIDTH = 96
 SIDEBAR_MIN_HEIGHT = 24
-ACTIVITY_FRAMES = ("Working |", "Working /", "Working -", "Working \\")
+ACTIVITY_FRAMES = ("|", "/", "-", "\\")
 
 
 class LoginRequiredProvider:
@@ -829,6 +829,14 @@ class TauTuiApp(App[None]):
         border: tall $tau-prompt-border;
     }
 
+    #activity-status {
+        height: 1;
+        margin: 0 1 0 1;
+        padding: 0 1;
+        background: $tau-screen-background;
+        color: $tau-muted-text;
+    }
+
     #compact-session-info {
         height: auto;
         max-height: 3;
@@ -1082,6 +1090,7 @@ class TauTuiApp(App[None]):
                     highlight=True,
                     markup=False,
                 )
+                yield Static("", id="activity-status")
                 yield PromptInput(
                     placeholder="Ask Tau…  Enter submits, Shift+Enter inserts a newline",
                     id="prompt",
@@ -1611,24 +1620,33 @@ class TauTuiApp(App[None]):
                 )
             else:
                 self._activity_timer.resume()
+            self._apply_activity_indicator()
             return
         self._activity_frame = 0
         if self._activity_timer is not None:
             self._activity_timer.pause()
+        self._apply_activity_indicator()
 
     def _tick_activity(self) -> None:
         if not self.state.running:
             return
         self._activity_frame = (self._activity_frame + 1) % len(ACTIVITY_FRAMES)
-        status = self.query_one("#status", Static)
-        status.update(self._status_text())
+        self._apply_activity_indicator()
+
+    def _apply_activity_indicator(self) -> None:
+        activity = self.query_one("#activity-status", Static)
+        activity.update(self._activity_text())
+
+    def _activity_text(self) -> str:
+        if not self.state.running:
+            return ""
+        return f"working {ACTIVITY_FRAMES[self._activity_frame]}"
 
     def _status_text(self) -> str:
         queue_text = _queue_status_text(self.state)
-        if not self.state.running:
-            return f"Ready | queued: {queue_text}" if queue_text else "Ready"
-        status = ACTIVITY_FRAMES[self._activity_frame]
-        return f"{status} | queued: {queue_text}" if queue_text else status
+        if self.state.running:
+            return f"queued: {queue_text}" if queue_text else ""
+        return f"Ready | queued: {queue_text}" if queue_text else "Ready"
 
     def _refresh_completions(self) -> None:
         suggestions = self.query_one("#autocomplete", Static)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -706,27 +706,33 @@ def test_tui_app_loads_restored_messages_into_display_state() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_animates_activity_status_while_running() -> None:
+async def test_tui_app_shows_working_indicator_above_prompt_while_running() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test():
         status = app.query_one("#status")
+        activity = app.query_one("#activity-status")
+        prompt = app.query_one("#prompt")
 
         assert str(status.render()) == "Ready"
+        assert str(activity.render()) == ""
+        assert activity.region.y < prompt.region.y
 
         app.adapter.apply(AgentStartEvent())
         app._refresh()
 
-        assert str(status.render()) == "Working |"
+        assert str(status.render()) == ""
+        assert str(activity.render()) == "working |"
 
         app._tick_activity()
 
-        assert str(status.render()) == "Working /"
+        assert str(activity.render()) == "working /"
 
         app.adapter.apply(AgentEndEvent())
         app._refresh()
 
         assert str(status.render()) == "Ready"
+        assert str(activity.render()) == ""
 
 
 @pytest.mark.anyio
@@ -735,6 +741,7 @@ async def test_tui_app_clears_activity_status_on_error() -> None:
 
     async with app.run_test():
         status = app.query_one("#status")
+        activity = app.query_one("#activity-status")
 
         app.adapter.apply(AgentStartEvent())
         app._refresh()
@@ -742,6 +749,7 @@ async def test_tui_app_clears_activity_status_on_error() -> None:
         app._refresh()
 
         assert str(status.render()) == "Ready"
+        assert str(activity.render()) == ""
 
 
 @pytest.mark.anyio
@@ -1938,9 +1946,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: (_ for _ in ()).throw(
-            RuntimeError("Missing provider API key.")
-        ),
+        lambda provider, **kwargs: (_ for _ in ()).throw(RuntimeError("Missing provider API key.")),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)


### PR DESCRIPTION
## Summary

- add a dedicated working indicator row directly above the prompt input
- move spinner animation out of the top status line so it cannot overlap typing
- keep the activity row allocated while idle to avoid prompt layout jumps

Fixes #50.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Style**
- Activity indicator animation redesigned with simplified spinner symbols
- TUI status display layout reorganized with activity indicator in dedicated area
- Queue message count information repositioned to main status section
- "Ready" status displayed when the application is idle
- Status reporting structure updated with separate animation and queue information areas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->