### PR TITLE
[codex] Harden TUI code block highlighting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,10 @@ full visible row can include Tau's left accent marker.
 Use `Alt+Up` / `Alt+Down` to select transcript messages and `Ctrl+C` to copy the
 selected message text through Textual's terminal clipboard integration.
 
+Assistant Markdown renders fenced code blocks with syntax highlighting when the
+fence language is known. Unknown fence languages fall back to plain code
+formatting so assistant output remains readable.
+
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown
 themes, unknown keybinding names, empty keys, and duplicate assignments so

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from subprocess import TimeoutExpired, run
 from typing import Any, Protocol
 
+from pygments.lexers import get_lexer_by_name  # type: ignore[import-untyped]
+from pygments.util import ClassNotFound  # type: ignore[import-untyped]
 from rich import box
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
@@ -498,7 +500,7 @@ def _render_fenced_body(
             return None
 
         _append_plain(renderables, text[cursor:fence_start], body_style=body_style)
-        language = _fence_language(text[fence_start + 3 : fence_line_end])
+        language = _syntax_language(text[fence_start + 3 : fence_line_end])
         code = text[fence_line_end + 1 : closing_start]
         renderables.append(
             Syntax(
@@ -561,7 +563,7 @@ def _context_file_label(path: Path, *, cwd: Path) -> str:
         expanded_path = cwd / expanded_path
     try:
         return str(expanded_path.resolve().relative_to(cwd.expanduser().resolve()))
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return _short_path(expanded_path)
 
 
@@ -604,6 +606,17 @@ def _has_unclosed_fence(text: str) -> bool:
 def _fence_language(raw: str) -> str:
     language = raw.strip().split(maxsplit=1)[0] if raw.strip() else ""
     return language or "text"
+
+
+def _syntax_language(raw: str) -> str:
+    language = _fence_language(raw)
+    if language == "text":
+        return language
+    try:
+        get_lexer_by_name(language)
+    except ClassNotFound:
+        return "text"
+    return language
 
 
 def render_completion_suggestions(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -48,6 +48,7 @@ from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
     TranscriptView,
     _compact_token_count,
+    _syntax_language,
     render_chat_item,
     render_compact_session_info,
     render_session_sidebar,
@@ -351,6 +352,33 @@ def test_chat_items_render_fenced_code_without_markers() -> None:
     assert 'print("hi")' in output
     assert "```" not in output
     assert "python" not in output
+
+
+def test_assistant_chat_items_apply_syntax_highlighting_to_code_fences() -> None:
+    console = Console(record=True, width=80, color_system="truecolor")
+    item = ChatItem(role="assistant", text="```python\ndef hi():\n    return 1\n```")
+
+    console.print(render_chat_item(item))
+    output = console.export_text(styles=True)
+
+    assert "def" in output
+    assert "return" in output
+    assert "\x1b[94;48;2;0;0;0mdef" in output
+    assert "\x1b[94;48;2;0;0;0mreturn" in output
+
+
+def test_chat_items_fallback_unknown_fenced_language_to_plain_code() -> None:
+    assert _syntax_language("definitely-not-a-lexer") == "text"
+
+    console = Console(record=True, width=60)
+    item = ChatItem(role="assistant", text="```definitely-not-a-lexer\nvalue\n```")
+
+    console.print(render_chat_item(item))
+    output = console.export_text()
+
+    assert "value" in output
+    assert "```" not in output
+    assert "definitely-not-a-lexer" not in output
 
 
 def test_tool_chat_items_hide_and_show_result_text() -> None:
@@ -1938,9 +1966,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: (_ for _ in ()).throw(
-            RuntimeError("Missing provider API key.")
-        ),
+        lambda provider, **kwargs: (_ for _ in ()).throw(RuntimeError("Missing provider API key.")),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)


### PR DESCRIPTION
## Summary

- validate fenced-code languages before Tau-owned syntax rendering
- fall back unknown languages to plain text instead of passing invalid lexer names through
- add regression coverage for highlighted assistant Python fences and unknown-language fallback

Fixes #59.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/widgets.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/widgets.py tests/test_tui_app.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant chat messages now display code blocks with enhanced syntax highlighting for recognized programming languages. Unknown language declarations gracefully fall back to plain text formatting to maintain readability.

* **Documentation**
  * Configuration documentation clarifies how assistant Markdown renders code blocks with syntax highlighting support for known languages and plain text fallback for unknown languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->