### PR TITLE
[codex] Copy visible transcript selections

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,8 +152,10 @@ skills, prompt templates, and context files such as `AGENTS.md`.
 Transcript text supports Textual selection for visible user, assistant, tool, and
 error output. Copy shortcuts are terminal-emulator dependent, and selecting the
 full visible row can include Tau's left accent marker.
-Use `Alt+Up` / `Alt+Down` to select transcript messages and `Ctrl+C` to copy the
-selected message text through Textual's terminal clipboard integration.
+When visible transcript text is selected, `Ctrl+C` copies that selection through
+Textual's terminal clipboard integration. Without a visible selection, use
+`Alt+Up` / `Alt+Down` to select transcript messages and `Ctrl+C` to copy the
+selected message text.
 
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1354,6 +1354,16 @@ class TauTuiApp(App[None]):
 
     def action_copy_selected_message(self) -> None:
         """Copy the selected transcript message to the terminal clipboard."""
+        selected_text = self._visible_selection_text()
+        if selected_text is not None:
+            try:
+                self.copy_to_clipboard(selected_text)
+            except Exception as exc:  # noqa: BLE001 - terminal clipboard support varies
+                self._notify(f"Could not copy selection: {exc}", severity="error")
+                return
+            self._notify("Copied selected text.")
+            return
+
         text = self._selected_message_text()
         if text is None:
             self._notify("Select a transcript message first.", severity="warning")
@@ -1372,6 +1382,12 @@ class TauTuiApp(App[None]):
         if item.role == "tool" and self.state.show_tool_results and item.tool_result_text:
             return f"{item.text}\n\n{item.tool_result_text}"
         return item.text
+
+    def _visible_selection_text(self) -> str | None:
+        selected_text = self.screen.get_selected_text()
+        if selected_text is None or not selected_text.strip():
+            return None
+        return selected_text
 
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1592,6 +1592,42 @@ async def test_tui_app_copies_selected_transcript_messages() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_copies_visible_transcript_selection_first() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=(
+                UserMessage(content="User prompt"),
+                AssistantMessage(content="Assistant response\n\n```python\nprint('hi')\n```"),
+            )
+        )
+    )
+    copied: list[str] = []
+    notifications: list[str] = []
+
+    def fake_copy(text: str) -> None:
+        copied.append(text)
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app.copy_to_clipboard = fake_copy  # type: ignore[method-assign]
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.text_select_all()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+    assert len(copied) == 1
+    assert "User prompt" in copied[0]
+    assert "Assistant response" in copied[0]
+    assert "print('hi')" in copied[0]
+    assert notifications == ["Copied selected text."]
+
+
+@pytest.mark.anyio
 async def test_tui_app_copy_selected_message_reports_failures() -> None:
     app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))
     notifications: list[tuple[str, str | None]] = []
@@ -1938,9 +1974,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: (_ for _ in ()).throw(
-            RuntimeError("Missing provider API key.")
-        ),
+        lambda provider, **kwargs: (_ for _ in ()).throw(RuntimeError("Missing provider API key.")),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)


### PR DESCRIPTION
## Summary

- copy visible Textual transcript selections before falling back to selected-message copy
- preserve the existing keyboard-only selected-message workflow
- document selection copy versus selected-message copy behavior

Fixes #58.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `git diff --check`