### PR TITLE
[codex] Add light TUI theme

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,6 +142,8 @@ The built-in themes are:
 
 - `tau-dark`, the default Toad-inspired dark theme with subtle left-accent
   conversation rows.
+- `tau-light`, a light theme using the same TUI components with light
+  backgrounds and darker foreground colors.
 - `high-contrast`, a sharper dark theme for brighter terminal contrast.
 
 The built-in sidebar is responsive: Tau shows it on medium or larger terminal

--- a/src/tau_coding/tui/__init__.py
+++ b/src/tau_coding/tui/__init__.py
@@ -6,6 +6,7 @@ from tau_coding.tui.autocomplete import CompletionOption
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
     TAU_DARK_THEME,
+    TAU_LIGHT_THEME,
     TuiConfigError,
     TuiKeybindings,
     TuiRoleStyle,
@@ -33,6 +34,7 @@ __all__ = [
     "TauTuiApp",
     "SessionSidebar",
     "TAU_DARK_THEME",
+    "TAU_LIGHT_THEME",
     "TranscriptView",
     "TuiEventAdapter",
     "TuiConfigError",

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -51,7 +51,7 @@ class TuiKeybindings:
         }
 
 
-type TuiThemeName = Literal["tau-dark", "high-contrast"]
+type TuiThemeName = Literal["tau-dark", "tau-light", "high-contrast"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,8 +153,41 @@ HIGH_CONTRAST_THEME = TuiTheme(
 )
 
 
+TAU_LIGHT_THEME = TuiTheme(
+    name="tau-light",
+    screen_background="#ffffff",
+    screen_text="#111827",
+    chrome_background="#f3f4f6",
+    chrome_text="#111827",
+    muted_text="#667085",
+    sidebar_background="#f8fafc",
+    border="#cbd5e1",
+    transcript_background="#ffffff",
+    prompt_background="#f8fafc",
+    prompt_text="#111827",
+    prompt_border="#2563eb",
+    autocomplete_background="#ffffff",
+    accent="#0f766e",
+    highlight_background="#dbeafe",
+    highlight_text="#0f172a",
+    completion_selected="bold #0f172a on #dbeafe",
+    completion_selected_description="#334155 on #dbeafe",
+    completion_description="#667085",
+    syntax_theme="ansi_light",
+    role_styles={
+        "user": TuiRoleStyle(border="#2563eb", body="#111827 on #ffffff"),
+        "assistant": TuiRoleStyle(border="#0f766e", body="#111827 on #ffffff"),
+        "tool": TuiRoleStyle(border="#a16207", body="#1f2937 on #ffffff"),
+        "error": TuiRoleStyle(border="#b91c1c", body="#7f1d1d on #ffffff"),
+        "status": TuiRoleStyle(border="#64748b", body="#334155 on #ffffff"),
+        "thinking": TuiRoleStyle(border="#6b7280", body="#4b5563 on #ffffff"),
+    },
+)
+
+
 _THEMES: dict[TuiThemeName, TuiTheme] = {
     TAU_DARK_THEME.name: TAU_DARK_THEME,
+    TAU_LIGHT_THEME.name: TAU_LIGHT_THEME,
     HIGH_CONTRAST_THEME.name: HIGH_CONTRAST_THEME,
 }
 
@@ -241,7 +274,7 @@ def _theme_name(value: object) -> TuiThemeName:
     if not isinstance(value, str) or not value.strip():
         raise TuiConfigError("TUI theme must be a non-empty string")
     name = value.strip()
-    if name == "tau-dark" or name == "high-contrast":
+    if name == "tau-dark" or name == "tau-light" or name == "high-contrast":
         return cast(TuiThemeName, name)
     raise TuiConfigError(f"Unknown TUI theme: {name}")
 
@@ -252,7 +285,6 @@ def _reject_duplicate_keys(values: dict[str, str]) -> None:
         previous_action = key_to_action.get(key)
         if previous_action is not None:
             raise TuiConfigError(
-                f"TUI keybinding {key!r} is assigned to both "
-                f"{previous_action!r} and {action!r}"
+                f"TUI keybinding {key!r} is assigned to both {previous_action!r} and {action!r}"
             )
         key_to_action[key] = action

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -654,6 +654,17 @@ def test_tui_app_uses_configured_theme_css_variables() -> None:
     assert variables["tau-prompt-border"] == "#00ff66"
 
 
+def test_tui_app_uses_light_theme_css_variables() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme="tau-light"))
+
+    variables = app.get_theme_variable_defaults()
+
+    assert variables["tau-screen-background"] == "#ffffff"
+    assert variables["tau-chrome-background"] == "#f3f4f6"
+    assert variables["tau-prompt-background"] == "#f8fafc"
+    assert variables["tau-prompt-border"] == "#2563eb"
+
+
 def test_tau_dark_theme_uses_black_chat_backgrounds() -> None:
     theme = TuiSettings().resolved_theme
 
@@ -662,6 +673,18 @@ def test_tau_dark_theme_uses_black_chat_backgrounds() -> None:
     assert theme.prompt_background == "#101419"
     assert theme.role_styles["user"].body.endswith("on #000000")
     assert theme.role_styles["assistant"].body.endswith("on #000000")
+
+
+def test_tau_light_theme_uses_light_chat_backgrounds() -> None:
+    theme = TuiSettings(theme="tau-light").resolved_theme
+
+    assert theme.screen_background == "#ffffff"
+    assert theme.transcript_background == "#ffffff"
+    assert theme.prompt_text == "#111827"
+    assert theme.syntax_theme == "ansi_light"
+    assert theme.role_styles["user"].body.endswith("on #ffffff")
+    assert theme.role_styles["assistant"].body.endswith("on #ffffff")
+    assert theme.role_styles["error"].border == "#b91c1c"
 
 
 def test_tui_app_loads_restored_messages_into_display_state() -> None:
@@ -1938,9 +1961,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: (_ for _ in ()).throw(
-            RuntimeError("Missing provider API key.")
-        ),
+        lambda provider, **kwargs: (_ for _ in ()).throw(RuntimeError("Missing provider API key.")),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -89,6 +89,14 @@ def test_tui_settings_reject_unknown_theme() -> None:
         tui_settings_from_json({"theme": "solarized"})
 
 
+def test_tui_settings_accept_light_theme() -> None:
+    settings = tui_settings_from_json({"theme": "tau-light"})
+
+    assert settings.theme == "tau-light"
+    assert settings.resolved_theme.screen_background == "#ffffff"
+    assert settings.resolved_theme.syntax_theme == "ansi_light"
+
+
 def test_tui_keybindings_serialize_to_json() -> None:
     settings = TuiSettings(
         keybindings=TuiKeybindings(
@@ -118,4 +126,5 @@ def test_tui_keybindings_serialize_to_json() -> None:
 
 def test_get_tui_theme_returns_builtin_theme() -> None:
     assert get_tui_theme("high-contrast").prompt_border == "#00ff66"
+    assert get_tui_theme("tau-light").prompt_border == "#2563eb"
     assert get_tui_theme("tau-dark").screen_background == "#000000"


### PR DESCRIPTION
## Summary

- add `tau-light` as a built-in TUI theme
- export the light theme through `tau_coding.tui`
- document and test light-theme config, CSS variables, role backgrounds, and syntax theme selection

Fixes #62.

## Validation

- `uv run pytest tests/test_tui_config.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/config.py src/tau_coding/tui/__init__.py tests/test_tui_config.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/config.py src/tau_coding/tui/__init__.py tests/test_tui_config.py tests/test_tui_app.py`
- `git diff --check`