### PR TITLE
Clear prompt on Ctrl+C

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -232,7 +232,13 @@ class PromptInput(TextArea):
         self._completion_target().action_select_next_message()
 
     def action_copy_selected_message(self) -> None:
-        """Copy the selected transcript message."""
+        """Clear the current prompt before falling back to message copy."""
+        if self.selected_text:
+            return
+        if self.text:
+            self.text = ""
+            self.move_cursor((0, 0))
+            return
         self._completion_target().action_copy_selected_message()
 
     async def action_submit_follow_up(self) -> None:
@@ -297,7 +303,12 @@ class PromptInput(TextArea):
             if self.selected_text:
                 return
             event.stop()
-            self._completion_target().action_copy_selected_message()
+            event.prevent_default()
+            if self.text:
+                self.text = ""
+                self.move_cursor((0, 0))
+            else:
+                self._completion_target().action_copy_selected_message()
         elif event.key == keybindings.completion_next:
             event.stop()
             if self._has_completion_options():

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1857,6 +1857,38 @@ async def test_tui_app_copies_visible_transcript_selection_first() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_prompt_ctrl_c_clears_text_before_copying_message() -> None:
+    app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))
+    copied: list[str] = []
+    notifications: list[str] = []
+
+    def fake_copy(text: str) -> None:
+        copied.append(text)
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app.copy_to_clipboard = fake_copy  # type: ignore[method-assign]
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.focus()
+        prompt.text = "discard this prompt"
+        await pilot.pause()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert prompt.text == ""
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+    assert copied == []
+    assert notifications == ["Select a transcript message first."]
+
+
+@pytest.mark.anyio
 async def test_tui_app_copy_selected_message_reports_failures() -> None:
     app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))
     notifications: list[tuple[str, str | None]] = []


### PR DESCRIPTION
## Summary

- clear the focused TUI prompt when `Ctrl+C` is pressed and text is present
- preserve selected-text copy behavior and fall back to transcript message copy when the prompt is empty
- add regression coverage for the prompt clearing behavior

Closes #72

## Tests

- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Ctrl+C behavior in the prompt field: now clears typed text before attempting to copy transcript messages, improving the copy-message workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->