### PR TITLE
Slow TUI activity animation

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -73,6 +73,7 @@ type BindingEntry = Binding | tuple[str, str] | tuple[str, str, str]
 SIDEBAR_MIN_WIDTH = 96
 SIDEBAR_MIN_HEIGHT = 24
 ACTIVITY_TRAIL_PERIOD = 80
+ACTIVITY_TICK_SECONDS = 0.4
 ACTIVITY_FRAMES = ("|", "/", "-", "\\")
 
 
@@ -1718,7 +1719,7 @@ class TauTuiApp(App[None]):
         if self.state.running:
             if self._activity_timer is None:
                 self._activity_timer = self.set_interval(
-                    0.2,
+                    ACTIVITY_TICK_SECONDS,
                     self._tick_activity,
                     name="activity-indicator",
                 )

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -842,6 +842,7 @@ async def test_tui_app_shows_activity_indicators_while_running() -> None:
         assert trail.display is True
         assert "•" in str(trail.render())
         assert str(activity.render()) == "working |"
+        assert tui_app.ACTIVITY_TICK_SECONDS == pytest.approx(0.4)
 
         app._tick_activity()
 


### PR DESCRIPTION
## Summary
- slow the TUI activity/thinking animation tick from 0.2s to 0.4s
- add test coverage for the configured activity tick duration

## Tests
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced activity indicator performance by optimizing its refresh rate during session execution, improving system efficiency while maintaining clear visual feedback about ongoing operations.

* **Tests**
  * Added test coverage to verify activity indicator refresh rate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->