### PR TITLE
[codex] Remove TUI top status bar

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -936,13 +936,6 @@ class TauTuiApp(App[None]):
         color: $tau-accent;
     }
 
-    #status {
-        height: 1;
-        padding: 0 1;
-        background: $tau-screen-background;
-        color: $tau-muted-text;
-    }
-
     #workspace {
         height: 1fr;
     }
@@ -1254,7 +1247,6 @@ class TauTuiApp(App[None]):
     def compose(self) -> ComposeResult:
         """Compose the TUI widgets."""
         yield Header()
-        yield Static("Ready", id="status")
         with Horizontal(id="workspace"):
             yield SessionSidebar(id="sidebar")
             with Vertical(id="main-pane"):
@@ -1776,8 +1768,6 @@ class TauTuiApp(App[None]):
         queued_messages.display = self.state.queued_message_count > 0
         queued_messages.update(_render_queued_messages(self.state, theme=theme))
         self._sync_activity_indicator()
-        status = self.query_one("#status", Static)
-        status.update(self._status_text())
         self._refresh_footer_bindings()
 
     def _sync_queue_state(self) -> None:
@@ -1808,8 +1798,6 @@ class TauTuiApp(App[None]):
             return
         self._activity_frame += 1
         self._apply_activity_indicator()
-        status = self.query_one("#status", Static)
-        status.update(self._status_text())
 
     def _apply_activity_indicator(self) -> None:
         prompt = self.query_one("#prompt", PromptInput)
@@ -1821,12 +1809,6 @@ class TauTuiApp(App[None]):
                 running=self.state.running,
             ),
         )
-
-    def _status_text(self) -> str:
-        queue_text = _queue_status_text(self.state)
-        if self.state.running:
-            return f"queued: {queue_text}" if queue_text else ""
-        return f"Ready | queued: {queue_text}" if queue_text else "Ready"
 
     def _refresh_completions(self) -> None:
         suggestions = self.query_one("#autocomplete", Static)
@@ -2040,19 +2022,6 @@ def _theme_css_variables(theme: TuiTheme) -> dict[str, str]:
         "footer-key-foreground": theme.accent,
         "footer-item-background": theme.chrome_background,
     }
-
-
-def _queue_status_text(state: TuiState) -> str:
-    parts: list[str] = []
-    steering_count = len(state.queued_steering)
-    follow_up_count = len(state.queued_follow_up)
-    if steering_count:
-        suffix = "" if steering_count == 1 else "s"
-        parts.append(f"{steering_count} steering message{suffix}")
-    if follow_up_count:
-        suffix = "" if follow_up_count == 1 else "s"
-        parts.append(f"{follow_up_count} follow-up message{suffix}")
-    return ", ".join(parts)
 
 
 def _render_queued_messages(state: TuiState, *, theme: TuiTheme) -> Group:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -40,11 +40,17 @@ from tau_coding.tui.app import (
     LoginScreen,
     ModelPickerScreen,
     OAuthLoginScreen,
-    ThemePickerScreen,
     SessionPickerScreen,
     TauTuiApp,
+    ThemePickerScreen,
 )
-from tau_coding.tui.config import HIGH_CONTRAST_THEME, TAU_LIGHT_THEME, TuiKeybindings, TuiSettings, tui_settings_path
+from tau_coding.tui.config import (
+    HIGH_CONTRAST_THEME,
+    TAU_LIGHT_THEME,
+    TuiKeybindings,
+    TuiSettings,
+    tui_settings_path,
+)
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
     TranscriptView,
@@ -860,18 +866,16 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test():
-        status = app.query_one("#status")
         prompt = app.query_one("#prompt")
 
-        assert str(status.render()) == "Ready"
+        assert not app.query("#status")
         assert not app.query("#activity-status")
         assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
 
         app.adapter.apply(AgentStartEvent())
         app._refresh()
 
-        assert str(status.render()) == ""
-        assert tui_app.ACTIVITY_TICK_SECONDS == pytest.approx(0.15)
+        assert pytest.approx(tui_app.ACTIVITY_TICK_SECONDS) == 0.15
         assert tui_app.ACTIVITY_COLOR_FADE_STEPS == 24
         assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
 
@@ -882,7 +886,7 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
         app.adapter.apply(AgentEndEvent())
         app._refresh()
 
-        assert str(status.render()) == "Ready"
+        assert not app.query("#status")
         assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
 
 
@@ -891,14 +895,15 @@ async def test_tui_app_clears_activity_status_on_error() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test():
-        status = app.query_one("#status")
+        prompt = app.query_one("#prompt")
         app.adapter.apply(AgentStartEvent())
         app._refresh()
         app.adapter.apply(ErrorEvent(message="provider failed", recoverable=False))
         app._refresh()
 
-        assert str(status.render()) == "Ready"
+        assert not app.query("#status")
         assert not app.query("#activity-status")
+        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #86.

Removes the redundant top TUI status bar that rendered `Ready` and queued-message counts. Queued steering and follow-up messages remain visible in the input-area queue stack.

## Root cause

The app rendered both a top status widget and input-adjacent queued-message feedback, reserving an extra terminal row for redundant state.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the status indicator UI element from the terminal application. Prompt queuing and activity handling continue to function normally through existing rendering mechanisms.

* **Tests**
  * Updated test cases to verify behavior following the removal of the status display element. Tests now validate activity and error handling without the status widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->