### PR TITLE
[codex] Deduplicate active TUI notifications

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1245,6 +1245,7 @@ class TauTuiApp(App[None]):
         self._completion_state = CompletionState()
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
+        self._active_notification_keys: set[tuple[str, str]] = set()
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Return Tau-specific CSS variables for the selected TUI theme."""
@@ -1761,6 +1762,15 @@ class TauTuiApp(App[None]):
         *,
         severity: Literal["information", "warning", "error"] = "information",
     ) -> None:
+        key = (message, severity)
+        if key in self._active_notification_keys:
+            return
+        self._active_notification_keys.add(key)
+        self.set_timer(
+            self.NOTIFICATION_TIMEOUT,
+            lambda: self._active_notification_keys.discard(key),
+            name=f"notification-dedupe-{hash(key)}",
+        )
         self.notify(message, severity=severity)
 
     def _refresh(self) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -40,11 +40,17 @@ from tau_coding.tui.app import (
     LoginScreen,
     ModelPickerScreen,
     OAuthLoginScreen,
-    ThemePickerScreen,
     SessionPickerScreen,
     TauTuiApp,
+    ThemePickerScreen,
 )
-from tau_coding.tui.config import HIGH_CONTRAST_THEME, TAU_LIGHT_THEME, TuiKeybindings, TuiSettings, tui_settings_path
+from tau_coding.tui.config import (
+    HIGH_CONTRAST_THEME,
+    TAU_LIGHT_THEME,
+    TuiKeybindings,
+    TuiSettings,
+    tui_settings_path,
+)
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
     TranscriptView,
@@ -871,7 +877,7 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
         app._refresh()
 
         assert str(status.render()) == ""
-        assert tui_app.ACTIVITY_TICK_SECONDS == pytest.approx(0.15)
+        assert pytest.approx(0.15) == tui_app.ACTIVITY_TICK_SECONDS
         assert tui_app.ACTIVITY_COLOR_FADE_STEPS == 24
         assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
 
@@ -1343,6 +1349,26 @@ def test_tui_model_picker_guides_setup_when_no_provider_is_usable() -> None:
 
     assert notifications == [
         ("No configured providers are usable. Run /login to set up a provider.", "warning")
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_deduplicates_active_notifications() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(notifications=True) as pilot:
+        app._notify("Thinking controls are not available.", severity="warning")
+        app._notify("Thinking controls are not available.", severity="warning")
+        app._notify("Thinking controls are not available.", severity="error")
+        await pilot.pause()
+
+        active_notifications = tuple(app._notifications)
+
+    assert [
+        (notification.message, notification.severity) for notification in active_notifications
+    ] == [
+        ("Thinking controls are not available.", "warning"),
+        ("Thinking controls are not available.", "error"),
     ]
 
 


### PR DESCRIPTION
## Summary

Closes #81.

Prevents repeated identical TUI notifications from stacking while the prior notification is still active. Messages with a different severity still render separately.

## Root cause

Tau forwarded every `_notify` call directly to Textual, so repeated key presses could post duplicate notifications before the existing toast expired.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the in-app toast/notification behavior by suppressing duplicate notifications while they’re active (based on the same message and severity), reducing visual clutter and improving clarity.

* **Tests**
  * Added an async test to verify notifications are properly deduplicated, including handling repeats with the same message/severity and multiple severities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->