### PR TITLE
[codex] Center command info modals

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1010,7 +1010,8 @@ class TauTuiApp(App[None]):
         border: tall $tau-border;
     }
 
-    SessionPickerScreen {
+    SessionPickerScreen,
+    CommandOutputScreen {
         align: center middle;
     }
 
@@ -1055,12 +1056,13 @@ class TauTuiApp(App[None]):
     }
 
     #command-output {
-        width: 82;
-        max-width: 92%;
-        height: 70%;
-        max-height: 80%;
+        width: 76;
+        max-width: 90%;
+        height: auto;
+        max-height: 70%;
         padding: 1 2;
         background: $tau-chrome-background;
+        color: $tau-chrome-text;
         border: tall $tau-border;
     }
 
@@ -1072,7 +1074,8 @@ class TauTuiApp(App[None]):
     }
 
     #command-output-scroll {
-        height: 1fr;
+        height: auto;
+        max-height: 18;
         background: $tau-transcript-background;
         border: tall $tau-border;
     }
@@ -1570,16 +1573,13 @@ class TauTuiApp(App[None]):
         return item.apply(value)
 
     def _show_command_message(self, command_text: str, message: str) -> None:
-        if "\n" in message:
-            self.push_screen(
-                CommandOutputScreen(
-                    _command_output_title(command_text),
-                    message,
-                    theme=self.tui_settings.resolved_theme,
-                )
+        self.push_screen(
+            CommandOutputScreen(
+                _command_output_title(command_text),
+                message,
+                theme=self.tui_settings.resolved_theme,
             )
-            return
-        self._notify(message)
+        )
 
     def _open_login_picker(self) -> None:
         self.push_screen(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1400,6 +1400,26 @@ async def test_tui_app_command_modal_renders_literal_markup_text() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_command_modal_uses_centered_picker_style() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        app._show_command_message("/context", "Active context files")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CommandOutputScreen)
+        command_output = app.screen.query_one("#command-output")
+        command_scroll = app.screen.query_one("#command-output-scroll")
+        assert app.screen.styles.align == ("center", "middle")
+        assert command_output.styles.width.value == 76
+        assert command_output.styles.max_width.value == 90
+        assert command_output.styles.height.is_auto
+        assert command_output.styles.max_height.value == 70
+        assert command_scroll.styles.height.is_auto
+        assert command_scroll.styles.max_height.value == 18
+
+
+@pytest.mark.anyio
 async def test_tui_app_escape_cancels_running_session_from_prompt() -> None:
     class RunningSession(FakeSession):
         @property


### PR DESCRIPTION
## Summary

Closes #70.

Makes slash-command informational output consistently render in a centered modal, including single-line command messages. The command output modal now follows the same centered picker-style dimensions, chrome background, and bounded scroll area as the rest of the TUI modal family.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command output messages are now consistently displayed in a centered modal dialog with improved layout and sizing.
  * Enhanced scrolling behavior for command output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->