### PR TITLE
[codex] Improve login popup keyboard navigation

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -417,14 +417,31 @@ class SessionPickerScreen(ModalScreen[str | None]):
         self.dismiss(None)
 
 
+class CommandOutputScroll(VerticalScroll):
+    """Scrollable command output area with deterministic arrow-key scrolling."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("up", "scroll_up", "Scroll up", show=False, priority=True),
+        Binding("down", "scroll_down", "Scroll down", show=False, priority=True),
+    ]
+
+    def action_scroll_up(self) -> None:
+        """Scroll command output up."""
+        self.scroll_y = max(0, self.scroll_y - 1)
+
+    def action_scroll_down(self) -> None:
+        """Scroll command output down."""
+        self.scroll_y = min(self.max_scroll_y, self.scroll_y + 1)
+
+
 class CommandOutputScreen(ModalScreen[None]):
     """Dismissible modal for slash-command output."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = [
         Binding("escape", "close", "Close"),
         Binding("enter", "close", "Close"),
-        Binding("up", "scroll_up", "Scroll up", show=False),
-        Binding("down", "scroll_down", "Scroll down", show=False),
+        Binding("up", "scroll_up", "Scroll up", show=False, priority=True),
+        Binding("down", "scroll_down", "Scroll down", show=False, priority=True),
     ]
 
     def __init__(self, title: str, message: str, *, theme: TuiTheme) -> None:
@@ -437,7 +454,7 @@ class CommandOutputScreen(ModalScreen[None]):
         """Compose command output."""
         with Vertical(id="command-output"):
             yield Static(self.title_text, id="command-output-title")
-            with VerticalScroll(id="command-output-scroll"):
+            with CommandOutputScroll(id="command-output-scroll"):
                 yield Static(self.message, id="command-output-body", markup=False)
             yield Static("Enter or Escape closes", id="command-output-help")
 
@@ -460,13 +477,11 @@ class CommandOutputScreen(ModalScreen[None]):
 
     def action_scroll_up(self) -> None:
         """Scroll command output up."""
-        scroll = self.query_one("#command-output-scroll", VerticalScroll)
-        scroll.scroll_y = max(0, scroll.scroll_y - 1)
+        self.query_one("#command-output-scroll", CommandOutputScroll).action_scroll_up()
 
     def action_scroll_down(self) -> None:
         """Scroll command output down."""
-        scroll = self.query_one("#command-output-scroll", VerticalScroll)
-        scroll.scroll_y = min(scroll.max_scroll_y, scroll.scroll_y + 1)
+        self.query_one("#command-output-scroll", CommandOutputScroll).action_scroll_down()
 
 
 class LoginProviderPickerScreen(ModalScreen[str | None]):
@@ -1554,6 +1569,9 @@ class TauTuiApp(App[None]):
 
     def action_completion_next(self) -> None:
         """Select the next prompt completion or move down in the prompt."""
+        if isinstance(self.screen, CommandOutputScreen):
+            self.screen.action_scroll_down()
+            return
         if isinstance(
             self.screen,
             SessionPickerScreen | LoginProviderPickerScreen | ThemePickerScreen | ModelPickerScreen,
@@ -1568,6 +1586,9 @@ class TauTuiApp(App[None]):
 
     def action_completion_previous(self) -> None:
         """Select the previous prompt completion or move up in the prompt."""
+        if isinstance(self.screen, CommandOutputScreen):
+            self.screen.action_scroll_up()
+            return
         if isinstance(
             self.screen,
             SessionPickerScreen | LoginProviderPickerScreen | ThemePickerScreen | ModelPickerScreen,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -520,7 +520,10 @@ class LoginMethodPickerScreen(ModalScreen[str | None]):
     """Login method picker for the TUI login flow."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = [
-        Binding("escape", "cancel", "Cancel"),
+        Binding("escape", "cancel", "Cancel", priority=True),
+        Binding("up", "cursor_up", "Up", show=False, priority=True),
+        Binding("down", "cursor_down", "Down", show=False, priority=True),
+        Binding("enter", "select_cursor", "Select", show=False, priority=True),
     ]
 
     def __init__(self, *, theme: TuiTheme) -> None:
@@ -532,20 +535,36 @@ class LoginMethodPickerScreen(ModalScreen[str | None]):
         with Vertical(id="login-method-picker"):
             yield Static("Login", id="login-method-title")
             yield Static("Choose how to authenticate.", id="login-method-intro")
-            with Vertical(id="login-method-actions"):
-                yield Button(
-                    "Subscription",
+            yield LoginMethodListView(
+                ListItem(
+                    Label("Subscription\n  Sign in with an OAuth account.", markup=False),
                     id="login-method-subscription",
-                    variant="primary",
-                )
-                yield Static("Sign in with an OAuth account.", classes="login-method-description")
-                yield Button("API key", id="login-method-api-key")
-                yield Static("Save a provider API key.", classes="login-method-description")
+                ),
+                ListItem(
+                    Label("API key\n  Save a provider API key.", markup=False),
+                    id="login-method-api-key",
+                ),
+                id="login-method-list",
+            )
             yield Static("Enter selects - Escape closes", id="login-method-help")
 
     def on_mount(self) -> None:
         """Focus the default subscription method."""
-        self.query_one("#login-method-subscription", Button).focus()
+        method_list = self.query_one("#login-method-list", ListView)
+        method_list.index = 0
+        method_list.focus()
+
+    def on_key(self, event: Key) -> None:
+        """Route arrow keys between login method buttons."""
+        if event.key == "up":
+            event.stop()
+            self.action_cursor_up()
+        elif event.key == "down":
+            event.stop()
+            self.action_cursor_down()
+        elif event.key == "enter":
+            event.stop()
+            self.action_select_cursor()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Dismiss with the selected login method."""
@@ -554,9 +573,57 @@ class LoginMethodPickerScreen(ModalScreen[str | None]):
         elif event.button.id == "login-method-api-key":
             self.dismiss("api-key")
 
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Dismiss with the selected login method."""
+        if event.item.id == "login-method-subscription":
+            self.dismiss("subscription")
+        elif event.item.id == "login-method-api-key":
+            self.dismiss("api-key")
+
     def action_cancel(self) -> None:
         """Close without selecting a login method."""
         self.dismiss(None)
+
+    def action_cursor_up(self) -> None:
+        """Focus the previous login method."""
+        self._move_method_cursor(offset=-1)
+
+    def action_cursor_down(self) -> None:
+        """Focus the next login method."""
+        self._move_method_cursor(offset=1)
+
+    def action_select_cursor(self) -> None:
+        """Select the currently focused login method."""
+        self.query_one("#login-method-list", ListView).action_select_cursor()
+
+    def _move_method_cursor(self, *, offset: int) -> None:
+        method_list = self.query_one("#login-method-list", ListView)
+        item_count = len(method_list.children)
+        if item_count == 0:
+            method_list.index = None
+            return
+        current_index = method_list.index if method_list.index is not None else 0
+        method_list.index = (current_index + offset) % item_count
+
+
+class LoginMethodListView(ListView):
+    """List view with wrapping arrow navigation for the login method picker."""
+
+    def action_cursor_up(self) -> None:
+        """Move to the previous login method."""
+        self._move_cursor(offset=-1)
+
+    def action_cursor_down(self) -> None:
+        """Move to the next login method."""
+        self._move_cursor(offset=1)
+
+    def _move_cursor(self, *, offset: int) -> None:
+        item_count = len(self.children)
+        if item_count == 0:
+            self.index = None
+            return
+        current_index = self.index if self.index is not None else 0
+        self.index = (current_index + offset) % item_count
 
 
 class ThemePickerScreen(ModalScreen[TuiThemeName | None]):
@@ -1088,6 +1155,7 @@ class TauTuiApp(App[None]):
         color: $tau-muted-text;
     }
 
+    LoginMethodPickerScreen,
     LoginProviderPickerScreen,
     ThemePickerScreen,
     ModelPickerScreen {
@@ -1118,6 +1186,7 @@ class TauTuiApp(App[None]):
         margin-bottom: 1;
     }
 
+    #login-method-list,
     #login-provider-list,
     #theme-picker-list,
     #model-picker-list {
@@ -1128,26 +1197,21 @@ class TauTuiApp(App[None]):
         border: tall $tau-border;
     }
 
+    #login-method-list ListItem Label,
     #login-provider-list ListItem Label,
     #theme-picker-list ListItem Label,
     #model-picker-list ListItem Label {
         color: $tau-screen-text;
     }
 
-    #login-method-intro,
-    .login-method-description {
+    #login-method-intro {
         height: 1;
         color: $tau-muted-text;
-    }
-
-    #login-method-actions {
-        height: auto;
         margin-bottom: 1;
     }
 
-    #login-method-actions Button {
-        width: 100%;
-        margin-top: 1;
+    #login-method-list {
+        max-height: 6;
     }
 
     #model-picker-search {

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1554,7 +1554,11 @@ class TauTuiApp(App[None]):
         """Accept the currently selected prompt completion."""
         if isinstance(
             self.screen,
-            SessionPickerScreen | LoginProviderPickerScreen | ThemePickerScreen | ModelPickerScreen,
+            SessionPickerScreen
+            | LoginMethodPickerScreen
+            | LoginProviderPickerScreen
+            | ThemePickerScreen
+            | ModelPickerScreen,
         ):
             self.screen.action_select_cursor()
             return
@@ -1574,7 +1578,11 @@ class TauTuiApp(App[None]):
             return
         if isinstance(
             self.screen,
-            SessionPickerScreen | LoginProviderPickerScreen | ThemePickerScreen | ModelPickerScreen,
+            SessionPickerScreen
+            | LoginMethodPickerScreen
+            | LoginProviderPickerScreen
+            | ThemePickerScreen
+            | ModelPickerScreen,
         ):
             self.screen.action_cursor_down()
             return
@@ -1591,7 +1599,11 @@ class TauTuiApp(App[None]):
             return
         if isinstance(
             self.screen,
-            SessionPickerScreen | LoginProviderPickerScreen | ThemePickerScreen | ModelPickerScreen,
+            SessionPickerScreen
+            | LoginMethodPickerScreen
+            | LoginProviderPickerScreen
+            | ThemePickerScreen
+            | ModelPickerScreen,
         ):
             self.screen.action_cursor_up()
             return

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -423,6 +423,8 @@ class CommandOutputScreen(ModalScreen[None]):
     BINDINGS: ClassVar[list[BindingEntry]] = [
         Binding("escape", "close", "Close"),
         Binding("enter", "close", "Close"),
+        Binding("up", "scroll_up", "Scroll up", show=False),
+        Binding("down", "scroll_down", "Scroll down", show=False),
     ]
 
     def __init__(self, title: str, message: str, *, theme: TuiTheme) -> None:
@@ -439,9 +441,32 @@ class CommandOutputScreen(ModalScreen[None]):
                 yield Static(self.message, id="command-output-body", markup=False)
             yield Static("Enter or Escape closes", id="command-output-help")
 
+    def on_mount(self) -> None:
+        """Focus the scroll area so arrow keys navigate long output."""
+        self.query_one("#command-output-scroll", VerticalScroll).focus()
+
+    def on_key(self, event: Key) -> None:
+        """Route arrow keys to the command output scroll area."""
+        if event.key == "up":
+            event.stop()
+            self.action_scroll_up()
+        elif event.key == "down":
+            event.stop()
+            self.action_scroll_down()
+
     def action_close(self) -> None:
         """Close the command output modal."""
         self.dismiss(None)
+
+    def action_scroll_up(self) -> None:
+        """Scroll command output up."""
+        scroll = self.query_one("#command-output-scroll", VerticalScroll)
+        scroll.scroll_y = max(0, scroll.scroll_y - 1)
+
+    def action_scroll_down(self) -> None:
+        """Scroll command output down."""
+        scroll = self.query_one("#command-output-scroll", VerticalScroll)
+        scroll.scroll_y = min(scroll.max_scroll_y, scroll.scroll_y + 1)
 
 
 class LoginProviderPickerScreen(ModalScreen[str | None]):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1401,9 +1401,11 @@ async def test_tui_app_command_modal_arrow_keys_scroll_output() -> None:
         scroll = app.screen.query_one("#command-output-scroll", VerticalScroll)
         await pilot.pause()
         assert scroll.max_scroll_y > 0
+        assert app.screen.focused is scroll
         assert scroll.scroll_y == 0
 
-        app.screen.action_scroll_down()
+        await pilot.press("down")
+        await pilot.pause()
 
         assert scroll.scroll_y > 0
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7,7 +7,7 @@ import pytest
 from rich.console import Console
 from rich.panel import Panel
 from textual.containers import VerticalScroll
-from textual.widgets import Button, Footer, Input, Label, ListItem, ListView, TextArea
+from textual.widgets import Footer, Input, Label, ListItem, ListView, TextArea
 
 from tau_agent import (
     AgentEndEvent,
@@ -1613,10 +1613,45 @@ async def test_tui_login_opens_method_picker() -> None:
         await pilot.pause()
 
         assert isinstance(app.screen, LoginMethodPickerScreen)
-        assert str(app.screen.query_one("#login-method-subscription", Button).label) == (
-            "Subscription"
-        )
-        assert str(app.screen.query_one("#login-method-api-key", Button).label) == "API key"
+        method_list = app.screen.query_one("#login-method-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in method_list.children]
+        assert labels == [
+            "Subscription\n  Sign in with an OAuth account.",
+            "API key\n  Save a provider API key.",
+        ]
+        assert app.screen.focused is method_list
+        assert method_list.index == 0
+
+
+@pytest.mark.anyio
+async def test_tui_login_method_picker_supports_arrow_keys() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginMethodPickerScreen)
+        method_list = app.screen.query_one("#login-method-list", ListView)
+        assert app.screen.focused is method_list
+        assert method_list.index == 0
+
+        app.screen.action_cursor_down()
+        assert method_list.index == 1
+
+        app.screen.action_cursor_up()
+        assert method_list.index == 0
+
+        app.screen.action_cursor_down()
+        app.screen.action_select_cursor()
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginProviderPickerScreen)
+        provider_list = app.screen.query_one("#login-provider-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in provider_list.children]
+        assert labels[0] == "OpenAI\n  openai"
 
 
 @pytest.mark.anyio
@@ -1630,7 +1665,7 @@ async def test_tui_login_subscription_opens_oauth_provider_picker() -> None:
         await pilot.pause()
 
         assert isinstance(app.screen, LoginMethodPickerScreen)
-        await pilot.click("#login-method-subscription")
+        await pilot.press("enter")
         await pilot.pause()
 
         assert isinstance(app.screen, LoginProviderPickerScreen)
@@ -1651,7 +1686,8 @@ async def test_tui_login_api_key_opens_api_provider_picker() -> None:
         await pilot.pause()
 
         assert isinstance(app.screen, LoginMethodPickerScreen)
-        await pilot.click("#login-method-api-key")
+        app.screen.action_cursor_down()
+        app.screen.action_select_cursor()
         await pilot.pause()
 
         assert isinstance(app.screen, LoginProviderPickerScreen)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1662,14 +1662,16 @@ async def test_tui_login_method_picker_supports_arrow_keys() -> None:
         assert app.screen.focused is method_list
         assert method_list.index == 0
 
-        app.screen.action_cursor_down()
+        await pilot.press("down")
+        await pilot.pause()
         assert method_list.index == 1
 
-        app.screen.action_cursor_up()
+        await pilot.press("up")
+        await pilot.pause()
         assert method_list.index == 0
 
-        app.screen.action_cursor_down()
-        app.screen.action_select_cursor()
+        await pilot.press("down")
+        await pilot.press("enter")
         await pilot.pause()
 
         assert isinstance(app.screen, LoginProviderPickerScreen)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1383,7 +1383,29 @@ async def test_tui_app_help_uses_modal_instead_of_transcript() -> None:
         assert isinstance(app.screen, CommandOutputScreen)
         assert app.state.items == []
         assert "Available commands:" in app.screen.message
-        assert app.screen.query_one("#command-output-scroll", VerticalScroll) is not None
+        scroll = app.screen.query_one("#command-output-scroll", VerticalScroll)
+        assert scroll is not None
+        assert app.screen.focused is scroll
+
+
+@pytest.mark.anyio
+async def test_tui_app_command_modal_arrow_keys_scroll_output() -> None:
+    app = TauTuiApp(FakeSession())
+    long_message = "\n".join(f"line {index}" for index in range(80))
+
+    async with app.run_test(size=(100, 20)) as pilot:
+        app._show_command_message("/long", long_message)
+        await pilot.pause()
+
+        assert isinstance(app.screen, CommandOutputScreen)
+        scroll = app.screen.query_one("#command-output-scroll", VerticalScroll)
+        await pilot.pause()
+        assert scroll.max_scroll_y > 0
+        assert scroll.scroll_y == 0
+
+        app.screen.action_scroll_down()
+
+        assert scroll.scroll_y > 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #84.

Reworks the login method popup to use the same highlighted ListView interaction model as Tau's other picker modals. The method picker now has explicit up/down/enter actions, starts with a clear focused selection, and supports keyboard-only selection into the subscription or API-key provider picker.

## Validation

- `uv run pytest tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command output modal now supports arrow-key scrolling for better navigation through lengthy outputs.
  * Login method picker now uses keyboard-driven list navigation with arrow keys and Enter to select.

* **Style**
  * Improved visual styling and spacing for the login method picker interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->