### PR TITLE
[codex] Add TUI file reference suggestions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,12 @@ OpenAI-compatible providers can opt in by adding `thinking_levels`,
 provider entry. Add `thinking_models` when only some configured models support
 those levels.
 
+Typing `@` in the TUI prompt opens file-reference suggestions for the current
+session working directory. Suggestions include matching files and directories
+from the project tree and insert paths such as `@src/app.py`. Tau intentionally
+skips hidden paths and common generated/cache directories such as `.git`,
+`.venv`, `node_modules`, `__pycache__`, `build`, and `dist`.
+
 ## Context Management
 
 `/status` shows a rough context-size estimate:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1847,6 +1847,7 @@ class TauTuiApp(App[None]):
             thinking_levels=getattr(self.session, "available_thinking_levels", ()),
             theme_names=BUILTIN_TUI_THEME_NAMES,
             session_options=_session_options(self.session),
+            cwd=self.session.cwd,
         )
 
     def _refresh_footer_bindings(self) -> None:

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -2,10 +2,29 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 from tau_coding.commands import CommandRegistry, SlashCommand
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.skills import Skill
+
+IGNORED_FILE_COMPLETION_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tau",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+    }
+)
+MAX_FILE_COMPLETIONS = 50
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,10 +95,13 @@ def build_completion_state(
     theme_names: Sequence[str] = (),
     session_ids: Sequence[str] = (),
     session_options: Sequence[CompletionOption] = (),
+    cwd: Path | None = None,
 ) -> CompletionState:
     """Build autocomplete suggestions for the current prompt text."""
     del prompt_templates
     if not text.startswith("/") or text.startswith("//"):
+        if cwd is not None:
+            return CompletionState(_file_reference_completions(text=text, cwd=cwd))
         return CompletionState()
 
     token_end = _first_token_end(text)
@@ -108,6 +130,71 @@ def build_completion_state(
     )
 
 
+def _file_reference_completions(*, text: str, cwd: Path) -> tuple[CompletionItem, ...]:
+    token = _active_file_reference_token(text)
+    if token is None:
+        return ()
+    start, end = token
+    prefix = text[start + 1 : end]
+    suggestions: list[CompletionItem] = []
+    for path in _iter_file_reference_paths(cwd):
+        relative = path.relative_to(cwd).as_posix()
+        if prefix.lower() not in relative.lower():
+            continue
+        display = f"@{relative}{'/' if path.is_dir() else ''}"
+        suggestions.append(
+            CompletionItem(
+                display=display,
+                replacement=display,
+                start=start,
+                end=end,
+                description="File reference",
+            )
+        )
+        if len(suggestions) >= MAX_FILE_COMPLETIONS:
+            break
+    return tuple(suggestions)
+
+
+def _active_file_reference_token(text: str) -> tuple[int, int] | None:
+    cursor = len(text)
+    token_start = max(text.rfind(" ", 0, cursor), text.rfind("\n", 0, cursor)) + 1
+    at_index = text.rfind("@", token_start, cursor)
+    if at_index == -1:
+        return None
+    return at_index, cursor
+
+
+def _iter_file_reference_paths(cwd: Path) -> tuple[Path, ...]:
+    if not cwd.exists() or not cwd.is_dir():
+        return ()
+    paths: list[Path] = []
+    stack = [cwd]
+    while stack:
+        directory = stack.pop()
+        try:
+            children = sorted(directory.iterdir(), key=lambda path: path.name.lower())
+        except OSError:
+            continue
+        for child in children:
+            if _is_ignored_file_completion_path(child, cwd=cwd):
+                continue
+            paths.append(child)
+            if child.is_dir():
+                stack.append(child)
+    return tuple(paths)
+
+
+def _is_ignored_file_completion_path(path: Path, *, cwd: Path) -> bool:
+    try:
+        relative_parts = path.relative_to(cwd).parts
+    except ValueError:
+        return True
+    return any(
+        part.startswith(".") or part in IGNORED_FILE_COMPLETION_DIRS for part in relative_parts
+    )
+
+
 def _command_completions(
     *, token: str, token_end: int, registry: CommandRegistry
 ) -> tuple[CompletionItem, ...]:
@@ -122,9 +209,7 @@ def _command_alias_completions(
     command: SlashCommand, *, prefix: str, token_end: int
 ) -> list[CompletionItem]:
     names = (
-        (command.name,)
-        if not prefix
-        else (command.name, *command.aliases, *command.search_terms)
+        (command.name,) if not prefix else (command.name, *command.aliases, *command.search_terms)
     )
     suggestions: list[CompletionItem] = []
     seen: set[str] = set()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1120,6 +1120,28 @@ async def test_tui_app_enter_accepts_arrow_selected_completion() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_accepts_file_reference_completion(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+
+    session = FakeSession()
+    session.cwd = tmp_path
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "inspect @main"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        assert [item.display for item in app._completion_state.items] == ["@src/main.py"]
+        await pilot.press("tab")
+
+        assert prompt.value == "inspect @src/main.py"
+
+
+@pytest.mark.anyio
 async def test_tui_app_completes_skill_name() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -196,3 +196,38 @@ def test_resume_argument_completion_uses_session_options_with_descriptions() -> 
         "Newer - qwen - /repo",
         "Older - gpt - /repo",
     ]
+
+
+def test_file_reference_completion_matches_workspace_files(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    (tmp_path / ".hidden").write_text("secret\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "ignored.js").write_text("", encoding="utf-8")
+
+    state = build_completion_state(
+        "please read @app",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["@src/app.py"]
+    assert state.selected is not None
+    assert state.selected.apply("please read @app") == "please read @src/app.py"
+
+
+def test_file_reference_completion_stays_off_for_slash_commands(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "/help @read",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["/help"]


### PR DESCRIPTION
## Summary

Closes #48.

Adds `@` file-reference suggestions to the TUI prompt. Matching lives in the reusable autocomplete helper, uses the active session working directory, inserts references like `@src/app.py`, and intentionally skips hidden/generated/cache paths such as `.git`, `.venv`, `node_modules`, `__pycache__`, `build`, and `dist`.

## Validation

- `uv run pytest tests/test_tui_autocomplete.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/tui/autocomplete.py src/tau_coding/tui/app.py tests/test_tui_autocomplete.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/autocomplete.py src/tau_coding/tui/app.py tests/test_tui_autocomplete.py tests/test_tui_app.py`
- `git diff --check`
