### PR TITLE
[codex] Support editing queued follow-ups

### DIFF
--- a/docs/architecture/queued-steering-follow-ups.md
+++ b/docs/architecture/queued-steering-follow-ups.md
@@ -43,10 +43,13 @@ The built-in Textual frontend maps:
 
 - `Enter` while running to steering queueing
 - `Alt-Enter` while running to follow-up queueing
+- `Up` on an empty prompt while running to edit the latest queued follow-up
 
-Pending queues are visible in the status line while the run continues. Once a
-queued message is injected, it appears in the transcript as a normal user
-message and the pending count updates.
+Pending queues are visible above the prompt while the run continues. If several
+follow-ups are queued, edit pulls the most recently queued follow-up back into
+the prompt and removes it from the queue. Once a queued message is injected, it
+appears in the transcript as a normal user message and the pending queue display
+updates.
 
 ## Boundary
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,7 +292,9 @@ Remap the thinking-mode cycle shortcut with the `thinking_cycle` keybinding.
 While the agent is running in the TUI, `Enter` queues the prompt as steering for
 the active run. `Alt-Enter` queues the prompt as a follow-up that waits until the
 active run would otherwise stop. Remap the follow-up shortcut with
-`queue_follow_up`.
+`queue_follow_up`. Press `Up` on an empty prompt while the agent is running to
+edit the most recently queued follow-up; Tau removes it from the queue and puts
+its text back in the prompt.
 
 Thinking controls are model-aware. Tau enables them only when the active
 provider configuration declares supported levels for the active model. Custom

--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -159,6 +159,12 @@ class AgentHarness:
         self._follow_up_queue.clear()
         return snapshot
 
+    def pop_latest_follow_up(self) -> AgentMessage | None:
+        """Remove and return the most recently queued follow-up message."""
+        if not self._follow_up_queue:
+            return None
+        return self._follow_up_queue.pop()
+
     def queue_update_event(self) -> QueueUpdateEvent:
         """Return the current queue state as a portable agent event."""
         return QueueUpdateEvent(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -400,6 +400,11 @@ class CodingSession:
         """Clear queued steering and follow-up messages."""
         return self._harness.clear_queues()
 
+    def pop_latest_follow_up_message(self) -> str | None:
+        """Remove and return the most recently queued follow-up message."""
+        message = self._harness.pop_latest_follow_up()
+        return None if message is None else message.content
+
     def set_model(self, model: str) -> None:
         """Switch the active model for future turns in this process."""
         self._harness.config.model = model

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -132,6 +132,8 @@ class CompletionActionTarget(Protocol):
 
     def action_toggle_thinking(self) -> None: ...
 
+    def action_edit_queued_follow_up(self) -> bool: ...
+
     async def action_submit_prompt(self) -> None: ...
 
     async def action_submit_follow_up(self) -> None: ...
@@ -218,6 +220,8 @@ class PromptInput(TextArea):
         """Select the previous app-level completion or move up in the prompt."""
         if self._has_completion_options():
             self._completion_target().action_completion_previous()
+        elif self._completion_target().action_edit_queued_follow_up():
+            return
         else:
             self.action_cursor_up()
 
@@ -329,10 +333,7 @@ class PromptInput(TextArea):
                 self.action_cursor_down()
         elif event.key == keybindings.completion_previous:
             event.stop()
-            if self._has_completion_options():
-                self._completion_target().action_completion_previous()
-            else:
-                self.action_cursor_up()
+            self.action_completion_previous()
         elif event.key == keybindings.quit:
             event.stop()
             await self.action_quit()
@@ -972,7 +973,7 @@ class TauTuiApp(App[None]):
     #queued-messages {
         height: auto;
         max-height: 8;
-        margin: 0 1 0 1;
+        margin: 0 1 1 1;
         padding: 0 1;
         background: $tau-screen-background;
         color: $tau-muted-text;
@@ -1490,6 +1491,26 @@ class TauTuiApp(App[None]):
             return
         self._completion_state = self._completion_state.select_previous()
         self._refresh_completions()
+
+    def action_edit_queued_follow_up(self) -> bool:
+        """Move the latest queued follow-up back into the prompt for editing."""
+        if not self.state.running:
+            return False
+        prompt = self.query_one("#prompt", PromptInput)
+        if prompt.text.strip():
+            return False
+        pop_follow_up = getattr(self.session, "pop_latest_follow_up_message", None)
+        if not callable(pop_follow_up):
+            return False
+        message = pop_follow_up()
+        if not message:
+            return False
+        prompt.text = message
+        prompt.move_cursor(_text_end_location(message))
+        self._sync_queue_state()
+        self._completion_state = self._build_completion_state(prompt.text)
+        self._refresh()
+        return True
 
     def action_open_command_palette(self) -> None:
         """Open the slash-command palette in the prompt."""

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -105,6 +105,21 @@ def test_harness_can_clear_queued_messages() -> None:
     assert harness.queue_update_event().follow_up == ()
 
 
+def test_harness_can_pop_latest_follow_up_message() -> None:
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=FakeProvider([]), model="fake", system="You are Tau.")
+    )
+
+    harness.follow_up("First")
+    harness.follow_up("Second")
+    popped = harness.pop_latest_follow_up()
+
+    assert popped == UserMessage(content="Second")
+    assert harness.queue_update_event().follow_up == ("First",)
+    assert harness.pop_latest_follow_up() == UserMessage(content="First")
+    assert harness.pop_latest_follow_up() is None
+
+
 @pytest.mark.anyio
 async def test_subscribed_listeners_receive_events_and_can_unsubscribe() -> None:
     assistant = AssistantMessage(content="Hello")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -180,6 +180,13 @@ class FakeSession:
             follow_up=self.queued_follow_up_messages,
         )
 
+    def pop_latest_follow_up_message(self) -> str | None:
+        if not self.queued_follow_up_messages:
+            return None
+        message = self.queued_follow_up_messages[-1]
+        self.queued_follow_up_messages = self.queued_follow_up_messages[:-1]
+        return message
+
     async def prompt(
         self,
         text: str,
@@ -1824,6 +1831,29 @@ async def test_tui_app_queues_follow_up_prompt_from_keybinding() -> None:
         ]
 
     assert notifications == []
+
+
+@pytest.mark.anyio
+async def test_tui_app_up_arrow_edits_latest_queued_follow_up() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        session.queued_follow_up_messages = ("first follow-up", "latest follow-up")
+        app._refresh()
+
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.focus()
+        prompt.text = ""
+        prompt.action_completion_previous()
+        await pilot.pause()
+
+        assert prompt.text == "latest follow-up"
+        assert session.queued_follow_up_messages == ("first follow-up",)
+        assert app.state.queued_follow_up == ("first follow-up",)
+        queued_messages = app.query_one("#queued-messages")
+        assert queued_messages.display is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #53.

Adds more spacing above the prompt for queued messages and lets users edit queued follow-ups. Pressing Up on an empty prompt while the agent is running pulls the most recently queued follow-up back into the prompt, removes it from the queue, and refreshes the visible queue state. The latest-follow-up-first behavior is documented.

## Validation

- `uv run pytest tests/test_agent_harness.py tests/test_coding_session.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_agent/harness.py src/tau_coding/session.py src/tau_coding/tui/app.py tests/test_agent_harness.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_agent/harness.py src/tau_coding/session.py src/tau_coding/tui/app.py tests/test_agent_harness.py tests/test_tui_app.py`
- `git diff --check`
