### PR TITLE
[codex] Support input terminal commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,13 @@ the active run. `Alt-Enter` queues the prompt as a follow-up that waits until th
 active run would otherwise stop. Remap the follow-up shortcut with
 `queue_follow_up`.
 
+Input beginning with `!` runs a terminal command in the session working
+directory and records the command plus output in the agent context. Input
+beginning with `!!` runs the command and displays the output without adding it
+to context/history. Terminal input commands use the same shell execution,
+output truncation, failure reporting, and timeout assumptions as Tau's built-in
+`bash` tool.
+
 Thinking controls are model-aware. Tau enables them only when the active
 provider configuration declares supported levels for the active model. Custom
 OpenAI-compatible providers can opt in by adding `thinking_levels`,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -33,7 +33,13 @@ from tau_coding.provider_config import (
 from tau_coding.provider_runtime import create_model_provider
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.resources import TauResourcePaths
-from tau_coding.session import CodingSession, CodingSessionConfig, jsonl_session_storage
+from tau_coding.session import (
+    CodingSession,
+    CodingSessionConfig,
+    TerminalCommandResult,
+    jsonl_session_storage,
+    parse_terminal_command,
+)
 from tau_coding.session_export import default_session_export_path, export_session_html
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
@@ -407,6 +413,14 @@ async def run_print_mode(
     )
     renderer = create_event_renderer(output)
     try:
+        terminal_command = parse_terminal_command(prompt)
+        if terminal_command is not None:
+            result = await session.run_terminal_command(
+                terminal_command.command,
+                add_to_context=terminal_command.add_to_context,
+            )
+            typer.echo(_format_terminal_command_result(result))
+            return result.ok
         async for event in session.prompt(prompt):
             renderer.render(event)
         return renderer.finish()
@@ -425,3 +439,8 @@ class _MemorySessionStorage:
 
     async def read_all(self) -> list[SessionEntry]:
         return list(self.entries)
+
+
+def _format_terminal_command_result(result: TerminalCommandResult) -> str:
+    context_status = "added to context" if result.added_to_context else "not added to context"
+    return f"$ {result.command}\n[{context_status}]\n{result.output}"

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -13,7 +13,7 @@ from tau_agent import (
     QueuedMessages,
     QueueUpdateEvent,
 )
-from tau_agent.messages import AgentMessage
+from tau_agent.messages import AgentMessage, UserMessage
 from tau_agent.session import (
     CompactionEntry,
     JsonlSessionStorage,
@@ -75,7 +75,7 @@ from tau_coding.thinking import (
     next_thinking_level,
     normalize_thinking_level,
 )
-from tau_coding.tools import create_coding_tools
+from tau_coding.tools import create_bash_tool, create_coding_tools
 
 StreamingBehavior = Literal["steer", "follow_up"]
 
@@ -86,6 +86,25 @@ class ModelChoice:
 
     provider_name: str
     model: str
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalCommandResult:
+    """Result of an input-bar terminal command."""
+
+    command: str
+    output: str
+    exit_code: int | None
+    ok: bool
+    added_to_context: bool
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalCommandRequest:
+    """Parsed input-bar terminal command request."""
+
+    command: str
+    add_to_context: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -657,6 +676,44 @@ class CodingSession:
         expanded_skill = expand_skill_command(text, self._skills)
         return expanded_skill if expanded_skill is not None else text
 
+    async def run_terminal_command(
+        self,
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        """Run a shell command in the session cwd, optionally adding output to context."""
+        normalized_command = command.strip()
+        if not normalized_command:
+            raise ValueError("Terminal command cannot be empty")
+
+        bash_tool = create_bash_tool(cwd=self.cwd)
+        result = await bash_tool.execute({"command": normalized_command})
+        exit_code = None
+        if result.data is not None:
+            raw_exit_code = result.data.get("exit_code")
+            exit_code = raw_exit_code if isinstance(raw_exit_code, int) else None
+
+        if add_to_context:
+            before_count = len(self._harness.messages)
+            self._harness.append_message(
+                UserMessage(
+                    content=_terminal_command_context_message(
+                        normalized_command,
+                        result.content,
+                    )
+                )
+            )
+            await self._persist_new_messages(before_count)
+
+        return TerminalCommandResult(
+            command=normalized_command,
+            output=result.content,
+            exit_code=exit_code,
+            ok=result.ok,
+            added_to_context=add_to_context,
+        )
+
     async def prompt(
         self,
         content: str,
@@ -842,6 +899,30 @@ def _coerced_thinking_level(
         return current
     default = provider_default_thinking_level(provider, model=model)
     return default or levels[0]
+
+
+def _terminal_command_context_message(command: str, output: str) -> str:
+    return (
+        "Terminal command executed by the user.\n\n"
+        f"Command:\n```bash\n{command}\n```\n\n"
+        f"Output:\n```text\n{output}\n```"
+    )
+
+
+def parse_terminal_command(text: str) -> TerminalCommandRequest | None:
+    """Parse input-bar terminal command syntax."""
+    stripped = text.strip()
+    if stripped.startswith("!!"):
+        command = stripped[2:].strip()
+        if not command:
+            return None
+        return TerminalCommandRequest(command=command, add_to_context=False)
+    if stripped.startswith("!"):
+        command = stripped[1:].strip()
+        if not command:
+            return None
+        return TerminalCommandRequest(command=command, add_to_context=True)
+    return None
 
 
 def _load_session_resources(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -55,6 +55,7 @@ from tau_coding.session import (
     CodingSessionConfig,
     ModelChoice,
     jsonl_session_storage,
+    parse_terminal_command,
 )
 from tau_coding.session_manager import SessionManager
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
@@ -1326,6 +1327,14 @@ class TauTuiApp(App[None]):
         if not text:
             return
 
+        terminal_command = parse_terminal_command(text)
+        if terminal_command is not None:
+            await self._run_terminal_command(
+                terminal_command.command,
+                add_to_context=terminal_command.add_to_context,
+            )
+            return
+
         command = self.session.handle_command(text)
         if command.handled:
             if command.clear_requested:
@@ -1373,6 +1382,25 @@ class TauTuiApp(App[None]):
         run_id = self._prompt_run_id
         self._refresh()
         self._prompt_worker = self.run_worker(self._run_prompt(text, run_id), exclusive=True)
+
+    async def _run_terminal_command(self, command: str, *, add_to_context: bool) -> None:
+        run_terminal_command = getattr(self.session, "run_terminal_command", None)
+        if not callable(run_terminal_command):
+            self._notify("Terminal commands are not available.", severity="error")
+            return
+        try:
+            result = await run_terminal_command(command, add_to_context=add_to_context)
+        except Exception as exc:  # noqa: BLE001 - surface command execution failures in the TUI
+            self._notify(f"Could not run command: {exc}", severity="error")
+            return
+        status = "✓" if result.ok else "✗"
+        suffix = " · added to context" if result.added_to_context else " · not added to context"
+        self.state.add_item(
+            "tool",
+            f"$ {result.command}",
+            tool_result_text=f"{status} bash{suffix}\n{result.output}",
+        )
+        self._refresh()
 
     def _set_tui_theme(self, theme: TuiThemeName) -> None:
         self.tui_settings = TuiSettings(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -152,6 +152,7 @@ class PromptInput(TextArea):
     """Multiline prompt input with completion key bindings."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = []
+    shell_mode_style: str = ""
 
     def __init__(
         self,
@@ -253,6 +254,18 @@ class PromptInput(TextArea):
         if self.text:
             self.text = ""
             self.move_cursor((0, 0))
+
+    def get_line(self, line_index: int) -> Text:
+        """Retrieve one prompt line with shell prefixes highlighted."""
+        line = super().get_line(line_index)
+        if line_index != 0 or not self.shell_mode_style:
+            return line
+        span = _terminal_command_prefix_span(self.text)
+        if span is None:
+            return line
+        start, end = span
+        line.stylize(self.shell_mode_style, start, end)
+        return line
 
     async def action_submit_follow_up(self) -> None:
         """Submit the prompt as an app-level follow-up."""
@@ -993,6 +1006,10 @@ class TauTuiApp(App[None]):
         border: tall $tau-prompt-border;
     }
 
+    #prompt.-shell-mode {
+        border: tall $tau-accent;
+    }
+
     #compact-session-info {
         height: auto;
         max-height: 3;
@@ -1271,7 +1288,10 @@ class TauTuiApp(App[None]):
 
     async def on_mount(self) -> None:
         """Focus the prompt when the app starts."""
-        self.query_one(PromptInput).focus()
+        prompt = self.query_one(PromptInput)
+        prompt.shell_mode_style = self.tui_settings.resolved_theme.accent
+        self._sync_prompt_shell_mode(prompt.text)
+        prompt.focus()
         self._update_responsive_layout(self.size.width, self.size.height)
         self._refresh()
         self._refresh_completions()
@@ -1294,6 +1314,7 @@ class TauTuiApp(App[None]):
         """Update prompt autocomplete when the prompt text changes."""
         if event.text_area.id != "prompt":
             return
+        self._sync_prompt_shell_mode(event.text_area.text)
         self._completion_state = self._build_completion_state(event.text_area.text)
         self._refresh_completions()
 
@@ -1848,6 +1869,7 @@ class TauTuiApp(App[None]):
                 self.tui_settings.resolved_theme,
                 frame=self._activity_frame,
                 running=self.state.running,
+                shell_mode=_is_terminal_command_prompt(prompt.text),
             ),
         )
 
@@ -1884,9 +1906,24 @@ class TauTuiApp(App[None]):
         prompt = self.query_one("#prompt", PromptInput)
         prompt.set_footer_mode(_prompt_footer_mode(self.state, self._completion_state))
 
+    def _sync_prompt_shell_mode(self, text: str) -> None:
+        prompt = self.query_one("#prompt", PromptInput)
+        prompt.shell_mode_style = self.tui_settings.resolved_theme.accent
+        prompt.set_class(_is_terminal_command_prompt(text), "-shell-mode")
+        prompt.refresh()
+        self._apply_activity_indicator()
 
-def _activity_prompt_border_color(theme: TuiTheme, *, frame: int, running: bool) -> str:
+
+def _activity_prompt_border_color(
+    theme: TuiTheme,
+    *,
+    frame: int,
+    running: bool,
+    shell_mode: bool,
+) -> str:
     """Return the prompt border color for the current activity animation frame."""
+    if shell_mode:
+        return theme.accent
     if not running:
         return theme.prompt_border
     palette = (
@@ -1905,6 +1942,22 @@ def _activity_prompt_border_color(theme: TuiTheme, *, frame: int, running: bool)
         palette[segment_index + 1],
         fraction=fraction,
     )
+
+
+def _is_terminal_command_prompt(text: str) -> bool:
+    """Return whether the prompt is currently in terminal-command mode."""
+    return _terminal_command_prefix_span(text) is not None
+
+
+def _terminal_command_prefix_span(text: str) -> tuple[int, int] | None:
+    """Return the input span for a leading ! or !! terminal-command prefix."""
+    leading_whitespace = len(text) - len(text.lstrip())
+    stripped = text[leading_whitespace:]
+    if stripped.startswith("!!"):
+        return (leading_whitespace, leading_whitespace + 2)
+    if stripped.startswith("!"):
+        return (leading_whitespace, leading_whitespace + 1)
+    return None
 
 
 def _blend_hex_colors(start: str, end: str, *, fraction: float) -> str:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -70,7 +70,7 @@ from tau_coding.tui.config import (
     load_tui_settings,
     save_tui_settings,
 )
-from tau_coding.tui.state import TuiState
+from tau_coding.tui.state import TuiState, format_terminal_command_result_block
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
     SessionSidebar,
@@ -1393,12 +1393,15 @@ class TauTuiApp(App[None]):
         except Exception as exc:  # noqa: BLE001 - surface command execution failures in the TUI
             self._notify(f"Could not run command: {exc}", severity="error")
             return
-        status = "✓" if result.ok else "✗"
-        suffix = " · added to context" if result.added_to_context else " · not added to context"
         self.state.add_item(
             "tool",
             f"$ {result.command}",
-            tool_result_text=f"{status} bash{suffix}\n{result.output}",
+            tool_result_text=format_terminal_command_result_block(
+                ok=result.ok,
+                added_to_context=result.added_to_context,
+                output=result.output,
+            ),
+            always_show_tool_result=True,
         )
         self._refresh()
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -12,6 +12,7 @@ ChatItemRole = Literal["user", "assistant", "tool", "error", "status", "thinking
 TOOL_RESULT_PREVIEW_LINES = 8
 TOOL_PATCH_PREVIEW_LINES = 32
 TOOL_RESULT_PREVIEW_CHARS = 2_000
+TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 
 
 @dataclass(slots=True)
@@ -22,6 +23,7 @@ class ChatItem:
     text: str
     tool_call_id: str | None = None
     tool_result_text: str | None = None
+    always_show_tool_result: bool = False
 
 
 @dataclass(slots=True)
@@ -44,6 +46,7 @@ class TuiState:
         *,
         tool_call_id: str | None = None,
         tool_result_text: str | None = None,
+        always_show_tool_result: bool = False,
     ) -> None:
         """Append a transcript item."""
         self.items.append(
@@ -52,6 +55,7 @@ class TuiState:
                 text=text,
                 tool_call_id=tool_call_id,
                 tool_result_text=tool_result_text,
+                always_show_tool_result=always_show_tool_result,
             )
         )
 
@@ -232,6 +236,21 @@ def format_tool_result_block(
     patch = _result_patch(name=name, ok=ok, data=data)
     if patch:
         lines.extend(["", "Patch:", _preview_text(patch, max_lines=TOOL_PATCH_PREVIEW_LINES)])
+    return "\n".join(lines)
+
+
+def format_terminal_command_result_block(
+    *,
+    ok: bool,
+    added_to_context: bool,
+    output: str,
+) -> str:
+    """Format an input-bar terminal command result for visible TUI display."""
+    status = "✓" if ok else "✗"
+    suffix = " · added to context" if added_to_context else " · not added to context"
+    lines = [f"{status} bash{suffix}"]
+    if output:
+        lines.append(_preview_text(output, max_lines=TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES))
     return "\n".join(lines)
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -137,7 +137,7 @@ class TranscriptView(RichLog):
                 render_chat_item(
                     item,
                     theme=theme,
-                    show_tool_results=state.show_tool_results,
+                    show_tool_results=state.show_tool_results or item.always_show_tool_result,
                 ),
                 expand=True,
                 shrink=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,6 +220,60 @@ async def test_run_print_mode_persists_session_entries(
 
 
 @pytest.mark.anyio
+async def test_run_print_mode_terminal_command_adds_context(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "print-session.jsonl")
+    provider = FakeProvider([])
+
+    ok = await run_print_mode(
+        prompt="! printf hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        storage=storage,
+    )
+
+    captured = capsys.readouterr()
+    entries = await storage.read_all()
+    messages = [entry.message for entry in entries if isinstance(entry, MessageEntry)]
+
+    assert ok is True
+    assert "$ printf hello" in captured.out
+    assert "[added to context]" in captured.out
+    assert "hello" in captured.out
+    assert len(messages) == 1
+    assert "Terminal command executed by the user." in messages[0].content
+    assert provider.calls == []
+
+
+@pytest.mark.anyio
+async def test_run_print_mode_terminal_command_can_skip_context(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "print-session.jsonl")
+    provider = FakeProvider([])
+
+    ok = await run_print_mode(
+        prompt="!! printf hidden",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        storage=storage,
+    )
+
+    captured = capsys.readouterr()
+    entries = await storage.read_all()
+
+    assert ok is True
+    assert "$ printf hidden" in captured.out
+    assert "[not added to context]" in captured.out
+    assert "hidden" in captured.out
+    assert not any(isinstance(entry, MessageEntry) for entry in entries)
+    assert provider.calls == []
+
+
+@pytest.mark.anyio
 async def test_run_print_mode_expands_skill_commands(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -42,6 +42,7 @@ from tau_coding import (
     TauResourcePaths,
 )
 from tau_coding import session as coding_session_module
+from tau_coding.session import parse_terminal_command
 
 
 async def _collect_session_events(session_stream: object) -> list[object]:
@@ -208,6 +209,52 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
     assert entries[-1].type == "leaf"
     assert entries[-1].entry_id == message_entries[-1].id
     assert session.messages == (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
+
+
+@pytest.mark.anyio
+async def test_terminal_command_can_persist_output_to_context(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    result = await session.run_terminal_command("printf hello", add_to_context=True)
+
+    assert result.ok is True
+    assert result.output == "hello"
+    assert result.added_to_context is True
+    entries = await storage.read_all()
+    messages = [entry.message for entry in entries if isinstance(entry, MessageEntry)]
+    assert len(messages) == 1
+    assert isinstance(messages[0], UserMessage)
+    assert "Terminal command executed by the user." in messages[0].content
+    assert "printf hello" in messages[0].content
+    assert "hello" in messages[0].content
+
+
+@pytest.mark.anyio
+async def test_terminal_command_can_run_without_context(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    result = await session.run_terminal_command("printf hidden", add_to_context=False)
+
+    assert result.ok is True
+    assert result.output == "hidden"
+    assert result.added_to_context is False
+    entries = await storage.read_all()
+    assert not any(isinstance(entry, MessageEntry) for entry in entries)
+
+
+def test_parse_terminal_command_prefixes() -> None:
+    assert parse_terminal_command("! pwd") is not None
+    add_request = parse_terminal_command("! pwd")
+    assert add_request is not None
+    assert add_request.command == "pwd"
+    assert add_request.add_to_context is True
+    hidden_request = parse_terminal_command("!! pwd")
+    assert hidden_request is not None
+    assert hidden_request.command == "pwd"
+    assert hidden_request.add_to_context is False
+    assert parse_terminal_command("hello") is None
 
 
 @pytest.mark.anyio
@@ -767,7 +814,7 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
             [
                 ProviderResponseStartEvent(model="fake"),
                 ProviderResponseEndEvent(message=AssistantMessage(content="Next answer")),
-            ]
+            ],
         ]
     )
     session = await CodingSession.load(_config(tmp_path, provider, storage))

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -40,9 +40,12 @@ from tau_coding.tui.app import (
     LoginScreen,
     ModelPickerScreen,
     OAuthLoginScreen,
+    PromptInput,
     SessionPickerScreen,
     TauTuiApp,
     ThemePickerScreen,
+    _activity_prompt_border_color,
+    _terminal_command_prefix_span,
 )
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
@@ -605,6 +608,48 @@ async def test_tui_app_mounts_sidebar_and_transcript() -> None:
         prompt = app.query_one("#prompt")
         assert isinstance(prompt, TextArea)
         assert prompt.soft_wrap is True
+
+
+def test_terminal_command_prefix_span_detects_shell_mode_prefix() -> None:
+    assert _terminal_command_prefix_span("! pwd") == (0, 1)
+    assert _terminal_command_prefix_span("!! pwd") == (0, 2)
+    assert _terminal_command_prefix_span("  !! pwd") == (2, 4)
+    assert _terminal_command_prefix_span("hello ! pwd") is None
+
+
+def test_activity_prompt_border_uses_theme_accent_color_in_shell_mode() -> None:
+    theme = TAU_LIGHT_THEME
+
+    assert (
+        _activity_prompt_border_color(theme, frame=0, running=False, shell_mode=True)
+        == theme.accent
+    )
+
+
+@pytest.mark.anyio
+async def test_tui_app_highlights_prompt_shell_mode() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "!! pwd"
+        await pilot.pause()
+
+        assert prompt.has_class("-shell-mode")
+        assert _activity_prompt_border_color(
+            app.tui_settings.resolved_theme,
+            frame=0,
+            running=False,
+            shell_mode=prompt.has_class("-shell-mode"),
+        ) == app.tui_settings.resolved_theme.accent
+        assert prompt.get_line(0).spans[-1].start == 0
+        assert prompt.get_line(0).spans[-1].end == 2
+        assert str(prompt.get_line(0).spans[-1].style) == app.tui_settings.resolved_theme.accent
+
+        prompt.value = "ask tau"
+        await pilot.pause()
+
+        assert not prompt.has_class("-shell-mode")
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -27,7 +27,7 @@ from tau_agent import (
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import OAuthCredential
 from tau_coding.provider_config import OpenAICompatibleProviderConfig, ProviderSettings
-from tau_coding.session import ModelChoice
+from tau_coding.session import ModelChoice, TerminalCommandResult
 from tau_coding.session_manager import CodingSessionRecord
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
@@ -101,6 +101,7 @@ class FakeSession:
         self.queued_steering_messages: tuple[str, ...] = ()
         self.queued_follow_up_messages: tuple[str, ...] = ()
         self.streaming_behaviors: list[str | None] = []
+        self.terminal_commands: list[tuple[str, bool]] = []
         self.cancel_count = 0
 
     def handle_command(self, text: str) -> CommandResult:
@@ -178,6 +179,21 @@ class FakeSession:
         return QueueUpdateEvent(
             steering=self.queued_steering_messages,
             follow_up=self.queued_follow_up_messages,
+        )
+
+    async def run_terminal_command(
+        self,
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        self.terminal_commands.append((command, add_to_context))
+        return TerminalCommandResult(
+            command=command,
+            output="command output",
+            exit_code=0,
+            ok=True,
+            added_to_context=add_to_context,
         )
 
     async def prompt(
@@ -1725,6 +1741,40 @@ async def test_tui_app_thinking_command_updates_session() -> None:
     assert session.thinking_level == "high"
     assert notifications == []
     assert session.prompt_texts == []
+
+
+@pytest.mark.anyio
+async def test_tui_app_runs_terminal_command_and_adds_context() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "! pwd"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.terminal_commands == [("pwd", True)]
+    assert session.prompt_texts == []
+    assert [(item.role, item.text, item.tool_result_text) for item in app.state.items] == [
+        ("tool", "$ pwd", "✓ bash · added to context\ncommand output")
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_runs_terminal_command_without_context() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "!! pwd"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.terminal_commands == [("pwd", False)]
+    assert session.prompt_texts == []
+    assert app.state.items[-1].tool_result_text == "✓ bash · not added to context\ncommand output"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1775,6 +1775,56 @@ async def test_tui_app_runs_terminal_command_without_context() -> None:
     assert session.terminal_commands == [("pwd", False)]
     assert session.prompt_texts == []
     assert app.state.items[-1].tool_result_text == "✓ bash · not added to context\ncommand output"
+    assert app.state.items[-1].always_show_tool_result is True
+
+
+@pytest.mark.anyio
+async def test_tui_app_renders_terminal_command_output_when_tool_results_are_collapsed() -> None:
+    item = ChatItem(
+        role="tool",
+        text="$ pwd",
+        tool_result_text="✓ bash · not added to context\ncommand output",
+        always_show_tool_result=True,
+    )
+
+    console = Console(record=True, width=80)
+    console.print(render_chat_item(item, show_tool_results=item.always_show_tool_result))
+
+    assert "command output" in console.export_text()
+
+
+@pytest.mark.anyio
+async def test_tui_app_limits_terminal_command_output_preview() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    output = "\n".join(f"line {index}" for index in range(130))
+
+    async def fake_run_terminal_command(
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        return TerminalCommandResult(
+            command=command,
+            output=output,
+            exit_code=0,
+            ok=True,
+            added_to_context=add_to_context,
+        )
+
+    session.run_terminal_command = fake_run_terminal_command  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "!! seq 130"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    result_text = app.state.items[-1].tool_result_text
+    assert result_text is not None
+    assert "line 119" in result_text
+    assert "line 120" not in result_text
+    assert "10 more lines" in result_text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #49.

Adds Pi-style input terminal commands:

- `! <command>` runs in the session cwd, displays output, and persists the command/output as context.
- `!! <command>` runs in the session cwd and displays output without adding it to context/history.

The implementation reuses Tau's existing bash tool execution path for shell execution, output truncation, failures, and timeout behavior. The feature works in both TUI prompt input and non-interactive print mode.

## Validation

- `uv run pytest tests/test_coding_session.py tests/test_tui_app.py tests/test_cli.py -q`
- `uv run ruff check src/tau_coding/session.py src/tau_coding/tui/app.py src/tau_coding/cli.py tests/test_coding_session.py tests/test_tui_app.py tests/test_cli.py`
- `uv run ruff format --check src/tau_coding/session.py src/tau_coding/tui/app.py src/tau_coding/cli.py tests/test_coding_session.py tests/test_tui_app.py tests/test_cli.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added terminal command execution support using `!` prefix (adds output to context) and `!!` prefix (runs without context).
  * Shell-mode indicators now visually highlight in both CLI and TUI prompts.
  * Long terminal outputs are automatically truncated with line-count summaries.

* **Documentation**
  * Updated configuration guide explaining terminal command syntax and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->