### PR TITLE
[codex] Render skill invocations compactly

### DIFF
--- a/docs/architecture/phase-20-3-skill-invocation.md
+++ b/docs/architecture/phase-20-3-skill-invocation.md
@@ -46,12 +46,27 @@ add parser tests
 The block is self-contained: it includes the source file and tells the model
 where relative references inside the skill should resolve.
 
+## TUI Display
+
+The session still sends and persists the full expanded skill block so the agent
+has the complete instructions. The TUI parses that structured block when
+rendering user messages and displays a compact skill item instead:
+
+```text
+Using skill: testing
+```
+
+If the original `/skill:<name>` input included additional instructions, those
+instructions render as the visible user message after the compact skill item.
+The full skill markdown is not shown in the normal conversation view.
+
 ## Boundary
 
 Skill discovery and prompt expansion remain in `tau_coding`. `tau_agent` only
 sees ordinary provider-neutral messages and tool calls. The model-visible skill
 index uses the existing `read` tool instead of adding a special skill tool to
-the reusable harness.
+the reusable harness. TUI parsing is presentation-only and does not change the
+stored or provider-visible message content.
 
 ## Tests
 
@@ -62,6 +77,8 @@ tests/test_skills.py
 tests/test_cli.py
 tests/test_coding_session.py
 tests/test_system_prompt.py
+tests/test_tui_adapter.py
+tests/test_tui_app.py
 ```
 
 The tests verify both paths:

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -91,6 +91,7 @@ from tau_coding.skills import (
     format_skill_invocation,
     load_skills,
     load_skills_with_diagnostics,
+    parse_skill_invocation,
 )
 from tau_coding.system_prompt import (
     BuildSystemPromptOptions,
@@ -199,6 +200,7 @@ __all__ = [
     "summarize_messages_for_compaction",
     "expand_skill_command",
     "format_skill_invocation",
+    "parse_skill_invocation",
     "format_available_tools",
     "format_guidelines",
     "format_project_context",

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -1,5 +1,6 @@
 """Markdown skill loading and expansion."""
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +22,16 @@ class Skill:
     path: Path
     content: str
     description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SkillInvocation:
+    """Parsed expanded skill invocation message."""
+
+    name: str
+    location: str
+    content: str
+    additional_instructions: str | None = None
 
 
 def load_skills(paths: TauResourcePaths | None = None) -> list[Skill]:
@@ -106,6 +117,23 @@ def format_skill_invocation(
     if additional_instructions and additional_instructions.strip():
         return f"{skill_block}\n\n{additional_instructions.strip()}"
     return skill_block
+
+
+def parse_skill_invocation(text: str) -> SkillInvocation | None:
+    """Parse Tau's expanded skill invocation message format."""
+    match = re.match(
+        r'^<skill name="([^"]+)" location="([^"]+)">\n([\s\S]*?)\n</skill>(?:\n\n([\s\S]+))?$',
+        text,
+    )
+    if match is None:
+        return None
+    name, location, content, additional_instructions = match.groups()
+    return SkillInvocation(
+        name=name,
+        location=location,
+        content=content,
+        additional_instructions=additional_instructions,
+    )
 
 
 def build_skill_index(skills: Sequence[Skill]) -> str:

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -55,7 +55,7 @@ class TuiEventAdapter:
 
         if isinstance(event, MessageEndEvent):
             if event.message.role == "user":
-                self.state.add_item("user", event.message.content)
+                self.state.add_user_message(event.message.content)
                 return
             if event.message.role == "tool":
                 return

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -113,6 +113,7 @@ TAU_DARK_THEME = TuiTheme(
         "error": TuiRoleStyle(border="#ff4f4f", body="#ffb4b4 on #000000"),
         "status": TuiRoleStyle(border="#526070", body="#aab4c2 on #000000"),
         "thinking": TuiRoleStyle(border="#4b5563", body="#9ca3af on #000000"),
+        "skill": TuiRoleStyle(border="#b48ead", body="#e5d4ef on #000000"),
     },
 )
 
@@ -145,6 +146,7 @@ HIGH_CONTRAST_THEME = TuiTheme(
         "error": TuiRoleStyle(border="#ff4f4f", body="white on #260000"),
         "status": TuiRoleStyle(border="#ffffff", body="white on #111111"),
         "thinking": TuiRoleStyle(border="#00b7ff", body="white on #001626"),
+        "skill": TuiRoleStyle(border="#ff8cff", body="white on #260026"),
     },
 )
 
@@ -177,6 +179,7 @@ TAU_LIGHT_THEME = TuiTheme(
         "error": TuiRoleStyle(border="#b91c1c", body="#7f1d1d"),
         "status": TuiRoleStyle(border="#64748b", body="#334155"),
         "thinking": TuiRoleStyle(border="#6b7280", body="#4b5563"),
+        "skill": TuiRoleStyle(border="#7c3aed", body="#4c1d95"),
     },
 )
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -7,8 +7,9 @@ from typing import Literal
 from tau_agent.messages import AgentMessage
 from tau_agent.tools import AgentToolResult, ToolCall
 from tau_agent.types import JSONValue
+from tau_coding.skills import parse_skill_invocation
 
-ChatItemRole = Literal["user", "assistant", "tool", "error", "status", "thinking"]
+ChatItemRole = Literal["user", "assistant", "tool", "error", "status", "thinking", "skill"]
 TOOL_RESULT_PREVIEW_LINES = 8
 TOOL_PATCH_PREVIEW_LINES = 32
 TOOL_RESULT_PREVIEW_CHARS = 2_000
@@ -62,6 +63,16 @@ class TuiState:
             format_tool_call_block(tool_call),
             tool_call_id=tool_call.id,
         )
+
+    def add_user_message(self, content: str) -> None:
+        """Append a user-authored message, compacting skill invocations for display."""
+        skill_invocation = parse_skill_invocation(content)
+        if skill_invocation is None:
+            self.add_item("user", content)
+            return
+        self.add_item("skill", f"Using skill: {skill_invocation.name}")
+        if skill_invocation.additional_instructions:
+            self.add_item("user", skill_invocation.additional_instructions)
 
     def add_thinking_delta(self, delta: str) -> None:
         """Append a thinking/reasoning fragment to the current thinking block."""
@@ -119,7 +130,7 @@ class TuiState:
         """Populate the transcript from restored session messages."""
         for message in messages:
             if message.role == "user":
-                self.add_item("user", message.content)
+                self.add_user_message(message.content)
             elif message.role == "assistant":
                 if message.content:
                     self.add_item("assistant", message.content)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -10,6 +10,7 @@ from tau_coding import (
     format_skill_invocation,
     load_skills,
     load_skills_with_diagnostics,
+    parse_skill_invocation,
 )
 from tau_coding.resources import ResourceError
 
@@ -160,6 +161,24 @@ def test_format_skill_invocation_without_extra_instructions(tmp_path: Path) -> N
         "Run pytest.\n"
         "</skill>"
     )
+
+
+def test_parse_skill_invocation_extracts_display_metadata(tmp_path: Path) -> None:
+    skill = Skill(
+        name="testing",
+        path=tmp_path / "skills" / "testing" / "SKILL.md",
+        content="# Testing\nRun pytest.",
+        description="Test Python code",
+    )
+    formatted = format_skill_invocation(skill, "add parser tests")
+
+    parsed = parse_skill_invocation(formatted)
+
+    assert parsed is not None
+    assert parsed.name == "testing"
+    assert parsed.location == str(skill.path)
+    assert "# Testing" in parsed.content
+    assert parsed.additional_instructions == "add parser tests"
 
 
 def test_expand_skill_command_returns_none_for_normal_prompt(tmp_path: Path) -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tau_agent import (
     AgentEndEvent,
     AgentStartEvent,
@@ -16,6 +18,7 @@ from tau_agent import (
     ToolExecutionUpdateEvent,
     UserMessage,
 )
+from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.tui import TuiEventAdapter, TuiState
 from tau_coding.tui.state import format_tool_call_block, format_tool_result_block
 
@@ -58,6 +61,28 @@ def test_tui_adapter_builds_user_items_from_streamed_messages() -> None:
     assert [(item.role, item.text) for item in state.items] == [("user", "Hello Tau")]
 
 
+def test_tui_adapter_compacts_streamed_skill_invocations() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    skill = Skill(
+        name="review",
+        path=Path("/workspace/.tau/skills/review.md"),
+        content="# Review\nFull noisy instructions.",
+        description="Review code",
+    )
+
+    adapter.apply(
+        MessageEndEvent(
+            message=UserMessage(content=format_skill_invocation(skill, "check the auth flow"))
+        )
+    )
+
+    assert [(item.role, item.text) for item in state.items] == [
+        ("skill", "Using skill: review"),
+        ("user", "check the auth flow"),
+    ]
+
+
 def test_tui_adapter_groups_thinking_deltas_separately() -> None:
     state = TuiState()
     adapter = TuiEventAdapter(state)
@@ -65,11 +90,8 @@ def test_tui_adapter_groups_thinking_deltas_separately() -> None:
     adapter.apply(ThinkingDeltaEvent(delta="hidden "))
     adapter.apply(ThinkingDeltaEvent(delta="reasoning"))
 
-    assert [(item.role, item.text) for item in state.items] == [
-        ("thinking", "hidden reasoning")
-    ]
+    assert [(item.role, item.text) for item in state.items] == [("thinking", "hidden reasoning")]
     assert state.show_thinking is False
-
 
 
 def test_tui_adapter_flushes_assistant_buffer_before_tool_events() -> None:
@@ -210,15 +232,7 @@ def test_tui_adapter_renders_live_edit_patch() -> None:
         (
             "tool",
             "✓ edit",
-            "✓ edit\n"
-            "Successfully replaced 1 block.\n"
-            "\n"
-            "Patch:\n"
-            "--- a.py\n"
-            "+++ a.py\n"
-            "@@\n"
-            "-old\n"
-            "+new",
+            "✓ edit\nSuccessfully replaced 1 block.\n\nPatch:\n--- a.py\n+++ a.py\n@@\n-old\n+new",
         )
     ]
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -29,7 +29,7 @@ from tau_coding.credentials import OAuthCredential
 from tau_coding.provider_config import OpenAICompatibleProviderConfig, ProviderSettings
 from tau_coding.session import ModelChoice
 from tau_coding.session_manager import CodingSessionRecord
-from tau_coding.skills import Skill
+from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tools import create_coding_tools
 from tau_coding.tui import app as tui_app
@@ -432,6 +432,42 @@ def test_thinking_chat_items_use_distinct_style() -> None:
     output = console.export_text(styles=True)
     assert "Hidden reasoning" in output
     assert "38;2;156;163;175" in output
+
+
+def test_skill_chat_items_use_distinct_compact_style() -> None:
+    console = Console(record=True, width=80)
+
+    console.print(render_chat_item(ChatItem(role="skill", text="Using skill: review")))
+
+    output = console.export_text(styles=True)
+    assert "Using skill: review" in output
+    assert "38;2;229;212;239" in output
+
+
+def test_tui_state_compacts_expanded_skill_messages() -> None:
+    skill = Skill(
+        name="review",
+        path=Path("/workspace/.tau/skills/review.md"),
+        content="# Review\nFull noisy instructions.",
+        description="Review code",
+    )
+    state = tui_app.TuiState()
+
+    state.load_messages(
+        [
+            UserMessage(
+                content=format_skill_invocation(
+                    skill,
+                    "check the auth flow",
+                )
+            )
+        ]
+    )
+
+    assert [(item.role, item.text) for item in state.items] == [
+        ("skill", "Using skill: review"),
+        ("user", "check the auth flow"),
+    ]
 
 
 def test_light_theme_tool_success_uses_dark_text_without_background() -> None:


### PR DESCRIPTION
## Summary

Closes #51.

Keeps explicit `/skill:<name>` expansion in the coding/session layer so the full skill content remains provider-visible and persisted, while the TUI now parses the structured skill block for presentation and renders a compact skill item like `Using skill: review`. Additional user instructions render as the visible user message after the compact skill item.

This follows the Pi direction reviewed in the issue: skill expansion stays outside the TUI, and interactive rendering treats the structured skill block as a compact skill invocation message.

## Validation

- `uv run pytest tests/test_skills.py tests/test_coding_session.py tests/test_tui_adapter.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/skills.py src/tau_coding/tui/state.py src/tau_coding/tui/adapter.py src/tau_coding/tui/config.py src/tau_coding/__init__.py tests/test_skills.py tests/test_tui_adapter.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/skills.py src/tau_coding/tui/state.py src/tau_coding/tui/adapter.py src/tau_coding/tui/config.py src/tau_coding/__init__.py tests/test_skills.py tests/test_tui_adapter.py tests/test_tui_app.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill invocations now display compactly in the UI ("Using skill: <name>") while full skill expansion continues to be sent to providers.
  * Added skill-specific styling support across all color themes.

* **Documentation**
  * Updated architecture documentation to clarify skill invocation boundaries and TUI display behavior.

* **Tests**
  * Added tests for skill invocation parsing and TUI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->