### PR TITLE
[codex] Improve session export UX

### DIFF
--- a/docs/architecture/phase-20-4-session-export.md
+++ b/docs/architecture/phase-20-4-session-export.md
@@ -10,7 +10,16 @@ HTML document:
 ```bash
 tau export <session-id>
 tau export <session-id> session.html
+tau export <session-id> --format jsonl
 tau export ~/.tau/sessions/<project>/<session-id>.jsonl
+```
+
+When no destination is provided, `tau export` writes to the current working
+directory instead of Tau's internal session storage directory. Interactive
+sessions expose the same export flow through:
+
+```text
+/export [--format html|jsonl] [destination]
 ```
 
 The export contains two coordinated views:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,12 +199,14 @@ tau --resume <session-id>
 tau --new-session
 tau export <session-id>
 tau export <session-id> session.html
+tau export <session-id> --format jsonl
 ```
 
 `tau export` writes a standalone HTML file with the preserved session tree and
 the storage-order transcript. The source can be an indexed session id or a path
-to a JSONL session file. When no output path is provided, Tau writes the HTML
-next to the source session file with a `.html` suffix.
+to a JSONL session file. When no output path is provided, Tau writes the export
+artifact to the current working directory. HTML is the default format; pass
+`--format jsonl` or a `.jsonl` destination to export JSONL.
 
 Inside the TUI:
 
@@ -212,6 +214,7 @@ Inside the TUI:
 /resume
 /name <new name>
 /status
+/export [--format html|jsonl] [destination]
 ```
 
 `/name <new name>` renames the current indexed session. The new name is shown

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -40,7 +40,11 @@ from tau_coding.session import (
     jsonl_session_storage,
     parse_terminal_command,
 )
-from tau_coding.session_export import default_session_export_path, export_session_html
+from tau_coding.session_export import (
+    default_session_export_artifact_path,
+    export_session_artifact,
+    normalize_export_format,
+)
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui import run_tui_app
@@ -182,12 +186,18 @@ def main(
         raise typer.Exit()
 
     if prompt_option is None and command == "export":
-        if len(positional_args) not in {2, 3}:
-            raise typer.BadParameter("Usage: tau export <session-id-or-jsonl> [output.html]")
-        output_path = Path(positional_args[2]).expanduser() if len(positional_args) == 3 else None
         try:
-            exported_path = anyio.run(export_session_command, positional_args[1], output_path)
+            session_ref, output_path, export_format = _parse_export_cli_args(positional_args[1:])
         except RuntimeError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        try:
+            exported_path = anyio.run(
+                export_session_command,
+                session_ref,
+                output_path,
+                export_format,
+            )
+        except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
         typer.echo(f"Exported session to {exported_path}")
         raise typer.Exit()
@@ -272,17 +282,77 @@ def render_session_list(records: list[CodingSessionRecord]) -> None:
 async def export_session_command(
     session_ref: str,
     output_path: Path | None = None,
+    export_format: str | None = None,
     session_manager: SessionManager | None = None,
 ) -> Path:
-    """Export an indexed session id or JSONL file path to standalone HTML."""
+    """Export an indexed session id or JSONL file path."""
     session_path, title = _resolve_export_source(session_ref, session_manager)
     entries = await JsonlSessionStorage(session_path).read_all()
-    destination = output_path or default_session_export_path(session_path)
-    return export_session_html(
+    normalized_format = normalize_export_format(
+        export_format or (output_path.suffix.removeprefix(".") if output_path else "html")
+    )
+    destination = _resolve_export_destination(
+        output_path,
+        session_path=session_path,
+        format=normalized_format,
+    )
+    return export_session_artifact(
         entries,
         destination,
         title=title,
         source=str(session_path),
+        format=normalized_format,
+    )
+
+
+def _parse_export_cli_args(args: list[str]) -> tuple[str, Path | None, str | None]:
+    if not args:
+        raise RuntimeError("Usage: tau export <session-id-or-jsonl> [--format html|jsonl] [output]")
+    session_ref = args[0]
+    output_path: Path | None = None
+    export_format: str | None = None
+    index = 1
+    while index < len(args):
+        arg = args[index]
+        if arg == "--format":
+            index += 1
+            if index >= len(args):
+                raise RuntimeError(
+                    "Usage: tau export <session-id-or-jsonl> [--format html|jsonl] [output]"
+                )
+            export_format = args[index]
+        elif arg.startswith("--format="):
+            export_format = arg.partition("=")[2]
+        elif arg.startswith("-"):
+            raise RuntimeError(f"Unknown export option: {arg}")
+        elif output_path is None:
+            output_path = Path(arg).expanduser()
+        else:
+            raise RuntimeError(
+                "Usage: tau export <session-id-or-jsonl> [--format html|jsonl] [output]"
+            )
+        index += 1
+    return session_ref, output_path, export_format
+
+
+def _resolve_export_destination(
+    output_path: Path | None,
+    *,
+    session_path: Path,
+    format: str,
+) -> Path:
+    if output_path is None:
+        return default_session_export_artifact_path(
+            session_path,
+            destination_dir=Path.cwd(),
+            format=format,
+        )
+    if output_path.suffix:
+        return output_path
+    return default_session_export_artifact_path(
+        session_path,
+        destination_dir=output_path,
+        format=format,
     )
 
 

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -82,6 +82,9 @@ class CommandResult:
     clear_requested: bool = False
     new_session_requested: bool = False
     compact_summary: str | None = None
+    export_requested: bool = False
+    export_destination: Path | None = None
+    export_format: str | None = None
     resume_session_id: str | None = None
     resume_picker_requested: bool = False
     login_picker_requested: bool = False
@@ -206,6 +209,14 @@ def create_default_command_registry() -> CommandRegistry:
             usage="/compact <summary>",
             description="Replace active context with a manual summary.",
             handler=_compact_command,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            name="export",
+            usage="/export [--format html|jsonl] [destination]",
+            description="Export the current session.",
+            handler=_export_command,
         )
     )
     registry.register(
@@ -335,6 +346,19 @@ def _compact_command(context: CommandContext) -> CommandResult:
     return CommandResult(
         handled=True,
         compact_summary=context.args.strip(),
+    )
+
+
+def _export_command(context: CommandContext) -> CommandResult:
+    try:
+        export_format, destination = _parse_export_args(context.args)
+    except ValueError as exc:
+        return CommandResult(handled=True, message=str(exc))
+    return CommandResult(
+        handled=True,
+        export_requested=True,
+        export_destination=destination,
+        export_format=export_format,
     )
 
 
@@ -612,6 +636,30 @@ def _format_diagnostics(
 def _parse_command(text: str) -> tuple[str, str]:
     command, separator, args = text[1:].partition(" ")
     return _normalize_name(command), args.strip() if separator else ""
+
+
+def _parse_export_args(args: str) -> tuple[str | None, Path | None]:
+    parts = args.split()
+    export_format: str | None = None
+    destination: Path | None = None
+    index = 0
+    while index < len(parts):
+        part = parts[index]
+        if part == "--format":
+            index += 1
+            if index >= len(parts):
+                raise ValueError("Usage: /export [--format html|jsonl] [destination]")
+            export_format = parts[index]
+        elif part.startswith("--format="):
+            export_format = part.partition("=")[2]
+        elif part.startswith("-"):
+            raise ValueError(f"Unknown export option: {part}")
+        elif destination is None:
+            destination = Path(part).expanduser()
+        else:
+            raise ValueError("Usage: /export [--format html|jsonl] [destination]")
+        index += 1
+    return export_format, destination
 
 
 def _validated_session_name(value: str) -> str:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -61,6 +61,11 @@ from tau_coding.resources import (
     TauResourcePaths,
     resource_paths_with_cwd,
 )
+from tau_coding.session_export import (
+    default_session_export_artifact_path,
+    export_session_artifact,
+    normalize_export_format,
+)
 from tau_coding.session_manager import SessionManager
 from tau_coding.skills import Skill, expand_skill_command, load_skills_with_diagnostics
 from tau_coding.system_prompt import (
@@ -327,6 +332,32 @@ class CodingSession:
     def storage(self) -> SessionStorage:
         """Return the backing session storage."""
         return self._config.storage
+
+    async def export(
+        self,
+        destination: Path | None = None,
+        *,
+        format: str | None = None,
+    ) -> Path:
+        """Export the current session to a user-facing artifact."""
+        entries = await self._config.storage.read_all()
+        session_path = _storage_path(self._config.storage)
+        export_format = normalize_export_format(
+            format or (destination.suffix.removeprefix(".") if destination else "html")
+        )
+        output_path = _resolve_export_destination(
+            destination,
+            cwd=self.cwd,
+            session_path=session_path,
+            format=export_format,
+        )
+        return export_session_artifact(
+            entries,
+            output_path,
+            title=_session_export_title(self),
+            source=str(session_path) if session_path is not None else self.session_id,
+            format=export_format,
+        )
 
     @property
     def skills(self) -> tuple[Skill, ...]:
@@ -881,6 +912,48 @@ def _last_parent_id_from_state(state: SessionState) -> str | None:
     if state.entries:
         return state.entries[-1].id
     return None
+
+
+def _storage_path(storage: SessionStorage) -> Path | None:
+    path = getattr(storage, "path", None)
+    return path if isinstance(path, Path) else None
+
+
+def _resolve_export_destination(
+    destination: Path | None,
+    *,
+    cwd: Path,
+    session_path: Path | None,
+    format: str,
+) -> Path:
+    if destination is None:
+        if session_path is not None:
+            return default_session_export_artifact_path(
+                session_path,
+                destination_dir=cwd,
+                format=format,
+            )
+        return cwd / f"tau-session.{format}"
+
+    resolved = destination if destination.is_absolute() else cwd / destination
+    if resolved.suffix:
+        return resolved
+    name = session_path.stem if session_path is not None else "tau-session"
+    return default_session_export_artifact_path(
+        Path(name),
+        destination_dir=resolved,
+        format=format,
+    )
+
+
+def _session_export_title(session: CodingSession) -> str:
+    manager = session.session_manager
+    session_id = session.session_id
+    if manager is not None and session_id is not None:
+        record = manager.get_session(session_id)
+        if record is not None and record.title:
+            return record.title
+    return f"Tau session {session_id}" if session_id is not None else "Tau Session Export"
 
 
 def _state_thinking_level(

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -36,6 +36,25 @@ def default_session_export_path(session_path: Path) -> Path:
     return session_path.with_suffix(".html")
 
 
+def default_session_export_artifact_path(
+    session_path: Path,
+    *,
+    destination_dir: Path,
+    format: str = "html",
+) -> Path:
+    """Return the default user-facing export artifact path."""
+    suffix = _export_suffix(format)
+    return destination_dir / f"{session_path.stem}{suffix}"
+
+
+def export_session_jsonl(entries: Sequence[SessionEntry], output_path: Path) -> Path:
+    """Write session entries to a JSONL export and return its path."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [entry.model_dump_json() for entry in entries]
+    output_path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return output_path
+
+
 def export_session_html(
     entries: Sequence[SessionEntry],
     output_path: Path,
@@ -50,6 +69,35 @@ def export_session_html(
         encoding="utf-8",
     )
     return output_path
+
+
+def export_session_artifact(
+    entries: Sequence[SessionEntry],
+    output_path: Path,
+    *,
+    title: str = "Tau Session Export",
+    source: str | None = None,
+    format: str | None = None,
+) -> Path:
+    """Write a session export in the requested or inferred format."""
+    export_format = normalize_export_format(format or output_path.suffix.removeprefix("."))
+    if export_format == "jsonl":
+        return export_session_jsonl(entries, output_path)
+    return export_session_html(entries, output_path, title=title, source=source)
+
+
+def normalize_export_format(value: str | None) -> str:
+    """Normalize a session export format name."""
+    normalized = (value or "html").strip().lower().removeprefix(".")
+    if normalized in {"htm", "html"}:
+        return "html"
+    if normalized == "jsonl":
+        return "jsonl"
+    raise SessionExportError(f"Unsupported export format: {value}")
+
+
+def _export_suffix(format: str) -> str:
+    return ".jsonl" if normalize_export_format(format) == "jsonl" else ".html"
 
 
 def render_session_html(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1476,6 +1476,15 @@ class TauTuiApp(App[None]):
                     self._notify(compact_message)
                 except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
                     self._notify(f"Error: {exc}", severity="error")
+            if command.export_requested:
+                try:
+                    exported_path = await self.session.export(
+                        command.export_destination,
+                        format=command.export_format,
+                    )
+                    self._notify(f"Exported session to {exported_path}")
+                except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
+                    self._notify(f"Could not export session: {exc}", severity="error")
             if command.resume_session_id is not None:
                 await self._resume_session(command.resume_session_id)
             if command.resume_picker_requested:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -530,11 +530,18 @@ async def test_export_session_command_writes_html_for_indexed_session(tmp_path: 
 @pytest.mark.anyio
 async def test_export_session_command_writes_html_for_jsonl_path(tmp_path: Path) -> None:
     session_path = tmp_path / "session.jsonl"
+    cwd = Path.cwd()
     await JsonlSessionStorage(session_path).append(
         MessageEntry(id="root", message=UserMessage(content="Path export"))
     )
 
-    output_path = await cli.export_session_command(str(session_path))
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        output_path = await cli.export_session_command(str(session_path))
+    finally:
+        os.chdir(cwd)
 
     html = output_path.read_text(encoding="utf-8")
     assert output_path == tmp_path / "session.html"
@@ -542,18 +549,54 @@ async def test_export_session_command_writes_html_for_jsonl_path(tmp_path: Path)
     assert "Path export" in html
 
 
+@pytest.mark.anyio
+async def test_export_session_command_writes_jsonl_format_to_cwd(tmp_path: Path) -> None:
+    session_path = tmp_path / ".tau" / "sessions" / "session.jsonl"
+    cwd = Path.cwd()
+    await JsonlSessionStorage(session_path).append(
+        MessageEntry(id="root", message=UserMessage(content="JSONL export"))
+    )
+
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        output_path = await cli.export_session_command(str(session_path), export_format="jsonl")
+    finally:
+        os.chdir(cwd)
+
+    assert output_path == tmp_path / "session.jsonl"
+    assert "JSONL export" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_export_session_command_treats_suffixless_output_as_directory(
+    tmp_path: Path,
+) -> None:
+    session_path = tmp_path / "source" / "session.jsonl"
+    await JsonlSessionStorage(session_path).append(
+        MessageEntry(id="root", message=UserMessage(content="Directory export"))
+    )
+
+    output_path = await cli.export_session_command(str(session_path), tmp_path / "exports")
+
+    assert output_path == tmp_path / "exports" / "session.html"
+    assert "Directory export" in output_path.read_text(encoding="utf-8")
+
+
 def test_export_command_invokes_exporter(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    calls: list[tuple[str, Path | None]] = []
+    calls: list[tuple[str, Path | None, str | None]] = []
     output_path = tmp_path / "out.html"
 
     async def fake_export_session_command(
         session_ref: str,
         requested_output_path: Path | None = None,
+        requested_export_format: str | None = None,
     ) -> Path:
-        calls.append((session_ref, requested_output_path))
+        calls.append((session_ref, requested_output_path, requested_export_format))
         return output_path
 
     monkeypatch.setattr(cli, "export_session_command", fake_export_session_command)
@@ -561,8 +604,31 @@ def test_export_command_invokes_exporter(
     result = CliRunner().invoke(app, ["export", "session-1", str(output_path)])
 
     assert result.exit_code == 0
-    assert calls == [("session-1", output_path)]
+    assert calls == [("session-1", output_path, None)]
     assert f"Exported session to {output_path}" in result.stdout
+
+
+def test_export_command_accepts_format_option(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, Path | None, str | None]] = []
+    output_path = tmp_path / "out.jsonl"
+
+    async def fake_export_session_command(
+        session_ref: str,
+        requested_output_path: Path | None = None,
+        requested_export_format: str | None = None,
+    ) -> Path:
+        calls.append((session_ref, requested_output_path, requested_export_format))
+        return output_path
+
+    monkeypatch.setattr(cli, "export_session_command", fake_export_session_command)
+
+    result = CliRunner().invoke(app, ["export", "session-1", "--format", "jsonl"])
+
+    assert result.exit_code == 0
+    assert calls == [("session-1", None, "jsonl")]
 
 
 def test_providers_command_lists_default_provider(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -151,6 +151,32 @@ async def test_load_empty_session_appends_metadata(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_session_export_defaults_to_cwd(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / ".tau" / "sessions" / "session-1.jsonl")
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+    await storage.append(MessageEntry(id="root", message=UserMessage(content="Export me")))
+
+    output_path = await session.export()
+
+    assert output_path == tmp_path / "session-1.html"
+    html = output_path.read_text(encoding="utf-8")
+    assert "Export me" in html
+    assert str(storage.path) in html
+
+
+@pytest.mark.anyio
+async def test_session_export_writes_jsonl_to_destination_directory(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / ".tau" / "sessions" / "session-1.jsonl")
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+    await storage.append(MessageEntry(id="root", message=UserMessage(content="Export me")))
+
+    output_path = await session.export(Path("exports"), format="jsonl")
+
+    assert output_path == tmp_path / "exports" / "session-1.jsonl"
+    assert "Export me" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
 async def test_prompt_logs_unexpected_agent_call_exception(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     tau_paths = TauPaths(home=tmp_path / "tau-home", agents_home=tmp_path / "agents-home")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -74,6 +74,7 @@ def test_help_lists_registered_commands(tmp_path: Path) -> None:
     assert "/name <new name>" in result.message
     assert "/new" in result.message
     assert "/clear" not in result.message
+    assert "/export" in result.message
     assert "/skills" in result.message
 
 
@@ -96,6 +97,26 @@ def test_compact_command_requires_and_returns_summary(tmp_path: Path) -> None:
 
     assert missing.message == "Usage: /compact <summary>"
     assert requested.compact_summary == "Summary of prior work."
+
+
+def test_export_command_requests_default_export(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/export")
+
+    assert result.handled is True
+    assert result.export_requested is True
+    assert result.export_destination is None
+    assert result.export_format is None
+
+
+def test_export_command_parses_format_and_destination(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(
+        FakeSession(tmp_path),
+        "/export --format jsonl exports/session.jsonl",
+    )
+
+    assert result.export_requested is True
+    assert result.export_format == "jsonl"
+    assert result.export_destination == Path("exports/session.jsonl")
 
 
 def test_status_includes_session_details(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -106,6 +106,7 @@ class FakeSession:
         self.streaming_behaviors: list[str | None] = []
         self.terminal_commands: list[tuple[str, bool]] = []
         self.cancel_count = 0
+        self.export_calls: list[tuple[Path | None, str | None]] = []
 
     def handle_command(self, text: str) -> CommandResult:
         if text == "/help":
@@ -117,6 +118,15 @@ class FakeSession:
             return CommandResult(handled=True, new_session_requested=True)
         if text.startswith("/compact "):
             return CommandResult(handled=True, compact_summary=text.removeprefix("/compact "))
+        if text == "/export":
+            return CommandResult(handled=True, export_requested=True)
+        if text.startswith("/export "):
+            return CommandResult(
+                handled=True,
+                export_requested=True,
+                export_destination=Path("out.jsonl"),
+                export_format="jsonl",
+            )
         if text.startswith("/resume "):
             return CommandResult(handled=True, resume_session_id=text.removeprefix("/resume "))
         if text == "/resume":
@@ -162,6 +172,10 @@ class FakeSession:
         self.compact_summaries.append(summary)
         self.context_token_estimate = 42
         return "Compacted 2 context entries."
+
+    async def export(self, destination: Path | None = None, *, format: str | None = None) -> Path:
+        self.export_calls.append((destination, format))
+        return self.cwd / "session.html"
 
     async def resume(self, session_id: str) -> str:
         self.resumed_session_ids.append(session_id)
@@ -1089,6 +1103,28 @@ async def test_tui_app_compact_command_runs_session_compaction() -> None:
 
         assert session.compact_summaries == ["Summary of earlier work."]
         assert [(item.role, item.text) for item in app.state.items] == [("user", "Earlier")]
+
+
+@pytest.mark.anyio
+async def test_tui_app_export_command_runs_session_export() -> None:
+    session = FakeSession(messages=[UserMessage(content="Earlier")])
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/export --format jsonl out.jsonl"
+        await pilot.press("enter")
+
+        assert session.export_calls == [(Path("out.jsonl"), "jsonl")]
+        assert notifications == ["Exported session to /workspace/project/session.html"]
+        assert session.prompt_texts == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- default `tau export` artifacts to the current working directory instead of Tau session storage
- add HTML/JSONL export format handling and suffix/directory destination resolution
- add TUI `/export [--format html|jsonl] [destination]` backed by `CodingSession.export()`

## Pi alignment

Pi exposes `/export [file]` as an interactive session command and keeps export as a coding-agent workflow outside the reusable agent core. This PR mirrors that shape in Tau by keeping export behavior in `tau_coding` and leaving `tau_agent` session primitives unchanged.

## Validation

- `uv run pytest tests/test_session_export.py tests/test_cli.py tests/test_commands.py tests/test_coding_session.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_coding/cli.py src/tau_coding/commands.py src/tau_coding/session.py src/tau_coding/session_export.py tests/test_cli.py tests/test_commands.py tests/test_coding_session.py tests/test_tui_app.py`

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions can now be exported in JSONL format in addition to HTML.
  * Added `/export` interactive command with `--format` option to specify output format and destination paths.

* **Documentation**
  * Updated documentation for session export covering supported formats, destination handling, and command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->