### PR TITLE
[codex] Allow Esc to interrupt active operations

### DIFF
--- a/docs/architecture/phase-23-tui-polish.md
+++ b/docs/architecture/phase-23-tui-polish.md
@@ -116,7 +116,10 @@ worker visible while the provider or tool observes the cancellation token. The
 second press interrupts the current Textual worker immediately. This mirrors
 Pi's cancellation boundary: UI code requests cancellation, the portable agent
 loop carries a cancellation token, and long-running tools such as `bash` honor
-that token without making Textual a dependency of `tau_agent`.
+that token without making Textual a dependency of `tau_agent`. Because
+cancellation is an intentional user action, the built-in TUI renders the final
+cancellation event as status text instead of adding an error row to the
+transcript.
 
 Assistant code block rendering is now more defensive. Known fence languages use
 Rich/Pygments syntax highlighting, while unknown or custom fence labels fall

--- a/docs/architecture/phase-23-tui-polish.md
+++ b/docs/architecture/phase-23-tui-polish.md
@@ -110,6 +110,14 @@ completions are open, and switches again while an agent turn is running. Tau
 does not add a separate custom hint row; the built-in bottom toolbar remains the
 single shortcut surface.
 
+The TUI treats `Esc` as a two-step cancellation flow. The first press requests
+graceful cancellation through `CodingSession.cancel()` and leaves the active
+worker visible while the provider or tool observes the cancellation token. The
+second press interrupts the current Textual worker immediately. This mirrors
+Pi's cancellation boundary: UI code requests cancellation, the portable agent
+loop carries a cancellation token, and long-running tools such as `bash` honor
+that token without making Textual a dependency of `tau_agent`.
+
 Assistant code block rendering is now more defensive. Known fence languages use
 Rich/Pygments syntax highlighting, while unknown or custom fence labels fall
 back to plain code rendering instead of producing a broken transcript block.

--- a/docs/custom-tui.md
+++ b/docs/custom-tui.md
@@ -155,7 +155,9 @@ session.cancel()
 
 Cancellation is a request to stop the active agent turn. The frontend should
 still continue consuming events until the stream ends or reports an error, then
-update its running state.
+update its running state. The built-in Textual app treats the recoverable
+`Agent run cancelled` event as status text because it represents an intentional
+user action, not a failed provider or tool call.
 
 ## Autocomplete and Pickers
 

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -143,6 +143,7 @@ async def run_agent_loop(
             assistant_message.tool_calls,
             tool_by_name,
             messages,
+            signal,
         ):
             yield tool_event
 
@@ -188,23 +189,32 @@ async def _execute_tool_calls(
     tool_calls: list[ToolCall],
     tool_by_name: Mapping[str, AgentTool],
     messages: list[AgentMessage],
+    signal: CancellationToken | None,
 ) -> AsyncIterator[AgentEvent]:
     for tool_call in tool_calls:
+        if signal is not None and signal.is_cancelled():
+            yield ErrorEvent(message="Agent run cancelled", recoverable=True)
+            return
+
         yield ToolExecutionStartEvent(tool_call=tool_call)
 
         tool = tool_by_name.get(tool_call.name)
         if tool is None:
             result = _unknown_tool_result(tool_call)
         else:
-            result = await _execute_tool(tool, tool_call)
+            result = await _execute_tool(tool, tool_call, signal)
 
         messages.append(_tool_result_message(result))
         yield ToolExecutionEndEvent(result=result)
 
 
-async def _execute_tool(tool: AgentTool, tool_call: ToolCall) -> AgentToolResult:
+async def _execute_tool(
+    tool: AgentTool,
+    tool_call: ToolCall,
+    signal: CancellationToken | None,
+) -> AgentToolResult:
     try:
-        result = await tool.execute(tool_call.arguments)
+        result = await tool.execute(tool_call.arguments, signal=signal)
     except Exception as exc:  # noqa: BLE001 - tools are an isolation boundary
         return AgentToolResult(
             tool_call_id=tool_call.id,

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -191,8 +191,12 @@ async def _execute_tool_calls(
     messages: list[AgentMessage],
     signal: CancellationToken | None,
 ) -> AsyncIterator[AgentEvent]:
-    for tool_call in tool_calls:
+    for index, tool_call in enumerate(tool_calls):
         if signal is not None and signal.is_cancelled():
+            for cancelled_tool_call in tool_calls[index:]:
+                result = _cancelled_tool_result(cancelled_tool_call)
+                messages.append(_tool_result_message(result))
+                yield ToolExecutionEndEvent(result=result)
             yield ErrorEvent(message="Agent run cancelled", recoverable=True)
             return
 
@@ -231,6 +235,17 @@ async def _execute_tool(
 
 def _unknown_tool_result(tool_call: ToolCall) -> AgentToolResult:
     message = f"Unknown tool: {tool_call.name}"
+    return AgentToolResult(
+        tool_call_id=tool_call.id,
+        name=tool_call.name,
+        ok=False,
+        content=message,
+        error=message,
+    )
+
+
+def _cancelled_tool_result(tool_call: ToolCall) -> AgentToolResult:
+    message = "Tool call cancelled"
     return AgentToolResult(
         tool_call_id=tool_call.id,
         name=tool_call.name,

--- a/src/tau_agent/tools.py
+++ b/src/tau_agent/tools.py
@@ -2,12 +2,23 @@
 
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
+from inspect import signature
+from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from tau_agent.types import JSONValue
 
-ToolExecutor = Callable[[Mapping[str, JSONValue]], Awaitable["AgentToolResult"]]
+
+class ToolCancellationToken(Protocol):
+    """Minimal cancellation interface accepted by tools."""
+
+    def is_cancelled(self) -> bool:
+        """Return whether tool execution should stop."""
+        ...
+
+
+ToolExecutor = Callable[..., Awaitable["AgentToolResult"]]
 
 
 class ToolCall(BaseModel):
@@ -45,6 +56,20 @@ class AgentTool:
     prompt_snippet: str | None = None
     prompt_guidelines: tuple[str, ...] = ()
 
-    async def execute(self, arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def execute(
+        self,
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
         """Execute the tool with provider-neutral JSON-like arguments."""
+        if _accepts_signal(self.executor):
+            return await self.executor(arguments, signal)
         return await self.executor(arguments)
+
+
+def _accepts_signal(executor: ToolExecutor) -> bool:
+    try:
+        parameters = signature(executor).parameters
+    except (TypeError, ValueError):
+        return False
+    return len(parameters) >= 2

--- a/src/tau_agent/tools.py
+++ b/src/tau_agent/tools.py
@@ -1,8 +1,9 @@
 """Provider-neutral tool definitions and tool execution results."""
 
-from collections.abc import Awaitable, Callable, Mapping
+from __future__ import annotations
+
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
-from inspect import signature
 from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -18,7 +19,16 @@ class ToolCancellationToken(Protocol):
         ...
 
 
-ToolExecutor = Callable[..., Awaitable["AgentToolResult"]]
+class ToolExecutor(Protocol):
+    """Async callable used to execute a tool."""
+
+    def __call__(
+        self,
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> Awaitable[AgentToolResult]:
+        """Execute the tool with optional cancellation support."""
+        ...
 
 
 class ToolCall(BaseModel):
@@ -62,14 +72,4 @@ class AgentTool:
         signal: ToolCancellationToken | None = None,
     ) -> AgentToolResult:
         """Execute the tool with provider-neutral JSON-like arguments."""
-        if _accepts_signal(self.executor):
-            return await self.executor(arguments, signal)
-        return await self.executor(arguments)
-
-
-def _accepts_signal(executor: ToolExecutor) -> bool:
-    try:
-        parameters = signature(executor).parameters
-    except (TypeError, ValueError):
-        return False
-    return len(parameters) >= 2
+        return await self.executor(arguments, signal=signal)

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from time import monotonic
 
-from tau_agent.tools import AgentTool, AgentToolResult
+from tau_agent.tools import AgentTool, AgentToolResult, ToolCancellationToken
 from tau_agent.types import JSONValue
 
 DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
@@ -429,11 +429,16 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
     """
     root = Path.cwd() if cwd is None else Path(cwd)
 
-    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
         command = _str_arg(arguments, "command")
         timeout = _optional_float_arg(arguments, "timeout")
         if timeout is not None and timeout <= 0:
             raise ToolInputError("timeout must be greater than 0")
+        if signal is not None and signal.is_cancelled():
+            raise ToolInputError("Command cancelled")
 
         start = monotonic()
         if os.name == "posix":
@@ -452,12 +457,19 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
                 stderr=asyncio.subprocess.STDOUT,
             )
         timed_out = False
+        cancelled = False
+        output_bytes = b""
+        _stderr: bytes | None = None
         try:
-            output_bytes, _stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+            output_bytes, _stderr = await _communicate_with_cancellation(
+                process,
+                timeout=timeout,
+                signal=signal,
+            )
         except TimeoutError:
             timed_out = True
-            _kill_process_tree(process)
-            output_bytes, _stderr = await process.communicate()
+        except asyncio.CancelledError:
+            cancelled = True
 
         output = output_bytes.decode(errors="replace")
         truncation = truncate_tail(output)
@@ -490,12 +502,14 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
             status = (
                 f"Command timed out after {timeout:g} seconds" if timeout else "Command timed out"
             )
+        elif cancelled:
+            status = "Command cancelled"
         elif exit_code not in (0, None):
             status = f"Command exited with code {exit_code}"
         if status:
             output_text = append_status_block(output_text, status)
 
-        ok = exit_code == 0 and not timed_out
+        ok = exit_code == 0 and not timed_out and not cancelled
         return AgentToolResult(
             tool_call_id="",
             name="bash",
@@ -506,6 +520,7 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
                 "command": command,
                 "exit_code": exit_code,
                 "timed_out": timed_out,
+                "cancelled": cancelled,
                 "duration_seconds": round(monotonic() - start, 3),
                 "truncation": truncation.to_json(),
                 "full_output_path": full_output_path,
@@ -553,6 +568,45 @@ def format_size(bytes_count: int) -> str:
 def append_status_block(text: str, status: str) -> str:
     """Append command status text after a blank line when output already exists."""
     return f"{text}\n\n{status}" if text else status
+
+
+async def _communicate_with_cancellation(
+    process: asyncio.subprocess.Process,
+    *,
+    timeout: float | None,
+    signal: ToolCancellationToken | None,
+) -> tuple[bytes, bytes | None]:
+    communicate = asyncio.create_task(process.communicate())
+    try:
+        if signal is None:
+            return await asyncio.wait_for(communicate, timeout=timeout)
+
+        cancel_watch = asyncio.create_task(_wait_for_cancel(signal))
+        try:
+            done, _pending = await asyncio.wait(
+                {communicate, cancel_watch},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if communicate in done:
+                return communicate.result()
+            if cancel_watch in done:
+                _kill_process_tree(process)
+                await process.wait()
+                raise asyncio.CancelledError
+            _kill_process_tree(process)
+            await process.wait()
+            raise TimeoutError
+        finally:
+            cancel_watch.cancel()
+    finally:
+        if not communicate.done():
+            communicate.cancel()
+
+
+async def _wait_for_cancel(signal: ToolCancellationToken) -> None:
+    while not signal.is_cancelled():
+        await asyncio.sleep(0.05)
 
 
 def truncate_head(

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -456,20 +456,11 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-        timed_out = False
-        cancelled = False
-        output_bytes = b""
-        _stderr: bytes | None = None
-        try:
-            output_bytes, _stderr = await _communicate_with_cancellation(
-                process,
-                timeout=timeout,
-                signal=signal,
-            )
-        except TimeoutError:
-            timed_out = True
-        except asyncio.CancelledError:
-            cancelled = True
+        output_bytes, _stderr, timed_out, cancelled = await _communicate_with_cancellation(
+            process,
+            timeout=timeout,
+            signal=signal,
+        )
 
         output = output_bytes.decode(errors="replace")
         truncation = truncate_tail(output)
@@ -575,33 +566,39 @@ async def _communicate_with_cancellation(
     *,
     timeout: float | None,
     signal: ToolCancellationToken | None,
-) -> tuple[bytes, bytes | None]:
+) -> tuple[bytes, bytes | None, bool, bool]:
     communicate = asyncio.create_task(process.communicate())
+    cancel_watch: asyncio.Task[None] | None = None
     try:
-        if signal is None:
-            return await asyncio.wait_for(communicate, timeout=timeout)
+        wait_for = {communicate}
+        if signal is not None:
+            cancel_watch = asyncio.create_task(_wait_for_cancel(signal))
+            wait_for.add(cancel_watch)
 
-        cancel_watch = asyncio.create_task(_wait_for_cancel(signal))
+        done, _pending = await asyncio.wait(
+            wait_for,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if communicate in done:
+            output_bytes, stderr = communicate.result()
+            return output_bytes, stderr, False, False
+
+        cancelled = cancel_watch is not None and cancel_watch in done
+        _kill_process_tree(process)
         try:
-            done, _pending = await asyncio.wait(
-                {communicate, cancel_watch},
-                timeout=timeout,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if communicate in done:
-                return communicate.result()
-            if cancel_watch in done:
-                _kill_process_tree(process)
-                await process.wait()
-                raise asyncio.CancelledError
-            _kill_process_tree(process)
-            await process.wait()
-            raise TimeoutError
-        finally:
-            cancel_watch.cancel()
-    finally:
+            output_bytes, stderr = await communicate
+        except asyncio.CancelledError:
+            output_bytes, stderr = b"", None
+        return output_bytes, stderr, not cancelled, cancelled
+    except asyncio.CancelledError:
+        _kill_process_tree(process)
         if not communicate.done():
             communicate.cancel()
+        raise
+    finally:
+        if cancel_watch is not None:
+            cancel_watch.cancel()
 
 
 async def _wait_for_cancel(signal: ToolCancellationToken) -> None:

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from time import monotonic
 
-from tau_agent.tools import AgentTool, AgentToolResult, ToolCancellationToken
+from tau_agent.tools import AgentTool, AgentToolResult, ToolCancellationToken, ToolExecutor
 from tau_agent.types import JSONValue
 
 DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
@@ -74,14 +74,14 @@ class ToolDefinition:
     prompt_snippet: str
     prompt_guidelines: tuple[str, ...]
     input_schema: Mapping[str, JSONValue]
-    executor: object
+    executor: ToolExecutor
 
     def to_agent_tool(self) -> AgentTool:
         return AgentTool(
             name=self.name,
             description=self.description,
             input_schema=self.input_schema,
-            executor=self.executor,  # type: ignore[arg-type]
+            executor=self.executor,
             prompt_snippet=self.prompt_snippet,
             prompt_guidelines=self.prompt_guidelines,
         )
@@ -125,7 +125,11 @@ def create_read_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
     """
     root = Path.cwd() if cwd is None else Path(cwd)
 
-    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del signal
         raw_path = _str_arg(arguments, "path")
         path = _path_arg(arguments, "path", cwd=root)
         offset = _optional_int_arg(arguments, "offset")
@@ -260,7 +264,11 @@ def create_write_tool_definition(*, cwd: str | Path | None = None) -> ToolDefini
     """
     root = Path.cwd() if cwd is None else Path(cwd)
 
-    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del signal
         path = _path_arg(arguments, "path", cwd=root)
         content = _str_arg(arguments, "content")
 
@@ -321,7 +329,11 @@ def create_edit_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
     """
     root = Path.cwd() if cwd is None else Path(cwd)
 
-    async def execute(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del signal
         prepared = _prepare_edit_arguments(arguments)
         path = _path_arg(prepared, "path", cwd=root)
         edits = _edits_arg(prepared)

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -84,6 +84,9 @@ class TuiEventAdapter:
 
         if isinstance(event, ErrorEvent):
             self._flush_assistant_buffer()
+            if event.recoverable and event.message == "Agent run cancelled":
+                self.state.add_item("status", "Agent run cancelled.")
+                return
             self.state.error = event.message
             self.state.add_item("error", f"Error: {event.message}")
             if not event.recoverable:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1365,6 +1365,7 @@ class TauTuiApp(App[None]):
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
         self._active_notification_keys: set[tuple[str, str]] = set()
+        self._cancel_pending = False
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Return Tau-specific CSS variables for the selected TUI theme."""
@@ -1507,6 +1508,7 @@ class TauTuiApp(App[None]):
 
     def _submit_prompt(self, text: str) -> None:
         """Add a prompt to the transcript and start the agent worker."""
+        self._cancel_pending = False
         self._prompt_run_id += 1
         run_id = self._prompt_run_id
         self._refresh()
@@ -1580,12 +1582,13 @@ class TauTuiApp(App[None]):
         finally:
             if active_run_id == self._prompt_run_id:
                 self._prompt_worker = None
+                self._cancel_pending = False
 
     def action_cancel(self) -> None:
         """Cancel the active agent turn."""
         self._cancel_active_prompt(notify=True)
 
-    def _cancel_active_prompt(self, *, notify: bool) -> None:
+    def _cancel_active_prompt(self, *, notify: bool, interrupt: bool = False) -> None:
         """Cancel the active prompt worker and ignore any late events from it."""
         worker = self._prompt_worker
         is_worker_active = worker is not None and not worker.is_cancelled
@@ -1593,18 +1596,31 @@ class TauTuiApp(App[None]):
         if not (self.state.running or is_session_running or is_worker_active):
             return
 
-        self._prompt_run_id += 1
         cancel = getattr(self.session, "cancel", None)
+        if not self._cancel_pending and not interrupt:
+            if callable(cancel):
+                cancel()
+            self._cancel_pending = True
+            self._refresh()
+            if notify:
+                self._notify(
+                    "Agent will stop on the next turn. "
+                    "Press Esc again to interrupt the current operation."
+                )
+            return
+
+        self._prompt_run_id += 1
         if callable(cancel):
             cancel()
         if worker is not None and not worker.is_cancelled:
             worker.cancel()
         self._prompt_worker = None
+        self._cancel_pending = False
         self.state.running = False
         self.state.assistant_buffer = ""
         self._refresh()
         if notify:
-            self._notify("Cancellation requested.")
+            self._notify("Interrupted current operation.")
 
     def action_accept_completion(self) -> None:
         """Accept the currently selected prompt completion."""
@@ -1749,7 +1765,7 @@ class TauTuiApp(App[None]):
         self._refresh()
 
     async def _new_session(self) -> None:
-        self._cancel_active_prompt(notify=False)
+        self._cancel_active_prompt(notify=False, interrupt=True)
         new_session = getattr(self.session, "new_session", None)
         if new_session is None:
             self._notify("Session manager is not available.")

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -322,7 +322,11 @@ async def test_harness_can_drain_all_queued_messages_together() -> None:
 
 @pytest.mark.anyio
 async def test_harness_passes_tools_to_loop() -> None:
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del signal
         return AgentToolResult(
             tool_call_id="call-1",
             name="echo",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -10,6 +10,7 @@ from tau_agent import (
     ErrorEvent,
     QueueUpdateEvent,
     RetryEvent,
+    SimpleCancellationToken,
     ThinkingDeltaEvent,
     ToolCall,
     ToolExecutionEndEvent,
@@ -19,6 +20,7 @@ from tau_agent import (
 from tau_agent.loop import run_agent_loop
 from tau_agent.types import JSONValue
 from tau_ai import (
+    CancellationToken,
     FakeProvider,
     ProviderErrorEvent,
     ProviderResponseEndEvent,
@@ -189,6 +191,56 @@ async def test_agent_loop_executes_tools_and_continues_until_no_tool_calls() -> 
     ]
     assert len(provider.calls) == 2
     assert provider.calls[1][2] == messages[:3]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_passes_cancellation_signal_to_tools() -> None:
+    observed: list[CancellationToken | None] = []
+
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: CancellationToken | None = None,
+    ) -> AgentToolResult:
+        del arguments
+        observed.append(signal)
+        return AgentToolResult(tool_call_id="call-1", name="read", ok=True, content="ok")
+
+    tool = AgentTool(
+        name="read",
+        description="Read a file.",
+        input_schema={"type": "object"},
+        executor=executor,
+    )
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    first_assistant = AssistantMessage(content="I'll read it.", tool_calls=[tool_call])
+    final_assistant = AssistantMessage(content="Done.")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=first_assistant),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=final_assistant),
+            ],
+        ]
+    )
+    signal = SimpleCancellationToken()
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=[UserMessage(content="Read README.md")],
+            tools=[tool],
+            signal=signal,
+        )
+    )
+
+    assert observed
+    assert observed[0] is signal
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -117,7 +117,11 @@ async def test_agent_loop_streams_thinking_deltas_without_recording_them() -> No
 
 @pytest.mark.anyio
 async def test_agent_loop_executes_tools_and_continues_until_no_tool_calls() -> None:
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del signal
         return AgentToolResult(
             tool_call_id="call-1",
             name="read",
@@ -299,7 +303,11 @@ async def test_agent_loop_records_cancelled_results_for_skipped_tool_calls() -> 
 
 @pytest.mark.anyio
 async def test_agent_loop_injects_steering_after_tool_batch() -> None:
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del signal
         return AgentToolResult(
             tool_call_id="call-1",
             name="read",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -244,6 +244,60 @@ async def test_agent_loop_passes_cancellation_signal_to_tools() -> None:
 
 
 @pytest.mark.anyio
+async def test_agent_loop_records_cancelled_results_for_skipped_tool_calls() -> None:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: SimpleCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del arguments
+        if signal is not None:
+            signal.cancel()
+        return AgentToolResult(tool_call_id="call-1", name="read", ok=True, content="ok")
+
+    tool = AgentTool(
+        name="read",
+        description="Read a file.",
+        input_schema={"type": "object"},
+        executor=executor,
+    )
+    tool_calls = [
+        ToolCall(id="call-1", name="read", arguments={"path": "README.md"}),
+        ToolCall(id="call-2", name="read", arguments={"path": "pyproject.toml"}),
+    ]
+    assistant = AssistantMessage(content="I'll read both.", tool_calls=tool_calls)
+    messages = [UserMessage(content="Read project files")]
+    provider = FakeProvider(
+        [[ProviderResponseStartEvent(model="fake"), ProviderResponseEndEvent(message=assistant)]]
+    )
+    signal = SimpleCancellationToken()
+
+    events = await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[tool],
+            signal=signal,
+        )
+    )
+
+    assert messages == [
+        UserMessage(content="Read project files"),
+        assistant,
+        ToolResultMessage(tool_call_id="call-1", name="read", content="ok", ok=True),
+        ToolResultMessage(
+            tool_call_id="call-2",
+            name="read",
+            content="Tool call cancelled",
+            ok=False,
+            error="Tool call cancelled",
+        ),
+    ]
+    assert [event.type for event in events].count("tool_execution_end") == 2
+
+
+@pytest.mark.anyio
 async def test_agent_loop_injects_steering_after_tool_batch() -> None:
     async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
         return AgentToolResult(

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -60,7 +60,18 @@ def test_models_reject_unknown_fields() -> None:
 
 @pytest.mark.anyio
 async def test_agent_tool_executes_with_json_arguments() -> None:
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    class FakeCancellationToken:
+        def is_cancelled(self) -> bool:
+            return False
+
+    observed_signal: list[object | None] = []
+
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        *,
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        observed_signal.append(signal)
         return AgentToolResult(
             tool_call_id="call-1",
             name="echo",
@@ -75,10 +86,12 @@ async def test_agent_tool_executes_with_json_arguments() -> None:
         executor=executor,
     )
 
-    result = await tool.execute({"text": "hi"})
+    signal = FakeCancellationToken()
+    result = await tool.execute({"text": "hi"}, signal=signal)
 
     assert result.ok is True
     assert result.content == "hi"
+    assert observed_signal == [signal]
 
 
 def test_events_have_stable_type_names() -> None:

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from time import monotonic
 
@@ -12,6 +13,17 @@ from tau_coding import (
     create_read_tool_definition,
     create_write_tool,
 )
+
+
+class FakeCancellationToken:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+    def is_cancelled(self) -> bool:
+        return self.cancelled
 
 
 @pytest.mark.anyio
@@ -170,4 +182,23 @@ async def test_bash_tool_timeout_kills_shell_children(tmp_path: Path) -> None:
     assert result.ok is False
     assert result.data is not None
     assert result.data["timed_out"] is True
+    assert duration < 0.5
+
+
+@pytest.mark.anyio
+async def test_bash_tool_cancellation_kills_shell_children(tmp_path: Path) -> None:
+    tool = create_bash_tool(cwd=tmp_path)
+    token = FakeCancellationToken()
+
+    task = asyncio.create_task(tool.execute({"command": "sleep 1 & wait"}, signal=token))
+    await asyncio.sleep(0.05)
+    token.cancel()
+    start = monotonic()
+    result = await task
+    duration = monotonic() - start
+
+    assert result.ok is False
+    assert result.data is not None
+    assert result.data["cancelled"] is True
+    assert "cancelled" in result.content
     assert duration < 0.5

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -174,15 +174,20 @@ async def test_bash_tool_reports_timeout(tmp_path: Path) -> None:
 @pytest.mark.anyio
 async def test_bash_tool_timeout_kills_shell_children(tmp_path: Path) -> None:
     tool = create_bash_tool(cwd=tmp_path)
+    marker = tmp_path / "marker"
 
     start = monotonic()
-    result = await tool.execute({"command": "sleep 1 & wait", "timeout": 0.01})
+    result = await tool.execute(
+        {"command": "(sleep 0.25; touch marker) & wait", "timeout": 0.01}
+    )
     duration = monotonic() - start
+    await asyncio.sleep(0.35)
 
     assert result.ok is False
     assert result.data is not None
     assert result.data["timed_out"] is True
     assert duration < 0.5
+    assert not marker.exists()
 
 
 @pytest.mark.anyio

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -14,7 +14,8 @@ from tau_coding.system_prompt import (
 from tau_coding.tools import create_coding_tools
 
 
-async def _unused_executor(_arguments: object) -> AgentToolResult:
+async def _unused_executor(_arguments: object, signal: object | None = None) -> AgentToolResult:
+    del signal
     return AgentToolResult(tool_call_id="", name="hidden", ok=True, content="")
 
 
@@ -41,7 +42,7 @@ def test_tool_without_prompt_snippet_is_hidden_from_available_tools() -> None:
         name="hidden",
         description="Still sent to provider",
         input_schema={"type": "object"},
-        executor=_unused_executor,  # type: ignore[arg-type]
+        executor=_unused_executor,
     )
 
     assert format_available_tools([tool]) == "(none)"
@@ -114,7 +115,7 @@ def test_skills_are_included_only_when_read_tool_is_available(tmp_path: Path) ->
         name="custom",
         description="Custom",
         input_schema={"type": "object"},
-        executor=_unused_executor,  # type: ignore[arg-type]
+        executor=_unused_executor,
         prompt_snippet="Custom tool",
     )
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -246,7 +246,11 @@ async def test_openai_compatible_provider_streams_reasoning_content() -> None:
 
 @pytest.mark.anyio
 async def test_openai_compatible_provider_streams_tool_calls() -> None:
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del signal
         return AgentToolResult(
             tool_call_id="call-1",
             name="read",
@@ -555,7 +559,11 @@ async def test_openai_codex_provider_streams_tool_calls() -> None:
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
 
-    async def executor(arguments: Mapping[str, JSONValue]) -> AgentToolResult:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del signal
         return AgentToolResult(
             tool_call_id="call-1|fc-1",
             name="read",

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -249,3 +249,17 @@ def test_tui_adapter_records_errors_and_stops_on_non_recoverable_error() -> None
         ("assistant", "partial"),
         ("error", "Error: provider failed"),
     ]
+
+
+def test_tui_adapter_renders_cancellation_as_status() -> None:
+    state = TuiState(running=True, assistant_buffer="partial")
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(ErrorEvent(message="Agent run cancelled", recoverable=True))
+
+    assert state.running is True
+    assert state.error is None
+    assert [(item.role, item.text) for item in state.items] == [
+        ("assistant", "partial"),
+        ("status", "Agent run cancelled."),
+    ]

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1593,8 +1593,17 @@ async def test_tui_app_escape_cancels_running_session_from_prompt() -> None:
         await pilot.press("escape")
 
         assert session.cancel_count == 1
+        assert app.state.running is True
+        assert notifications == [
+            "Agent will stop on the next turn. "
+            "Press Esc again to interrupt the current operation."
+        ]
+
+        await pilot.press("escape")
+
+        assert session.cancel_count == 2
         assert app.state.running is False
-        assert notifications == ["Cancellation requested."]
+        assert notifications[-1] == "Interrupted current operation."
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- make `Esc` a two-step TUI cancellation flow: graceful stop first, hard interrupt second
- thread the agent cancellation token through tool execution
- make the bash tool honor cancellation by killing the shell process group

## Pi alignment

I checked Pi’s agent loop and bash tool code. Pi carries an abort signal through provider and tool execution, and the bash tool kills the process tree when the signal aborts. Tau now follows the same boundary: Textual requests cancellation in `tau_coding.tui`, `tau_agent` carries the token, and the coding bash tool owns local process cleanup.

## Validation

- `uv run pytest tests/test_agent_loop.py tests/test_agent_harness.py tests/test_coding_tools.py tests/test_tui_app.py -q`
- `uv run ruff check src/tau_agent/tools.py src/tau_agent/loop.py src/tau_coding/tools.py src/tau_coding/tui/app.py tests/test_agent_loop.py tests/test_coding_tools.py tests/test_tui_app.py`

Closes #96