### PR TITLE
#103: Add shell filesystem autocomplete

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,6 +313,11 @@ to context/history. Terminal input commands use the same shell execution,
 output truncation, failure reporting, and timeout assumptions as Tau's built-in
 `bash` tool.
 
+In the TUI, terminal input commands complete relative files and directories from
+the session working directory. Press `Tab` while typing a path such as
+`!cat README` or `!!cat src/ma` to insert the matching filename; directory
+matches include a trailing `/` so you can keep typing the next path segment.
+
 Thinking controls are model-aware. Tau enables them only when the active
 provider configuration declares supported levels for the active model. Custom
 OpenAI-compatible providers can opt in by adding `thinking_levels`,

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -101,6 +101,9 @@ def build_completion_state(
     del prompt_templates
     if not text.startswith("/") or text.startswith("//"):
         if cwd is not None:
+            shell_completions = _shell_path_completions(text=text, cwd=cwd)
+            if shell_completions is not None:
+                return CompletionState(shell_completions)
             return CompletionState(_file_reference_completions(text=text, cwd=cwd))
         return CompletionState()
 
@@ -193,6 +196,105 @@ def _is_ignored_file_completion_path(path: Path, *, cwd: Path) -> bool:
     return any(
         part.startswith(".") or part in IGNORED_FILE_COMPLETION_DIRS for part in relative_parts
     )
+
+
+def _shell_path_completions(*, text: str, cwd: Path) -> tuple[CompletionItem, ...] | None:
+    prefix_span = _shell_command_prefix_span(text)
+    if prefix_span is None:
+        return None
+
+    start, end = _active_shell_path_token(text=text, command_start=prefix_span[1])
+    token = text[start:end]
+    if not token:
+        return ()
+
+    shell_path = _parse_shell_path_token(token)
+    if shell_path is None:
+        return ()
+    parent_text, name_prefix, replacement_prefix = shell_path
+
+    parent_dir = cwd / parent_text if parent_text else cwd
+    if not parent_dir.exists() or not parent_dir.is_dir():
+        return ()
+    if parent_dir != cwd and _is_ignored_file_completion_path(parent_dir, cwd=cwd):
+        return ()
+
+    try:
+        children = sorted(parent_dir.iterdir(), key=lambda path: path.name.lower())
+    except OSError:
+        return ()
+
+    suggestions: list[CompletionItem] = []
+    for child in children:
+        if _is_ignored_file_completion_path(child, cwd=cwd):
+            continue
+        if not child.name.lower().startswith(name_prefix.lower()):
+            continue
+        relative = child.relative_to(cwd).as_posix()
+        replacement = f"{replacement_prefix}{relative}{'/' if child.is_dir() else ''}"
+        if replacement == token:
+            continue
+        suggestions.append(
+            CompletionItem(
+                display=replacement,
+                replacement=replacement,
+                start=start,
+                end=end,
+                description="Directory" if child.is_dir() else "File",
+            )
+        )
+        if len(suggestions) >= MAX_FILE_COMPLETIONS:
+            break
+    return tuple(suggestions)
+
+
+def _shell_command_prefix_span(text: str) -> tuple[int, int] | None:
+    leading_whitespace = len(text) - len(text.lstrip())
+    stripped = text[leading_whitespace:]
+    if stripped.startswith("!!"):
+        return (leading_whitespace, leading_whitespace + 2)
+    if stripped.startswith("!"):
+        return (leading_whitespace, leading_whitespace + 1)
+    return None
+
+
+def _active_shell_path_token(*, text: str, command_start: int) -> tuple[int, int]:
+    cursor = len(text)
+    token_start = command_start
+    escaped = False
+    for index in range(cursor - 1, command_start - 1, -1):
+        char = text[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char.isspace():
+            token_start = index + 1
+            break
+    return token_start, cursor
+
+
+def _parse_shell_path_token(token: str) -> tuple[str, str, str] | None:
+    replacement_prefix = ""
+    path_text = token
+    if path_text.startswith("./"):
+        replacement_prefix = "./"
+        path_text = path_text[2:]
+    if path_text.startswith(("/", "~")):
+        return None
+    if any(char in path_text for char in "\"'`$*?[{"):
+        return None
+
+    parent_text, separator, name_prefix = path_text.rpartition("/")
+    if separator and not parent_text:
+        return None
+
+    parent_parts = parent_text.split("/") if parent_text else []
+    if any(part in {"", ".", ".."} for part in parent_parts):
+        return None
+    return parent_text, name_prefix, replacement_prefix
 
 
 def _command_completions(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1336,6 +1336,26 @@ async def test_tui_app_accepts_file_reference_completion(tmp_path: Path) -> None
 
 
 @pytest.mark.anyio
+async def test_tui_app_accepts_shell_path_completion(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+
+    session = FakeSession()
+    session.cwd = tmp_path
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "!cat READ"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        assert [item.display for item in app._completion_state.items] == ["README.md"]
+        await pilot.press("tab")
+
+        assert prompt.value == "!cat README.md"
+
+
+@pytest.mark.anyio
 async def test_tui_app_completes_skill_name() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -229,3 +229,77 @@ def test_file_reference_completion_stays_off_for_slash_commands(tmp_path: Path) 
     )
 
     assert state.items == ()
+
+
+def test_shell_path_completion_preserves_bang_prefix(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "!cat READ",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["README.md"]
+    assert state.selected is not None
+    assert state.selected.apply("!cat READ") == "!cat README.md"
+
+
+def test_shell_path_completion_preserves_double_bang_prefix(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "!!cat READ",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["README.md"]
+    assert state.selected is not None
+    assert state.selected.apply("!!cat READ") == "!!cat README.md"
+
+
+def test_shell_path_completion_matches_relative_paths(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "!cat src/ma",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["src/main.py"]
+    assert state.selected is not None
+    assert state.selected.apply("!cat src/ma") == "!cat src/main.py"
+
+
+def test_shell_path_completion_adds_trailing_slash_for_directories(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+
+    directory_state = build_completion_state(
+        "!cat sr",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+    child_state = build_completion_state(
+        "!cat src/",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in directory_state.items] == ["src/"]
+    assert directory_state.selected is not None
+    assert directory_state.selected.apply("!cat sr") == "!cat src/"
+    assert [item.display for item in child_state.items] == ["src/main.py"]


### PR DESCRIPTION
## Summary

- Adds shell-mode filesystem completions for prompts beginning with `!` or `!!` through the reusable TUI autocomplete helper.
- Completes relative file and directory path tokens from the session working directory while preserving the shell-mode prefix.
- Appends `/` to directory completions so users can continue entering nested paths.
- Adds focused pure autocomplete coverage, a real TUI `Tab` acceptance test, and a short configuration doc note.

Closes #103.

## Validation

- `uv run pytest tests/test_tui_autocomplete.py tests/test_tui_app.py -q` -> 134 passed
- `uv run pytest -q` -> 424 passed
- `uv run ruff check src/tau_coding/tui/autocomplete.py tests/test_tui_autocomplete.py tests/test_tui_app.py` -> passed
- `uv run --group docs mkdocs build --strict` -> passed; emitted the existing Material for MkDocs warning and existing nav info for `architecture/phase-24-session-tree-branching.md`

## Existing Unrelated Repo-wide Failures

- `uv run ruff check .` fails on existing unrelated lint in `src/tau_coding/tui/app.py`, `src/tau_coding/tui/widgets.py`, and `tests/test_commands.py`.
- `uv run mypy` fails on existing unrelated type errors in `src/tau_coding/tools.py` around subprocess task/result typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shell-style path autocomplete in TUI terminal commands: Tab now completes filenames and directories relative to the current working directory when typing after `!` or `!!` prefixes, with directories indicated by trailing slashes.

* **Documentation**
  * Updated configuration guide to document terminal input command behavior and tab completion functionality.

* **Tests**
  * Added tests for shell-path autocomplete behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->