### PR TITLE
Issue #83: selectable transcript message widgets

### DIFF
--- a/docs/architecture/phase-12-textual-tui.md
+++ b/docs/architecture/phase-12-textual-tui.md
@@ -94,7 +94,7 @@ It uses:
 - `Footer`
 - `Static` for status and sidebar content
 - `Horizontal` and `Vertical` containers for the sidebar/main layout
-- `RichLog` for transcript output
+- a scrollable transcript made from selectable message widgets
 - `Input` for prompt submission
 
 Prompt execution runs in a Textual worker so the UI can continue updating while events stream.

--- a/docs/architecture/phase-17-5-transcript-wrapping.md
+++ b/docs/architecture/phase-17-5-transcript-wrapping.md
@@ -32,17 +32,18 @@ TranscriptView renders blocks
 
 ## Wrapping behavior
 
-`TranscriptView` still uses Textual's `RichLog`, but it is created with:
+`TranscriptView` is now a `VerticalScroll` container of individual
+`TranscriptMessageWidget` children. The container keeps:
 
 ```python
-min_width=1
-wrap=True
+min_width = 1
 ```
 
-This removes RichLog's default wide minimum width and lets normal user and
-assistant messages reflow to the available terminal width. Chat block bodies use
-Rich `Text` with folded overflow so long unbroken strings are wrapped inside the
-block instead of forcing horizontal scrolling.
+Each message widget owns its Rich renderable and its selected-text extraction.
+This keeps normal user and assistant messages reflowing to the available
+terminal width while avoiding one large transcript-wide selection surface. Chat
+block bodies use Rich `Text` with folded overflow so long unbroken strings are
+wrapped inside the block instead of forcing horizontal scrolling.
 
 Tool output and code-like text preserve line breaks. Very long unbroken chunks
 are folded intentionally rather than clipped.
@@ -78,3 +79,4 @@ The tests verify:
 - chat items render without `you:`, `assistant:`, or `tool:` prefixes
 - long unbroken message text folds within a narrow console width
 - the mounted transcript uses a narrow `min_width`
+- selection extraction is scoped to one message widget or adjacent message widgets

--- a/docs/architecture/phase-23-tui-polish.md
+++ b/docs/architecture/phase-23-tui-polish.md
@@ -26,6 +26,12 @@ syntax renderables inside the same Pi-style stacked message blocks. The
 transcript state still stores plain role/text items; this is renderer-only
 polish in the Textual frontend.
 
+The transcript surface is a scroll container of selectable message widgets, not
+one large `RichLog`. Each message widget owns selected-text extraction for its
+rendered block, so partial mouse selection stays scoped to the intended message
+and adjacent-message copies do not accidentally expand to the full
+conversation.
+
 Assistant transcript blocks now also render common Markdown constructs such as
 headings, bullets, blockquotes, links, inline code, and emphasis through Rich
 Markdown. User, tool, status, and error blocks stay literal unless they are

--- a/src/tau_coding/tui/__init__.py
+++ b/src/tau_coding/tui/__init__.py
@@ -23,10 +23,12 @@ from tau_coding.tui.state import ChatItem, TuiState
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
     SessionSidebar,
+    TranscriptMessageWidget,
     TranscriptView,
     render_chat_item,
     render_compact_session_info,
     render_session_sidebar,
+    transcript_item_selection_text,
 )
 
 __all__ = [
@@ -38,6 +40,7 @@ __all__ = [
     "SessionSidebar",
     "TAU_DARK_THEME",
     "TAU_LIGHT_THEME",
+    "TranscriptMessageWidget",
     "TranscriptView",
     "TuiEventAdapter",
     "TuiConfigError",
@@ -55,5 +58,6 @@ __all__ = [
     "render_session_sidebar",
     "run_tui_app",
     "save_tui_settings",
+    "transcript_item_selection_text",
     "tui_settings_path",
 ]

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -12,6 +12,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingsMap
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
 from textual.timer import Timer
@@ -1149,7 +1150,10 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
             help_text = (
                 "all models: no matching models - Tab switches to scoped models"
                 if not self.visible_choices
-                else f"All models - Enter selects active model - Tab switches tabs - {scope_count} scoped"
+                else (
+                    "All models - Enter selects active model - "
+                    f"Tab switches tabs - {scope_count} scoped"
+                )
             )
         else:
             tabs.update("Tabs: ○ All models  ● Scoped models")
@@ -2431,7 +2435,11 @@ class TauTuiApp(App[None]):
 
     def _apply_activity_indicator(self) -> None:
         theme = self.tui_settings.resolved_theme
-        prompt = self.query_one("#prompt", PromptInput)
+        try:
+            prompt = self.query_one("#prompt", PromptInput)
+            indicator = self.query_one("#activity-indicator", Static)
+        except NoMatches:
+            return
         prompt.styles.border = (
             "tall",
             _activity_prompt_border_color(
@@ -2441,7 +2449,6 @@ class TauTuiApp(App[None]):
                 shell_mode=_is_terminal_command_prompt(prompt.text),
             ),
         )
-        indicator = self.query_one("#activity-indicator", Static)
         indicator.update(
             _render_activity_indicator(
                 theme,

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1,6 +1,7 @@
 """Small Textual widgets for Tau's interactive TUI."""
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from subprocess import TimeoutExpired, run
 from typing import Any, Protocol
@@ -17,8 +18,11 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
+from textual.containers import VerticalScroll
 from textual.events import Resize
-from textual.widgets import RichLog, Static
+from textual.geometry import Offset
+from textual.selection import Selection
+from textual.widgets import Static
 
 from tau_agent.tools import AgentTool
 from tau_coding.prompt_templates import PromptTemplate
@@ -29,6 +33,22 @@ from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import ChatItem, TuiState
 
 TAU_SIDEBAR_LOGO = "τ = 2π"
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptLine:
+    """Plain transcript line used by compatibility inspection helpers."""
+
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class _RenderedSelectionLine:
+    """One rendered transcript line mapped back to copyable body text."""
+
+    rendered_y: int
+    rendered_prefix_width: int
+    text: str
 
 
 class SessionSummarySource(Protocol):
@@ -91,11 +111,61 @@ class CompactSessionInfo(Static):
         self.update(render_compact_session_info(session, theme=theme))
 
 
-class TranscriptView(RichLog):
-    """Scrollable transcript view backed by ``TuiState``."""
+class TranscriptMessageWidget(Static):
+    """One selectable transcript message block."""
+
+    DEFAULT_CSS = """
+    TranscriptMessageWidget {
+        width: 1fr;
+        height: auto;
+    }
+    """
+
+    def __init__(
+        self,
+        item: ChatItem,
+        *,
+        theme: TuiTheme,
+        show_tool_results: bool,
+    ) -> None:
+        self.item = item
+        self.selection_text = transcript_item_selection_text(
+            item,
+            show_tool_results=show_tool_results,
+        )
+        super().__init__(
+            render_chat_item(
+                item,
+                theme=theme,
+                show_tool_results=show_tool_results,
+            ),
+            expand=True,
+            shrink=True,
+            markup=False,
+            classes="transcript-message",
+        )
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """Return selected text from this message, not the whole transcript."""
+        selected_text = _extract_rendered_selection(self, selection)
+        if selected_text is None:
+            selected_text = _extract_text_selection(self.selection_text, selection)
+        if not selected_text:
+            return None
+        return selected_text, "\n"
+
+
+class TranscriptView(VerticalScroll):
+    """Scrollable transcript view backed by individual selectable message widgets."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        for legacy_option in ("wrap", "highlight", "markup"):
+            kwargs.pop(legacy_option, None)
+        min_width = kwargs.pop("min_width", None)
         super().__init__(*args, **kwargs)
+        self.min_width = min_width
+        if min_width is not None:
+            self.styles.min_width = min_width
         self._render_state: TuiState | None = None
         self._render_theme: TuiTheme = TAU_DARK_THEME
         self._last_render_width = 0
@@ -113,7 +183,7 @@ class TranscriptView(RichLog):
 
     def on_resize(self, event: Resize) -> None:
         """Re-render transcript entries when the terminal width changes."""
-        super().on_resize(event)
+        del event
         if self._render_state is None:
             return
         width = self.scrollable_content_region.width
@@ -129,31 +199,138 @@ class TranscriptView(RichLog):
             return
         theme = self._render_theme
         self._last_render_width = self.scrollable_content_region.width
-        self.clear()
-        for index, item in enumerate(state.items):
+        self.remove_children(TranscriptMessageWidget)
+        for item in state.items:
             if item.role == "thinking" and not state.show_thinking:
                 continue
-            self.write(
-                render_chat_item(
+            self.mount(
+                TranscriptMessageWidget(
                     item,
                     theme=theme,
                     show_tool_results=state.show_tool_results or item.always_show_tool_result,
-                ),
-                expand=True,
-                shrink=True,
-                scroll_end=scroll_end,
+                )
             )
         if state.assistant_buffer:
-            self.write(
-                render_chat_item(
+            self.mount(
+                TranscriptMessageWidget(
                     ChatItem(role="assistant", text=state.assistant_buffer),
                     theme=theme,
                     show_tool_results=state.show_tool_results,
-                ),
-                expand=True,
-                shrink=True,
-                scroll_end=scroll_end,
+                )
             )
+        self.refresh(layout=True)
+        if scroll_end:
+            self.scroll_end(animate=False)
+
+    @property
+    def lines(self) -> tuple[TranscriptLine, ...]:
+        """Compatibility text view for tests and lightweight transcript inspection."""
+        return tuple(
+            TranscriptLine(line)
+            for message in self.query(TranscriptMessageWidget)
+            for line in message.selection_text.splitlines()
+        )
+
+
+def transcript_item_selection_text(
+    item: ChatItem,
+    *,
+    show_tool_results: bool = False,
+) -> str:
+    """Return the plain text represented by a selectable transcript item."""
+    return _visible_chat_text(item, show_tool_results=show_tool_results)
+
+
+def _extract_rendered_selection(
+    widget: TranscriptMessageWidget,
+    selection: Selection,
+) -> str | None:
+    lines = _rendered_selection_lines(widget)
+    if not lines:
+        return None
+    selected_lines: list[str] = []
+    for line in lines:
+        span = selection.get_span(line.rendered_y)
+        if span is None:
+            continue
+        start, end = span
+        text_start = max(start - line.rendered_prefix_width, 0)
+        text_end = len(line.text) if end == -1 else max(end - line.rendered_prefix_width, 0)
+        selected_lines.append(line.text[text_start:text_end])
+    return "\n".join(selected_lines)
+
+
+def _rendered_selection_lines(widget: TranscriptMessageWidget) -> list[_RenderedSelectionLine]:
+    if widget.size.height <= 0:
+        return []
+    rendered_lines = [widget.render_line(y).text for y in range(widget.size.height)]
+    content_bounds = _rendered_content_bounds(rendered_lines)
+    if content_bounds is None:
+        return []
+    first_content_line, last_content_line = content_bounds
+    body_prefix_width = _body_prefix_width(rendered_lines[first_content_line])
+    selection_lines: list[_RenderedSelectionLine] = []
+    for rendered_y in range(first_content_line, last_content_line + 1):
+        line = rendered_lines[rendered_y]
+        prefix_width = _line_prefix_width(line, body_prefix_width)
+        selection_lines.append(
+            _RenderedSelectionLine(
+                rendered_y=rendered_y,
+                rendered_prefix_width=prefix_width,
+                text=line[prefix_width:].rstrip(),
+            )
+        )
+    return selection_lines
+
+
+def _rendered_content_bounds(lines: list[str]) -> tuple[int, int] | None:
+    first = next((index for index, line in enumerate(lines) if line.strip()), None)
+    if first is None:
+        return None
+    last = next(
+        index for index in range(len(lines) - 1, -1, -1) if lines[index].strip()
+    )
+    return first, last
+
+
+def _body_prefix_width(first_content_line: str) -> int:
+    if first_content_line.startswith("▌"):
+        if len(first_content_line) > 1 and first_content_line[1] == " ":
+            return 2
+        return 1
+    return len(first_content_line) - len(first_content_line.lstrip(" "))
+
+
+def _line_prefix_width(line: str, body_prefix_width: int) -> int:
+    if line.startswith("▌"):
+        return min(body_prefix_width, len(line))
+    prefix_width = 0
+    while prefix_width < min(body_prefix_width, len(line)) and line[prefix_width] == " ":
+        prefix_width += 1
+    return prefix_width
+
+
+def _extract_text_selection(text: str, selection: Selection) -> str:
+    clipped_selection = _clip_selection_to_text(selection, text)
+    return clipped_selection.extract(text)
+
+
+def _clip_selection_to_text(selection: Selection, text: str) -> Selection:
+    lines = text.splitlines()
+    if not lines:
+        return Selection(Offset(0, 0), Offset(0, 0))
+    return Selection(
+        _clip_selection_offset(selection.start, lines),
+        _clip_selection_offset(selection.end, lines),
+    )
+
+
+def _clip_selection_offset(offset: Offset | None, lines: list[str]) -> Offset | None:
+    if offset is None:
+        return None
+    line_index = min(max(offset.y, 0), len(lines) - 1)
+    column = min(max(offset.x, 0), len(lines[line_index]))
+    return Offset(column, line_index)
 
 
 def render_session_sidebar(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7,6 +7,8 @@ import pytest
 from rich.console import Console
 from rich.panel import Panel
 from textual.containers import VerticalScroll
+from textual.geometry import Offset
+from textual.selection import SELECT_ALL, Selection
 from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
 
 from tau_agent import (
@@ -57,12 +59,14 @@ from tau_coding.tui.config import (
 )
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
+    TranscriptMessageWidget,
     TranscriptView,
     _compact_token_count,
     _syntax_language,
     render_chat_item,
     render_compact_session_info,
     render_session_sidebar,
+    transcript_item_selection_text,
 )
 
 
@@ -697,6 +701,84 @@ def test_chat_items_preserve_malformed_fenced_code() -> None:
 
     assert "```python" in output
     assert 'print("hi")' in output
+
+
+@pytest.mark.anyio
+async def test_transcript_message_widget_extracts_partial_rendered_selection() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content="alpha beta\ngamma"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(TranscriptMessageWidget)
+
+        assert widget.get_selection(Selection(Offset(8, 1), Offset(12, 1))) == (
+            "beta",
+            "\n",
+        )
+
+
+@pytest.mark.anyio
+async def test_tui_transcript_selects_only_one_message() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content="first message"),
+                AssistantMessage(content="second message"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        messages = list(app.query(TranscriptMessageWidget))
+
+        app.screen.selections = {messages[0]: SELECT_ALL}
+
+        assert app.screen.get_selected_text() == "first message"
+
+
+@pytest.mark.anyio
+async def test_tui_transcript_extracts_adjacent_message_selection() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content="first one"),
+                AssistantMessage(content="middle message"),
+                UserMessage(content="third item"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        messages = list(app.query(TranscriptMessageWidget))
+
+        app.screen.selections = {
+            messages[0]: Selection(Offset(8, 1), None),
+            messages[1]: SELECT_ALL,
+            messages[2]: Selection(None, Offset(7, 1)),
+        }
+
+        assert app.screen.get_selected_text() == "one\nmiddle message\nthird"
+
+
+def test_transcript_selection_text_tracks_tool_result_visibility() -> None:
+    item = ChatItem(
+        role="tool",
+        text="→ read README.md",
+        tool_result_text="✓ read\nREADME contents",
+    )
+
+    assert transcript_item_selection_text(item, show_tool_results=False) == "→ read README.md"
+    assert transcript_item_selection_text(item, show_tool_results=True) == (
+        "→ read README.md\n\n✓ read\nREADME contents"
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #83.

Refactors the Textual transcript away from one large `RichLog` into a `VerticalScroll` of selectable `TranscriptMessageWidget` blocks. Each message widget now owns rendered-coordinate selected-text extraction, so partial copies stay scoped to the intended message and adjacent-message selection can copy across blocks without expanding to the full conversation.

This preserves the existing chat rendering path via `render_chat_item`, keeps tool-result visibility reflected in selectable text, maintains transcript reflow and scroll-to-bottom behavior, and updates the TUI docs to describe the new transcript surface.

## Validation

- `uv run pytest -q` -> 423 passed
- `uv run --group docs mkdocs build --strict` -> passed
- `uv run ruff check src/tau_coding/tui/widgets.py src/tau_coding/tui/app.py src/tau_coding/tui/__init__.py tests/test_tui_app.py` -> passed
- `uv run mypy src/tau_coding/tui/widgets.py src/tau_coding/tui/app.py src/tau_coding/tui/__init__.py` -> passed

## Repo-wide lint/type status

Repo-wide checks were also run after the issue branch was committed. They still fail on files outside this PR's issue #83 scope:

- `uv run ruff check` fails in `tests/test_commands.py` for one unused import and two pre-existing line-length violations.
- `uv run mypy` fails in `src/tau_coding/tools.py` for existing task type errors around subprocess stream handling.
