### PR TITLE
Issue #54: Add raw LLM API observability

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -49,6 +49,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Phase 20.3: Skill Invocation Reliability](phase-20-3-skill-invocation.md)
 - [Phase 20.4: Session Export and Visualization](phase-20-4-session-export.md)
 - [Queued Steering and Follow-ups](queued-steering-follow-ups.md)
+- [LLM API Observability](llm-observability.md)
 - [Pre-extension Hardening Summary](pre-extension-hardening.md)
 - [Phase 22: Compaction Replay Foundation](phase-22-compaction-foundation.md)
 - [Phase 23: Advanced TUI and Product Polish](phase-23-tui-polish.md)

--- a/docs/architecture/llm-observability.md
+++ b/docs/architecture/llm-observability.md
@@ -1,0 +1,101 @@
+# LLM API Observability
+
+Issue #54 adds the first opt-in path for inspecting the HTTP traffic Tau sends
+to model providers.
+
+## Placement
+
+Observation is provider-adjacent but not app-owned:
+
+```text
+tau_ai adapter builds provider-specific request
+        |
+        v
+tau_ai.observability emits redacted LLMObservation records
+        |
+        v
+tau_coding.diagnostics writes JSONL when enabled
+```
+
+`tau_agent` is intentionally not involved. The harness still sees only
+provider-neutral messages, tools, and events. It does not know about HTTP
+headers, provider URLs, local log paths, environment variables, Textual, Rich, or
+CLI flags.
+
+`tau_ai` also does not write files. It defines:
+
+- `LLMObservation`
+- `LLMObserver`
+- redaction helpers
+- small helper functions for request, response, and error observations
+
+`tau_coding` owns enablement and persistence. It creates an observer from
+`TAU_LLM_OBSERVABILITY`, threads it through runtime provider construction, and
+writes to Tau's diagnostic log directory.
+
+## First captured data
+
+The first implementation captures one JSONL record per provider lifecycle point:
+
+- request: adapter name, model, method, URL, attempt, stream flag, redacted
+  request headers, and redacted serialized request body
+- response: HTTP status code and redacted response headers
+- error: HTTP status error bodies and network exception metadata, redacted
+
+Each retry attempt is recorded separately. Streaming requests are marked with
+`"stream": true`, but individual streamed chunks are not logged yet. That keeps
+the first version low-volume and avoids accidentally retaining full assistant
+output, reasoning deltas, or tool-call argument streams.
+
+## Redaction and privacy
+
+Redaction is mandatory in this implementation.
+
+Credential-like request and response headers are replaced with `[REDACTED]`.
+This includes authorization, cookie, API-key, token, session, credential, secret,
+and ChatGPT account-id style headers.
+
+Prompt-like body fields are replaced with metadata instead of raw text:
+
+```json
+{
+  "redacted": true,
+  "kind": "text",
+  "length": 42,
+  "sha256": "..."
+}
+```
+
+This applies to fields such as `content`, `text`, `instructions`, `system`,
+`output`, `arguments`, `body`, `description`, and streamed-fragment-shaped
+fields. Structured metadata such as `model`, `role`, `type`, tool names, status
+codes, and provider URLs remains visible.
+
+The log is still diagnostic material. Lengths, hashes, URLs, model names, tool
+names, and schema shape can reveal sensitive context, so the file should be kept
+local and shared deliberately.
+
+## Enable and view
+
+Set:
+
+```bash
+TAU_LLM_OBSERVABILITY=1 tau --provider local -p "debug this request"
+```
+
+or start the TUI with the same environment variable.
+
+Tau appends JSONL records to:
+
+```text
+~/.tau/logs/llm-observations.jsonl
+```
+
+## Deferred work
+
+Useful follow-ups are:
+
+- streamed chunk capture with explicit retention limits
+- a TUI view or export command for recent observations
+- per-session or per-run controls beyond the environment variable
+- an intentionally unsafe raw-body mode with stronger warnings, if needed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Important files and directories:
 ~/.tau/providers.json
 ~/.tau/tui.json
 ~/.tau/sessions/
+~/.tau/logs/
 ~/.tau/skills/
 ~/.tau/prompts/
 ~/.tau/AGENTS.md
@@ -115,6 +116,30 @@ TUI cycling. Open `/model`, highlight a model, and press `Space` to add or
 remove it from the scoped list. Press `Tab` in the picker to show only scoped
 models. Press `Ctrl+P` in the prompt to cycle through scoped models without
 opening the picker.
+
+## Diagnostic Logs
+
+Tau writes durable diagnostics under:
+
+```text
+~/.tau/logs/
+```
+
+Current logs are:
+
+```text
+~/.tau/logs/agent-calls.jsonl
+~/.tau/logs/llm-observations.jsonl
+```
+
+`agent-calls.jsonl` records unexpected agent-call failures and non-recoverable
+error events without prompt or provider payload bodies.
+
+`llm-observations.jsonl` is only written when `TAU_LLM_OBSERVABILITY=1` is set.
+It contains redacted provider HTTP request, response, and error observations.
+Credential headers and prompt-like body text are removed by default, but the
+file can still reveal provider URLs, models, tool names, schema shape, lengths,
+and text hashes.
 
 ## TUI Settings
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Tau currently has:
 - provider setup and switching
 - stored Tau credentials with environment-variable fallback
 - context accounting, manual/automatic compaction, and HTML session export
+- opt-in redacted LLM request and response observation logs
 - a Textual TUI with responsive sidebar, text selection, selected-message copy,
   activity status, thinking controls, optional thinking-token display, and
   queued steering/follow-up prompts while the agent is running

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,6 +35,41 @@ export OPENAI_MAX_RETRY_DELAY_SECONDS="0.5"
 
 The provider uses `/chat/completions` with streaming enabled.
 
+## LLM request observations
+
+Tau can write an opt-in, redacted JSONL trace of provider HTTP requests and
+response metadata. This is useful when debugging model selection, prompt
+construction, tool schemas, provider URLs, retry behavior, or provider error
+bodies.
+
+Enable it for one command:
+
+```bash
+TAU_LLM_OBSERVABILITY=1 tau --provider local -p "summarize this project"
+```
+
+or set the same environment variable before starting the TUI.
+
+Records are appended to:
+
+```text
+~/.tau/logs/llm-observations.jsonl
+```
+
+The log captures the adapter name, model, method, URL, retry attempt, streaming
+flag, redacted headers, redacted serialized request body, HTTP status, redacted
+response headers, and redacted HTTP/network errors. Streaming response chunks
+are not logged in this first version.
+
+Redaction is mandatory. Credential-like headers are replaced with `[REDACTED]`.
+Prompt-like text fields such as `content`, `text`, `instructions`, `system`,
+`output`, `arguments`, and error `body` are replaced with length and SHA-256
+metadata instead of raw text. The file can still reveal sensitive diagnostic
+context, so keep it local unless intentionally sharing it.
+
+See [LLM API Observability](architecture/llm-observability.md) for the
+architecture and privacy notes.
+
 ## OpenAI Codex Subscription Provider
 
 Tau also includes an `openai-codex` provider for Codex / ChatGPT subscription

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - "Phase 20.4: Session Export and Visualization": architecture/phase-20-4-session-export.md
       - "Provider Retry Events": architecture/provider-retries.md
       - "Queued Steering and Follow-ups": architecture/queued-steering-follow-ups.md
+      - "LLM API Observability": architecture/llm-observability.md
       - "Pre-extension Hardening Summary": architecture/pre-extension-hardening.md
       - "Phase 22: Compaction Replay Foundation": architecture/phase-22-compaction-foundation.md
       - "Phase 23: Advanced TUI and Product Polish": architecture/phase-23-tui-polish.md

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -21,6 +21,15 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.fake import FakeProvider
+from tau_ai.observability import (
+    LLMObservation,
+    LLMObserver,
+    observe_llm_error,
+    observe_llm_request,
+    observe_llm_response,
+    redact_headers,
+    redact_json_value,
+)
 from tau_ai.openai_codex import (
     DEFAULT_OPENAI_CODEX_BASE_URL,
     OpenAICodexConfig,
@@ -46,6 +55,8 @@ __all__ = [
     "OpenAICodexProvider",
     "OpenAICompatibleConfig",
     "OpenAICompatibleProvider",
+    "LLMObservation",
+    "LLMObserver",
     "ProviderErrorEvent",
     "ProviderEvent",
     "ProviderResponseEndEvent",
@@ -54,5 +65,10 @@ __all__ = [
     "ProviderThinkingDeltaEvent",
     "ProviderTextDeltaEvent",
     "ProviderToolCallEvent",
+    "observe_llm_error",
+    "observe_llm_request",
+    "observe_llm_response",
     "openai_compatible_config_from_env",
+    "redact_headers",
+    "redact_json_value",
 ]

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -19,6 +19,12 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.observability import (
+    LLMObserver,
+    observe_llm_error,
+    observe_llm_request,
+    observe_llm_response,
+)
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -34,10 +40,12 @@ class AnthropicProvider:
         config: AnthropicConfig,
         *,
         client: httpx.AsyncClient | None = None,
+        observer: LLMObserver | None = None,
     ) -> None:
         self._config = config
         self._client = client
         self._owns_client = client is None
+        self._observer = observer
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client if this provider created it."""
@@ -76,11 +84,48 @@ class AnthropicProvider:
             while True:
                 emitted_content = False
                 try:
+                    observe_llm_request(
+                        self._observer,
+                        provider="anthropic",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        headers=headers,
+                        body=payload,
+                        attempt=attempt + 1,
+                        stream=True,
+                    )
                     async with client.stream(
                         "POST", url, json=payload, headers=headers
                     ) as response:
+                        observe_llm_response(
+                            self._observer,
+                            provider="anthropic",
+                            model=model,
+                            method="POST",
+                            url=url,
+                            status_code=response.status_code,
+                            headers=response.headers,
+                            attempt=attempt + 1,
+                            stream=True,
+                        )
                         if response.status_code >= 400:
                             body = await response.aread()
+                            body_text = body.decode(errors="replace")
+                            observe_llm_error(
+                                self._observer,
+                                provider="anthropic",
+                                model=model,
+                                method="POST",
+                                url=url,
+                                attempt=attempt + 1,
+                                stream=True,
+                                error={
+                                    "type": "http_status",
+                                    "status_code": response.status_code,
+                                    "body": body_text,
+                                },
+                            )
                             if self._should_retry(attempt, status_code=response.status_code):
                                 delay = retry_delay_seconds(
                                     attempt,
@@ -93,7 +138,7 @@ class AnthropicProvider:
                                     reason=f"HTTP {response.status_code}",
                                     data={
                                         "status_code": response.status_code,
-                                        "body": body.decode(errors="replace"),
+                                        "body": body_text,
                                     },
                                 )
                                 attempt += 1
@@ -102,11 +147,10 @@ class AnthropicProvider:
                                 continue
                             yield ProviderErrorEvent(
                                 message=(
-                                    "Provider request failed with status "
-                                    f"{response.status_code}"
+                                    f"Provider request failed with status {response.status_code}"
                                 ),
                                 data={
-                                    "body": body.decode(errors="replace"),
+                                    "body": body_text,
                                     "attempts": attempt + 1,
                                 },
                             )
@@ -171,8 +215,7 @@ class AnthropicProvider:
                                 delta = chunk.get("delta")
                                 if isinstance(delta, Mapping):
                                     finish_reason = (
-                                        _string_or_empty(delta.get("stop_reason"))
-                                        or finish_reason
+                                        _string_or_empty(delta.get("stop_reason")) or finish_reason
                                     )
                             elif event_type == "error":
                                 error = chunk.get("error")
@@ -183,8 +226,7 @@ class AnthropicProvider:
                                 return
 
                         tool_calls = [
-                            builder.build(index)
-                            for index, builder in sorted(tool_builders.items())
+                            builder.build(index) for index, builder in sorted(tool_builders.items())
                         ]
                         for tool_call in tool_calls:
                             yield ProviderToolCallEvent(tool_call=tool_call)
@@ -198,6 +240,19 @@ class AnthropicProvider:
                         )
                         return
                 except httpx.HTTPError as exc:
+                    observe_llm_error(
+                        self._observer,
+                        provider="anthropic",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        attempt=attempt + 1,
+                        stream=True,
+                        error={
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        },
+                    )
                     if not emitted_content and self._should_retry(attempt):
                         delay = retry_delay_seconds(
                             attempt,

--- a/src/tau_ai/observability.py
+++ b/src/tau_ai/observability.py
@@ -1,0 +1,260 @@
+"""Opt-in provider request/response observation primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Literal, Protocol
+
+from tau_agent.types import JSONValue
+
+LLMObservationKind = Literal["request", "response", "error"]
+
+_REDACTED = "[REDACTED]"
+_SENSITIVE_HEADER_PARTS = (
+    "authorization",
+    "api-key",
+    "apikey",
+    "cookie",
+    "credential",
+    "secret",
+    "session",
+    "token",
+    "chatgpt-account-id",
+)
+_SENSITIVE_SCALAR_KEYS = {
+    "arguments",
+    "body",
+    "content",
+    "delta",
+    "description",
+    "instructions",
+    "message",
+    "output",
+    "partial_json",
+    "refusal",
+    "system",
+    "text",
+    "thinking",
+}
+_SENSITIVE_SUBTREE_KEYS = {"input"}
+_STRUCTURAL_STRING_KEYS = {
+    "call_id",
+    "finish_reason",
+    "id",
+    "model",
+    "name",
+    "role",
+    "status",
+    "strict",
+    "tool_choice",
+    "tool_use_id",
+    "type",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LLMObservation:
+    """A redacted observation of one provider HTTP request lifecycle point."""
+
+    kind: LLMObservationKind
+    provider: str
+    model: str
+    method: str
+    url: str
+    attempt: int
+    stream: bool
+    data: dict[str, JSONValue]
+
+    def to_json(self) -> dict[str, JSONValue]:
+        """Return a JSON-serializable representation."""
+        return {
+            "kind": self.kind,
+            "provider": self.provider,
+            "model": self.model,
+            "method": self.method,
+            "url": self.url,
+            "attempt": self.attempt,
+            "stream": self.stream,
+            "data": self.data,
+        }
+
+
+class LLMObserver(Protocol):
+    """Receives provider-layer observations without owning output policy."""
+
+    def record(self, observation: LLMObservation) -> None:
+        """Record one redacted provider observation."""
+        ...
+
+
+def observe_llm_request(
+    observer: LLMObserver | None,
+    *,
+    provider: str,
+    model: str,
+    method: str,
+    url: str,
+    headers: Mapping[str, object],
+    body: object,
+    attempt: int,
+    stream: bool,
+) -> None:
+    """Emit a redacted provider request observation, if enabled."""
+    _record_safely(
+        observer,
+        LLMObservation(
+            kind="request",
+            provider=provider,
+            model=model,
+            method=method,
+            url=url,
+            attempt=attempt,
+            stream=stream,
+            data={
+                "request": {
+                    "headers": redact_headers(headers),
+                    "body": redact_json_value(body),
+                }
+            },
+        ),
+    )
+
+
+def observe_llm_response(
+    observer: LLMObserver | None,
+    *,
+    provider: str,
+    model: str,
+    method: str,
+    url: str,
+    status_code: int,
+    headers: Mapping[str, object],
+    attempt: int,
+    stream: bool,
+) -> None:
+    """Emit a redacted provider response-metadata observation, if enabled."""
+    _record_safely(
+        observer,
+        LLMObservation(
+            kind="response",
+            provider=provider,
+            model=model,
+            method=method,
+            url=url,
+            attempt=attempt,
+            stream=stream,
+            data={
+                "response": {
+                    "status_code": status_code,
+                    "headers": redact_headers(headers),
+                }
+            },
+        ),
+    )
+
+
+def observe_llm_error(
+    observer: LLMObserver | None,
+    *,
+    provider: str,
+    model: str,
+    method: str,
+    url: str,
+    attempt: int,
+    stream: bool,
+    error: Mapping[str, object],
+) -> None:
+    """Emit a redacted provider error observation, if enabled."""
+    _record_safely(
+        observer,
+        LLMObservation(
+            kind="error",
+            provider=provider,
+            model=model,
+            method=method,
+            url=url,
+            attempt=attempt,
+            stream=stream,
+            data={"error": redact_json_value(error)},
+        ),
+    )
+
+
+def redact_headers(headers: Mapping[str, object]) -> dict[str, JSONValue]:
+    """Return headers with known credential-bearing values removed."""
+    redacted: dict[str, JSONValue] = {}
+    for key, value in headers.items():
+        name = str(key)
+        if _is_sensitive_header(name):
+            redacted[name] = _REDACTED
+        else:
+            redacted[name] = str(value)
+    return redacted
+
+
+def redact_json_value(
+    value: object,
+    *,
+    key: str | None = None,
+    redact_subtree_strings: bool = False,
+) -> JSONValue:
+    """Redact secret-prone text while preserving JSON structure."""
+    normalized_key = key.lower() if key is not None else None
+    child_redacts = redact_subtree_strings or normalized_key in _SENSITIVE_SUBTREE_KEYS
+
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): redact_json_value(
+                item_value,
+                key=str(item_key),
+                redact_subtree_strings=child_redacts,
+            )
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return [
+            redact_json_value(
+                item,
+                key=key,
+                redact_subtree_strings=child_redacts,
+            )
+            for item in value
+        ]
+    if isinstance(value, str):
+        if _should_redact_string(normalized_key, child_redacts):
+            return _redacted_text(value)
+        return value
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    return _redacted_text(str(value))
+
+
+def _record_safely(observer: LLMObserver | None, observation: LLMObservation) -> None:
+    if observer is None:
+        return
+    try:
+        observer.record(observation)
+    except Exception:
+        return
+
+
+def _is_sensitive_header(name: str) -> bool:
+    normalized = name.lower()
+    return any(part in normalized for part in _SENSITIVE_HEADER_PARTS)
+
+
+def _should_redact_string(key: str | None, redact_subtree_strings: bool) -> bool:
+    if key is not None and key in _SENSITIVE_SCALAR_KEYS:
+        return True
+    return redact_subtree_strings and key not in _STRUCTURAL_STRING_KEYS
+
+
+def _redacted_text(value: str) -> dict[str, JSONValue]:
+    return {
+        "redacted": True,
+        "kind": "text",
+        "length": len(value),
+        "sha256": sha256(value.encode("utf-8")).hexdigest(),
+    }

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -25,6 +25,12 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.observability import (
+    LLMObserver,
+    observe_llm_error,
+    observe_llm_request,
+    observe_llm_response,
+)
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -63,10 +69,12 @@ class OpenAICodexProvider:
         config: OpenAICodexConfig,
         *,
         client: httpx.AsyncClient | None = None,
+        observer: LLMObserver | None = None,
     ) -> None:
         self._config = config
         self._client = client
         self._owns_client = client is None
+        self._observer = observer
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client if this provider created it."""
@@ -106,15 +114,51 @@ class OpenAICodexProvider:
                         account_id=credentials.account_id,
                         originator=self._config.originator,
                     )
+                    observe_llm_request(
+                        self._observer,
+                        provider="openai-codex",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        headers=headers,
+                        body=payload,
+                        attempt=attempt + 1,
+                        stream=True,
+                    )
                     async with client.stream(
                         "POST",
                         url,
                         json=payload,
                         headers=headers,
                     ) as response:
+                        observe_llm_response(
+                            self._observer,
+                            provider="openai-codex",
+                            model=model,
+                            method="POST",
+                            url=url,
+                            status_code=response.status_code,
+                            headers=response.headers,
+                            attempt=attempt + 1,
+                            stream=True,
+                        )
                         if response.status_code >= 400:
                             body = await response.aread()
                             body_text = body.decode(errors="replace")
+                            observe_llm_error(
+                                self._observer,
+                                provider="openai-codex",
+                                model=model,
+                                method="POST",
+                                url=url,
+                                attempt=attempt + 1,
+                                stream=True,
+                                error={
+                                    "type": "http_status",
+                                    "status_code": response.status_code,
+                                    "body": body_text,
+                                },
+                            )
                             if self._should_retry(
                                 attempt,
                                 status_code=response.status_code,
@@ -160,6 +204,19 @@ class OpenAICodexProvider:
                             yield event
                         return
                 except httpx.HTTPError as exc:
+                    observe_llm_error(
+                        self._observer,
+                        provider="openai-codex",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        attempt=attempt + 1,
+                        stream=True,
+                        error={
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        },
+                    )
                     if not emitted_content and self._should_retry(attempt):
                         delay = retry_delay_seconds(
                             attempt,
@@ -185,6 +242,19 @@ class OpenAICodexProvider:
                     )
                     return
                 except Exception as exc:  # noqa: BLE001 - provider errors are surfaced as events
+                    observe_llm_error(
+                        self._observer,
+                        provider="openai-codex",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        attempt=attempt + 1,
+                        stream=True,
+                        error={
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        },
+                    )
                     yield ProviderErrorEvent(message=str(exc), data={"attempts": attempt + 1})
                     return
 

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -19,6 +19,12 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.observability import (
+    LLMObserver,
+    observe_llm_error,
+    observe_llm_request,
+    observe_llm_response,
+)
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -31,10 +37,12 @@ class OpenAICompatibleProvider:
         config: OpenAICompatibleConfig,
         *,
         client: httpx.AsyncClient | None = None,
+        observer: LLMObserver | None = None,
     ) -> None:
         self._config = config
         self._client = client
         self._owns_client = client is None
+        self._observer = observer
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client if this provider created it."""
@@ -72,11 +80,48 @@ class OpenAICompatibleProvider:
             while True:
                 emitted_content = False
                 try:
+                    observe_llm_request(
+                        self._observer,
+                        provider="openai-compatible",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        headers=headers,
+                        body=payload,
+                        attempt=attempt + 1,
+                        stream=True,
+                    )
                     async with client.stream(
                         "POST", url, json=payload, headers=headers
                     ) as response:
+                        observe_llm_response(
+                            self._observer,
+                            provider="openai-compatible",
+                            model=model,
+                            method="POST",
+                            url=url,
+                            status_code=response.status_code,
+                            headers=response.headers,
+                            attempt=attempt + 1,
+                            stream=True,
+                        )
                         if response.status_code >= 400:
                             body = await response.aread()
+                            body_text = body.decode(errors="replace")
+                            observe_llm_error(
+                                self._observer,
+                                provider="openai-compatible",
+                                model=model,
+                                method="POST",
+                                url=url,
+                                attempt=attempt + 1,
+                                stream=True,
+                                error={
+                                    "type": "http_status",
+                                    "status_code": response.status_code,
+                                    "body": body_text,
+                                },
+                            )
                             if self._should_retry(attempt, status_code=response.status_code):
                                 delay = retry_delay_seconds(
                                     attempt,
@@ -89,7 +134,7 @@ class OpenAICompatibleProvider:
                                     reason=f"HTTP {response.status_code}",
                                     data={
                                         "status_code": response.status_code,
-                                        "body": body.decode(errors="replace"),
+                                        "body": body_text,
                                     },
                                 )
                                 attempt += 1
@@ -98,11 +143,10 @@ class OpenAICompatibleProvider:
                                 continue
                             yield ProviderErrorEvent(
                                 message=(
-                                    "Provider request failed with status "
-                                    f"{response.status_code}"
+                                    f"Provider request failed with status {response.status_code}"
                                 ),
                                 data={
-                                    "body": body.decode(errors="replace"),
+                                    "body": body_text,
                                     "attempts": attempt + 1,
                                 },
                             )
@@ -153,9 +197,7 @@ class OpenAICompatibleProvider:
                             for tool_call_delta in _tool_call_deltas(delta):
                                 emitted_content = True
                                 index = int(tool_call_delta.get("index", 0))
-                                builder = tool_call_builders.setdefault(
-                                    index, _ToolCallBuilder()
-                                )
+                                builder = tool_call_builders.setdefault(index, _ToolCallBuilder())
                                 builder.add_delta(tool_call_delta)
 
                         tool_calls = [
@@ -169,11 +211,22 @@ class OpenAICompatibleProvider:
                             content="".join(content_parts),
                             tool_calls=tool_calls,
                         )
-                        yield ProviderResponseEndEvent(
-                            message=message, finish_reason=finish_reason
-                        )
+                        yield ProviderResponseEndEvent(message=message, finish_reason=finish_reason)
                         return
                 except httpx.HTTPError as exc:
+                    observe_llm_error(
+                        self._observer,
+                        provider="openai-compatible",
+                        model=model,
+                        method="POST",
+                        url=url,
+                        attempt=attempt + 1,
+                        stream=True,
+                        error={
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        },
+                    )
                     if not emitted_content and self._should_retry(attempt):
                         delay = retry_delay_seconds(
                             attempt,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -12,11 +12,13 @@ from tau_ai import (
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES,
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS,
     DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
+    LLMObserver,
     ModelProvider,
 )
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
 from tau_coding import __version__
 from tau_coding.credentials import FileCredentialStore
+from tau_coding.diagnostics import llm_observer_from_env
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER_NAME,
@@ -422,10 +424,12 @@ async def run_openai_print_mode(
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     settings = load_provider_settings()
     selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
+    llm_observer = llm_observer_from_env()
     provider = create_model_provider(
         selection.provider,
         model=selection.model,
         thinking_level=DEFAULT_THINKING_LEVEL,
+        llm_observer=llm_observer,
     )
     manager = session_manager or SessionManager()
     record = manager.create_session(cwd=cwd, model=selection.model)
@@ -442,6 +446,7 @@ async def run_openai_print_mode(
             provider_name=selection.provider.name,
             provider_settings=settings,
             runtime_provider_config=selection.provider,
+            llm_observer=llm_observer,
         )
     finally:
         await provider.aclose()
@@ -461,6 +466,7 @@ async def run_print_mode(
     provider_name: str = DEFAULT_PROVIDER_NAME,
     provider_settings: ProviderSettings | None = None,
     runtime_provider_config: ProviderConfig | None = None,
+    llm_observer: LLMObserver | None = None,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -479,6 +485,7 @@ async def run_print_mode(
             provider_name=provider_name,
             provider_settings=provider_settings,
             runtime_provider_config=runtime_provider_config,
+            llm_observer=llm_observer,
         )
     )
     renderer = create_event_renderer(output)

--- a/src/tau_coding/diagnostics.py
+++ b/src/tau_coding/diagnostics.py
@@ -6,12 +6,16 @@ import json
 import traceback
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from os import environ
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 from tau_agent.events import ErrorEvent
+from tau_ai.observability import LLMObservation, LLMObserver
 from tau_coding.paths import TauPaths
+
+LLM_OBSERVABILITY_ENV = "TAU_LLM_OBSERVABILITY"
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +77,45 @@ class AgentCallDiagnosticLogger:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("a", encoding="utf-8") as file:
             file.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+class LLMObservationLogger(LLMObserver):
+    """Append opt-in redacted LLM request/response observations as JSONL."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @classmethod
+    def from_paths(cls, paths: TauPaths | None = None) -> LLMObservationLogger:
+        """Create a logger using Tau's default path layout."""
+        return cls((paths or TauPaths()).llm_observations_log_path)
+
+    def record(self, observation: LLMObservation) -> None:
+        """Append one already-redacted provider observation."""
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            **observation.to_json(),
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def llm_observability_enabled() -> bool:
+    """Return whether provider request observation is enabled for this process."""
+    return environ.get(LLM_OBSERVABILITY_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def llm_observer_from_env(paths: TauPaths | None = None) -> LLMObserver | None:
+    """Create the configured LLM observer, if provider observation is enabled."""
+    if not llm_observability_enabled():
+        return None
+    return LLMObservationLogger.from_paths(paths)
 
 
 def new_agent_call_run_id() -> str:

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -33,6 +33,11 @@ class TauPaths:
         return self.logs_dir / "agent-calls.jsonl"
 
     @property
+    def llm_observations_log_path(self) -> Path:
+        """Return the JSONL diagnostic log for opt-in LLM API observations."""
+        return self.logs_dir / "llm-observations.jsonl"
+
+    @property
     def user_skills_dir(self) -> Path:
         """Return Tau's user-level skills directory."""
         return self.home / "skills"

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from tau_ai import (
     AnthropicProvider,
+    LLMObserver,
     ModelProvider,
     OpenAICodexConfig,
     OpenAICodexCredentials,
@@ -41,12 +42,14 @@ def create_model_provider(
     credential_store: FileCredentialStore | None = None,
     model: str | None = None,
     thinking_level: ThinkingLevel | None = None,
+    llm_observer: LLMObserver | None = None,
 ) -> ClosableModelProvider:
     """Create a runtime model provider from durable provider settings."""
     credentials = credential_store or FileCredentialStore()
     if isinstance(provider, AnthropicProviderConfig):
         return AnthropicProvider(
-            anthropic_config_from_provider(provider, credential_reader=credentials)
+            anthropic_config_from_provider(provider, credential_reader=credentials),
+            observer=llm_observer,
         )
     if isinstance(provider, OpenAICodexProviderConfig):
         return OpenAICodexProvider(
@@ -60,7 +63,8 @@ def create_model_provider(
                 timeout_seconds=provider.timeout_seconds,
                 max_retries=provider.max_retries,
                 max_retry_delay_seconds=provider.max_retry_delay_seconds,
-            )
+            ),
+            observer=llm_observer,
         )
     return OpenAICompatibleProvider(
         openai_compatible_config_from_provider(
@@ -68,7 +72,8 @@ def create_model_provider(
             credential_reader=credentials,
             model=model,
             thinking_level=thinking_level,
-        )
+        ),
+        observer=llm_observer,
     )
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -29,7 +29,7 @@ from tau_agent.session import (
 from tau_agent.session.entries import SessionEntry
 from tau_agent.session.tree import SessionTreeError, path_to_entry
 from tau_agent.tools import AgentTool
-from tau_ai import ModelProvider
+from tau_ai import LLMObserver, ModelProvider
 from tau_coding.commands import CommandRegistry, CommandResult, create_default_command_registry
 from tau_coding.context import discover_project_context_with_diagnostics
 from tau_coding.context_window import (
@@ -159,6 +159,7 @@ class CodingSessionConfig:
     runtime_provider_config: ProviderConfig | None = None
     auto_compact_token_threshold: int | None = None
     thinking_level: ThinkingLevel = DEFAULT_THINKING_LEVEL
+    llm_observer: LLMObserver | None = None
 
 
 class CodingSession:
@@ -194,6 +195,7 @@ class CodingSession:
         self._provider_name = config.provider_name
         self._provider_settings = config.provider_settings
         self._runtime_provider_config = config.runtime_provider_config
+        self._llm_observer = config.llm_observer
         self._resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
         self._auto_compact_token_threshold = config.auto_compact_token_threshold
         self._thinking_level = _state_thinking_level(state, config.thinking_level)
@@ -613,6 +615,7 @@ class CodingSession:
                 credential_store=self._credential_store,
                 model=model,
                 thinking_level=thinking_level,
+                llm_observer=self._llm_observer,
             )
         except RuntimeError as exc:
             raise ProviderConfigError(str(exc)) from exc
@@ -702,6 +705,7 @@ class CodingSession:
                 credential_store=self._credential_store,
                 model=self.model,
                 thinking_level=self._thinking_level,
+                llm_observer=self._llm_observer,
             )
         except RuntimeError as exc:
             raise ProviderConfigError(str(exc)) from exc
@@ -760,6 +764,7 @@ class CodingSession:
                 runtime_provider_config=self._runtime_provider_config,
                 auto_compact_token_threshold=self._auto_compact_token_threshold,
                 thinking_level=self._thinking_level,
+                llm_observer=self._llm_observer,
             )
         )
         self._config = replacement._config
@@ -774,6 +779,7 @@ class CodingSession:
         self._provider_name = replacement._provider_name
         self._provider_settings = replacement._provider_settings
         self._runtime_provider_config = replacement._runtime_provider_config
+        self._llm_observer = replacement._llm_observer
         self._resource_paths = replacement._resource_paths
         self._auto_compact_token_threshold = replacement._auto_compact_token_threshold
         self._thinking_level = replacement._thinking_level
@@ -812,6 +818,7 @@ class CodingSession:
         self._provider_name = replacement._provider_name
         self._provider_settings = replacement._provider_settings
         self._runtime_provider_config = replacement._runtime_provider_config
+        self._llm_observer = replacement._llm_observer
         self._resource_paths = replacement._resource_paths
         self._auto_compact_token_threshold = replacement._auto_compact_token_threshold
         self._thinking_level = replacement._thinking_level
@@ -1163,10 +1170,10 @@ def _messages_after_entry_on_active_path(
     except StopIteration:
         return ()
     return tuple(
-        entry.message
-        for entry in active_path[target_index + 1 :]
-        if entry.type == "message"
+        entry.message for entry in active_path[target_index + 1 :] if entry.type == "message"
     )
+
+
 def _storage_path(storage: SessionStorage) -> Path | None:
     path = getattr(storage, "path", None)
     return path if isinstance(path, Path) else None

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -35,6 +35,7 @@ from tau_ai import ProviderErrorEvent, ProviderEvent
 from tau_ai.provider import CancellationToken
 from tau_coding.commands import CommandRegistry, create_default_command_registry
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.diagnostics import llm_observer_from_env
 from tau_coding.oauth import OAuthAuthInfo, OAuthPrompt, login_openai_codex
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
@@ -985,9 +986,7 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
         """Compose the model picker."""
         with Vertical(id="model-picker"):
             title = (
-                f"Model: {self.provider_name}"
-                if self.picker_kind == "model"
-                else "Scoped models"
+                f"Model: {self.provider_name}" if self.picker_kind == "model" else "Scoped models"
             )
             yield Static(title, id="model-picker-title")
             yield Static("", id="model-picker-tabs")
@@ -1149,7 +1148,10 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
             help_text = (
                 "all models: no matching models - Tab switches to scoped models"
                 if not self.visible_choices
-                else f"All models - Enter selects active model - Tab switches tabs - {scope_count} scoped"
+                else (
+                    "All models - Enter selects active model - Tab switches tabs - "
+                    f"{scope_count} scoped"
+                )
             )
         else:
             tabs.update("Tabs: ○ All models  ● Scoped models")
@@ -1925,7 +1927,7 @@ class TauTuiApp(App[None]):
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen
-            | ThemePickerScreen
+            | ThemePickerScreen,
         ):
             self.screen.action_select_cursor()
             return
@@ -2966,11 +2968,13 @@ async def run_tui_app(
     )
     startup_message: str | None = None
     runtime_provider_config: ProviderConfig | None = selection.provider
+    llm_observer = llm_observer_from_env()
     try:
         provider = create_model_provider(
             selection.provider,
             model=selection.model,
             thinking_level=DEFAULT_THINKING_LEVEL,
+            llm_observer=llm_observer,
         )
     except RuntimeError:
         startup_message = (
@@ -3002,6 +3006,7 @@ async def run_tui_app(
                 provider_settings=provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=auto_compact_token_threshold,
+                llm_observer=llm_observer,
             )
         )
         app = TauTuiApp(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -442,8 +442,9 @@ async def test_session_refreshes_runtime_provider_for_thinking_level(
         credential_store: FileCredentialStore | None = None,
         model: str | None = None,
         thinking_level: str | None = None,
+        llm_observer: object | None = None,
     ) -> SwitchableFakeProvider:
-        del provider_config, credential_store
+        del provider_config, credential_store, llm_observer
         created.append((model, thinking_level))
         return SwitchableFakeProvider(object())
 
@@ -1067,8 +1068,9 @@ async def test_session_switches_configured_provider(
         credential_store: FileCredentialStore | None = None,
         model: str | None = None,
         thinking_level: str | None = None,
+        llm_observer: object | None = None,
     ) -> SwitchableFakeProvider:
-        del credential_store, model, thinking_level
+        del credential_store, model, thinking_level, llm_observer
         provider = SwitchableFakeProvider(provider_config)
         created_providers.append(provider)
         return provider
@@ -1137,8 +1139,9 @@ async def test_session_switch_uses_session_credential_store(
         credential_store: FileCredentialStore | None = None,
         model: str | None = None,
         thinking_level: str | None = None,
+        llm_observer: object | None = None,
     ) -> SwitchableFakeProvider:
-        del provider_config, model, thinking_level
+        del provider_config, model, thinking_level, llm_observer
         assert credential_store is not None
         credential_store_paths.append(credential_store.path)
         return SwitchableFakeProvider(object())

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+from tau_ai import LLMObservation
+from tau_coding.diagnostics import (
+    LLM_OBSERVABILITY_ENV,
+    LLMObservationLogger,
+    llm_observer_from_env,
+)
+from tau_coding.paths import TauPaths
+
+
+def test_llm_observer_from_env_is_disabled_by_default(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv(LLM_OBSERVABILITY_ENV, raising=False)
+
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+
+    assert llm_observer_from_env(paths) is None
+
+
+def test_llm_observer_from_env_writes_jsonl_when_enabled(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(LLM_OBSERVABILITY_ENV, "1")
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+
+    observer = llm_observer_from_env(paths)
+
+    assert isinstance(observer, LLMObservationLogger)
+    observer.record(
+        LLMObservation(
+            kind="request",
+            provider="openai-compatible",
+            model="test-model",
+            method="POST",
+            url="https://example.test/v1/chat/completions",
+            attempt=1,
+            stream=True,
+            data={"request": {"headers": {"Authorization": "[REDACTED]"}}},
+        )
+    )
+
+    lines = paths.llm_observations_log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["kind"] == "request"
+    assert entry["provider"] == "openai-compatible"
+    assert entry["model"] == "test-model"
+    assert entry["data"]["request"]["headers"]["Authorization"] == "[REDACTED]"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -7,6 +7,8 @@ def test_tau_paths_user_locations(tmp_path: Path) -> None:
     paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
 
     assert paths.sessions_dir == tmp_path / ".tau" / "sessions"
+    assert paths.agent_calls_log_path == tmp_path / ".tau" / "logs" / "agent-calls.jsonl"
+    assert paths.llm_observations_log_path == tmp_path / ".tau" / "logs" / "llm-observations.jsonl"
     assert paths.user_skills_dir == tmp_path / ".tau" / "skills"
     assert paths.user_prompts_dir == tmp_path / ".tau" / "prompts"
     assert paths.user_agents_skills_dir == tmp_path / ".agents" / "skills"

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncIterator, Mapping
-from json import loads
+from json import dumps, loads
 
 import httpx
 import pytest
@@ -10,6 +10,7 @@ from tau_ai import (
     AnthropicConfig,
     AnthropicProvider,
     FakeProvider,
+    LLMObservation,
     OpenAICodexConfig,
     OpenAICodexCredentials,
     OpenAICodexProvider,
@@ -23,11 +24,21 @@ from tau_ai import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
     openai_compatible_config_from_env,
+    redact_headers,
+    redact_json_value,
 )
 
 
 async def _collect(stream: AsyncIterator[object]) -> list[object]:
     return [event async for event in stream]
+
+
+class RecordingLLMObserver:
+    def __init__(self) -> None:
+        self.records: list[LLMObservation] = []
+
+    def record(self, observation: LLMObservation) -> None:
+        self.records.append(observation)
 
 
 @pytest.mark.anyio
@@ -87,6 +98,46 @@ def test_openai_compatible_config_from_env_rejects_invalid_retry_settings(
 
     with pytest.raises(RuntimeError, match="0 or greater"):
         openai_compatible_config_from_env()
+
+
+def test_llm_observation_redacts_headers_and_prompt_like_text() -> None:
+    headers = redact_headers(
+        {
+            "Authorization": "Bearer secret-key",
+            "X-Api-Key": "api-secret",
+            "X-HF-Bill-To": "my-org",
+        }
+    )
+
+    assert headers["Authorization"] == "[REDACTED]"
+    assert headers["X-Api-Key"] == "[REDACTED]"
+    assert headers["X-HF-Bill-To"] == "my-org"
+
+    body = redact_json_value(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "secret prompt"}],
+            "input": {"type": "function_call", "path": "/private/file.txt"},
+        }
+    )
+
+    assert isinstance(body, dict)
+    assert body["model"] == "test-model"
+    messages = body["messages"]
+    assert isinstance(messages, list)
+    message = messages[0]
+    assert isinstance(message, dict)
+    assert message["role"] == "user"
+    content = message["content"]
+    assert isinstance(content, dict)
+    assert content["redacted"] is True
+    assert content["length"] == len("secret prompt")
+    input_value = body["input"]
+    assert isinstance(input_value, dict)
+    assert input_value["type"] == "function_call"
+    path = input_value["path"]
+    assert isinstance(path, dict)
+    assert path["redacted"] is True
 
 
 @pytest.mark.anyio
@@ -165,6 +216,91 @@ async def test_openai_compatible_provider_formats_request_and_streams_text() -> 
         {"role": "system", "content": "You are Tau."},
         {"role": "user", "content": "Say hello"},
     ]
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_observes_redacted_request_and_response() -> None:
+    observer = RecordingLLMObserver()
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n',
+            headers={"content-type": "text/event-stream", "x-request-id": "req-1"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+            observer=observer,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="system secret",
+                messages=[UserMessage(content="user secret")],
+                tools=[],
+            )
+        )
+
+    assert [record.kind for record in observer.records] == ["request", "response"]
+    request = observer.records[0]
+    assert request.provider == "openai-compatible"
+    assert request.model == "test-model"
+    assert request.method == "POST"
+    assert request.url == "https://example.test/v1/chat/completions"
+    assert request.attempt == 1
+    assert request.stream is True
+    assert request.data["request"]["headers"]["Authorization"] == "[REDACTED]"  # type: ignore[index]
+    request_body = request.data["request"]["body"]  # type: ignore[index]
+    assert request_body["model"] == "test-model"  # type: ignore[index]
+    assert request_body["stream"] is True  # type: ignore[index]
+    system_content = request_body["messages"][0]["content"]  # type: ignore[index]
+    user_content = request_body["messages"][1]["content"]  # type: ignore[index]
+    assert system_content["redacted"] is True  # type: ignore[index]
+    assert system_content["length"] == len("system secret")  # type: ignore[index]
+    assert user_content["redacted"] is True  # type: ignore[index]
+    assert "system secret" not in dumps(request.to_json())
+    assert "user secret" not in dumps(request.to_json())
+    assert "test-key" not in dumps(request.to_json())
+
+    response = observer.records[1]
+    assert response.data["response"]["status_code"] == 200  # type: ignore[index]
+    assert response.data["response"]["headers"]["x-request-id"] == "req-1"  # type: ignore[index]
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_observes_redacted_error_body() -> None:
+    observer = RecordingLLMObserver()
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="bad request includes user secret")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+            observer=observer,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert [record.kind for record in observer.records] == ["request", "response", "error"]
+    error = observer.records[-1]
+    error_body = error.data["error"]["body"]  # type: ignore[index]
+    assert error_body["redacted"] is True  # type: ignore[index]
+    assert error_body["length"] == len("bad request includes user secret")  # type: ignore[index]
+    assert "bad request includes user secret" not in dumps(error.to_json())
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #54.

This adds the first opt-in path for observing raw or near-raw LLM API traffic without coupling the reusable agent harness to app diagnostics or local filesystem policy.

Design decision:
- Capture lives provider-adjacent in `tau_ai`, where the final provider URL, headers, serialized body, HTTP status, and provider errors exist.
- Persistence and enablement live in `tau_coding`, where Tau already owns diagnostics and `~/.tau/logs`.
- `tau_agent` remains untouched and continues to see only provider-neutral messages, tools, and events.

Minimal implementation:
- Adds `LLMObservation` / `LLMObserver` primitives and mandatory redaction helpers.
- Emits request, response metadata, and error observations from OpenAI-compatible, Anthropic, and OpenAI Codex providers.
- Enables JSONL logging with `TAU_LLM_OBSERVABILITY=1` to `~/.tau/logs/llm-observations.jsonl`.
- Redacts credential-like headers and prompt-like body text by default, preserving structural metadata such as model, role, type, tool names, URLs, status codes, lengths, and hashes.
- Documents the architecture, privacy tradeoffs, usage, and deferred work such as streamed chunk capture or a TUI/export view.

## Validation

Passed:
- `uv run pytest` — 424 passed
- `uv run --group docs mkdocs build --strict`
- changed-module mypy: `uv run mypy src/tau_ai src/tau_coding/diagnostics.py src/tau_coding/paths.py src/tau_coding/provider_runtime.py src/tau_coding/session.py src/tau_coding/cli.py src/tau_coding/tui/app.py`
- touched-file ruff format/check

Known unrelated existing repo-wide failures:
- `uv run mypy` still fails in `src/tau_coding/tools.py` at lines 588, 599, and 604.
- repo-wide `uv run ruff check src tests` still reports unrelated existing issues in `src/tau_coding/tui/widgets.py` and `tests/test_commands.py`.
- repo-wide `uv run ruff format --check src tests` still reports unrelated existing formatting drift in several files, including `src/tau_agent/session/memory.py`, `src/tau_ai/retry.py`, `src/tau_coding/context_window.py`, `src/tau_coding/provider_config.py`, and some tests.
- MkDocs prints a non-fatal Material/MkDocs 2.0 warning and notes the existing unnaved `architecture/phase-24-session-tree-branching.md` page.