### PR TITLE
Issue #104: Tune /reload behavior

### DIFF
--- a/docs/architecture/phase-15-slash-command-registry.md
+++ b/docs/architecture/phase-15-slash-command-registry.md
@@ -44,7 +44,7 @@ The default registry includes:
 - `/resume` — open previous-session selection or resume a specific session id
 - `/model` — choose or switch the current model
 - `/login` — add or refresh a built-in provider login
-- `/reload` — reload resources and provider configuration
+- `/reload` — reload local resources and project context
 - `/name` — rename the current session
 - `/theme` — show or set the TUI theme
 

--- a/docs/architecture/phase-18-provider-config-foundation.md
+++ b/docs/architecture/phase-18-provider-config-foundation.md
@@ -131,8 +131,10 @@ process when the model is known for the active provider.
 
 In the TUI, `/model` opens an interactive picker. The picker can include models
 from every configured provider, so selecting a model can switch the active
-provider behind the scenes. `/login` is the TUI path for adding or refreshing a
-built-in provider.
+provider behind the scenes. The model command refreshes provider settings before
+validating or showing choices. `/login` is the TUI path for adding or refreshing
+a built-in provider, and it refreshes provider settings after credentials are
+saved.
 
 The same provider settings file can also store scoped models:
 

--- a/docs/architecture/phase-19-context-discovery.md
+++ b/docs/architecture/phase-19-context-discovery.md
@@ -69,11 +69,15 @@ Tau now has:
 - prompt templates
 - project context files
 - resource diagnostics
-- provider settings used by `/login` and `/model`
 
-When the session is using Tau's generated system prompt, reload also rebuilds
-the harness system string so the next model request sees the updated resources
-and context. The transcript and session tree are left untouched.
+When the session is using Tau's generated system prompt, reload rebuilds the
+harness system string only when the resources that feed that prompt changed.
+The transcript and session tree are left untouched.
+
+`/reload` does not refresh provider configuration. Provider/model settings are
+refreshed by the provider-specific flows that use them, such as `/login` after
+saving credentials and `/model` before validating choices or opening the model
+picker.
 
 `/status` and `/resources` also include the current context-file count.
 
@@ -81,8 +85,8 @@ and context. The transcript and session tree are left untouched.
 
 Reload is a `tau_coding` operation. It updates the coding-session environment
 around the harness, then gives the harness a rebuilt system string for future
-turns. `tau_agent` does not know where skills, prompts, context files, or
-provider settings come from.
+turns when needed. `tau_agent` does not know where skills, prompts, or context
+files come from.
 
 ## Tests
 
@@ -102,4 +106,5 @@ The tests verify:
 - discovered context included in print-mode system prompts
 - `/context`, `/status`, and `/resources` command output
 - `/reload` command output
-- reload updating resources and the next-turn system prompt
+- reload updating resources and the next-turn system prompt only when prompt
+  inputs changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,9 @@ Useful TUI commands:
 /theme tau-light
 ```
 
+`/reload` refreshes local coding resources and project instruction context for
+future turns. Provider settings are refreshed by `/login` and `/model` instead.
+
 In the TUI, `Shift-Tab` cycles the active thinking mode by default. `Ctrl+T`
 toggles display of streamed thinking/reasoning tokens when the active provider
 emits them. Thinking tokens are hidden by default and can be remapped in

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -126,14 +126,14 @@ Inside the TUI:
 /model
 /model qwen
 /login
-/reload
 ```
 
 `/model` opens the interactive model picker. The picker includes models from
 configured providers, so selecting a model can also switch the active runtime
-provider. `/login` adds or refreshes a built-in provider, including
-OAuth-backed providers such as `openai-codex`, and `/reload` refreshes provider
-settings for future command use.
+provider. The model flow refreshes provider settings before it validates or
+shows choices. `/login` adds or refreshes a built-in provider, including
+OAuth-backed providers such as `openai-codex`, and refreshes provider settings
+after saving credentials.
 
 When Tau loads `~/.tau/providers.json`, it merges the current built-in model
 catalog into built-in provider entries such as Hugging Face. Custom models and

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -8,6 +8,7 @@ from typing import Protocol
 from tau_agent.tools import AgentTool
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_catalog import BUILTIN_PROVIDER_CATALOG, builtin_provider_entry
+from tau_coding.reload import CodingReloadSummary, ReloadCategorySummary
 from tau_coding.resources import ResourceDiagnostic
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.skills import Skill
@@ -70,7 +71,9 @@ class CommandSession(Protocol):
 
     def set_model(self, model: str) -> None: ...
 
-    def reload(self) -> None: ...
+    def reload(self) -> CodingReloadSummary: ...
+
+    def reload_provider_settings(self) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,7 +240,7 @@ def create_default_command_registry() -> CommandRegistry:
         SlashCommand(
             name="reload",
             usage="/reload",
-            description="Reload resources and provider configuration.",
+            description="Reload local resources and project context.",
             handler=_reload_command,
         )
     )
@@ -428,21 +431,13 @@ def _resources_command(context: CommandContext) -> CommandResult:
 
 def _reload_command(context: CommandContext) -> CommandResult:
     try:
-        context.session.reload()
+        summary = context.session.reload()
     except ValueError as exc:
         return CommandResult(handled=True, message=f"Could not reload: {exc}")
 
-    session = context.session
     return CommandResult(
         handled=True,
-        message=(
-            "Reloaded resources and provider configuration.\n"
-            f"Skills: {len(session.skills)}\n"
-            f"Prompt templates: {len(session.prompt_templates)}\n"
-            f"Context files: {len(session.context_files)}\n"
-            f"Providers: {len(session.available_providers)}\n"
-            f"Resource diagnostics: {len(session.resource_diagnostics)}"
-        ),
+        message=_format_reload_summary(summary),
     )
 
 
@@ -535,6 +530,10 @@ def _format_sessions(context: CommandContext) -> str:
 
 
 def _model_command(context: CommandContext) -> CommandResult:
+    refresh_error = _refresh_provider_settings(context.session)
+    if refresh_error is not None:
+        return refresh_error
+
     if context.args:
         model = context.args.strip()
         available_models = set(context.session.available_models)
@@ -552,6 +551,10 @@ def _model_command(context: CommandContext) -> CommandResult:
 
 
 def _scoped_models_command(context: CommandContext) -> CommandResult:
+    refresh_error = _refresh_provider_settings(context.session)
+    if refresh_error is not None:
+        return refresh_error
+
     if context.args:
         return CommandResult(handled=True, message="Usage: /scoped-models")
     return CommandResult(handled=True, scoped_models_picker_requested=True)
@@ -644,6 +647,48 @@ def _format_diagnostics(
     lines = ["Resource diagnostics:"]
     lines.extend(f"- {diagnostic.format()}" for diagnostic in filtered)
     return lines
+
+
+def _refresh_provider_settings(session: CommandSession) -> CommandResult | None:
+    try:
+        session.reload_provider_settings()
+    except ValueError as exc:
+        return CommandResult(
+            handled=True,
+            message=f"Could not refresh provider settings: {exc}",
+        )
+    return None
+
+
+def _format_reload_summary(summary: CodingReloadSummary) -> str:
+    lines = [
+        "Reloaded local coding resources and project context.",
+        "Resources:",
+        f"- Skills: {_format_reload_category(summary.skills)}",
+        f"- Prompt templates: {_format_reload_category(summary.prompt_templates)}",
+        "Context:",
+        f"- Project context files: {_format_reload_category(summary.context_files)}",
+        "- Next-turn system prompt: "
+        + ("rebuilt" if summary.system_prompt_rebuilt else "unchanged"),
+        "Diagnostics:",
+        f"- Resource diagnostics: {_format_reload_category(summary.diagnostics)}",
+        "Provider config:",
+        "- Not refreshed by /reload; use /login or /model for provider/model settings.",
+    ]
+    return "\n".join(lines)
+
+
+def _format_reload_category(summary: ReloadCategorySummary) -> str:
+    status = "changed" if summary.changed else "unchanged"
+    delta = _format_count_delta(summary.delta)
+    suffix = f", {delta}" if delta is not None else ""
+    return f"{summary.after} total ({status}{suffix})"
+
+
+def _format_count_delta(delta: int) -> str | None:
+    if delta == 0:
+        return None
+    return f"{delta:+d}"
 
 
 def _parse_command(text: str) -> tuple[str, str]:

--- a/src/tau_coding/reload.py
+++ b/src/tau_coding/reload.py
@@ -1,0 +1,28 @@
+"""Reload summary types for Tau coding-session resources."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ReloadCategorySummary:
+    """Before/after state for one reload category."""
+
+    before: int
+    after: int
+    changed: bool
+
+    @property
+    def delta(self) -> int:
+        """Return the count delta for this category."""
+        return self.after - self.before
+
+
+@dataclass(frozen=True, slots=True)
+class CodingReloadSummary:
+    """Summary of a local coding-resource reload."""
+
+    skills: ReloadCategorySummary
+    prompt_templates: ReloadCategorySummary
+    context_files: ReloadCategorySummary
+    diagnostics: ReloadCategorySummary
+    system_prompt_rebuilt: bool

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -60,6 +60,7 @@ from tau_coding.provider_config import (
     save_provider_settings,
 )
 from tau_coding.provider_runtime import ClosableModelProvider, create_model_provider
+from tau_coding.reload import CodingReloadSummary, ReloadCategorySummary
 from tau_coding.resources import (
     ResourceDiagnostic,
     ResourceError,
@@ -709,28 +710,78 @@ class CodingSession:
         self._harness.config.provider = provider
         self._runtime_provider_config = provider_config
 
-    def reload(self) -> None:
-        """Reload Tau-owned resources and provider settings for future turns."""
+    def reload(self) -> CodingReloadSummary:
+        """Reload local coding resources and project context for future turns."""
+        before_skills = _skill_signatures(self._skills)
+        before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
+        before_context_files = _context_file_signatures(self._context_files)
+        before_diagnostics = _diagnostic_signatures(self._resource_diagnostics)
+        before_system_prompt_inputs = _system_prompt_resource_signatures(
+            skills=self._skills,
+            context_files=self._context_files,
+        )
+
         resources = _load_session_resources(self._resource_paths, self._config.context_files)
+
+        after_skills = _skill_signatures(resources.skills)
+        after_prompt_templates = _prompt_template_signatures(resources.prompt_templates)
+        after_context_files = _context_file_signatures(resources.context_files)
+        after_diagnostics = _diagnostic_signatures(resources.diagnostics)
+        after_system_prompt_inputs = _system_prompt_resource_signatures(
+            skills=resources.skills,
+            context_files=resources.context_files,
+        )
+
+        rebuilt_system_prompt: str | None = None
+        system_prompt_rebuilt = False
+        if (
+            self._config.system is None
+            and before_system_prompt_inputs != after_system_prompt_inputs
+        ):
+            rebuilt_system_prompt = build_system_prompt(
+                BuildSystemPromptOptions(
+                    cwd=self._config.cwd,
+                    tools=self._harness.config.tools,
+                    skills=resources.skills,
+                    custom_prompt=self._config.custom_system_prompt,
+                    append_system_prompt=self._config.append_system_prompt,
+                    context_files=resources.context_files,
+                )
+            )
+            system_prompt_rebuilt = True
+
         self._skills = resources.skills
         self._prompt_templates = resources.prompt_templates
         self._context_files = resources.context_files
         self._resource_diagnostics = resources.diagnostics
-        if self._provider_settings is not None:
-            self._provider_settings = load_provider_settings()
+        if rebuilt_system_prompt is not None:
+            self._harness.config.system = rebuilt_system_prompt
+
+        return CodingReloadSummary(
+            skills=_category_summary(before_skills, after_skills),
+            prompt_templates=_category_summary(
+                before_prompt_templates,
+                after_prompt_templates,
+            ),
+            context_files=_category_summary(before_context_files, after_context_files),
+            diagnostics=_category_summary(before_diagnostics, after_diagnostics),
+            system_prompt_rebuilt=system_prompt_rebuilt,
+        )
+
+    def reload_provider_settings(self) -> None:
+        """Reload provider settings for login and model-selection flows."""
+        if self._provider_settings is None:
+            return
+        previous_settings = self._provider_settings
+        previous_thinking_level = self._thinking_level
+        self._provider_settings = load_provider_settings(self._resource_paths.paths)
+        try:
             self._sync_thinking_level_to_active_model()
             self._refresh_runtime_provider()
-        if self._config.system is None:
-            self._harness.config.system = build_system_prompt(
-                BuildSystemPromptOptions(
-                    cwd=self._config.cwd,
-                    tools=self._harness.config.tools,
-                    skills=self._skills,
-                    custom_prompt=self._config.custom_system_prompt,
-                    append_system_prompt=self._config.append_system_prompt,
-                    context_files=self._context_files,
-                )
-            )
+        except ProviderConfigError:
+            self._provider_settings = previous_settings
+            self._thinking_level = previous_thinking_level
+            raise
 
     async def resume(self, session_id: str) -> str:
         """Replace this session's active state with another indexed session."""
@@ -1163,10 +1214,10 @@ def _messages_after_entry_on_active_path(
     except StopIteration:
         return ()
     return tuple(
-        entry.message
-        for entry in active_path[target_index + 1 :]
-        if entry.type == "message"
+        entry.message for entry in active_path[target_index + 1 :] if entry.type == "message"
     )
+
+
 def _storage_path(storage: SessionStorage) -> Path | None:
     path = getattr(storage, "path", None)
     return path if isinstance(path, Path) else None
@@ -1254,6 +1305,65 @@ def parse_terminal_command(text: str) -> TerminalCommandRequest | None:
             return None
         return TerminalCommandRequest(command=command, add_to_context=True)
     return None
+
+
+def _category_summary(
+    before: tuple[tuple[object, ...], ...],
+    after: tuple[tuple[object, ...], ...],
+) -> ReloadCategorySummary:
+    return ReloadCategorySummary(
+        before=len(before),
+        after=len(after),
+        changed=before != after,
+    )
+
+
+def _skill_signatures(skills: tuple[Skill, ...]) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (skill.name, str(skill.path), skill.description, skill.content) for skill in skills
+    )
+
+
+def _prompt_template_signatures(
+    prompt_templates: tuple[PromptTemplate, ...],
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (template.name, str(template.path), template.description, template.content)
+        for template in prompt_templates
+    )
+
+
+def _context_file_signatures(
+    context_files: tuple[ProjectContextFile, ...],
+) -> tuple[tuple[object, ...], ...]:
+    return tuple((context_file.path, context_file.content) for context_file in context_files)
+
+
+def _diagnostic_signatures(
+    diagnostics: tuple[ResourceDiagnostic, ...],
+) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (
+            diagnostic.kind,
+            diagnostic.message,
+            str(diagnostic.path) if diagnostic.path is not None else None,
+            diagnostic.name,
+            diagnostic.severity,
+        )
+        for diagnostic in diagnostics
+    )
+
+
+def _system_prompt_resource_signatures(
+    *,
+    skills: tuple[Skill, ...],
+    context_files: tuple[ProjectContextFile, ...],
+) -> tuple[tuple[object, ...], tuple[object, ...]]:
+    prompt_skills = tuple(
+        (skill.name, str(skill.path), skill.description)
+        for skill in sorted(skills, key=lambda item: item.name)
+    )
+    return (prompt_skills, _context_file_signatures(context_files))
 
 
 def _load_session_resources(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -985,9 +985,7 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
         """Compose the model picker."""
         with Vertical(id="model-picker"):
             title = (
-                f"Model: {self.provider_name}"
-                if self.picker_kind == "model"
-                else "Scoped models"
+                f"Model: {self.provider_name}" if self.picker_kind == "model" else "Scoped models"
             )
             yield Static(title, id="model-picker-title")
             yield Static("", id="model-picker-tabs")
@@ -1149,7 +1147,10 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
             help_text = (
                 "all models: no matching models - Tab switches to scoped models"
                 if not self.visible_choices
-                else f"All models - Enter selects active model - Tab switches tabs - {scope_count} scoped"
+                else (
+                    "All models - Enter selects active model - Tab switches tabs - "
+                    f"{scope_count} scoped"
+                )
             )
         else:
             tabs.update("Tabs: ○ All models  ● Scoped models")
@@ -1925,7 +1926,7 @@ class TauTuiApp(App[None]):
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen
-            | ThemePickerScreen
+            | ThemePickerScreen,
         ):
             self.screen.action_select_cursor()
             return
@@ -2198,7 +2199,7 @@ class TauTuiApp(App[None]):
             settings = load_provider_settings()
             provider = provider_config_from_catalog_entry(entry.name)
             save_provider_settings(upsert_provider(settings, provider, set_default=True))
-            self.session.reload()
+            self.session.reload_provider_settings()
             self.session.set_provider(entry.name)
         except Exception as exc:  # noqa: BLE001 - surface login failures in the TUI
             self._notify(f"Could not save login: {exc}", severity="error")
@@ -2218,7 +2219,7 @@ class TauTuiApp(App[None]):
             settings = load_provider_settings()
             provider = provider_config_from_catalog_entry(entry.name)
             save_provider_settings(upsert_provider(settings, provider, set_default=True))
-            self.session.reload()
+            self.session.reload_provider_settings()
             self.session.set_provider(entry.name)
         except Exception as exc:  # noqa: BLE001 - surface login failures in the TUI
             self._notify(f"Could not save login: {exc}", severity="error")

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -953,16 +953,118 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
     )
     (tmp_path / "AGENTS.md").write_text("Reloaded project rules.", encoding="utf-8")
 
+    entries_before = await storage.read_all()
     result = session.handle_command("/reload")
+    entries_after = await storage.read_all()
     _events = await _collect_session_events(session.prompt("Hello"))
 
     assert result.message is not None
-    assert "Skills: 1" in result.message
-    assert "Context files: 1" in result.message
+    assert "Reloaded local coding resources and project context." in result.message
+    assert "Skills: 1 total (changed, +1)" in result.message
+    assert "Project context files: 1 total (changed, +1)" in result.message
+    assert "Next-turn system prompt: rebuilt" in result.message
+    assert "Not refreshed by /reload" in result.message
+    assert entries_after == entries_before
     assert [skill.name for skill in session.skills] == ["testing"]
     assert [Path(context_file.path).name for context_file in session.context_files] == ["AGENTS.md"]
     assert "Reloaded project rules." in provider.calls[0][1]
     assert "<name>testing</name>" in provider.calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_session_reload_skips_provider_settings_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_load_provider_settings(paths: TauPaths | None = None) -> ProviderSettings:
+        del paths
+        raise AssertionError("/reload should not refresh provider settings")
+
+    monkeypatch.setattr(
+        coding_session_module,
+        "load_provider_settings",
+        fail_load_provider_settings,
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_settings=ProviderSettings(
+                providers=(OpenAICompatibleProviderConfig(name="openai"),)
+            ),
+        )
+    )
+
+    result = session.handle_command("/reload")
+
+    assert result.message is not None
+    assert "Provider config:" in result.message
+    assert "Not refreshed by /reload" in result.message
+
+
+@pytest.mark.anyio
+async def test_session_reload_leaves_system_prompt_when_inputs_are_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    def fail_build_system_prompt(options: object) -> str:
+        del options
+        raise AssertionError("system prompt should not be rebuilt")
+
+    monkeypatch.setattr(
+        coding_session_module,
+        "build_system_prompt",
+        fail_build_system_prompt,
+    )
+
+    result = session.handle_command("/reload")
+
+    assert result.message is not None
+    assert "Next-turn system prompt: unchanged" in result.message
+
+
+@pytest.mark.anyio
+async def test_session_provider_settings_reload_uses_session_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tau_paths = TauPaths(home=tmp_path / "tau-home", agents_home=tmp_path / "agents-home")
+    seen_paths: list[TauPaths | None] = []
+
+    def load_provider_settings(paths: TauPaths | None = None) -> ProviderSettings:
+        seen_paths.append(paths)
+        return ProviderSettings(providers=(OpenAICompatibleProviderConfig(name="openai"),))
+
+    monkeypatch.setattr(coding_session_module, "load_provider_settings", load_provider_settings)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "provider-reload-session.jsonl"),
+            cwd=tmp_path,
+            provider_settings=ProviderSettings(
+                providers=(OpenAICompatibleProviderConfig(name="openai"),)
+            ),
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    session.reload_provider_settings()
+
+    assert seen_paths == [tau_paths]
 
 
 @pytest.mark.anyio

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from tau_coding.commands import CommandRegistry, SlashCommand, create_default_command_registry
 from tau_coding.paths import TauPaths
-from tau_coding.resources import ResourceDiagnostic
+from tau_coding.reload import CodingReloadSummary, ReloadCategorySummary
 from tau_coding.session import ModelChoice
 from tau_coding.session_manager import SessionManager
 from tau_coding.skills import Skill
@@ -44,6 +44,7 @@ class FakeSession:
         self.session_id = "session-1"
         self.session_manager: SessionManager | None = manager
         self.reload_called = False
+        self.provider_reload_called = False
 
     def set_model(self, model: str) -> None:
         self.model = model
@@ -53,8 +54,30 @@ class FakeSession:
         self.model = "local-model"
         self.available_models = ("local-model",)
 
-    def reload(self) -> None:
+    def reload(self) -> CodingReloadSummary:
         self.reload_called = True
+        return CodingReloadSummary(
+            skills=ReloadCategorySummary(before=0, after=len(self.skills), changed=True),
+            prompt_templates=ReloadCategorySummary(
+                before=0,
+                after=len(self.prompt_templates),
+                changed=False,
+            ),
+            context_files=ReloadCategorySummary(
+                before=0,
+                after=len(self.context_files),
+                changed=True,
+            ),
+            diagnostics=ReloadCategorySummary(
+                before=0,
+                after=len(self.resource_diagnostics),
+                changed=False,
+            ),
+            system_prompt_rebuilt=True,
+        )
+
+    def reload_provider_settings(self) -> None:
+        self.provider_reload_called = True
 
 
 def test_registry_ignores_ordinary_prompts_and_skill_expansion(tmp_path: Path) -> None:
@@ -154,7 +177,10 @@ def test_session_command_includes_session_details(tmp_path: Path) -> None:
     assert "Auto compact threshold: 200" in result.message
     assert "Resource diagnostics: 0" in result.message
     assert "Session: session-1" in result.message
-    assert create_default_command_registry().execute(FakeSession(tmp_path), "/status").message == "Unknown command: /status"
+    assert (
+        create_default_command_registry().execute(FakeSession(tmp_path), "/status").message
+        == "Unknown command: /status"
+    )
 
 
 def test_hotkeys_command_lists_common_tui_shortcuts(tmp_path: Path) -> None:
@@ -177,6 +203,7 @@ def test_model_command_requests_picker_and_switches_models(tmp_path: Path) -> No
     assert list_result.model_picker_requested is True
     assert switch_result.message == "Current model: other-model"
     assert session.model == "other-model"
+    assert session.provider_reload_called is True
 
 
 def test_scoped_models_command_requests_scoped_picker(tmp_path: Path) -> None:
@@ -188,6 +215,7 @@ def test_scoped_models_command_requests_scoped_picker(tmp_path: Path) -> None:
 
     assert dashed_result.scoped_models_picker_requested is True
     assert pi_style_result.scoped_models_picker_requested is True
+    assert session.provider_reload_called is True
 
 
 def test_model_command_rejects_unknown_model(tmp_path: Path) -> None:
@@ -198,6 +226,17 @@ def test_model_command_rejects_unknown_model(tmp_path: Path) -> None:
     assert result.message is not None
     assert "Unknown model for provider openai: missing" in result.message
     assert session.model == "fake-model"
+
+
+def test_model_command_reports_provider_refresh_failure(tmp_path: Path) -> None:
+    class FailingRefreshSession(FakeSession):
+        def reload_provider_settings(self) -> None:
+            raise ValueError("providers.json is invalid")
+
+    result = create_default_command_registry().execute(FailingRefreshSession(tmp_path), "/model")
+
+    assert result.message == "Could not refresh provider settings: providers.json is invalid"
+    assert result.model_picker_requested is False
 
 
 def test_theme_command_requests_picker_and_sets_theme(tmp_path: Path) -> None:
@@ -244,12 +283,16 @@ def test_reload_command_refreshes_session_resources(tmp_path: Path) -> None:
     result = create_default_command_registry().execute(session, "/reload")
 
     assert result.message is not None
-    assert "Reloaded resources and provider configuration." in result.message
-    assert "Skills: 1" in result.message
-    assert "Prompt templates: 0" in result.message
-    assert "Context files: 1" in result.message
-    assert "Providers: 2" in result.message
+    assert "Reloaded local coding resources and project context." in result.message
+    assert "Resources:" in result.message
+    assert "Skills: 1 total (changed, +1)" in result.message
+    assert "Prompt templates: 0 total (unchanged)" in result.message
+    assert "Project context files: 1 total (changed, +1)" in result.message
+    assert "Next-turn system prompt: rebuilt" in result.message
+    assert "Provider config:" in result.message
+    assert "Not refreshed by /reload" in result.message
     assert session.reload_called is True
+    assert session.provider_reload_called is False
 
 
 def test_resume_without_argument_requests_picker(tmp_path: Path) -> None:
@@ -343,7 +386,9 @@ def test_registry_rejects_duplicate_commands_and_aliases() -> None:
         name="test",
         usage="/test",
         description="Test",
-        handler=lambda context: create_default_command_registry().execute(context.session, "/session"),
+        handler=lambda context: create_default_command_registry().execute(
+            context.session, "/session"
+        ),
     )
     registry.register(command)
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -104,6 +104,7 @@ class FakeSession:
         self.new_session_count = 0
         self.prompt_texts: list[str] = []
         self.reload_count = 0
+        self.provider_reload_count = 0
         self.queued_steering_messages: tuple[str, ...] = ()
         self.queued_follow_up_messages: tuple[str, ...] = ()
         self.streaming_behaviors: list[str | None] = []
@@ -187,6 +188,9 @@ class FakeSession:
 
     def reload(self) -> None:
         self.reload_count += 1
+
+    def reload_provider_settings(self) -> None:
+        self.provider_reload_count += 1
 
     async def set_thinking_level(self, level: str) -> str:
         self.thinking_level = level
@@ -739,12 +743,15 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
         await pilot.pause()
 
         assert prompt.has_class("-shell-mode")
-        assert _activity_prompt_border_color(
-            app.tui_settings.resolved_theme,
-            frame=0,
-            running=False,
-            shell_mode=prompt.has_class("-shell-mode"),
-        ) == app.tui_settings.resolved_theme.accent
+        assert (
+            _activity_prompt_border_color(
+                app.tui_settings.resolved_theme,
+                frame=0,
+                running=False,
+                shell_mode=prompt.has_class("-shell-mode"),
+            )
+            == app.tui_settings.resolved_theme.accent
+        )
         assert prompt.get_line(0).spans[-1].start == 0
         assert prompt.get_line(0).spans[-1].end == 2
         assert str(prompt.get_line(0).spans[-1].style) == app.tui_settings.resolved_theme.accent
@@ -1893,7 +1900,8 @@ async def test_tui_login_saves_provider_key(
         await pilot.press("enter")
         await pilot.pause()
 
-    assert session.reload_count == 1
+    assert session.reload_count == 0
+    assert session.provider_reload_count == 1
     assert session.provider_name == "openai"
     assert session.prompt_texts == []
     assert all(item.text != "stored-openai-key" for item in app.state.items)
@@ -1932,7 +1940,8 @@ async def test_tui_login_openai_codex_saves_oauth_credentials(
         )
         await pilot.pause()
 
-    assert session.reload_count == 1
+    assert session.reload_count == 0
+    assert session.provider_reload_count == 1
     assert session.provider_name == "openai-codex"
     assert all("access-token" not in item.text for item in app.state.items)
     credentials = (tmp_path / ".tau" / "credentials.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Scope `/reload` to local coding resources and project context instead of provider configuration.
- Add a structured reload summary so command output reports changed/unchanged counts by resources, context, diagnostics, and next-turn system prompt status.
- Rebuild the generated system prompt only when the skills/context inputs that feed it changed.
- Move provider settings refresh to explicit model/login paths via `reload_provider_settings()`.
- Update docs and tests for the tuned behavior, including transcript/session-tree preservation after reload.

Closes #104.

## Validation

- `uv run pytest tests/test_commands.py tests/test_coding_session.py tests/test_tui_app.py -q` (`183 passed`)
- `uv run pytest -q` (`423 passed`)
- `uv run --group docs mkdocs build --strict` (passed; emitted the existing MkDocs Material warning and noted `architecture/phase-24-session-tree-branching.md` is not in nav)
- `uv run ruff check src/tau_coding/reload.py src/tau_coding/session.py src/tau_coding/commands.py src/tau_coding/tui/app.py tests/test_commands.py tests/test_coding_session.py tests/test_tui_app.py` (passed)
- `git diff --check` (passed)

## Repo-wide lint/type baseline

These appear unrelated to this PR's touched files:

- `uv run ruff check .` fails with `B007` in `src/tau_coding/tui/widgets.py:133`.
- `uv run ruff format --check .` reports 8 unrelated files would be reformatted: `src/tau_agent/session/memory.py`, `src/tau_ai/anthropic.py`, `src/tau_ai/openai_compatible.py`, `src/tau_ai/retry.py`, `src/tau_coding/context_window.py`, `src/tau_coding/provider_config.py`, `tests/test_coding_tools.py`, and `tests/test_context.py`.
- `uv run mypy` reports 3 errors in `src/tau_coding/tools.py` at lines 588, 599, and 604.