### PR TITLE
Issue #102: configurable tool output previews

### DIFF
--- a/docs/architecture/phase-11-print-event-rendering.md
+++ b/docs/architecture/phase-11-print-event-rendering.md
@@ -23,6 +23,7 @@ The CLI exposes this with:
 tau --output text "summarize this project"
 tau --output json "summarize this project"
 tau --output transcript "summarize this project"
+tau --output transcript --tool-output full "debug this failing command"
 ```
 
 `text` is the default mode.
@@ -72,11 +73,17 @@ Transcript mode preserves Tau's earlier print-mode behavior:
 
 - assistant deltas stream to stdout
 - tool starts, progress updates, and tool results render to stderr
-- successful and failed tool result content renders to stderr
+- successful and failed tool result detail renders to stderr according to
+  `--tool-output none|short|full`
 - errors render to stderr
 
 The transcript renderer uses Rich for human-oriented stderr output while keeping
 the default `text` mode script-friendly.
+
+`short` is the default tool-output visibility for transcript mode. It shows a
+bounded preview with truncation markers and uses the same shared preview helper
+as the Textual frontend. `edit` results include a compact unified diff preview
+when patch metadata is available; `full` prints the complete available result.
 
 This is useful while Tau does not yet have a full interactive TUI.
 
@@ -86,6 +93,7 @@ This is useful while Tau does not yet have a full interactive TUI.
 
 ```python
 output: PrintOutputMode = PrintOutputMode.text
+tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short
 ```
 
 It creates a renderer with:

--- a/docs/architecture/phase-23-tui-polish.md
+++ b/docs/architecture/phase-23-tui-polish.md
@@ -15,9 +15,10 @@ Textual widgets render the transcript and controls
 
 ## Current polish slices
 
-Live tool results now render successful output previews in the transcript,
-matching restored session history. The TUI shows the first few lines and a
-preview hint when additional content is hidden, so large `read` or `bash`
+Live tool results now render through a configurable visibility level: `none`,
+`short`, or `full`. `short` is the default and shows a bounded preview with a
+clear truncation marker, while `full` remains available for debugging. The TUI
+derives this display from preserved tool-result data, so large `read` or `bash`
 results do not flood the conversation while the durable session still keeps the
 complete tool result for model context and replay.
 
@@ -32,11 +33,11 @@ Markdown. User, tool, status, and error blocks stay literal unless they are
 handled by the explicit code or patch renderers, which keeps pasted prompts and
 tool output predictable.
 
-Live `edit` tool results now include their unified patch in the tool block. This
-provides an inline diff view for file edits while keeping the event adapter and
-Textual widgets decoupled. Tool-result metadata is now preserved in
-`ToolResultMessage`, so restored session history can render the same edit patch
-blocks from persisted JSONL entries.
+Live `edit` tool results include their unified patch in `short` and `full` tool
+output modes. This provides an inline diff view for file edits while keeping the
+event adapter and Textual widgets decoupled. Tool-result metadata is preserved
+in `ToolResultMessage`, so restored session history can render the same edit
+patch blocks from persisted JSONL entries.
 
 The TUI also has a command-palette entry point. Pressing `Ctrl+K` focuses the
 prompt, inserts `/`, and shows all slash-command completions using the existing
@@ -68,10 +69,11 @@ then resumes the selected session through `CodingSession.resume()`. The picker
 lives entirely in the Textual frontend; the portable harness still has no
 session-selection policy.
 
-The built-in Textual frontend now reads optional keybinding settings from
-`~/.tau/tui.json`. This lets users remap the command palette, completion
-navigation, session picker, cancellation, and quit keys while keeping the
-configuration in `tau_coding.tui` instead of the reusable agent harness.
+The built-in Textual frontend now reads optional keybinding and tool-output
+visibility settings from `~/.tau/tui.json`. This lets users remap the command
+palette, completion navigation, session picker, cancellation, and quit keys
+while keeping the configuration in `tau_coding.tui` instead of the reusable
+agent harness.
 
 The same TUI settings file now supports named built-in themes. `tau-dark`
 remains the default, and `high-contrast` provides a brighter dark palette. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,7 @@ Example:
 ```json
 {
   "theme": "high-contrast",
+  "tool_output_visibility": "short",
   "keybindings": {
     "cancel": "escape",
     "command_palette": "ctrl+j",
@@ -175,10 +176,24 @@ Assistant Markdown renders fenced code blocks with syntax highlighting when the
 fence language is known. Unknown fence languages fall back to plain code
 formatting so assistant output remains readable.
 
+Tool output visibility controls how much result detail appears in the Textual
+transcript:
+
+- `none` shows only the tool invocation and success/failure status.
+- `short` shows a bounded preview with a clear truncation marker when output is
+  hidden. This is the default.
+- `full` shows the complete available tool result, which is useful for
+  debugging but can be noisy.
+
+In `short` mode, `edit` tool results include a compact unified diff preview with
+the edited file path when patch metadata is available. Press `Ctrl+O` in the TUI
+to cycle through `short`, `full`, and `none` for the current session.
+
 Any omitted keybinding uses the built-in default. Key names use Textual's key
 syntax, such as `ctrl+k`, `tab`, `shift+tab`, `down`, `up`, and `f2`. Tau rejects unknown
-themes, unknown keybinding names, empty keys, and duplicate assignments so
-mistakes fail early instead of silently changing terminal behavior.
+themes, unknown tool output visibility levels, unknown keybinding names, empty
+keys, and duplicate assignments so mistakes fail early instead of silently
+changing terminal behavior.
 
 ## Sessions
 

--- a/docs/custom-tui.md
+++ b/docs/custom-tui.md
@@ -232,6 +232,11 @@ settings from `~/.tau/tui.json` through `tau_coding.tui.load_tui_settings()`,
 but a custom TUI can ignore that file or map the same action names to its own
 input and styling system.
 
+Tool-output visibility is also frontend policy. The built-in app supports
+`none`, `short`, and `full`; `short` uses the shared preview formatter in
+`tau_coding.rendering` so print mode and TUI previews follow the same truncation
+rules without adding UI concepts to `tau_agent`.
+
 The built-in configurable action names are:
 
 - `cancel`

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -67,6 +67,7 @@ from tau_coding.rendering import (
     FinalTextRenderer,
     JsonEventRenderer,
     PrintOutputMode,
+    ToolOutputVisibility,
     TranscriptRenderer,
     create_event_renderer,
 )
@@ -168,6 +169,7 @@ __all__ = [
     "TauPaths",
     "TauResourcePaths",
     "ToolDefinition",
+    "ToolOutputVisibility",
     "TranscriptRenderer",
     "ThinkingLevel",
     "ThinkingParameter",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -31,7 +31,7 @@ from tau_coding.provider_config import (
     upsert_openai_compatible_provider,
 )
 from tau_coding.provider_runtime import create_model_provider
-from tau_coding.rendering import PrintOutputMode, create_event_renderer
+from tau_coding.rendering import PrintOutputMode, ToolOutputVisibility, create_event_renderer
 from tau_coding.resources import TauResourcePaths
 from tau_coding.session import (
     CodingSession,
@@ -149,6 +149,13 @@ def main(
         PrintOutputMode,
         typer.Option("--output", "-o", help="Output mode for print mode."),
     ] = PrintOutputMode.text,
+    tool_output: Annotated[
+        ToolOutputVisibility | None,
+        typer.Option(
+            "--tool-output",
+            help="Tool result detail for transcript/TUI output: none, short, or full.",
+        ),
+    ] = None,
     resume: Annotated[
         str | None,
         typer.Option("--resume", help="Resume a session id in TUI mode."),
@@ -230,6 +237,7 @@ def main(
                 provider,
                 auto_compact_threshold,
                 initial_prompt,
+                tool_output,
             )
         except RuntimeError as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -240,7 +248,15 @@ def main(
         raise AssertionError("prompt option should be set outside TUI mode")
 
     try:
-        ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd(), output, provider)
+        ok = anyio.run(
+            run_openai_print_mode,
+            prompt,
+            model,
+            cwd or Path.cwd(),
+            output,
+            provider,
+            tool_output or ToolOutputVisibility.short,
+        )
     except RuntimeError as exc:
         raise typer.BadParameter(str(exc)) from exc
     if not ok:
@@ -255,6 +271,7 @@ async def run_openai_tui(
     provider_name: str | None = None,
     auto_compact_token_threshold: int | None = None,
     initial_prompt: str | None = None,
+    tool_output_visibility: ToolOutputVisibility | None = None,
 ) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
     await run_tui_app(
@@ -265,6 +282,7 @@ async def run_openai_tui(
         provider_name=provider_name,
         auto_compact_token_threshold=auto_compact_token_threshold,
         initial_prompt=initial_prompt,
+        tool_output_visibility=tool_output_visibility,
     )
 
 
@@ -417,6 +435,7 @@ async def run_openai_print_mode(
     cwd: Path,
     output: PrintOutputMode = PrintOutputMode.text,
     provider_name: str | None = None,
+    tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short,
     session_manager: SessionManager | None = None,
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
@@ -436,6 +455,7 @@ async def run_openai_print_mode(
             cwd=record.cwd,
             provider=provider,
             output=output,
+            tool_output_visibility=tool_output_visibility,
             storage=jsonl_session_storage(record.path),
             session_id=record.id,
             session_manager=manager,
@@ -454,6 +474,7 @@ async def run_print_mode(
     cwd: Path,
     provider: ModelProvider,
     output: PrintOutputMode = PrintOutputMode.text,
+    tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short,
     resource_paths: TauResourcePaths | None = None,
     storage: SessionStorage | None = None,
     session_id: str | None = None,
@@ -481,7 +502,7 @@ async def run_print_mode(
             runtime_provider_config=runtime_provider_config,
         )
     )
-    renderer = create_event_renderer(output)
+    renderer = create_event_renderer(output, tool_output_visibility=tool_output_visibility)
     try:
         terminal_command = parse_terminal_command(prompt)
         if terminal_command is not None:

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -385,7 +385,7 @@ def _hotkeys_command(context: CommandContext) -> CommandResult:
         "- Ctrl+R: open session picker",
         "- Shift+Tab: cycle thinking mode",
         "- Ctrl+T: toggle thinking tokens",
-        "- Ctrl+O: collapse or expand tool output",
+        "- Ctrl+O: cycle tool output (short, full, none)",
         "- Ctrl+C: clear prompt input",
         "- Ctrl+D: quit",
     ]

--- a/src/tau_coding/rendering/__init__.py
+++ b/src/tau_coding/rendering/__init__.py
@@ -3,16 +3,28 @@
 from tau_coding.rendering.base import EventRenderer, PrintOutputMode
 from tau_coding.rendering.json import JsonEventRenderer
 from tau_coding.rendering.plain import FinalTextRenderer
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    format_terminal_command_result_block,
+    format_tool_result_block,
+    format_tool_result_summary,
+    normalize_tool_output_visibility,
+    preview_text,
+)
 from tau_coding.rendering.transcript import TranscriptRenderer
 
 
-def create_event_renderer(mode: PrintOutputMode) -> EventRenderer:
+def create_event_renderer(
+    mode: PrintOutputMode,
+    *,
+    tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short,
+) -> EventRenderer:
     """Create a renderer for a print output mode."""
     if mode is PrintOutputMode.text:
         return FinalTextRenderer()
     if mode is PrintOutputMode.json:
         return JsonEventRenderer()
-    return TranscriptRenderer()
+    return TranscriptRenderer(tool_output_visibility=tool_output_visibility)
 
 
 __all__ = [
@@ -21,5 +33,11 @@ __all__ = [
     "JsonEventRenderer",
     "PrintOutputMode",
     "TranscriptRenderer",
+    "ToolOutputVisibility",
     "create_event_renderer",
+    "format_terminal_command_result_block",
+    "format_tool_result_block",
+    "format_tool_result_summary",
+    "normalize_tool_output_visibility",
+    "preview_text",
 ]

--- a/src/tau_coding/rendering/tool_output.py
+++ b/src/tau_coding/rendering/tool_output.py
@@ -1,0 +1,140 @@
+"""Shared formatting for visible tool-output previews."""
+
+from enum import StrEnum
+
+from tau_agent.types import JSONValue
+
+TOOL_RESULT_PREVIEW_LINES = 8
+TOOL_PATCH_PREVIEW_LINES = 32
+TOOL_RESULT_PREVIEW_CHARS = 2_000
+TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
+
+
+class ToolOutputVisibility(StrEnum):
+    """Visible detail levels for rendered tool results."""
+
+    none = "none"
+    short = "short"
+    full = "full"
+
+
+def normalize_tool_output_visibility(value: object) -> ToolOutputVisibility:
+    """Parse a user/config value into a tool-output visibility level."""
+    if isinstance(value, ToolOutputVisibility):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        try:
+            return ToolOutputVisibility(normalized)
+        except ValueError as exc:
+            raise ValueError(f"Unknown tool output visibility: {value}") from exc
+    raise ValueError("Tool output visibility must be one of: none, short, full")
+
+
+def format_tool_result_summary(*, name: str, ok: bool) -> str:
+    """Format a terse tool result line for orphaned results."""
+    status = "✓" if ok else "✗"
+    return f"{status} {name}"
+
+
+def format_tool_result_block(
+    *,
+    name: str,
+    ok: bool,
+    content: str,
+    data: dict[str, JSONValue] | None = None,
+    visibility: ToolOutputVisibility = ToolOutputVisibility.short,
+) -> str:
+    """Format a tool result according to the requested visible detail level."""
+    status_line = format_tool_result_summary(name=name, ok=ok)
+    if visibility is ToolOutputVisibility.none:
+        return status_line
+
+    lines = [status_line]
+    if content:
+        if visibility is ToolOutputVisibility.full:
+            lines.append(content)
+        else:
+            lines.append(preview_text(content, max_lines=TOOL_RESULT_PREVIEW_LINES))
+
+    patch = _result_patch(name=name, ok=ok, data=data)
+    if patch:
+        lines.append("")
+        path = _result_path(data)
+        if path:
+            lines.append(f"File: {path}")
+        lines.append("Diff:")
+        if visibility is ToolOutputVisibility.full:
+            lines.append(patch)
+        else:
+            lines.append(preview_text(patch, max_lines=TOOL_PATCH_PREVIEW_LINES))
+    return "\n".join(lines)
+
+
+def format_terminal_command_result_block(
+    *,
+    ok: bool,
+    added_to_context: bool,
+    output: str,
+) -> str:
+    """Format an input-bar terminal command result for visible TUI display."""
+    status = "✓" if ok else "✗"
+    suffix = " · added to context" if added_to_context else " · not added to context"
+    lines = [f"{status} bash{suffix}"]
+    if output:
+        lines.append(preview_text(output, max_lines=TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES))
+    return "\n".join(lines)
+
+
+def preview_text(
+    text: str,
+    *,
+    max_lines: int,
+    max_chars: int = TOOL_RESULT_PREVIEW_CHARS,
+) -> str:
+    """Return a bounded text preview with a clear truncation marker."""
+    lines = text.splitlines()
+    if not lines:
+        return _clip_text(text, max_chars=max_chars)
+
+    preview_lines = lines[:max_lines]
+    preview = "\n".join(preview_lines)
+    hidden_lines = max(0, len(lines) - len(preview_lines))
+
+    truncated_by_chars = len(preview) > max_chars
+    if truncated_by_chars:
+        preview = preview[:max_chars].rstrip()
+
+    if hidden_lines or truncated_by_chars:
+        details: list[str] = []
+        if hidden_lines:
+            details.append(f"{hidden_lines} more line{'s' if hidden_lines != 1 else ''}")
+        if truncated_by_chars:
+            details.append("additional text")
+        preview = f"{preview}\n\n[Preview only: {', '.join(details)} hidden.]"
+    return preview
+
+
+def _clip_text(text: str, *, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}\n\n[Preview only: additional text hidden.]"
+
+
+def _result_patch(
+    *,
+    name: str,
+    ok: bool,
+    data: dict[str, JSONValue] | None,
+) -> str | None:
+    if name != "edit" or not ok or data is None:
+        return None
+    patch = data.get("patch")
+    return patch if isinstance(patch, str) and patch.strip() else None
+
+
+def _result_path(data: dict[str, JSONValue] | None) -> str | None:
+    if data is None:
+        return None
+    path = data.get("path")
+    return path if isinstance(path, str) and path.strip() else None

--- a/src/tau_coding/rendering/transcript.py
+++ b/src/tau_coding/rendering/transcript.py
@@ -16,17 +16,26 @@ from tau_agent import (
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
 )
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    format_tool_result_block,
+)
 from tau_coding.tui.state import format_tool_call_block
 
 
 class TranscriptRenderer:
     """Render assistant deltas live and tool activity to stderr."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short,
+    ) -> None:
         self._assistant_started = False
         self._assistant_ended = False
         self._failed = False
         self._console = Console(stderr=True, highlight=False)
+        self._tool_output_visibility = tool_output_visibility
 
     def render(self, event: AgentEvent) -> None:
         """Render one agent event."""
@@ -59,8 +68,16 @@ class TranscriptRenderer:
             status = "✓" if event.result.ok else "✗"
             style = "green" if event.result.ok else "red"
             self._print_tool_line(status, event.result.name, style=style)
-            if event.result.content:
-                self._print_tool_content(event.result.content)
+            result_block = format_tool_result_block(
+                name=event.result.name,
+                ok=event.result.ok,
+                content=event.result.content,
+                data=event.result.data,
+                visibility=self._tool_output_visibility,
+            )
+            details = "\n".join(result_block.splitlines()[1:])
+            if details:
+                self._print_tool_content(details)
             return
 
         if isinstance(event, ErrorEvent):

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -50,6 +50,10 @@ from tau_coding.provider_config import (
     upsert_provider,
 )
 from tau_coding.provider_runtime import create_model_provider
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    format_terminal_command_result_block,
+)
 from tau_coding.session import (
     CodingSession,
     CodingSessionConfig,
@@ -71,7 +75,7 @@ from tau_coding.tui.config import (
     load_tui_settings,
     save_tui_settings,
 )
-from tau_coding.tui.state import TuiState, format_terminal_command_result_block
+from tau_coding.tui.state import TuiState
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
     SessionSidebar,
@@ -985,9 +989,7 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
         """Compose the model picker."""
         with Vertical(id="model-picker"):
             title = (
-                f"Model: {self.provider_name}"
-                if self.picker_kind == "model"
-                else "Scoped models"
+                f"Model: {self.provider_name}" if self.picker_kind == "model" else "Scoped models"
             )
             yield Static(title, id="model-picker-title")
             yield Static("", id="model-picker-tabs")
@@ -1149,7 +1151,10 @@ class ModelPickerScreen(ModalScreen[ModelChoice | None]):
             help_text = (
                 "all models: no matching models - Tab switches to scoped models"
                 if not self.visible_choices
-                else f"All models - Enter selects active model - Tab switches tabs - {scope_count} scoped"
+                else (
+                    "All models - Enter selects active model - "
+                    f"Tab switches tabs - {scope_count} scoped"
+                )
             )
         else:
             tabs.update("Tabs: ○ All models  ● Scoped models")
@@ -1648,7 +1653,7 @@ class TauTuiApp(App[None]):
         super().__init__()
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
-        self.state = TuiState()
+        self.state = TuiState(tool_output_visibility=self.tui_settings.tool_output_visibility)
         self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
@@ -1845,6 +1850,7 @@ class TauTuiApp(App[None]):
         self.tui_settings = TuiSettings(
             keybindings=self.tui_settings.keybindings,
             theme=theme,
+            tool_output_visibility=self.tui_settings.tool_output_visibility,
         )
         save_tui_settings(self.tui_settings)
         self.refresh_css(animate=False)
@@ -1925,7 +1931,7 @@ class TauTuiApp(App[None]):
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen
-            | ThemePickerScreen
+            | ThemePickerScreen,
         ):
             self.screen.action_select_cursor()
             return
@@ -2042,10 +2048,10 @@ class TauTuiApp(App[None]):
         self.run_worker(self._cycle_scoped_model(), exclusive=False)
 
     def action_toggle_tool_results(self) -> None:
-        """Toggle inline tool result details in the transcript."""
-        expanded = self.state.toggle_tool_results()
+        """Cycle inline tool-result visibility in the transcript."""
+        visibility = self.state.cycle_tool_output_visibility()
         self._refresh()
-        self._notify("Tool results expanded." if expanded else "Tool results collapsed.")
+        self._notify(f"Tool output: {visibility.value}.")
 
     def action_toggle_thinking(self) -> None:
         """Toggle thinking-token display in the transcript."""
@@ -2952,6 +2958,7 @@ async def run_tui_app(
     provider_name: str | None = None,
     auto_compact_token_threshold: int | None = None,
     initial_prompt: str | None = None,
+    tool_output_visibility: ToolOutputVisibility | None = None,
     session_manager: SessionManager | None = None,
 ) -> None:
     """Create the default provider/session and run the Textual app."""
@@ -3004,9 +3011,16 @@ async def run_tui_app(
                 auto_compact_token_threshold=auto_compact_token_threshold,
             )
         )
+        tui_settings = load_tui_settings()
+        if tool_output_visibility is not None:
+            tui_settings = TuiSettings(
+                keybindings=tui_settings.keybindings,
+                theme=tui_settings.theme,
+                tool_output_visibility=tool_output_visibility,
+            )
         app = TauTuiApp(
             session,
-            tui_settings=load_tui_settings(),
+            tui_settings=tui_settings,
             startup_message=startup_message,
             initial_prompt=initial_prompt,
         )

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from tau_coding.paths import TauPaths
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    normalize_tool_output_visibility,
+)
 
 
 class TuiConfigError(ValueError):
@@ -205,12 +209,14 @@ class TuiSettings:
 
     keybindings: TuiKeybindings = field(default_factory=TuiKeybindings)
     theme: TuiThemeName = "tau-dark"
+    tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short
 
     def to_json(self) -> dict[str, Any]:
         """Serialize these settings to JSON-compatible data."""
         return {
             "keybindings": self.keybindings.to_json(),
             "theme": self.theme,
+            "tool_output_visibility": self.tool_output_visibility.value,
         }
 
     @property
@@ -245,7 +251,7 @@ def save_tui_settings(settings: TuiSettings, paths: TauPaths | None = None) -> P
 
 def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
     """Parse TUI settings from JSON-compatible data."""
-    allowed_fields = {"keybindings", "theme"}
+    allowed_fields = {"keybindings", "theme", "tool_output_visibility"}
     unknown_fields = set(data) - allowed_fields
     if unknown_fields:
         raise TuiConfigError(f"Unknown TUI settings field: {sorted(unknown_fields)[0]}")
@@ -256,6 +262,9 @@ def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
     return TuiSettings(
         keybindings=_keybindings_from_json(keybindings_data),
         theme=_theme_name(data.get("theme", "tau-dark")),
+        tool_output_visibility=_tool_output_visibility(
+            data.get("tool_output_visibility", ToolOutputVisibility.short)
+        ),
     )
 
 
@@ -288,6 +297,13 @@ def _theme_name(value: object) -> TuiThemeName:
     if name == "tau-dark" or name == "tau-light" or name == "high-contrast":
         return cast(TuiThemeName, name)
     raise TuiConfigError(f"Unknown TUI theme: {name}")
+
+
+def _tool_output_visibility(value: object) -> ToolOutputVisibility:
+    try:
+        return normalize_tool_output_visibility(value)
+    except ValueError as exc:
+        raise TuiConfigError(str(exc)) from exc
 
 
 def _reject_duplicate_keys(values: dict[str, str]) -> None:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -7,13 +7,14 @@ from typing import Literal
 from tau_agent.messages import AgentMessage
 from tau_agent.tools import AgentToolResult, ToolCall
 from tau_agent.types import JSONValue
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    format_tool_result_block,
+    format_tool_result_summary,
+)
 from tau_coding.skills import parse_skill_invocation
 
 ChatItemRole = Literal["user", "assistant", "tool", "error", "status", "thinking", "skill"]
-TOOL_RESULT_PREVIEW_LINES = 8
-TOOL_PATCH_PREVIEW_LINES = 32
-TOOL_RESULT_PREVIEW_CHARS = 2_000
-TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 
 
 @dataclass(slots=True)
@@ -23,7 +24,9 @@ class ChatItem:
     role: ChatItemRole
     text: str
     tool_call_id: str | None = None
+    tool_call: ToolCall | None = None
     tool_result_text: str | None = None
+    tool_result: AgentToolResult | None = None
     always_show_tool_result: bool = False
 
 
@@ -35,7 +38,7 @@ class TuiState:
     assistant_buffer: str = ""
     running: bool = False
     error: str | None = None
-    show_tool_results: bool = False
+    tool_output_visibility: ToolOutputVisibility = ToolOutputVisibility.short
     show_thinking: bool = False
     queued_steering: tuple[str, ...] = ()
     queued_follow_up: tuple[str, ...] = ()
@@ -46,7 +49,9 @@ class TuiState:
         text: str,
         *,
         tool_call_id: str | None = None,
+        tool_call: ToolCall | None = None,
         tool_result_text: str | None = None,
+        tool_result: AgentToolResult | None = None,
         always_show_tool_result: bool = False,
     ) -> None:
         """Append a transcript item."""
@@ -55,7 +60,9 @@ class TuiState:
                 role=role,
                 text=text,
                 tool_call_id=tool_call_id,
+                tool_call=tool_call,
                 tool_result_text=tool_result_text,
+                tool_result=tool_result,
                 always_show_tool_result=always_show_tool_result,
             )
         )
@@ -66,6 +73,7 @@ class TuiState:
             "tool",
             format_tool_call_block(tool_call),
             tool_call_id=tool_call.id,
+            tool_call=tool_call,
         )
 
     def add_user_message(self, content: str) -> None:
@@ -87,26 +95,67 @@ class TuiState:
 
     def record_tool_result(self, result: AgentToolResult) -> None:
         """Attach a tool result to its matching call, or append an orphan result."""
+        for item in reversed(self.items):
+            if item.role == "tool" and item.tool_call_id == result.tool_call_id:
+                result = _result_with_tool_call_context(result, item.tool_call)
+                result_text = format_tool_result_block(
+                    name=result.name,
+                    ok=result.ok,
+                    content=result.content,
+                    data=result.data,
+                    visibility=self.tool_output_visibility,
+                )
+                item.tool_result_text = result_text
+                item.tool_result = result
+                return
         result_text = format_tool_result_block(
             name=result.name,
             ok=result.ok,
             content=result.content,
             data=result.data,
+            visibility=self.tool_output_visibility,
         )
-        for item in reversed(self.items):
-            if item.role == "tool" and item.tool_call_id == result.tool_call_id:
-                item.tool_result_text = result_text
-                return
         self.add_item(
             "tool",
             format_tool_result_summary(name=result.name, ok=result.ok),
             tool_call_id=result.tool_call_id,
             tool_result_text=result_text,
+            tool_result=result,
         )
+
+    @property
+    def show_tool_results(self) -> bool:
+        """Return whether any tool result detail is visible."""
+        return self.tool_output_visibility is not ToolOutputVisibility.none
+
+    @show_tool_results.setter
+    def show_tool_results(self, value: bool) -> None:
+        """Compatibility setter for the old collapsed/expanded boolean state."""
+        self.set_tool_output_visibility(
+            ToolOutputVisibility.short if value else ToolOutputVisibility.none
+        )
+
+    def set_tool_output_visibility(self, visibility: ToolOutputVisibility) -> None:
+        """Set tool-output visibility and refresh cached result text."""
+        self.tool_output_visibility = visibility
+        self._refresh_tool_result_text()
+
+    def cycle_tool_output_visibility(self) -> ToolOutputVisibility:
+        """Cycle visible tool output through short, full, and none."""
+        order = (
+            ToolOutputVisibility.short,
+            ToolOutputVisibility.full,
+            ToolOutputVisibility.none,
+        )
+        next_index = (order.index(self.tool_output_visibility) + 1) % len(order)
+        self.set_tool_output_visibility(order[next_index])
+        return self.tool_output_visibility
 
     def toggle_tool_results(self) -> bool:
         """Toggle expanded display for tool results and return the new state."""
-        self.show_tool_results = not self.show_tool_results
+        self.set_tool_output_visibility(
+            ToolOutputVisibility.none if self.show_tool_results else ToolOutputVisibility.short
+        )
         return self.show_tool_results
 
     def toggle_thinking(self) -> bool:
@@ -129,6 +178,18 @@ class TuiState:
         self.items.clear()
         self.assistant_buffer = ""
         self.error = None
+
+    def _refresh_tool_result_text(self) -> None:
+        for item in self.items:
+            if item.tool_result is None:
+                continue
+            item.tool_result_text = format_tool_result_block(
+                name=item.tool_result.name,
+                ok=item.tool_result.ok,
+                content=item.tool_result.content,
+                data=item.tool_result.data,
+                visibility=self.tool_output_visibility,
+            )
 
     def load_messages(self, messages: Iterable[AgentMessage]) -> None:
         """Populate the transcript from restored session messages."""
@@ -226,75 +287,17 @@ def _number_argument(arguments: dict[str, JSONValue], key: str) -> int | float |
     return value if isinstance(value, int | float) else None
 
 
-def format_tool_result_summary(*, name: str, ok: bool) -> str:
-    """Format a terse tool result line for orphaned results."""
-    status = "✓" if ok else "✗"
-    return f"{status} {name}"
-
-
-def format_tool_result_block(
-    *,
-    name: str,
-    ok: bool,
-    content: str,
-    data: dict[str, JSONValue] | None = None,
-) -> str:
-    """Format a tool result for live and restored transcript blocks."""
-    status = "✓" if ok else "✗"
-    lines = [f"{status} {name}"]
-    if content:
-        lines.append(_preview_text(content, max_lines=TOOL_RESULT_PREVIEW_LINES))
-    patch = _result_patch(name=name, ok=ok, data=data)
-    if patch:
-        lines.extend(["", "Patch:", _preview_text(patch, max_lines=TOOL_PATCH_PREVIEW_LINES)])
-    return "\n".join(lines)
-
-
-def format_terminal_command_result_block(
-    *,
-    ok: bool,
-    added_to_context: bool,
-    output: str,
-) -> str:
-    """Format an input-bar terminal command result for visible TUI display."""
-    status = "✓" if ok else "✗"
-    suffix = " · added to context" if added_to_context else " · not added to context"
-    lines = [f"{status} bash{suffix}"]
-    if output:
-        lines.append(_preview_text(output, max_lines=TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES))
-    return "\n".join(lines)
-
-
-def _result_patch(
-    *,
-    name: str,
-    ok: bool,
-    data: dict[str, JSONValue] | None,
-) -> str | None:
-    if name != "edit" or not ok or data is None:
-        return None
-    patch = data.get("patch")
-    return patch if isinstance(patch, str) and patch.strip() else None
-
-
-def _preview_text(text: str, *, max_lines: int) -> str:
-    lines = text.splitlines()
-    if not lines:
-        return text[:TOOL_RESULT_PREVIEW_CHARS]
-
-    preview_lines = lines[:max_lines]
-    preview = "\n".join(preview_lines)
-    hidden_lines = max(0, len(lines) - len(preview_lines))
-
-    truncated_by_chars = len(preview) > TOOL_RESULT_PREVIEW_CHARS
-    if truncated_by_chars:
-        preview = preview[:TOOL_RESULT_PREVIEW_CHARS].rstrip()
-
-    if hidden_lines or truncated_by_chars:
-        details: list[str] = []
-        if hidden_lines:
-            details.append(f"{hidden_lines} more line{'s' if hidden_lines != 1 else ''}")
-        if truncated_by_chars:
-            details.append("additional text")
-        preview = f"{preview}\n\n[Preview only: {', '.join(details)} hidden from the TUI.]"
-    return preview
+def _result_with_tool_call_context(
+    result: AgentToolResult,
+    tool_call: ToolCall | None,
+) -> AgentToolResult:
+    if result.name != "edit" or tool_call is None:
+        return result
+    path = _string_argument(tool_call.arguments, "path")
+    if path is None:
+        return result
+    data = dict(result.data or {})
+    if isinstance(data.get("path"), str):
+        return result
+    data["path"] = path
+    return result.model_copy(update={"data": data})

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -22,6 +22,10 @@ from textual.widgets import RichLog, Static
 
 from tau_agent.tools import AgentTool
 from tau_coding.prompt_templates import PromptTemplate
+from tau_coding.rendering.tool_output import (
+    ToolOutputVisibility,
+    format_tool_result_block,
+)
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
@@ -130,14 +134,14 @@ class TranscriptView(RichLog):
         theme = self._render_theme
         self._last_render_width = self.scrollable_content_region.width
         self.clear()
-        for index, item in enumerate(state.items):
+        for item in state.items:
             if item.role == "thinking" and not state.show_thinking:
                 continue
             self.write(
                 render_chat_item(
                     item,
                     theme=theme,
-                    show_tool_results=state.show_tool_results or item.always_show_tool_result,
+                    tool_output_visibility=_item_tool_output_visibility(state, item),
                 ),
                 expand=True,
                 shrink=True,
@@ -148,7 +152,7 @@ class TranscriptView(RichLog):
                 render_chat_item(
                     ChatItem(role="assistant", text=state.assistant_buffer),
                     theme=theme,
-                    show_tool_results=state.show_tool_results,
+                    tool_output_visibility=state.tool_output_visibility,
                 ),
                 expand=True,
                 shrink=True,
@@ -249,20 +253,28 @@ def render_chat_item(
     item: ChatItem,
     *,
     theme: TuiTheme = TAU_DARK_THEME,
-    show_tool_results: bool = False,
+    show_tool_results: bool | None = None,
+    tool_output_visibility: ToolOutputVisibility | None = None,
 ) -> RenderableType:
     """Render a chat item as a standalone Toad-inspired transcript block."""
+    resolved_tool_output_visibility = _resolved_tool_output_visibility(
+        show_tool_results=show_tool_results,
+        tool_output_visibility=tool_output_visibility,
+    )
     role_style = _chat_item_role_style(item, theme)
     body = (
         _render_tool_chat_body(
             item,
             body_style=theme.role_styles["tool"].body,
             accent_style=_tool_accent_style(item, theme=theme),
-            show_tool_results=show_tool_results,
+            tool_output_visibility=resolved_tool_output_visibility,
         )
         if item.role == "tool"
         else _render_chat_body(
-            _visible_chat_text(item, show_tool_results=show_tool_results),
+            _visible_chat_text(
+                item,
+                tool_output_visibility=resolved_tool_output_visibility,
+            ),
             role=item.role,
             body_style=role_style.body,
             syntax_theme=theme.syntax_theme,
@@ -277,6 +289,44 @@ def render_chat_item(
         Padding(body, (0, 1, 0, 1), style=role_style.body),
     )
     return Padding(table, (1, 1, 1, 0), style=role_style.body)
+
+
+def _item_tool_output_visibility(state: TuiState, item: ChatItem) -> ToolOutputVisibility:
+    if item.always_show_tool_result and state.tool_output_visibility is ToolOutputVisibility.none:
+        return ToolOutputVisibility.short
+    return state.tool_output_visibility
+
+
+def _resolved_tool_output_visibility(
+    *,
+    show_tool_results: bool | None,
+    tool_output_visibility: ToolOutputVisibility | None,
+) -> ToolOutputVisibility:
+    if tool_output_visibility is not None:
+        return tool_output_visibility
+    if show_tool_results is None:
+        return ToolOutputVisibility.none
+    return ToolOutputVisibility.full if show_tool_results else ToolOutputVisibility.none
+
+
+def _visible_tool_result_text(
+    item: ChatItem,
+    *,
+    tool_output_visibility: ToolOutputVisibility,
+) -> str | None:
+    if item.tool_result is not None:
+        return format_tool_result_block(
+            name=item.tool_result.name,
+            ok=item.tool_result.ok,
+            content=item.tool_result.content,
+            data=item.tool_result.data,
+            visibility=tool_output_visibility,
+        )
+    if item.tool_result_text is None:
+        return None
+    if tool_output_visibility is ToolOutputVisibility.none:
+        return item.tool_result_text.splitlines()[0]
+    return item.tool_result_text
 
 
 def _chat_item_role_style(item: ChatItem, theme: TuiTheme) -> TuiRoleStyle:
@@ -325,12 +375,16 @@ def _render_tool_chat_body(
     *,
     body_style: str,
     accent_style: str | None,
-    show_tool_results: bool,
+    tool_output_visibility: ToolOutputVisibility,
 ) -> Text:
     text = _render_tool_invocation(item.text, body_style=body_style, accent_style=accent_style)
-    if show_tool_results and item.tool_result_text:
+    tool_result_text = _visible_tool_result_text(
+        item,
+        tool_output_visibility=tool_output_visibility,
+    )
+    if tool_result_text:
         text.append("\n\n")
-        text.append(item.tool_result_text, style=body_style)
+        text.append(tool_result_text, style=body_style)
     return text
 
 
@@ -355,10 +409,18 @@ def _split_tool_invocation(text: str) -> tuple[str, str, str]:
     return "", name, f"{separator}{remainder}" if separator else ""
 
 
-def _visible_chat_text(item: ChatItem, *, show_tool_results: bool) -> str:
-    if item.role != "tool" or not show_tool_results or not item.tool_result_text:
+def _visible_chat_text(
+    item: ChatItem,
+    *,
+    tool_output_visibility: ToolOutputVisibility,
+) -> str:
+    tool_result_text = _visible_tool_result_text(
+        item,
+        tool_output_visibility=tool_output_visibility,
+    )
+    if item.role != "tool" or not tool_result_text:
         return item.text
-    return f"{item.text}\n\n{item.tool_result_text}"
+    return f"{item.text}\n\n{tool_result_text}"
 
 
 def _render_chat_body(
@@ -405,7 +467,7 @@ def _render_patch_body(
     body_style: str,
     syntax_theme: str,
 ) -> RenderableType | None:
-    marker = "\nPatch:\n"
+    marker = "\nDiff:\n" if "\nDiff:\n" in text else "\nPatch:\n"
     if marker not in text:
         return None
     before_patch, patch = text.split(marker, 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ from tau_coding.provider_config import (
     ProviderSettings,
     load_provider_settings,
 )
-from tau_coding.rendering import PrintOutputMode
+from tau_coding.rendering import PrintOutputMode, ToolOutputVisibility
 from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
@@ -36,7 +36,18 @@ def test_version_command() -> None:
 def test_cli_without_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
+    calls: list[
+        tuple[
+            str | None,
+            Path,
+            str | None,
+            bool,
+            str | None,
+            int | None,
+            str | None,
+            ToolOutputVisibility | None,
+        ]
+    ] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -46,6 +57,7 @@ def test_cli_without_prompt_invokes_tui_runner(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        tool_output_visibility: ToolOutputVisibility | None,
     ) -> None:
         calls.append(
             (
@@ -56,6 +68,7 @@ def test_cli_without_prompt_invokes_tui_runner(
                 provider_name,
                 auto_compact_token_threshold,
                 initial_prompt,
+                tool_output_visibility,
             )
         )
 
@@ -65,13 +78,24 @@ def test_cli_without_prompt_invokes_tui_runner(
     result = CliRunner().invoke(app, [])
 
     assert result.exit_code == 0
-    assert calls == [(None, tmp_path, None, False, None, None, None)]
+    assert calls == [(None, tmp_path, None, False, None, None, None, None)]
 
 
 def test_cli_positional_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
+    calls: list[
+        tuple[
+            str | None,
+            Path,
+            str | None,
+            bool,
+            str | None,
+            int | None,
+            str | None,
+            ToolOutputVisibility | None,
+        ]
+    ] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -81,6 +105,7 @@ def test_cli_positional_prompt_invokes_tui_runner(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        tool_output_visibility: ToolOutputVisibility | None,
     ) -> None:
         calls.append(
             (
@@ -91,6 +116,7 @@ def test_cli_positional_prompt_invokes_tui_runner(
                 provider_name,
                 auto_compact_token_threshold,
                 initial_prompt,
+                tool_output_visibility,
             )
         )
 
@@ -100,7 +126,7 @@ def test_cli_positional_prompt_invokes_tui_runner(
     result = CliRunner().invoke(app, ["explain this repo"])
 
     assert result.exit_code == 0
-    assert calls == [(None, tmp_path, None, False, None, None, "explain this repo")]
+    assert calls == [(None, tmp_path, None, False, None, None, "explain this repo", None)]
 
 
 @pytest.mark.anyio
@@ -371,7 +397,9 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
         cwd: Path,
         output: PrintOutputMode,
         provider_name: str | None,
+        tool_output_visibility: ToolOutputVisibility,
     ) -> bool:
+        del prompt, model, cwd, output, provider_name, tool_output_visibility
         return False
 
     monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
@@ -381,10 +409,51 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
     assert result.exit_code == 1
 
 
+def test_cli_passes_tool_output_visibility_to_print_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, PrintOutputMode, ToolOutputVisibility]] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        tool_output_visibility: ToolOutputVisibility,
+    ) -> bool:
+        del model, cwd, provider_name
+        calls.append((prompt, output, tool_output_visibility))
+        return True
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(
+        app,
+        ["--output", "transcript", "--tool-output", "full", "-p", "hello"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("hello", PrintOutputMode.transcript, ToolOutputVisibility.full)]
+
+
 def test_default_tui_invokes_tui_runner_with_flags(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str | None, Path, str | None, bool, str | None, int | None, str | None]] = []
+    calls: list[
+        tuple[
+            str | None,
+            Path,
+            str | None,
+            bool,
+            str | None,
+            int | None,
+            str | None,
+            ToolOutputVisibility | None,
+        ]
+    ] = []
 
     async def fake_run_openai_tui(
         model: str | None,
@@ -394,6 +463,7 @@ def test_default_tui_invokes_tui_runner_with_flags(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        tool_output_visibility: ToolOutputVisibility | None,
     ) -> None:
         calls.append(
             (
@@ -404,6 +474,7 @@ def test_default_tui_invokes_tui_runner_with_flags(
                 provider_name,
                 auto_compact_token_threshold,
                 initial_prompt,
+                tool_output_visibility,
             )
         )
 
@@ -426,7 +497,7 @@ def test_default_tui_invokes_tui_runner_with_flags(
     )
 
     assert result.exit_code == 0
-    assert calls == [("fake", tmp_path, "session-1", False, "local", 1000, None)]
+    assert calls == [("fake", tmp_path, "session-1", False, "local", 1000, None, None)]
 
 
 def test_default_tui_rejects_resume_with_new_session(
@@ -440,9 +511,10 @@ def test_default_tui_rejects_resume_with_new_session(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        tool_output_visibility: ToolOutputVisibility | None,
     ) -> None:
         del model, cwd, session_id, new_session, provider_name, auto_compact_token_threshold
-        del initial_prompt
+        del initial_prompt, tool_output_visibility
         raise RuntimeError("--resume and --new-session cannot be used together")
 
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -18,6 +18,58 @@ from tau_agent import (
     ToolExecutionUpdateEvent,
 )
 from tau_coding.rendering import FinalTextRenderer, JsonEventRenderer, TranscriptRenderer
+from tau_coding.rendering.tool_output import ToolOutputVisibility, format_tool_result_block
+
+
+def test_tool_result_block_supports_visibility_levels() -> None:
+    content = "\n".join(f"line {index}" for index in range(1, 12))
+
+    none = format_tool_result_block(
+        name="read",
+        ok=True,
+        content=content,
+        visibility=ToolOutputVisibility.none,
+    )
+    short = format_tool_result_block(
+        name="read",
+        ok=True,
+        content=content,
+        visibility=ToolOutputVisibility.short,
+    )
+    full = format_tool_result_block(
+        name="read",
+        ok=True,
+        content=content,
+        visibility=ToolOutputVisibility.full,
+    )
+
+    assert none == "✓ read"
+    assert "line 1" in short
+    assert "line 8" in short
+    assert "line 9" not in short
+    assert "3 more lines" in short
+    assert "line 11" in full
+    assert "Preview only" not in full
+
+
+def test_tool_result_block_formats_edit_diff_preview() -> None:
+    patch = "\n".join(["--- a.py", "+++ a.py", "@@"] + [f"+line {index}" for index in range(40)])
+
+    block = format_tool_result_block(
+        name="edit",
+        ok=True,
+        content="Successfully replaced 1 block.",
+        data={"path": "a.py", "patch": patch},
+        visibility=ToolOutputVisibility.short,
+    )
+
+    assert "Successfully replaced 1 block." in block
+    assert "File: a.py" in block
+    assert "Diff:" in block
+    assert "--- a.py" in block
+    assert "+line 28" in block
+    assert "+line 32" not in block
+    assert "Preview only" in block
 
 
 def test_transcript_renderer_streams_text_and_tool_events(
@@ -71,6 +123,27 @@ def test_transcript_renderer_fails_on_non_recoverable_error(
     captured = capsys.readouterr()
     assert renderer.finish() is False
     assert "Error: provider failed" in captured.err
+
+
+def test_transcript_renderer_respects_tool_output_visibility(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    renderer = TranscriptRenderer(tool_output_visibility=ToolOutputVisibility.none)
+
+    renderer.render(
+        ToolExecutionEndEvent(
+            result=AgentToolResult(
+                tool_call_id="call-1",
+                name="read",
+                ok=True,
+                content="hidden content",
+            )
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert "✓ read" in captured.err
+    assert "hidden content" not in captured.err
 
 
 def test_final_text_renderer_prints_only_final_message(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -232,7 +232,7 @@ def test_tui_adapter_renders_live_edit_patch() -> None:
         (
             "tool",
             "✓ edit",
-            "✓ edit\nSuccessfully replaced 1 block.\n\nPatch:\n--- a.py\n+++ a.py\n@@\n-old\n+new",
+            "✓ edit\nSuccessfully replaced 1 block.\n\nDiff:\n--- a.py\n+++ a.py\n@@\n-old\n+new",
         )
     ]
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -27,6 +27,7 @@ from tau_agent import (
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import OAuthCredential
 from tau_coding.provider_config import OpenAICompatibleProviderConfig, ProviderSettings
+from tau_coding.rendering import ToolOutputVisibility
 from tau_coding.session import ModelChoice, SessionTreeChoice, TerminalCommandResult
 from tau_coding.session_manager import CodingSessionRecord
 from tau_coding.skills import Skill, format_skill_invocation
@@ -739,12 +740,15 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
         await pilot.pause()
 
         assert prompt.has_class("-shell-mode")
-        assert _activity_prompt_border_color(
-            app.tui_settings.resolved_theme,
-            frame=0,
-            running=False,
-            shell_mode=prompt.has_class("-shell-mode"),
-        ) == app.tui_settings.resolved_theme.accent
+        assert (
+            _activity_prompt_border_color(
+                app.tui_settings.resolved_theme,
+                frame=0,
+                running=False,
+                shell_mode=prompt.has_class("-shell-mode"),
+            )
+            == app.tui_settings.resolved_theme.accent
+        )
         assert prompt.get_line(0).spans[-1].start == 0
         assert prompt.get_line(0).spans[-1].end == 2
         assert str(prompt.get_line(0).spans[-1].style) == app.tui_settings.resolved_theme.accent
@@ -1016,7 +1020,8 @@ def test_tui_app_loads_restored_messages_into_display_state() -> None:
             "✓ edit\n"
             "Successfully replaced 1 block.\n"
             "\n"
-            "Patch:\n"
+            "File: README.md\n"
+            "Diff:\n"
             "--- README.md\n"
             "+++ README.md\n"
             "@@\n"
@@ -2228,15 +2233,22 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
     app._notify = fake_notify  # type: ignore[method-assign]
 
     async with app.run_test() as pilot:
-        assert app.state.show_tool_results is False
+        assert app.state.tool_output_visibility is ToolOutputVisibility.short
         await pilot.press("ctrl+o")
         await pilot.pause()
-        assert app.state.show_tool_results is True
+        assert app.state.tool_output_visibility is ToolOutputVisibility.full
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.tool_output_visibility is ToolOutputVisibility.none
         await pilot.press("ctrl+o")
         await pilot.pause()
 
-    assert app.state.show_tool_results is False
-    assert notifications == ["Tool results expanded.", "Tool results collapsed."]
+    assert app.state.tool_output_visibility is ToolOutputVisibility.short
+    assert notifications == [
+        "Tool output: full.",
+        "Tool output: none.",
+        "Tool output: short.",
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from tau_coding.paths import TauPaths
+from tau_coding.rendering import ToolOutputVisibility
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
     TuiConfigError,
@@ -27,6 +28,7 @@ def test_load_tui_settings_returns_defaults_when_file_is_missing(tmp_path: Path)
 
     assert load_tui_settings(paths) == TuiSettings()
     assert load_tui_settings(paths).keybindings.quit == "ctrl+d"
+    assert load_tui_settings(paths).tool_output_visibility is ToolOutputVisibility.short
 
 
 def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
@@ -46,7 +48,8 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
             "toggle_thinking": "f4",
             "copy_message": "ctrl+b"
           },
-          "theme": "high-contrast"
+          "theme": "high-contrast",
+          "tool_output_visibility": "full"
         }
         """,
         encoding="utf-8",
@@ -66,15 +69,23 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     assert settings.keybindings.cancel == "escape"
     assert settings.theme == "high-contrast"
     assert settings.resolved_theme == HIGH_CONTRAST_THEME
+    assert settings.tool_output_visibility is ToolOutputVisibility.full
 
 
 def test_save_tui_settings_writes_json(tmp_path: Path) -> None:
     paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
 
-    path = save_tui_settings(TuiSettings(theme="tau-light"), paths)
+    path = save_tui_settings(
+        TuiSettings(
+            theme="tau-light",
+            tool_output_visibility=ToolOutputVisibility.none,
+        ),
+        paths,
+    )
 
     assert path == tmp_path / ".tau" / "tui.json"
     assert load_tui_settings(paths).theme == "tau-light"
+    assert load_tui_settings(paths).tool_output_visibility is ToolOutputVisibility.none
 
 
 def test_tui_settings_ignores_removed_message_selection_keybindings() -> None:
@@ -112,6 +123,11 @@ def test_tui_settings_reject_unknown_theme() -> None:
         tui_settings_from_json({"theme": "solarized"})
 
 
+def test_tui_settings_reject_unknown_tool_output_visibility() -> None:
+    with pytest.raises(TuiConfigError, match="Unknown tool output visibility"):
+        tui_settings_from_json({"tool_output_visibility": "verbose"})
+
+
 def test_tui_settings_accept_light_theme() -> None:
     settings = tui_settings_from_json({"theme": "tau-light"})
 
@@ -133,6 +149,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
             copy_message="ctrl+b",
         ),
         theme="high-contrast",
+        tool_output_visibility=ToolOutputVisibility.full,
     )
 
     assert settings.to_json()["keybindings"]["command_palette"] == "ctrl+j"
@@ -145,6 +162,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
     assert settings.to_json()["keybindings"]["model_cycle"] == "f6"
     assert settings.to_json()["keybindings"]["copy_message"] == "ctrl+b"
     assert settings.to_json()["theme"] == "high-contrast"
+    assert settings.to_json()["tool_output_visibility"] == "full"
 
 
 def test_get_tui_theme_returns_builtin_theme() -> None:


### PR DESCRIPTION
## Summary

Closes #102.

Adds configurable tool-result visibility for Tau frontends and transcript output:

- Adds `none`, `short`, and `full` tool output visibility levels.
- Adds a shared preview formatter in `tau_coding.rendering` so print-mode transcript output and the Textual TUI use consistent truncation markers.
- Shows compact unified diff previews for `edit` results in short mode, including file path context when available.
- Wires visibility through `--tool-output`, `~/.tau/tui.json`, and the TUI `Ctrl+O` cycle.
- Preserves full raw tool result data in TUI state so display level changes remain a rendering concern.
- Updates docs, help text, and tests for the new behavior.

## Validation

Passed:

- `uv run pytest` — 424 passed
- `uv run --group docs mkdocs build --strict` — passed

Repo-wide checks with unrelated existing failures:

- `uv run ruff check .` fails only in `tests/test_commands.py` for an unused `ResourceDiagnostic` import and two existing line-length violations.
- `uv run mypy` fails only in `src/tau_coding/tools.py` around existing async task typing in cancellation handling (`:588`, `:599`, `:604`).

## Notes

The PR is intentionally draft and is not merged.