### PR TITLE
Start new TUI sessions from last scoped model

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -398,7 +398,11 @@ class CodingSession:
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=self.model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+            )
         suffix = " with branch summary" if summary_entry is not None else ""
         return f"Branched session at {target_id}{suffix}."
 
@@ -560,7 +564,11 @@ class CodingSession:
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=model,
+                provider_name=self.provider_name,
+            )
 
     def set_model_choice(self, choice: ModelChoice) -> None:
         """Switch provider/model as one operation."""
@@ -635,7 +643,11 @@ class CodingSession:
         self._harness.config.model = model
         self._thinking_level = thinking_level
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=model,
+                provider_name=self.provider_name,
+            )
 
     async def set_thinking_level(self, level: str) -> str:
         """Persist and activate a thinking mode for future turns."""
@@ -672,7 +684,11 @@ class CodingSession:
         entries = await self._config.storage.read_all()
         self._state = SessionState.from_entries(entries, leaf_id=entry.id)
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=self.model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+            )
         return f"Thinking mode: {normalized}"
 
     async def cycle_thinking_level(self) -> str:
@@ -845,7 +861,11 @@ class CodingSession:
         if manager is None:
             raise ValueError("Session manager is not available")
 
-        record = manager.create_session(cwd=self.cwd, model=self.model)
+        record = manager.create_session(
+            cwd=self.cwd,
+            model=self.model,
+            provider_name=self.provider_name,
+        )
         replacement = await type(self).load(
             replace(
                 self._config,
@@ -1048,7 +1068,11 @@ class CodingSession:
         entries = await self._config.storage.read_all()
         self._state = SessionState.from_entries(entries)
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=self.model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+            )
 
     def _provider_is_usable(self, provider: ProviderConfig) -> bool:
         return provider_has_usable_credentials(
@@ -1094,7 +1118,11 @@ class CodingSession:
         self._state = SessionState.from_entries(entries, leaf_id=compaction.id)
         self._harness.replace_messages(self._state.messages)
         if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(self._config.session_id, model=self.model)
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+            )
         return compaction
 
 

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -19,6 +19,7 @@ class SessionRecordModel(BaseModel):
     path: str
     cwd: str
     model: str
+    provider_name: str | None = None
     title: str | None = None
     created_at: float
     updated_at: float
@@ -35,6 +36,7 @@ class CodingSessionRecord:
     title: str | None
     created_at: float
     updated_at: float
+    provider_name: str | None = None
 
     @classmethod
     def from_model(cls, model: SessionRecordModel) -> CodingSessionRecord:
@@ -47,6 +49,7 @@ class CodingSessionRecord:
             title=model.title,
             created_at=model.created_at,
             updated_at=model.updated_at,
+            provider_name=model.provider_name,
         )
 
     def to_model(self) -> SessionRecordModel:
@@ -59,6 +62,7 @@ class CodingSessionRecord:
             title=self.title,
             created_at=self.created_at,
             updated_at=self.updated_at,
+            provider_name=self.provider_name,
         )
 
 
@@ -104,6 +108,7 @@ class SessionManager:
         *,
         cwd: Path,
         model: str,
+        provider_name: str | None = None,
         title: str | None = None,
         session_id: str | None = None,
     ) -> CodingSessionRecord:
@@ -118,6 +123,7 @@ class SessionManager:
             path=path,
             cwd=resolved_cwd,
             model=model,
+            provider_name=provider_name,
             title=title,
             created_at=now,
             updated_at=now,
@@ -125,7 +131,9 @@ class SessionManager:
         self._upsert(record)
         return record
 
-    def get_or_create_default_session(self, *, cwd: Path, model: str) -> CodingSessionRecord:
+    def get_or_create_default_session(
+        self, *, cwd: Path, model: str, provider_name: str | None = None
+    ) -> CodingSessionRecord:
         """Return the default project session, creating an index record when needed."""
         resolved_cwd = cwd.resolve()
         project_hash = self.paths.project_session_dir(resolved_cwd).name
@@ -141,6 +149,7 @@ class SessionManager:
             path=path,
             cwd=resolved_cwd,
             model=model,
+            provider_name=provider_name,
             title="Default session",
             created_at=now,
             updated_at=now,
@@ -153,6 +162,7 @@ class SessionManager:
         session_id: str,
         *,
         model: str | None = None,
+        provider_name: str | None = None,
         title: str | None = None,
     ) -> CodingSessionRecord | None:
         """Update a session's last-used metadata."""
@@ -164,6 +174,7 @@ class SessionManager:
             path=existing.path,
             cwd=existing.cwd,
             model=model or existing.model,
+            provider_name=provider_name if provider_name is not None else existing.provider_name,
             title=title if title is not None else existing.title,
             created_at=existing.created_at,
             updated_at=time(),

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -94,6 +94,11 @@ class SessionManager:
                 return record
         return None
 
+    def latest_session_for_cwd(self, cwd: Path) -> CodingSessionRecord | None:
+        """Return the most recently updated session for a working directory."""
+        records = self.list_sessions(cwd)
+        return records[0] if records else None
+
     def create_session(
         self,
         *,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -43,8 +43,10 @@ from tau_coding.provider_catalog import (
 )
 from tau_coding.provider_config import (
     ProviderConfig,
+    ProviderSelection,
     load_provider_settings,
     provider_config_from_catalog_entry,
+    provider_has_usable_credentials,
     resolve_provider_selection,
     save_provider_settings,
     upsert_provider,
@@ -2957,6 +2959,127 @@ def _attach_diagnostic_log_path_to_error(state: TuiState, session: CodingSession
     state.add_item("error", message)
 
 
+def _explicit_resume_record(
+    manager: SessionManager,
+    *,
+    session_id: str | None,
+) -> object | None:
+    if session_id is None:
+        return None
+    record = manager.get_session(session_id)
+    if record is None:
+        raise RuntimeError(f"Unknown session: {session_id}")
+    return record
+
+
+def _latest_startup_record(manager: SessionManager, *, cwd: Path) -> object | None:
+    latest = getattr(manager, "latest_session_for_cwd", None)
+    if callable(latest):
+        return latest(cwd)
+    records = manager.list_sessions(cwd) if hasattr(manager, "list_sessions") else ()
+    return records[0] if records else None
+
+
+def _create_startup_session_record(
+    manager: SessionManager,
+    *,
+    cwd: Path,
+    selection: ProviderSelection,
+) -> object:
+    try:
+        return manager.create_session(
+            cwd=cwd,
+            model=selection.model,
+            provider_name=selection.provider.name,
+        )
+    except TypeError:
+        return manager.create_session(cwd=cwd, model=selection.model)  # type: ignore[call-arg]
+
+
+def _resolve_tui_startup_selection(
+    settings: Any,
+    *,
+    manager: SessionManager,
+    cwd: Path,
+    record: Any | None,
+    provider_name: str | None,
+    model: str | None,
+    explicit_resume: bool,
+) -> ProviderSelection:
+    if provider_name is not None or model is not None:
+        return resolve_provider_selection(settings, provider_name=provider_name, model=model)
+
+    reference = record if record is not None else _latest_startup_record(manager, cwd=cwd)
+    scoped = _usable_scoped_startup_choices(settings)
+    scoped_required = bool(settings.scoped_models) and not explicit_resume
+    record_selection = _selection_from_session_record(settings, reference)
+    if record_selection is not None:
+        record_choice = ModelChoice(
+            provider_name=record_selection.provider.name,
+            model=record_selection.model,
+        )
+        if not scoped_required or record_choice in scoped:
+            return record_selection
+
+    if scoped:
+        choice = scoped[0]
+        return resolve_provider_selection(
+            settings,
+            provider_name=choice.provider_name,
+            model=choice.model,
+        )
+
+    return resolve_provider_selection(settings)
+
+
+def _selection_from_session_record(settings: Any, record: Any | None) -> ProviderSelection | None:
+    if record is None:
+        return None
+    record_model = getattr(record, "model", None)
+    if not isinstance(record_model, str) or not record_model:
+        return None
+
+    record_provider = getattr(record, "provider_name", None)
+    if isinstance(record_provider, str) and record_provider:
+        try:
+            return resolve_provider_selection(
+                settings,
+                provider_name=record_provider,
+                model=record_model,
+            )
+        except Exception:
+            return None
+
+    for choice in _usable_scoped_startup_choices(settings):
+        if choice.model == record_model:
+            return resolve_provider_selection(
+                settings,
+                provider_name=choice.provider_name,
+                model=choice.model,
+            )
+
+    for provider in settings.providers:
+        if record_model in provider.models:
+            return ProviderSelection(provider=provider, model=record_model)
+    return None
+
+
+def _usable_scoped_startup_choices(settings: Any) -> tuple[ModelChoice, ...]:
+    credential_store = FileCredentialStore()
+    choices: list[ModelChoice] = []
+    for item in settings.scoped_models:
+        try:
+            provider = settings.get_provider(item.provider)
+        except Exception:
+            continue
+        if item.model not in provider.models:
+            continue
+        if not provider_has_usable_credentials(provider, credential_reader=credential_store):
+            continue
+        choices.append(ModelChoice(provider_name=item.provider, model=item.model))
+    return tuple(choices)
+
+
 async def run_tui_app(
     *,
     model: str | None,
@@ -2973,10 +3096,19 @@ async def run_tui_app(
         raise RuntimeError("--resume and --new-session cannot be used together")
 
     provider_settings = load_provider_settings()
-    selection = resolve_provider_selection(
+    manager = session_manager or SessionManager()
+    record = _explicit_resume_record(
+        manager,
+        session_id=session_id,
+    )
+    selection = _resolve_tui_startup_selection(
         provider_settings,
+        manager=manager,
+        cwd=cwd,
+        record=record,
         provider_name=provider_name,
         model=model,
+        explicit_resume=session_id is not None,
     )
     startup_message: str | None = None
     runtime_provider_config: ProviderConfig | None = selection.provider
@@ -2993,16 +3125,14 @@ async def run_tui_app(
         )
         provider = LoginRequiredProvider(startup_message)
         runtime_provider_config = None
-    manager = session_manager or SessionManager()
     session: CodingSession | None = None
     try:
-        if session_id is not None:
-            existing_record = manager.get_session(session_id)
-            if existing_record is None:
-                raise RuntimeError(f"Unknown session: {session_id}")
-            record = existing_record
-        else:
-            record = manager.create_session(cwd=cwd, model=selection.model)
+        if record is None:
+            record = _create_startup_session_record(
+                manager,
+                cwd=cwd,
+                selection=selection,
+            )
 
         session = await CodingSession.load(
             CodingSessionConfig(

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -37,6 +37,22 @@ def test_session_manager_filters_sessions_by_project_cwd(tmp_path: Path) -> None
     assert {record.id for record in manager.list_sessions()} == {first.id, second.id}
 
 
+def test_session_manager_returns_latest_session_for_cwd(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    older = manager.create_session(cwd=cwd, model="older", session_id="older")
+    newer = manager.create_session(cwd=cwd, model="newer", session_id="newer")
+    manager.touch_session(older.id)
+
+    latest = manager.latest_session_for_cwd(cwd)
+
+    assert latest is not None
+    assert latest.id == older.id
+    assert latest.model == "older"
+    assert newer in manager.list_sessions(cwd)
+
+
 def test_session_manager_gets_or_creates_default_session(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
     cwd = tmp_path / "project"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -9,8 +9,14 @@ def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
     cwd = tmp_path / "project"
     cwd.mkdir()
 
-    record = manager.create_session(cwd=cwd, model="fake", title="Test session")
+    record = manager.create_session(
+        cwd=cwd,
+        model="fake",
+        provider_name="fake-provider",
+        title="Test session",
+    )
 
+    assert record.provider_name == "fake-provider"
     assert record.path.parent.parent == tmp_path / ".tau" / "sessions"
     assert "project-" in record.path.parent.name
     assert len(record.path.parent.name.rsplit("-", maxsplit=1)[-1]) == 6
@@ -58,10 +64,13 @@ def test_session_manager_gets_or_creates_default_session(tmp_path: Path) -> None
     cwd = tmp_path / "project"
     cwd.mkdir()
 
-    first = manager.get_or_create_default_session(cwd=cwd, model="fake")
+    first = manager.get_or_create_default_session(
+        cwd=cwd, model="fake", provider_name="fake-provider"
+    )
     second = manager.get_or_create_default_session(cwd=cwd, model="other")
 
     assert first == second
+    assert first.provider_name == "fake-provider"
     assert first.id.startswith("default-")
     assert first.path.name == "default.jsonl"
     assert first.path.parent.exists()
@@ -73,11 +82,17 @@ def test_session_manager_touch_updates_metadata(tmp_path: Path) -> None:
     cwd.mkdir()
     record = manager.create_session(cwd=cwd, model="fake")
 
-    updated = manager.touch_session(record.id, model="new-model", title="Updated")
+    updated = manager.touch_session(
+        record.id,
+        model="new-model",
+        provider_name="new-provider",
+        title="Updated",
+    )
 
     assert updated is not None
     assert updated.id == record.id
     assert updated.model == "new-model"
+    assert updated.provider_name == "new-provider"
     assert updated.title == "Updated"
     assert updated.updated_at >= record.updated_at
     assert manager.get_session(record.id) == updated

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -26,7 +26,12 @@ from tau_agent import (
 )
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import OAuthCredential
-from tau_coding.provider_config import OpenAICompatibleProviderConfig, ProviderSettings
+from tau_coding.provider_config import (
+    OpenAICodexProviderConfig,
+    OpenAICompatibleProviderConfig,
+    ProviderSettings,
+    ScopedModelConfig,
+)
 from tau_coding.session import ModelChoice, SessionTreeChoice, TerminalCommandResult
 from tau_coding.session_manager import CodingSessionRecord
 from tau_coding.skills import Skill, format_skill_invocation
@@ -2674,6 +2679,207 @@ async def test_tui_app_runs_initial_prompt() -> None:
 
 
 @pytest.mark.anyio
+async def test_run_tui_app_starts_with_latest_directory_provider_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    record = CodingSessionRecord(
+        id="new-session",
+        path=tmp_path / "new-session.jsonl",
+        cwd=tmp_path,
+        model="gpt-5.5",
+        title=None,
+        created_at=1.0,
+        updated_at=1.0,
+        provider_name="openai-codex",
+    )
+
+    class FakeProvider:
+        async def aclose(self) -> None:
+            calls.append("provider_closed")
+
+    class FakeManager:
+        def latest_session_for_cwd(self, cwd: Path) -> CodingSessionRecord | None:
+            calls.append(f"latest:{cwd}")
+            return record
+
+        def create_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            return record
+
+        def get_session(self, session_id: str) -> CodingSessionRecord | None:
+            return None
+
+    class FakeCodingSession:
+        @classmethod
+        async def load(cls, config: object) -> str:
+            assert config.provider_name == "openai-codex"  # type: ignore[attr-defined]
+            assert config.model == "gpt-5.5"  # type: ignore[attr-defined]
+            calls.append("load")
+            return "session"
+
+    class FakeApp:
+        def __init__(self, session: str, **kwargs: object) -> None:
+            assert session == "session"
+
+        async def run_async(self) -> None:
+            calls.append("run")
+
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5.5",),
+                default_model="gpt-5.5",
+            ),
+            OpenAICodexProviderConfig(
+                name="openai-codex",
+                models=("gpt-5.5",),
+                default_model="gpt-5.5",
+            ),
+        ),
+    )
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
+    monkeypatch.setattr(
+        tui_app,
+        "create_model_provider",
+        lambda provider, **kwargs: calls.append(f"provider:{provider.name}:{kwargs['model']}")
+        or FakeProvider(),
+    )
+    monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
+    monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
+
+    await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
+
+    assert calls == [
+        f"latest:{tmp_path}",
+        "provider:openai-codex:gpt-5.5",
+        f"create:{tmp_path}:gpt-5.5:openai-codex",
+        "load",
+        "run",
+        "provider_closed",
+    ]
+
+
+@pytest.mark.anyio
+async def test_run_tui_app_falls_back_to_scoped_model_when_latest_is_out_of_scope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    latest = CodingSessionRecord(
+        id="latest-session",
+        path=tmp_path / "latest-session.jsonl",
+        cwd=tmp_path,
+        model="gpt-5.5",
+        title=None,
+        created_at=1.0,
+        updated_at=1.0,
+        provider_name="openai",
+    )
+    record = CodingSessionRecord(
+        id="new-session",
+        path=tmp_path / "new-session.jsonl",
+        cwd=tmp_path,
+        model="gpt-5.5",
+        title=None,
+        created_at=2.0,
+        updated_at=2.0,
+        provider_name="openai-codex",
+    )
+
+    class FakeProvider:
+        async def aclose(self) -> None:
+            calls.append("provider_closed")
+
+    class FakeCredentialStore:
+        def get(self, name: str) -> str | None:
+            return None
+
+        def get_oauth(self, name: str) -> object | None:
+            return object() if name == "openai-codex" else None
+
+    class FakeManager:
+        def latest_session_for_cwd(self, cwd: Path) -> CodingSessionRecord | None:
+            calls.append(f"latest:{cwd}")
+            return latest
+
+        def create_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            return record
+
+        def get_session(self, session_id: str) -> CodingSessionRecord | None:
+            return None
+
+    class FakeCodingSession:
+        @classmethod
+        async def load(cls, config: object) -> str:
+            assert config.provider_name == "openai-codex"  # type: ignore[attr-defined]
+            calls.append("load")
+            return "session"
+
+    class FakeApp:
+        def __init__(self, session: str, **kwargs: object) -> None:
+            assert session == "session"
+
+        async def run_async(self) -> None:
+            calls.append("run")
+
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5.5",),
+                default_model="gpt-5.5",
+            ),
+            OpenAICodexProviderConfig(
+                name="openai-codex",
+                models=("gpt-5.5",),
+                default_model="gpt-5.5",
+            ),
+        ),
+        scoped_models=(ScopedModelConfig(provider="openai-codex", model="gpt-5.5"),),
+    )
+    monkeypatch.setattr(tui_app, "FileCredentialStore", lambda: FakeCredentialStore())
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
+    monkeypatch.setattr(
+        tui_app,
+        "create_model_provider",
+        lambda provider, **kwargs: calls.append(f"provider:{provider.name}:{kwargs['model']}")
+        or FakeProvider(),
+    )
+    monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
+    monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+
+    await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
+
+    assert calls == [
+        f"latest:{tmp_path}",
+        "provider:openai-codex:gpt-5.5",
+        f"create:{tmp_path}:gpt-5.5:openai-codex",
+        "load",
+        "run",
+        "provider_closed",
+    ]
+
+
+@pytest.mark.anyio
 async def test_run_tui_app_creates_new_session_by_default(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2693,8 +2899,14 @@ async def test_run_tui_app_creates_new_session_by_default(
             calls.append("provider_closed")
 
     class FakeManager:
-        def create_session(self, *, cwd: Path, model: str) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}")
+        def create_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            calls.append(f"create:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -2741,6 +2953,7 @@ async def test_run_tui_app_creates_new_session_by_default(
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
 
     await tui_app.run_tui_app(
         model=None,
@@ -2751,7 +2964,7 @@ async def test_run_tui_app_creates_new_session_by_default(
         session_manager=FakeManager(),
     )
 
-    assert calls == [f"create:{tmp_path}:local-model", "load", "run", "provider_closed"]
+    assert calls == [f"create:{tmp_path}:local-model:local", "load", "run", "provider_closed"]
 
 
 @pytest.mark.anyio
@@ -2770,8 +2983,14 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     )
 
     class FakeManager:
-        def create_session(self, *, cwd: Path, model: str) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}")
+        def create_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            calls.append(f"create:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -2803,10 +3022,11 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
 
     await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
 
-    assert calls == [f"create:{tmp_path}:gpt-5.5", "load:LoginRequiredProvider", "run"]
+    assert calls == [f"create:{tmp_path}:gpt-5.5:openai", "load:LoginRequiredProvider", "run"]
 
 
 @pytest.mark.anyio
@@ -2829,7 +3049,13 @@ async def test_run_tui_app_resumes_explicit_session(
             calls.append("provider_closed")
 
     class FakeManager:
-        def create_session(self, *, cwd: Path, model: str) -> CodingSessionRecord:
+        def create_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
             raise AssertionError("explicit resume should not create a new session")
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -2859,6 +3085,7 @@ async def test_run_tui_app_resumes_explicit_session(
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
 
     await tui_app.run_tui_app(
         model="fake-model",


### PR DESCRIPTION
## Summary\n- persist provider names in session metadata so same-name models resolve to the right provider\n- start new TUI sessions from the latest directory model/provider when allowed\n- respect scoped model constraints by falling back to the first usable scoped model\n\nCloses #117\n\n## Tests\n- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session management to better track provider and model information across sessions.
  * Improved startup logic for provider and model selection, with better support for resuming previous sessions.
  * Refined session record handling to preserve provider metadata during session updates and creation.

* **Tests**
  * Expanded test coverage for session management, provider selection, and session resumption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->