### PR TITLE
Implement #126: show named thread in session output

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -70,6 +70,9 @@ class CommandSession(Protocol):
     def session_id(self) -> str | None: ...
 
     @property
+    def session_title(self) -> str | None: ...
+
+    @property
     def session_manager(self) -> SessionManager | None: ...
 
     def set_model(self, model: str) -> None: ...
@@ -372,6 +375,8 @@ def _status_command(context: CommandContext) -> CommandResult:
         lines.append(f"Auto compact threshold: {session.auto_compact_token_threshold}")
     if session.session_id is not None:
         lines.append(f"Session: {session.session_id}")
+    if session.session_title:
+        lines.append(f"Session name: {session.session_title}")
     return CommandResult(handled=True, message="\n".join(lines))
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -556,6 +556,16 @@ class CodingSession:
         return self._config.session_id
 
     @property
+    def session_title(self) -> str | None:
+        """Return this session's indexed human-friendly title, if named."""
+        if self._config.session_id is None or self._config.session_manager is None:
+            return None
+        record = self._config.session_manager.get_session(self._config.session_id)
+        if record is None:
+            return None
+        return record.title
+
+    @property
     def session_manager(self) -> SessionManager | None:
         """Return the session manager, if available."""
         return self._config.session_manager

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -44,6 +44,7 @@ class FakeSession:
         self.tui_theme = "tau-dark"
         self.resource_diagnostics = ()
         self.session_id = "session-1"
+        self.session_title: str | None = None
         self.session_manager: SessionManager | None = manager
         self.reload_called = False
         self.provider_reload_called = False
@@ -180,10 +181,22 @@ def test_session_command_includes_session_details(tmp_path: Path) -> None:
     assert "Auto compact threshold: 200" in result.message
     assert "Resource diagnostics: 0" in result.message
     assert "Session: session-1" in result.message
+    assert "Session name:" not in result.message
     assert (
         create_default_command_registry().execute(FakeSession(tmp_path), "/status").message
         == "Unknown command: /status"
     )
+
+
+def test_session_command_includes_named_session_title(tmp_path: Path) -> None:
+    session = FakeSession(tmp_path)
+    session.session_title = "Customer bugfix"
+
+    result = create_default_command_registry().execute(session, "/session")
+
+    assert result.message is not None
+    assert "Session: session-1" in result.message
+    assert "Session name: Customer bugfix" in result.message
 
 
 def test_session_command_explains_unavailable_thinking_controls(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #126

## Issue addressed
- GitHub issue #126: `/session` should show the current named thread when `/name <thread name>` has set one.

## Summary
- Added a `CodingSession.session_title` accessor backed by the existing indexed `SessionManager` record.
- Updated `/session` output to include `Session name: ...` only when the current session has a title.
- Left unnamed session output unchanged.

## Files/areas changed
- `src/tau_coding/commands.py`: command-session protocol and `/session` status output.
- `src/tau_coding/session.py`: read-only session title accessor.
- `tests/test_commands.py`: named and unnamed `/session` coverage.

## Tests/checks run and results
- `uv run pytest tests/test_commands.py -q` - passed, 29 tests.
- `uv run ruff check src/tau_coding/commands.py src/tau_coding/session.py tests/test_commands.py` - passed.

## Assumptions
- The existing session title field is the canonical human-friendly thread name set by `/name`.
- Unnamed sessions should keep the existing `/session` output unchanged.

## Follow-up work
- None identified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session titles are now displayed in the `/session` command output, helping you better identify and manage multiple sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->