### PR TITLE
Fix #124: remove thinking toggle notification

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2259,9 +2259,8 @@ class TauTuiApp(App[None]):
 
     def action_toggle_thinking(self) -> None:
         """Toggle thinking-token display in the transcript."""
-        visible = self.state.toggle_thinking()
+        self.state.toggle_thinking()
         self._refresh()
-        self._notify("Thinking tokens shown." if visible else "Thinking tokens hidden.")
 
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2792,7 +2792,7 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
         assert "Thinking… Press Ctrl+T to show thinking tokens." in transcript_text()
         assert "internal plan" not in transcript_text()
 
-    assert notifications == ["Thinking tokens shown.", "Thinking tokens hidden."]
+    assert notifications == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Issue addressed

Closes #124.

## Summary

- Removed the informational toast emitted when Ctrl+T toggles thinking-token visibility in the Textual TUI.
- Kept the Ctrl+T toggle behavior and transcript refresh unchanged.

## Files/areas changed

- `src/tau_coding/tui/app.py`: `action_toggle_thinking` now toggles state and refreshes without notifying.
- `tests/test_tui_app.py`: updated the Ctrl+T regression test to expect no notifications.

## Tests/checks run and results

- `uv run pytest tests/test_tui_app.py -k toggles_thinking_tokens_from_keybinding_while_running` - passed.
- `uv run pytest tests/test_tui_app.py` - passed, 135 tests.
- `git diff --check` - passed.

## Assumptions

- The issue only targets the notification/toast/status message emitted solely by the thinking-token visibility toggle, not footer binding labels or the transcript placeholder that tells users how to reveal hidden thinking tokens.

## Follow-up work

- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed notification messages when toggling thinking tokens on/off. The toggle functionality continues to work as expected with UI refresh.

* **Tests**
  * Updated tests to reflect the removal of thinking-token toggle notification messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->