### PR TITLE
Fix #127: shorten queued and steering message lines

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3013,14 +3013,20 @@ def _render_queued_messages(state: TuiState, *, theme: TuiTheme) -> Group:
     """Render queued prompts stacked above the prompt input."""
     rows: list[Text] = []
     for message in state.queued_steering:
-        row = Text("↪ steering · inserted at the next turn: ", style=theme.muted_text)
-        row.append(message, style=theme.prompt_text)
+        row = Text("↪ steering · queued: ", style=theme.muted_text)
+        row.append(_queued_message_preview(message), style=theme.prompt_text)
         rows.append(row)
     for message in state.queued_follow_up:
-        row = Text("↳ follow-up · queued after this turn: ", style=theme.muted_text)
-        row.append(message, style=theme.prompt_text)
+        row = Text("↳ follow-up · queued: ", style=theme.muted_text)
+        row.append(_queued_message_preview(message), style=theme.prompt_text)
         rows.append(row)
     return Group(*rows)
+
+
+def _queued_message_preview(message: str) -> str:
+    """Return the single-line preview shown above the prompt."""
+    lines = message.splitlines()
+    return lines[0] if lines else ""
 
 
 def _prompt_footer_mode(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2668,25 +2668,25 @@ async def test_tui_app_queues_steering_prompt_while_running() -> None:
     async with app.run_test() as pilot:
         app.state.running = True
         prompt = app.query_one("#prompt", TextArea)
-        prompt.text = "adjust course"
+        prompt.text = "adjust course\nwith extra detail"
 
         await pilot.press("enter")
         await pilot.pause()
 
         queued_messages = app.query_one("#queued-messages")
         assert prompt.text == ""
-        assert session.prompt_texts == ["adjust course"]
+        assert session.prompt_texts == ["adjust course\nwith extra detail"]
         assert session.streaming_behaviors == ["steer"]
-        assert app.state.queued_steering == ("adjust course",)
+        assert app.state.queued_steering == ("adjust course\nwith extra detail",)
         assert app.state.queued_follow_up == ()
         assert queued_messages.display is True
         rendered_queue = tui_app._render_queued_messages(
             app.state,
             theme=app.tui_settings.resolved_theme,
         )
-        assert "↪ steering · inserted at the next turn: adjust course" in [
-            str(row) for row in rendered_queue.renderables
-        ]
+        rendered_rows = [str(row) for row in rendered_queue.renderables]
+        assert "↪ steering · queued: adjust course" in rendered_rows
+        assert all("with extra detail" not in row for row in rendered_rows)
 
     assert notifications == []
 
@@ -2706,25 +2706,25 @@ async def test_tui_app_queues_follow_up_prompt_from_keybinding() -> None:
     async with app.run_test() as pilot:
         app.state.running = True
         prompt = app.query_one("#prompt", TextArea)
-        prompt.text = "after this"
+        prompt.text = "after this\nwith extra detail"
 
         await pilot.press("alt+enter")
         await pilot.pause()
 
         queued_messages = app.query_one("#queued-messages")
         assert prompt.text == ""
-        assert session.prompt_texts == ["after this"]
+        assert session.prompt_texts == ["after this\nwith extra detail"]
         assert session.streaming_behaviors == ["follow_up"]
         assert app.state.queued_steering == ()
-        assert app.state.queued_follow_up == ("after this",)
+        assert app.state.queued_follow_up == ("after this\nwith extra detail",)
         assert queued_messages.display is True
         rendered_queue = tui_app._render_queued_messages(
             app.state,
             theme=app.tui_settings.resolved_theme,
         )
-        assert "↳ follow-up · queued after this turn: after this" in [
-            str(row) for row in rendered_queue.renderables
-        ]
+        rendered_rows = [str(row) for row in rendered_queue.renderables]
+        assert "↳ follow-up · queued: after this" in rendered_rows
+        assert all("with extra detail" not in row for row in rendered_rows)
 
     assert notifications == []
 


### PR DESCRIPTION
Closes #127

## Issue addressed
- GitHub issue #127: shorten queued and steering message info lines in the TUI.

## Summary
- Shortened queued steering and follow-up prefixes to concise `queued:` lines.
- Limited queued-message previews above the prompt to the first line so multiline prompts do not take over the input area.
- Updated TUI tests to cover concise labels and multiline preview truncation.

## Files/areas changed
- `src/tau_coding/tui/app.py`: queued-message rendering only.
- `tests/test_tui_app.py`: focused steering/follow-up queue display assertions.

## Tests/checks run and results
- `uv run pytest tests/test_tui_app.py::test_tui_app_queues_steering_prompt_while_running tests/test_tui_app.py::test_tui_app_queues_follow_up_prompt_from_keybinding` - passed.
- `uv run pytest tests/test_tui_app.py` - passed, 135 tests.
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py` - passed.
- `uv run ruff format --check src/tau_coding/tui/app.py tests/test_tui_app.py` - failed because `tests/test_tui_app.py` has pre-existing formatting changes outside this issue scope; I left those unrelated hunks untouched.

## Assumptions
- The shortened steering wording should match follow-up wording as `queued:` while keeping the existing steering/follow-up row labels and icons.
- First-line preview truncation is display-only; the full queued prompt remains stored and submitted.

## Follow-up work
- Optional: run a separate formatting-only cleanup for existing `tests/test_tui_app.py` style drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queued steering and follow-up prompts now render as single-line previews, displaying only the first line of each message instead of full text
  * Queue message labels updated with arrow-style visual indicators (↪ steering · queued, ↳ follow-up · queued) to improve message distinction

* **Tests**
  * Test coverage enhanced to validate queued message display and preview rendering behavior with multi-line prompt text scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->