### PR TITLE
Fix #121: remove new session notification

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2346,10 +2346,9 @@ class TauTuiApp(App[None]):
             self._notify("Session manager is not available.")
             return
         try:
-            message = await new_session()
+            await new_session()
             self.state.clear()
             self.state.load_messages(self.session.messages)
-            self._notify(message)
         except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
             self._notify(f"Error: {exc}", severity="error")
         self._refresh()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1410,6 +1410,13 @@ async def test_tui_app_theme_command_argument_updates_theme_and_persists(
 @pytest.mark.anyio
 async def test_tui_app_new_command_starts_new_visible_state() -> None:
     app = TauTuiApp(FakeSession(messages=[UserMessage(content="Earlier")]))
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
 
     async with app.run_test() as pilot:
         prompt = app.query_one("#prompt")
@@ -1418,6 +1425,7 @@ async def test_tui_app_new_command_starts_new_visible_state() -> None:
 
         assert app.session.new_session_count == 1
         assert app.state.items == []
+        assert notifications == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Issue addressed
Closes #121

## Summary
- Stop the TUI `/new` command path from showing the successful `Started new session: ...` notification.
- Keep new-session creation, state reset, refresh behavior, and error notifications unchanged.

## Files/areas changed
- `src/tau_coding/tui/app.py`: ignore the success string returned by `session.new_session()` in the TUI handler.
- `tests/test_tui_app.py`: assert `/new` starts a new visible session without emitting a notification.

## Tests/checks run and results
- `uv run pytest tests/test_tui_app.py -k 'new_command_starts_new_visible_state or new_command_cancels_active_run_and_ignores_late_events or resume_refreshes_context_after_session_swap'` - passed, 3 tests.
- `uv run pytest tests/test_coding_session.py -k 'new_session_uses_default_provider_model'` - passed, 1 test.
- `uv run pytest tests/test_tui_app.py` - passed, 135 tests.

## Assumptions
- The issue concerns Textual/TUI notifications only; the coding-session helper can continue returning `Started new session: ...` for non-TUI command callers and existing tests.
- Other session notifications, including resume and error notifications, should remain visible.

## Follow-up work
- None identified.