### PR TITLE
Fix #122: use notification for name confirmation

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1938,7 +1938,9 @@ class TauTuiApp(App[None]):
             if command.theme is not None:
                 self._set_tui_theme(cast(TuiThemeName, command.theme))
             if command.message:
-                if _command_message_uses_transcript(text):
+                if _command_message_uses_notification(text, command.message):
+                    self._notify(command.message)
+                elif _command_message_uses_transcript(text):
                     self._append_command_message(text, command.message)
                 else:
                     self._show_command_message(text, command.message)
@@ -2968,6 +2970,12 @@ def _command_message_uses_transcript(command_text: str) -> bool:
     """Return whether slash-command output should appear inline in the transcript."""
     command_name = command_text.split(maxsplit=1)[0].casefold()
     return command_name == "/reload"
+
+
+def _command_message_uses_notification(command_text: str, message: str) -> bool:
+    """Return whether slash-command output should appear as a notification."""
+    command_name = command_text.split(maxsplit=1)[0].casefold()
+    return command_name == "/name" and message.startswith("Session renamed: ")
 
 
 def _command_output_title(command_text: str) -> str:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -172,6 +172,11 @@ class FakeSession:
             return CommandResult(handled=True, theme_picker_requested=True)
         if text.startswith("/theme "):
             return CommandResult(handled=True, theme=text.removeprefix("/theme "))
+        if text.startswith("/name "):
+            return CommandResult(
+                handled=True,
+                message=f"Session renamed: {text.removeprefix('/name ')}",
+            )
         return CommandResult(handled=False)
 
     def set_model(self, model: str) -> None:
@@ -2072,6 +2077,28 @@ async def test_tui_app_reload_appends_command_output_to_transcript() -> None:
                 text="/reload\nReloaded local coding resources and project context.",
             )
         ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_name_success_uses_notification_instead_of_modal() -> None:
+    app = TauTuiApp(FakeSession())
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/name Customer bugfix"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert notifications == ["Session renamed: Customer bugfix"]
+        assert not isinstance(app.screen, CommandOutputScreen)
+        assert app.state.items == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #122

## Issue addressed
- Fixes GitHub issue #122: successful `/name` confirmations were displayed in a command modal instead of a notification.

## Summary
- Route successful `/name <new name>` command messages to the TUI notification system.
- Preserve the existing command-output modal path for `/name` usage and error messages.

## Files/areas changed
- `src/tau_coding/tui/app.py`: added command-message routing for successful `/name` confirmations.
- `tests/test_tui_app.py`: added a regression test that verifies `/name` success notifies without opening `CommandOutputScreen` or adding transcript output.

## Tests/checks run and results
- `uv run pytest tests/test_tui_app.py::test_tui_app_name_success_uses_notification_instead_of_modal tests/test_tui_app.py::test_tui_app_reload_appends_command_output_to_transcript tests/test_tui_app.py::test_tui_app_help_uses_modal_instead_of_transcript` - passed.
- `uv run pytest tests/test_commands.py -k 'name_command'` - passed.\n- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py` - passed.\n- `git diff --check` - passed.\n\n## Assumptions\n- Only successful rename confirmations should move to notifications; failed renames, missing managers, unknown sessions, and usage output should remain in the clearer command-output modal.\n- The existing command-layer tests continue to cover the actual session rename behavior.\n\n## Follow-up work\n- None.