### PR TITLE
Implement #133: show elapsed task time

### DIFF
--- a/src/tau_coding/elapsed.py
+++ b/src/tau_coding/elapsed.py
@@ -1,0 +1,16 @@
+"""Elapsed-time formatting for Tau coding frontends."""
+
+
+def format_elapsed_time(seconds: float) -> str:
+    """Format elapsed seconds as M:SS or H:MM:SS."""
+    total_seconds = max(0, round(seconds))
+    minutes, seconds_part = divmod(total_seconds, 60)
+    hours, minutes_part = divmod(minutes, 60)
+    if hours:
+        return f"{hours}:{minutes_part:02d}:{seconds_part:02d}"
+    return f"{minutes_part}:{seconds_part:02d}"
+
+
+def format_elapsed_line(seconds: float) -> str:
+    """Format Tau's user-facing elapsed-time line."""
+    return f"took tau {format_elapsed_time(seconds)}"

--- a/src/tau_coding/rendering/plain.py
+++ b/src/tau_coding/rendering/plain.py
@@ -1,17 +1,30 @@
 """Pi-style final text renderer for print mode."""
 
+import time
+from collections.abc import Callable
+
 import typer
 
 from tau_agent import AgentEvent, ErrorEvent, MessageEndEvent
+from tau_coding.elapsed import format_elapsed_line
 
 
 class FinalTextRenderer:
     """Render only the final assistant text after the run finishes."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        started_at: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        show_elapsed: bool = True,
+    ) -> None:
         self._last_assistant_text = ""
         self._failed = False
         self._error_messages: list[str] = []
+        self._started_at = clock() if started_at is None else started_at
+        self._clock = clock
+        self._show_elapsed = show_elapsed
 
     def render(self, event: AgentEvent) -> None:
         """Record events needed for final text output."""
@@ -33,4 +46,6 @@ class FinalTextRenderer:
 
         if self._last_assistant_text:
             typer.echo(self._last_assistant_text)
+        if self._show_elapsed:
+            typer.echo(format_elapsed_line(self._clock() - self._started_at), err=True)
         return True

--- a/src/tau_coding/rendering/transcript.py
+++ b/src/tau_coding/rendering/transcript.py
@@ -1,5 +1,8 @@
 """Human-readable streaming transcript renderer."""
 
+import time
+from collections.abc import Callable
+
 import typer
 from rich.console import Console
 from rich.text import Text
@@ -16,17 +19,27 @@ from tau_agent import (
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
 )
+from tau_coding.elapsed import format_elapsed_line
 from tau_coding.tui.state import format_tool_call_block
 
 
 class TranscriptRenderer:
     """Render assistant deltas live and tool activity to stderr."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        started_at: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        show_elapsed: bool = True,
+    ) -> None:
         self._assistant_started = False
         self._assistant_ended = False
         self._failed = False
         self._console = Console(stderr=True, highlight=False)
+        self._started_at = clock() if started_at is None else started_at
+        self._clock = clock
+        self._show_elapsed = show_elapsed
 
     def render(self, event: AgentEvent) -> None:
         """Render one agent event."""
@@ -75,6 +88,10 @@ class TranscriptRenderer:
 
     def finish(self) -> bool:
         """Return whether the rendered run succeeded."""
+        if not self._failed and self._show_elapsed:
+            self._console.print(
+                Text(format_elapsed_line(self._clock() - self._started_at), style="bright_black")
+            )
         return not self._failed
 
     def _ensure_assistant_newline(self, *, final: bool = False) -> None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1,6 +1,7 @@
 """Minimal Textual app for Tau coding sessions."""
 
 import asyncio
+import time
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -53,6 +54,7 @@ from tau_ai import ProviderErrorEvent, ProviderEvent
 from tau_ai.provider import CancellationToken
 from tau_coding.commands import CommandRegistry, create_default_command_registry
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.elapsed import format_elapsed_line
 from tau_coding.oauth import OAuthAuthInfo, OAuthPrompt, login_openai_codex
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
@@ -2010,6 +2012,7 @@ class TauTuiApp(App[None]):
     async def _run_prompt(self, text: str, run_id: int | None = None) -> None:
         """Run one prompt and stream session events into the TUI state."""
         active_run_id = self._prompt_run_id if run_id is None else run_id
+        started_at = time.monotonic()
         try:
             async for event in self.session.prompt(text):
                 if active_run_id != self._prompt_run_id:
@@ -2028,7 +2031,29 @@ class TauTuiApp(App[None]):
             self._refresh()
         finally:
             if active_run_id == self._prompt_run_id:
+                if self.state.error is None:
+                    self.state.add_item(
+                        "status", format_elapsed_line(time.monotonic() - started_at)
+                    )
+                    await self._append_latest_transcript_item()
                 self._prompt_worker = None
+
+    async def _append_latest_transcript_item(self) -> None:
+        """Append the newest state item to the mounted transcript when possible."""
+        if not self.screen_stack or not self.state.items:
+            self._refresh()
+            return
+        try:
+            transcript = self.query_one("#transcript", TranscriptView)
+        except NoMatches:
+            self._refresh()
+            return
+        await transcript.append_item(
+            self.state.items[-1],
+            theme=self.tui_settings.resolved_theme,
+            show_tool_results=self.state.show_tool_results,
+        )
+        self._refresh_chrome()
 
     async def _apply_streaming_transcript_event(self, event: AgentEvent) -> None:
         """Apply an agent event to mounted transcript widgets without full redraws."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,7 +129,7 @@ async def test_run_print_mode_prints_final_assistant_text(
     captured = capsys.readouterr()
     assert ok is True
     assert captured.out == "Hello\n"
-    assert captured.err == ""
+    assert captured.err.startswith("took tau ")
     assert provider.calls[0][0] == "fake"
     assert provider.calls[0][1] == build_system_prompt(
         BuildSystemPromptOptions(cwd=tmp_path, tools=create_coding_tools(cwd=tmp_path))
@@ -361,7 +361,7 @@ async def test_run_print_mode_can_emit_live_transcript(
     captured = capsys.readouterr()
     assert ok is True
     assert captured.out == "Hello\n"
-    assert captured.err == ""
+    assert captured.err.startswith("took tau ")
 
 
 def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -17,13 +17,21 @@ from tau_agent import (
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
 )
+from tau_coding.elapsed import format_elapsed_line, format_elapsed_time
 from tau_coding.rendering import FinalTextRenderer, JsonEventRenderer, TranscriptRenderer
+
+
+def test_format_elapsed_time_uses_short_and_long_forms() -> None:
+    assert format_elapsed_time(0.4) == "0:00"
+    assert format_elapsed_time(65) == "1:05"
+    assert format_elapsed_time(3661) == "1:01:01"
+    assert format_elapsed_line(65) == "took tau 1:05"
 
 
 def test_transcript_renderer_streams_text_and_tool_events(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    renderer = TranscriptRenderer()
+    renderer = TranscriptRenderer(started_at=0, clock=lambda: 65)
 
     renderer.render(MessageStartEvent())
     renderer.render(ThinkingDeltaEvent(delta="hidden reasoning"))
@@ -49,8 +57,8 @@ def test_transcript_renderer_streams_text_and_tool_events(
         )
     )
 
-    captured = capsys.readouterr()
     assert renderer.finish() is True
+    captured = capsys.readouterr()
     assert captured.out == "Hello\n"
     assert "hidden reasoning" not in captured.out
     assert "hidden reasoning" not in captured.err
@@ -59,6 +67,7 @@ def test_transcript_renderer_streams_text_and_tool_events(
     assert "… reading" in captured.err
     assert "✓ read" in captured.err
     assert "done" in captured.err
+    assert "took tau 1:05" in captured.err
 
 
 def test_transcript_renderer_fails_on_non_recoverable_error(
@@ -76,7 +85,7 @@ def test_transcript_renderer_fails_on_non_recoverable_error(
 def test_final_text_renderer_prints_only_final_message(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    renderer = FinalTextRenderer()
+    renderer = FinalTextRenderer(show_elapsed=False)
 
     renderer.render(ThinkingDeltaEvent(delta="hidden reasoning"))
     renderer.render(MessageDeltaEvent(delta="ignored"))
@@ -89,12 +98,14 @@ def test_final_text_renderer_prints_only_final_message(
     assert captured_after_finish.out == ""
     assert captured_after_finish.err == ""
 
+    renderer = FinalTextRenderer(started_at=0, clock=lambda: 65)
     renderer.render(MessageEndEvent(message=AssistantMessage(content="Final answer")))
     ok = renderer.finish()
     captured = capsys.readouterr()
 
     assert ok is True
     assert captured.out == "Final answer\n"
+    assert captured.err == "took tau 1:05\n"
 
 
 def test_final_text_renderer_prints_errors_on_finish(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -969,6 +969,8 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
     assert full_refreshes == 1
     assert streamed.selection_text == "alpha beta"
     assert "alpha beta" in transcript_text
+    assert app.state.items[-1].role == "status"
+    assert app.state.items[-1].text.startswith("took tau ")
 
 
 @pytest.mark.anyio
@@ -2887,8 +2889,10 @@ async def test_tui_prompt_worker_refreshes_directly() -> None:
 
     await app._run_prompt("hello")
 
-    assert refreshes == 2
+    assert refreshes == 3
     assert app.state.running is False
+    assert app.state.items[-1].role == "status"
+    assert app.state.items[-1].text.startswith("took tau ")
 
 
 @pytest.mark.anyio
@@ -2975,12 +2979,14 @@ async def test_tui_prompt_worker_refreshes_context_after_message_changes() -> No
 
     await app._run_prompt("read README")
 
-    assert observed_context == [10, 20, 30, 40, 40, 50]
+    assert observed_context == [10, 20, 30, 40, 40, 50, 50]
     assert [(item.role, item.text, item.tool_result_text) for item in app.state.items] == [
         ("user", "read README", None),
         ("assistant", "Using a tool.", None),
         ("tool", "→ read README.md", "✓ read\ncontents"),
+        ("status", app.state.items[-1].text, None),
     ]
+    assert app.state.items[-1].text.startswith("took tau ")
 
 
 @pytest.mark.anyio
@@ -3033,6 +3039,7 @@ async def test_run_tui_app_falls_back_to_first_credentialed_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: list[str] = []
+
     class FakeCredentialStore:
         def get(self, name: str) -> str | None:
             return "stored-key" if name == "openai" else None
@@ -3109,8 +3116,9 @@ async def test_run_tui_app_falls_back_to_first_credentialed_provider(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: calls.append(f"provider:{provider.name}:{kwargs['model']}")
-        or FakeProvider(),
+        lambda provider, **kwargs: (
+            calls.append(f"provider:{provider.name}:{kwargs['model']}") or FakeProvider()
+        ),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
@@ -3210,8 +3218,9 @@ async def test_run_tui_app_ignores_latest_directory_provider_model_for_new_sessi
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: calls.append(f"provider:{provider.name}:{kwargs['model']}")
-        or FakeProvider(),
+        lambda provider, **kwargs: (
+            calls.append(f"provider:{provider.name}:{kwargs['model']}") or FakeProvider()
+        ),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
@@ -3320,8 +3329,9 @@ async def test_run_tui_app_does_not_start_new_session_from_scoped_model(
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: calls.append(f"provider:{provider.name}:{kwargs['model']}")
-        or FakeProvider(),
+        lambda provider, **kwargs: (
+            calls.append(f"provider:{provider.name}:{kwargs['model']}") or FakeProvider()
+        ),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)


### PR DESCRIPTION
## Issue addressed

Closes #133.

## Summary

- Added shared elapsed-time formatting for Tau coding frontends.
- Print-mode text and transcript renderers now write `took tau M:SS` / `H:MM:SS` to stderr after successful agent runs.
- TUI prompt runs now append a status transcript item with the elapsed task time after the active run completes.

## Files / areas changed

- `src/tau_coding/elapsed.py` for formatting helpers.
- `src/tau_coding/rendering/plain.py` and `src/tau_coding/rendering/transcript.py` for print-mode elapsed output.
- `src/tau_coding/tui/app.py` for TUI completion status display.
- `tests/test_rendering.py`, `tests/test_cli.py`, and `tests/test_tui_app.py` for coverage.

## Tests / checks run

- `uv run ruff format --check src/tau_coding/elapsed.py src/tau_coding/rendering/plain.py src/tau_coding/rendering/transcript.py src/tau_coding/tui/app.py tests/test_rendering.py tests/test_cli.py tests/test_tui_app.py` - passed
- `uv run ruff check src/tau_coding/elapsed.py src/tau_coding/rendering/plain.py src/tau_coding/rendering/transcript.py src/tau_coding/tui/app.py tests/test_rendering.py tests/test_cli.py tests/test_tui_app.py` - passed
- `uv run pytest tests/test_rendering.py tests/test_cli.py tests/test_tui_app.py` - 168 passed
- `uv run mypy src/tau_coding/elapsed.py src/tau_coding/rendering/plain.py src/tau_coding/rendering/transcript.py src/tau_coding/tui/app.py` - passed

## Assumptions

- JSON event output should remain valid JSONL, so the elapsed human-readable line is not emitted in JSON mode.
- The elapsed line is only shown after successful task completion; non-recoverable errors keep the existing error display.
- Print-mode elapsed output goes to stderr so stdout remains usable for assistant text.

## Follow-up work

- None required for this issue.
