### PR TITLE
Fix #114: prioritize alias autocomplete matches

### DIFF
--- a/docs/architecture/phase-17-tui-autocomplete.md
+++ b/docs/architecture/phase-17-tui-autocomplete.md
@@ -42,6 +42,13 @@ Examples:
 /ski      -> /skill:
 ```
 
+Command completion reads canonical command names, executable aliases, and
+non-executable search terms from the active `CommandRegistry`. Search terms are
+filters only: accepting one inserts the canonical command. For example, `/res`
+can match `/resume` directly and `/new` through the `/new` command's `reset`
+search term, so autocomplete ranks the direct command or alias match first and
+then keeps fallback search-term matches available below it.
+
 When the prompt starts with `/skill:`, Tau shows matching loaded skills.
 Accepting a skill completion preserves the rest of the request:
 

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -304,7 +304,15 @@ def _command_completions(
     suggestions: list[CompletionItem] = []
     for command in registry.list_commands():
         suggestions.extend(_command_alias_completions(command, prefix=prefix, token_end=token_end))
-    return tuple(sorted(suggestions, key=lambda item: item.display))
+    return tuple(sorted(suggestions, key=lambda item: _command_completion_sort_key(item, prefix)))
+
+
+def _command_completion_sort_key(item: CompletionItem, prefix: str) -> tuple[int, str]:
+    if not prefix:
+        return (0, item.display)
+    display_name = item.display.removeprefix("/").removesuffix(":").lower()
+    direct_match_rank = 0 if display_name.startswith(prefix) else 1
+    return (direct_match_rank, item.display)
 
 
 def _command_alias_completions(

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -55,6 +55,19 @@ def test_command_completion_matches_search_terms_with_canonical_replacement() ->
     assert sessions_state.selected.apply("/sess") == "/session"
 
 
+def test_command_completion_prioritizes_direct_matches_over_search_terms() -> None:
+    state = build_completion_state(
+        "/res",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+    )
+
+    assert [item.display for item in state.items[:2]] == ["/resume", "/new"]
+    assert state.selected is not None
+    assert state.selected.apply("/res") == "/resume"
+
+
 def test_skill_command_is_not_registered_for_command_completion() -> None:
     state = build_completion_state(
         "/ski",


### PR DESCRIPTION
## Issue addressed

Closes #114.

## Summary

- Prioritize slash-command completions whose displayed command or executable alias directly matches the typed prefix.
- Keep non-executable search-term fallback matches available below direct matches.
- Document how command names, aliases, and search terms feed TUI autocomplete.

## Files/areas changed

- `src/tau_coding/tui/autocomplete.py`: add command completion sort ranking for direct display-prefix matches before fallback matches.
- `tests/test_tui_autocomplete.py`: add regression coverage for `/res` selecting `/resume` before `/new`.
- `docs/architecture/phase-17-tui-autocomplete.md`: document alias/search-term completion behavior and the `/new` ordering root cause.

## Tests/checks run and results

- `uv run pytest tests/test_tui_autocomplete.py` - passed, 20 tests.
- `uv run ruff check src/tau_coding/tui/autocomplete.py tests/test_tui_autocomplete.py` - passed.
- `uv run mkdocs build --strict` - failed to start because `mkdocs` was not installed in the default project environment.
- `uv run --group docs mkdocs build --strict` - passed. MkDocs emitted an existing informational note that `docs/architecture/phase-24-session-tree-branching.md` is not in nav.

## Assumptions

- Search terms should remain useful discovery fallbacks, but direct command and alias prefix matches should win the default selected completion.
- The existing alphabetical order is still appropriate within each ranking bucket.

## Follow-up work

None required for this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slash-command autocomplete now ranks suggestions more intelligently, prioritizing the most relevant matches based on user input.

* **Documentation**
  * Clarified architecture documentation regarding slash-command autocomplete ranking behavior and suggestion prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->