### PR TITLE
Fix #118: allow tree branch from first user message

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1103,7 +1103,9 @@ class CodingSession:
         before_count = len(self._harness.messages)
         overflow_event: ErrorEvent | None = None
         try:
-            async for event in self._harness.prompt(expanded_content):
+            prompt_stream = self._harness.prompt(expanded_content)
+            before_count = await self._persist_initial_prompt_message(before_count)
+            async for event in prompt_stream:
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
                         context=context,
@@ -1193,6 +1195,14 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
             )
+
+    async def _persist_initial_prompt_message(self, before_count: int) -> int:
+        new_messages = self._harness.messages[before_count:]
+        if len(new_messages) != 1 or not isinstance(new_messages[0], UserMessage):
+            return before_count
+
+        await self._persist_new_messages(before_count)
+        return before_count + 1
 
     async def _try_auto_compact(
         self,

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -127,6 +127,36 @@ class WaitingProvider:
         return iterator()
 
 
+class CancellableWaitingProvider:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.calls: list[list[AgentMessage]] = []
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        del model, system, tools
+        self.calls.append(list(messages))
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            yield ProviderResponseStartEvent(model="fake")
+            self.started.set()
+            while not self.release.is_set():
+                if signal is not None and signal.is_cancelled():
+                    return
+                await asyncio.sleep(0)
+            yield ProviderResponseEndEvent(message=AssistantMessage(content="Finished"))
+
+        return iterator()
+
+
 @pytest.mark.anyio
 async def test_load_empty_session_appends_metadata(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
@@ -317,6 +347,8 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
         "session_info",
         "model_change",
         "thinking_level_change",
+        "message",
+        "leaf",
     ]
     assert session.messages == (
         UserMessage(content="Hello"),
@@ -329,6 +361,36 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     message_entries = [entry for entry in entries if entry.type == "message"]
     assert [entry.message for entry in message_entries] == list(session.messages)
     assert any(isinstance(event, QueueUpdateEvent) for event in run_events)
+
+
+@pytest.mark.anyio
+async def test_tree_can_branch_from_first_user_message_before_assistant_response(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = CancellableWaitingProvider()
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    async def run_prompt() -> None:
+        async for _event in session.prompt("Start here"):
+            pass
+
+    task = asyncio.create_task(run_prompt())
+    await provider.started.wait()
+
+    choices = await session.tree_choices()
+
+    session.cancel()
+    await task
+    result = await session.branch_to_entry(choices[0].entry_id)
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+
+    assert [choice.label for choice in choices] == ["user: Start here"]
+    assert result == f"Branched session at {choices[0].entry_id}."
+    assert [entry.message for entry in message_entries] == [UserMessage(content="Start here")]
+    assert isinstance(entries[-1], LeafEntry)
+    assert entries[-1].entry_id == choices[0].entry_id
 
 
 @pytest.mark.anyio
@@ -435,10 +497,7 @@ async def test_session_uses_active_model_thinking_capabilities(
     session.set_model("plain")
 
     assert session.available_thinking_levels == ()
-    assert (
-        session.thinking_unavailable_reason
-        == "openai:plain is not declared in thinking_models"
-    )
+    assert session.thinking_unavailable_reason == "openai:plain is not declared in thinking_models"
     with pytest.raises(ValueError, match="openai:plain is not declared in thinking_models"):
         await session.cycle_thinking_level()
 


### PR DESCRIPTION
## Issue addressed

Closes #118.

## Summary

- Persist the initial user prompt as a session message and active leaf immediately when a prompt run starts.
- Keep later assistant/tool transcript persistence on the existing completion path so cancelled runs do not need an assistant response before /tree has a branchable entry.
- Add a regression test for cancelling before any assistant response and branching back to the first user message.

## Files/areas changed

- src/tau_coding/session.py: prompt/session persistence boundary.
- tests/test_coding_session.py: cancellable provider fixture and /tree branchability regression coverage.

## Tests/checks run and results

- uv run pytest tests/test_coding_session.py -q: passed, 53 passed.
- uv run pytest -q: passed, 478 passed.
- uv run ruff check .: passed.
- git diff --check: passed.
- uv run ruff format --check .: failed only on pre-existing formatting drift in untouched files: src/tau_ai/anthropic.py, src/tau_ai/openai_compatible.py, src/tau_ai/retry.py, src/tau_coding/provider_config.py, src/tau_coding/tui/state.py, src/tau_coding/tui/widgets.py, tests/test_coding_tools.py, tests/test_commands.py, tests/test_context.py, tests/test_provider_config.py, tests/test_tui_app.py.
- uv run mypy: failed on pre-existing errors in untouched src/tau_coding/tools.py around task set typing in lines 588, 599, and 604.

## Assumptions

- It is acceptable for a running prompt to make the initial user message durable before the provider stream completes.
- Tool-call-only or cancelled runs should leave the prompt as the active leaf until later messages are durably appended.

## Follow-up work

- Clean up the existing repo-wide ruff format drift.
- Fix the existing mypy task typing issue in src/tau_coding/tools.py.