### PR TITLE
Fix #119: defer empty session transcripts

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -417,11 +417,11 @@ class CodingSession:
                     branch_root_id=entry_id,
                     summary=summary,
                 )
-                await self._config.storage.append(summary_entry)
+                await self._append_session_entry(summary_entry)
                 target_id = summary_entry.id
 
         leaf = LeafEntry(parent_id=target_id, entry_id=target_id)
-        await self._config.storage.append(leaf)
+        await self._append_session_entry(leaf)
         self._last_parent_id = target_id
 
         entries = await self._config.storage.read_all()
@@ -735,10 +735,9 @@ class CodingSession:
             parent_id=self._last_parent_id,
             thinking_level=normalized,
         )
-        await self._ensure_session_initialized()
-        await self._config.storage.append(entry)
+        await self._append_session_entry(entry)
         leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-        await self._config.storage.append(leaf)
+        await self._append_session_entry(leaf)
         self._last_parent_id = entry.id
 
         entries = await self._config.storage.read_all()
@@ -1179,17 +1178,16 @@ class CodingSession:
         new_messages = self._harness.messages[before_count:]
         if not new_messages:
             return
-        await self._ensure_session_initialized()
         last_message_entry_id: str | None = None
         for message in new_messages:
             entry = MessageEntry(parent_id=self._last_parent_id, message=message)
-            await self._config.storage.append(entry)
+            await self._append_session_entry(entry)
             self._last_parent_id = entry.id
             last_message_entry_id = entry.id
 
         if last_message_entry_id is not None:
             leaf = LeafEntry(parent_id=last_message_entry_id, entry_id=last_message_entry_id)
-            await self._config.storage.append(leaf)
+            await self._append_session_entry(leaf)
 
         entries = await self._config.storage.read_all()
         self._state = SessionState.from_entries(entries)
@@ -1199,6 +1197,11 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
             )
+
+    async def _append_session_entry(self, entry: SessionEntry) -> None:
+        """Append one durable entry after flushing deferred session metadata."""
+        await self._ensure_session_initialized()
+        await self._config.storage.append(entry)
 
     async def _ensure_session_initialized(self) -> None:
         if not self._pending_initial_entries:
@@ -1370,10 +1373,9 @@ class CodingSession:
             summary=summary,
             replaces_entry_ids=list(replace_entry_ids),
         )
-        await self._ensure_session_initialized()
-        await self._config.storage.append(compaction)
+        await self._append_session_entry(compaction)
         leaf = LeafEntry(parent_id=compaction.id, entry_id=compaction.id)
-        await self._config.storage.append(leaf)
+        await self._append_session_entry(leaf)
         self._last_parent_id = compaction.id
 
         entries = await self._config.storage.read_all()

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -202,11 +202,13 @@ class CodingSession:
         context_files: tuple[ProjectContextFile, ...] = (),
         resource_diagnostics: tuple[ResourceDiagnostic, ...] = (),
         command_registry: CommandRegistry | None = None,
+        pending_initial_entries: tuple[SessionEntry, ...] = (),
     ) -> None:
         self._config = config
         self._state = state
         self._harness = harness
         self._last_parent_id = last_parent_id
+        self._pending_initial_entries = pending_initial_entries
         self._skills = skills
         self._prompt_templates = prompt_templates
         self._context_files = context_files
@@ -230,6 +232,7 @@ class CodingSession:
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
         """Load a coding session from append-only storage."""
         entries = await config.storage.read_all()
+        pending_initial_entries: tuple[SessionEntry, ...] = ()
         if not entries:
             info = SessionInfoEntry(cwd=str(config.cwd))
             model = ModelChangeEntry(parent_id=info.id, model=config.model)
@@ -237,10 +240,8 @@ class CodingSession:
                 parent_id=model.id,
                 thinking_level=config.thinking_level,
             )
-            await config.storage.append(info)
-            await config.storage.append(model)
-            await config.storage.append(thinking)
             entries = [info, model, thinking]
+            pending_initial_entries = (info, model, thinking)
 
         linear_state = SessionState.from_entries(entries)
         state = (
@@ -284,6 +285,7 @@ class CodingSession:
             context_files=resources.context_files,
             resource_diagnostics=resources.diagnostics,
             command_registry=config.command_registry,
+            pending_initial_entries=pending_initial_entries,
         )
         session._sync_thinking_level_to_active_model()
         session._refresh_runtime_provider()
@@ -733,6 +735,7 @@ class CodingSession:
             parent_id=self._last_parent_id,
             thinking_level=normalized,
         )
+        await self._ensure_session_initialized()
         await self._config.storage.append(entry)
         leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
         await self._config.storage.append(leaf)
@@ -1174,6 +1177,9 @@ class CodingSession:
 
     async def _persist_new_messages(self, before_count: int) -> None:
         new_messages = self._harness.messages[before_count:]
+        if not new_messages:
+            return
+        await self._ensure_session_initialized()
         last_message_entry_id: str | None = None
         for message in new_messages:
             entry = MessageEntry(parent_id=self._last_parent_id, message=message)
@@ -1193,6 +1199,13 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
             )
+
+    async def _ensure_session_initialized(self) -> None:
+        if not self._pending_initial_entries:
+            return
+        for entry in self._pending_initial_entries:
+            await self._config.storage.append(entry)
+        self._pending_initial_entries = ()
 
     async def _try_auto_compact(
         self,
@@ -1357,6 +1370,7 @@ class CodingSession:
             summary=summary,
             replaces_entry_ids=list(replace_entry_ids),
         )
+        await self._ensure_session_initialized()
         await self._config.storage.append(compaction)
         leaf = LeafEntry(parent_id=compaction.id, entry_id=compaction.id)
         await self._config.storage.append(leaf)

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -128,23 +128,14 @@ class WaitingProvider:
 
 
 @pytest.mark.anyio
-async def test_load_empty_session_appends_metadata(tmp_path: Path) -> None:
+async def test_load_empty_session_defers_transcript_file(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
 
     session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
 
     entries = await storage.read_all()
-    assert isinstance(entries[0], SessionInfoEntry)
-    assert entries[0].cwd == str(tmp_path)
-    assert entries[1] == ModelChangeEntry(
-        id=entries[1].id, parent_id=entries[0].id, model="fake", timestamp=entries[1].timestamp
-    )
-    assert entries[2] == ThinkingLevelChangeEntry(
-        id=entries[2].id,
-        parent_id=entries[1].id,
-        thinking_level="medium",
-        timestamp=entries[2].timestamp,
-    )
+    assert entries == []
+    assert not storage.path.exists()
     assert session.messages == ()
     assert session.state.model == "fake"
     assert session.thinking_level == "medium"
@@ -231,6 +222,18 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
     _events = await _collect_session_events(session.prompt("Hello"))
 
     entries = await storage.read_all()
+    assert storage.path.exists()
+    assert isinstance(entries[0], SessionInfoEntry)
+    assert entries[0].cwd == str(tmp_path)
+    assert entries[1] == ModelChangeEntry(
+        id=entries[1].id, parent_id=entries[0].id, model="fake", timestamp=entries[1].timestamp
+    )
+    assert entries[2] == ThinkingLevelChangeEntry(
+        id=entries[2].id,
+        parent_id=entries[1].id,
+        thinking_level="medium",
+        timestamp=entries[2].timestamp,
+    )
     message_entries = [entry for entry in entries if entry.type == "message"]
     assert [entry.message for entry in message_entries] == [
         UserMessage(content="Hello"),
@@ -313,11 +316,7 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     await task
 
     assert queue_events == [QueueUpdateEvent(steering=("Queued steering",))]
-    assert [entry.type for entry in entries_before_release] == [
-        "session_info",
-        "model_change",
-        "thinking_level_change",
-    ]
+    assert entries_before_release == []
     assert session.messages == (
         UserMessage(content="Hello"),
         AssistantMessage(content="First"),


### PR DESCRIPTION
Issue addressed
- Closes #119.

Summary
- Defer writing synthetic session-info/model/thinking entries for a new CodingSession until the first durable session mutation.
- Preserve in-memory startup state so empty sessions still expose the selected model, thinking level, cwd, tools, and messages correctly.
- Ensure first persisted messages, thinking changes, and compactions flush the initial session entries before appending their own entries.

Files/areas changed
- src/tau_coding/session.py: lazy initial session entry flushing inside CodingSession.
- tests/test_coding_session.py: updated empty-load expectations and first-message persistence coverage.

Tests/checks run and results
- uv run pytest tests/test_coding_session.py tests/test_session_manager.py: 59 passed.
- uv run ruff check src/tau_coding/session.py tests/test_coding_session.py: passed.
- uv run mypy src/tau_coding/session.py: passed.
- uv run pytest: 477 passed.
- git diff --check: passed.

Assumptions
- The issue is specifically about avoiding empty JSONL transcript files; session index records may still be created at CLI/TUI startup so resume metadata flows continue to work.
- Non-message durable mutations such as thinking-level changes should still create a transcript because they change session state.

Follow-up work
- Consider a separate issue if Tau should also hide or garbage-collect indexed sessions that never receive a durable transcript entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized session persistence by deferring initialization metadata storage until the first session entry is appended, reducing unnecessary writes on session load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->