### PR TITLE
Persist session messages from stream events

### DIFF
--- a/docs/04-sessions.md
+++ b/docs/04-sessions.md
@@ -35,6 +35,21 @@ Tau can now:
 - reconstruct a root-to-leaf branch path
 - load a `tau_coding.CodingSession` that restores messages and persists new runs
 
+## Durable message boundary
+
+`CodingSession` treats `MessageEndEvent` as the durable-message boundary. When the harness emits a completed message, the coding session appends that message to storage immediately instead of waiting for the whole agent run to finish.
+
+This mirrors Pi's session model and matters for interactive UIs:
+
+- the first user prompt is branchable while the assistant is still responding
+- queued steering and follow-up messages become durable when they are injected
+- cancellation or process failure preserves completed messages
+- the TUI can read tree state that matches the active run
+
+Each persisted message is followed by a `leaf` entry pointing at that message. The leaf entries form an append-only history of the active branch pointer.
+
+Empty sessions are still deferred: loading a new session prepares initial metadata in memory, but Tau does not create the transcript file until the first durable session entry is appended. The first append materializes the pending `session_info`, model, and thinking-level entries before writing the message.
+
 ## Boundary
 
 Low-level session primitives belong in `tau_agent`. File locations, slash commands, and coding-agent workflows belong in `tau_coding`.

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -10,6 +10,7 @@ from tau_agent import (
     AgentHarness,
     AgentHarnessConfig,
     ErrorEvent,
+    MessageEndEvent,
     QueuedMessages,
     QueueUpdateEvent,
 )
@@ -424,19 +425,12 @@ class CodingSession:
         await self._append_session_entry(leaf)
         self._last_parent_id = target_id
 
-        entries = await self._config.storage.read_all()
-        self._state = SessionState.from_entries(entries, leaf_id=target_id)
+        await self._refresh_persisted_state(leaf_id=target_id)
         self._harness.replace_messages(self._state.messages)
         self._harness.config.model = self._state.model or self._config.model
         self._thinking_level = _state_thinking_level(self._state, self._config.thinking_level)
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
-        if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(
-                self._config.session_id,
-                model=self.model,
-                provider_name=self.provider_name,
-            )
         suffix = " with branch summary" if summary_entry is not None else ""
         return f"Branched session at {target_id}{suffix}."
 
@@ -740,14 +734,7 @@ class CodingSession:
         await self._append_session_entry(leaf)
         self._last_parent_id = entry.id
 
-        entries = await self._config.storage.read_all()
-        self._state = SessionState.from_entries(entries, leaf_id=entry.id)
-        if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(
-                self._config.session_id,
-                model=self.model,
-                provider_name=self.provider_name,
-            )
+        await self._refresh_persisted_state(leaf_id=entry.id)
         return f"Thinking mode: {normalized}"
 
     async def cycle_thinking_level(self) -> str:
@@ -1060,7 +1047,7 @@ class CodingSession:
                     )
                 )
             )
-            await self._persist_new_messages(before_count)
+            await self._persist_messages_since(before_count)
 
         return TerminalCommandResult(
             command=normalized_command,
@@ -1102,10 +1089,12 @@ class CodingSession:
             )
 
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
-        before_count = len(self._harness.messages)
+        persisted_count = len(self._harness.messages)
         overflow_event: ErrorEvent | None = None
         try:
             async for event in self._harness.prompt(expanded_content):
+                if isinstance(event, MessageEndEvent):
+                    persisted_count = await self._persist_messages_since(persisted_count)
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
                         context=context,
@@ -1115,12 +1104,16 @@ class CodingSession:
                     if _is_context_overflow_error(event):
                         overflow_event = event
                 yield event
+            persisted_count = await self._persist_messages_since(persisted_count)
             if overflow_event is not None:
-                await self._persist_new_messages(before_count)
                 compacted = await self._try_overflow_compact(context=context)
                 if compacted:
-                    retry_before_count = len(self._harness.messages)
+                    retry_persisted_count = len(self._harness.messages)
                     async for retry_event in self._harness.continue_():
+                        if isinstance(retry_event, MessageEndEvent):
+                            retry_persisted_count = await self._persist_messages_since(
+                                retry_persisted_count
+                            )
                         if isinstance(retry_event, ErrorEvent) and not retry_event.recoverable:
                             self._last_diagnostic_log_path = (
                                 self._diagnostic_logger.log_error_event(
@@ -1130,9 +1123,8 @@ class CodingSession:
                                 )
                             )
                         yield retry_event
-                    await self._persist_new_messages(retry_before_count)
+                    await self._persist_messages_since(retry_persisted_count)
                 return
-            await self._persist_new_messages(before_count)
             await self._try_auto_compact(context=context, phase="auto_compact_after_prompt")
         except Exception as exc:
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -1145,9 +1137,11 @@ class CodingSession:
     async def continue_(self) -> AsyncIterator[AgentEvent]:
         """Continue the agent from restored state and persist new messages."""
         context = self._diagnostic_context()
-        before_count = len(self._harness.messages)
+        persisted_count = len(self._harness.messages)
         try:
             async for event in self._harness.continue_():
+                if isinstance(event, MessageEndEvent):
+                    persisted_count = await self._persist_messages_since(persisted_count)
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
                         context=context,
@@ -1155,7 +1149,7 @@ class CodingSession:
                         event=event,
                     )
                 yield event
-            await self._persist_new_messages(before_count)
+            await self._persist_messages_since(persisted_count)
             await self._try_auto_compact(context=context, phase="auto_compact_after_continue")
         except Exception as exc:
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -1174,23 +1168,30 @@ class CodingSession:
             run_id=new_agent_call_run_id(),
         )
 
-    async def _persist_new_messages(self, before_count: int) -> None:
-        new_messages = self._harness.messages[before_count:]
+    async def _persist_messages_since(self, persisted_count: int) -> int:
+        """Persist completed harness messages after ``persisted_count``.
+
+        Message lifecycle events are the durable-message boundary. Each persisted
+        message advances the append-only tree and records a leaf pointer so tree
+        navigation can observe the current branch while a run is still active.
+        """
+        new_messages = self._harness.messages[persisted_count:]
         if not new_messages:
-            return
-        last_message_entry_id: str | None = None
+            return persisted_count
+
         for message in new_messages:
             entry = MessageEntry(parent_id=self._last_parent_id, message=message)
             await self._append_session_entry(entry)
             self._last_parent_id = entry.id
-            last_message_entry_id = entry.id
-
-        if last_message_entry_id is not None:
-            leaf = LeafEntry(parent_id=last_message_entry_id, entry_id=last_message_entry_id)
+            leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
             await self._append_session_entry(leaf)
 
+        await self._refresh_persisted_state()
+        return persisted_count + len(new_messages)
+
+    async def _refresh_persisted_state(self, *, leaf_id: str | None = None) -> None:
         entries = await self._config.storage.read_all()
-        self._state = SessionState.from_entries(entries)
+        self._state = SessionState.from_entries(entries, leaf_id=leaf_id)
         if self._config.session_id is not None and self._config.session_manager is not None:
             self._config.session_manager.touch_session(
                 self._config.session_id,
@@ -1378,15 +1379,8 @@ class CodingSession:
         await self._append_session_entry(leaf)
         self._last_parent_id = compaction.id
 
-        entries = await self._config.storage.read_all()
-        self._state = SessionState.from_entries(entries, leaf_id=compaction.id)
+        await self._refresh_persisted_state(leaf_id=compaction.id)
         self._harness.replace_messages(self._state.messages)
-        if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(
-                self._config.session_id,
-                model=self.model,
-                provider_name=self.provider_name,
-            )
         return compaction
 
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -127,6 +127,36 @@ class WaitingProvider:
         return iterator()
 
 
+class CancellableWaitingProvider:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.calls: list[list[AgentMessage]] = []
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        del model, system, tools
+        self.calls.append(list(messages))
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            yield ProviderResponseStartEvent(model="fake")
+            self.started.set()
+            while not self.release.is_set():
+                if signal is not None and signal.is_cancelled():
+                    return
+                await asyncio.sleep(0)
+            yield ProviderResponseEndEvent(message=AssistantMessage(content="Finished"))
+
+        return iterator()
+
+
 @pytest.mark.anyio
 async def test_load_empty_session_defers_transcript_file(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
@@ -235,10 +265,12 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
         timestamp=entries[2].timestamp,
     )
     message_entries = [entry for entry in entries if entry.type == "message"]
+    leaf_entries = [entry for entry in entries if entry.type == "leaf"]
     assert [entry.message for entry in message_entries] == [
         UserMessage(content="Hello"),
         AssistantMessage(content="Hi"),
     ]
+    assert [entry.entry_id for entry in leaf_entries] == [entry.id for entry in message_entries]
     assert entries[-1].type == "leaf"
     assert entries[-1].entry_id == message_entries[-1].id
     assert session.messages == (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
@@ -316,7 +348,12 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     await task
 
     assert queue_events == [QueueUpdateEvent(steering=("Queued steering",))]
-    assert entries_before_release == []
+    before_release_messages = [entry.message for entry in entries_before_release if entry.type == "message"]
+    assert before_release_messages == [UserMessage(content="Hello")]
+    assert entries_before_release[-1].type == "leaf"
+    assert entries_before_release[-1].entry_id == next(
+        entry.id for entry in entries_before_release if entry.type == "message"
+    )
     assert session.messages == (
         UserMessage(content="Hello"),
         AssistantMessage(content="First"),
@@ -326,8 +363,40 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     assert provider.calls[1] == list(session.messages[:3])
     entries = await storage.read_all()
     message_entries = [entry for entry in entries if entry.type == "message"]
+    leaf_entries = [entry for entry in entries if entry.type == "leaf"]
     assert [entry.message for entry in message_entries] == list(session.messages)
+    assert [entry.entry_id for entry in leaf_entries] == [entry.id for entry in message_entries]
     assert any(isinstance(event, QueueUpdateEvent) for event in run_events)
+
+
+@pytest.mark.anyio
+async def test_tree_can_branch_from_first_user_message_before_assistant_response(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = CancellableWaitingProvider()
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    async def run_prompt() -> None:
+        async for _event in session.prompt("Start here"):
+            pass
+
+    task = asyncio.create_task(run_prompt())
+    await provider.started.wait()
+
+    choices = await session.tree_choices()
+
+    session.cancel()
+    await task
+    result = await session.branch_to_entry(choices[0].entry_id)
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+
+    assert [choice.label for choice in choices] == ["user: Start here"]
+    assert result == f"Branched session at {choices[0].entry_id}."
+    assert [entry.message for entry in message_entries] == [UserMessage(content="Start here")]
+    assert isinstance(entries[-1], LeafEntry)
+    assert entries[-1].entry_id == choices[0].entry_id
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- persist completed coding-session messages when `MessageEndEvent` streams instead of waiting for the run to finish
- keep PR #142's deferred empty-session transcript behavior by routing first durable writes through session initialization
- write a leaf entry after each persisted message so tree state is current during active runs
- document the durable message boundary in the sessions guide

## Why

This moves Tau closer to Pi's model: completed messages become durable as part of the event stream. That makes the first user prompt branchable before the assistant finishes and gives richer TUIs/UIs and future extensions a more accurate session tree during active runs.

## Tests

- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance on durable message boundaries in coding sessions, including how queued durability, branching history, and cancellation/process failures are handled.

* **Improvements**
  * Updated session persistence to store completed messages at the message boundary, improving consistency for branching and interactive/queued UI flows.
  * Ensured incremental durability behavior during cancellations and retries.

* **Tests**
  * Strengthened persistence assertions and added coverage for cancellation timing and branching before an assistant reply arrives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->