### PR TITLE
Fix #125: allow thinking changes while working

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2240,9 +2240,6 @@ class TauTuiApp(App[None]):
 
     def action_cycle_thinking(self) -> None:
         """Cycle the active thinking mode."""
-        if self.state.running:
-            self._notify("Tau is already working. Press Escape to cancel.")
-            return
         self.run_worker(self._cycle_thinking_level(), exclusive=False)
 
     def action_cycle_model(self) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2905,6 +2905,27 @@ async def test_tui_app_cycles_thinking_from_keybinding() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_cycles_thinking_from_keybinding_while_running() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        await pilot.press("shift+tab")
+        await pilot.pause()
+
+    assert session.thinking_level == "high"
+    assert notifications == []
+
+
+@pytest.mark.anyio
 async def test_tui_app_cycles_scoped_model_from_keybinding() -> None:
     session = FakeSession()
     session.scoped_model_choices = (


### PR DESCRIPTION
## Issue addressed

Closes #125.

## Summary

- Allows the TUI thinking-cycle action to run while an agent task is already in progress.
- Keeps the selected thinking level persisted through the existing session thinking controls so it applies to the next user message / next agent task.
- Leaves unrelated busy guards in place for actions such as session and model switching.

## Files / areas changed

- `src/tau_coding/tui/app.py`: removed the running-state block from the thinking-cycle action only.
- `tests/test_tui_app.py`: added regression coverage for cycling thinking while the TUI is marked running, with no busy notification.

## Tests / checks run

- `uv run pytest tests/test_tui_app.py -q` - passed, 138 tests.
- `uv run pytest tests/test_thinking.py tests/test_coding_session.py -q` - passed, 60 tests.
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py` - passed.
- `git diff --check` - passed.

## Assumptions

- The active provider request should keep the thinking level it started with; this change only updates the stored/session-level setting for future turns.
- Cycling thinking while running is the requested exception to the busy guard; model/session switching should remain blocked while running.

## Follow-up work

- None required for this issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that previously prevented users from cycling the thinking level while the application is actively running or processing. Users can now adjust this setting at any time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->