### PR TITLE
Implement #123: render skill invocations distinctly

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -235,6 +235,15 @@ def create_default_command_registry() -> CommandRegistry:
     )
     registry.register(
         SlashCommand(
+            name="skill",
+            usage="/skill:<name> [request]",
+            description="Expand a loaded skill into your prompt.",
+            handler=_skill_command,
+            search_terms=("skills",),
+        )
+    )
+    registry.register(
+        SlashCommand(
             name="hotkeys",
             usage="/hotkeys",
             description="Show common keyboard shortcuts.",

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1937,6 +1937,7 @@ class TauTuiApp(App[None]):
                 await self._set_thinking_level(command.thinking_level)
             if command.theme is not None:
                 self._set_tui_theme(cast(TuiThemeName, command.theme))
+            self.state.set_skills(self.session.skills)
             if command.message:
                 if _command_message_uses_notification(text, command.message):
                     self._notify(command.message)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1753,7 +1753,7 @@ class TauTuiApp(App[None]):
         super().__init__()
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
-        self.state = TuiState()
+        self.state = TuiState(skills=session.skills)
         self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
@@ -1903,6 +1903,7 @@ class TauTuiApp(App[None]):
                     self._refresh()
                     compact_message = await self.session.compact(command.compact_summary)
                     self.state.clear()
+                    self.state.set_skills(self.session.skills)
                     self.state.load_messages(self.session.messages)
                     self._notify(compact_message)
                 except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
@@ -2272,6 +2273,7 @@ class TauTuiApp(App[None]):
         try:
             resume_message = await self.session.resume(session_id)
             self.state.clear()
+            self.state.set_skills(self.session.skills)
             self.state.load_messages(self.session.messages)
             self._notify(resume_message)
         except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
@@ -2333,6 +2335,7 @@ class TauTuiApp(App[None]):
             if isawaitable(result):
                 result = await result
             self.state.clear()
+            self.state.set_skills(self.session.skills)
             self.state.load_messages(self.session.messages)
             if isinstance(result, str):
                 self._notify(result)
@@ -2349,6 +2352,7 @@ class TauTuiApp(App[None]):
         try:
             await new_session()
             self.state.clear()
+            self.state.set_skills(self.session.skills)
             self.state.load_messages(self.session.messages)
         except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
             self._notify(f"Error: {exc}", severity="error")

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -78,7 +78,7 @@ class TuiState:
         if skill_name is not None:
             self.add_item(
                 "skill",
-                f"Reading skill: {skill_name}",
+                f"Loading skill: {skill_name}",
                 tool_call_id=tool_call.id,
             )
             return

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -2,12 +2,13 @@
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal
 
 from tau_agent.messages import AgentMessage
 from tau_agent.tools import AgentToolResult, ToolCall
 from tau_agent.types import JSONValue
-from tau_coding.skills import parse_skill_invocation
+from tau_coding.skills import Skill, parse_skill_invocation
 
 ChatItemRole = Literal[
     "user",
@@ -49,6 +50,7 @@ class TuiState:
     show_thinking: bool = False
     queued_steering: tuple[str, ...] = ()
     queued_follow_up: tuple[str, ...] = ()
+    skills: tuple[Skill, ...] = ()
 
     def add_item(
         self,
@@ -72,6 +74,14 @@ class TuiState:
 
     def add_tool_call(self, tool_call: ToolCall) -> None:
         """Append a collapsed tool-call item."""
+        skill_name = self._read_skill_name(tool_call)
+        if skill_name is not None:
+            self.add_item(
+                "skill",
+                f"Reading skill: {skill_name}",
+                tool_call_id=tool_call.id,
+            )
+            return
         self.add_item(
             "tool",
             format_tool_call_block(tool_call),
@@ -122,7 +132,7 @@ class TuiState:
             data=result.data,
         )
         for item in reversed(self.items):
-            if item.role == "tool" and item.tool_call_id == result.tool_call_id:
+            if item.role in {"tool", "skill"} and item.tool_call_id == result.tool_call_id:
                 item.tool_result_text = result_text
                 return
         self.add_item(
@@ -158,6 +168,10 @@ class TuiState:
         self.assistant_buffer = ""
         self.error = None
 
+    def set_skills(self, skills: Iterable[Skill]) -> None:
+        """Replace loaded skill metadata used for presentation-only path matching."""
+        self.skills = tuple(skills)
+
     def load_messages(self, messages: Iterable[AgentMessage]) -> None:
         """Populate the transcript from restored session messages."""
         for message in messages:
@@ -180,6 +194,18 @@ class TuiState:
                         error=message.error,
                     )
                 )
+
+    def _read_skill_name(self, tool_call: ToolCall) -> str | None:
+        if tool_call.name != "read":
+            return None
+        path = _string_argument(tool_call.arguments, "path")
+        if path is None:
+            return None
+        read_path = _normalized_path(path)
+        for skill in self.skills:
+            if _normalized_path(skill.path) == read_path:
+                return skill.name
+        return None
 
 
 def _parse_branch_summary_message(content: str) -> str | None:
@@ -256,6 +282,10 @@ def _fallback_tool_call_invocation(tool_call: ToolCall) -> str:
 def _string_argument(arguments: dict[str, JSONValue], key: str) -> str | None:
     value = arguments.get(key)
     return value if isinstance(value, str) else None
+
+
+def _normalized_path(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
 
 
 def _int_argument(arguments: dict[str, JSONValue], key: str) -> int | None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -868,7 +868,7 @@ def _visible_chat_text(item: ChatItem, *, show_tool_results: bool) -> str:
         if show_tool_results and item.tool_result_text:
             return f"**Compaction Summary**\n\n{item.tool_result_text}"
         return item.text
-    if item.role != "tool" or not show_tool_results or not item.tool_result_text:
+    if item.role not in {"tool", "skill"} or not show_tool_results or not item.tool_result_text:
         return item.text
     return f"{item.text}\n\n{item.tool_result_text}"
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -107,6 +107,7 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "resume",
         "scoped-models",
         "session",
+        "skill",
         "theme",
         "tree",
     ]

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -143,7 +143,7 @@ def test_tui_adapter_renders_skill_file_reads_with_skill_style() -> None:
     )
 
     assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
-        ("skill", "Reading skill: review", "✓ read\n# Review\nFull instructions.")
+        ("skill", "Loading skill: review", "✓ read\n# Review\nFull instructions.")
     ]
 
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -112,6 +112,66 @@ def test_tui_adapter_flushes_assistant_buffer_before_tool_events() -> None:
     assert "→ read" in state.items[1].text
 
 
+def test_tui_adapter_renders_skill_file_reads_with_skill_style() -> None:
+    skill = Skill(
+        name="review",
+        path=Path("/workspace/.tau/skills/review.md"),
+        content="# Review",
+        description="Review code",
+    )
+    state = TuiState(skills=(skill,))
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(
+        ToolExecutionStartEvent(
+            tool_call=ToolCall(
+                id="call-1",
+                name="read",
+                arguments={"path": "/workspace/.tau/skills/review.md"},
+            )
+        )
+    )
+    adapter.apply(
+        ToolExecutionEndEvent(
+            result=AgentToolResult(
+                tool_call_id="call-1",
+                name="read",
+                ok=True,
+                content="# Review\nFull instructions.",
+            )
+        )
+    )
+
+    assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
+        ("skill", "Reading skill: review", "✓ read\n# Review\nFull instructions.")
+    ]
+
+
+def test_tui_adapter_leaves_ordinary_reads_as_tool_items() -> None:
+    skill = Skill(
+        name="review",
+        path=Path("/workspace/.tau/skills/review.md"),
+        content="# Review",
+        description="Review code",
+    )
+    state = TuiState(skills=(skill,))
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(
+        ToolExecutionStartEvent(
+            tool_call=ToolCall(
+                id="call-1",
+                name="read",
+                arguments={"path": "/workspace/README.md"},
+            )
+        )
+    )
+
+    assert [(item.role, item.text) for item in state.items] == [
+        ("tool", "→ read /workspace/README.md")
+    ]
+
+
 def test_tool_call_blocks_use_human_readable_invocations() -> None:
     assert (
         format_tool_call_block(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -134,6 +134,13 @@ class FakeSession:
             )
         if text == "/reload":
             self.reload_count += 1
+            self.skills = (
+                Skill(
+                    name="reloaded",
+                    path=self.cwd / "reloaded.md",
+                    content="Reloaded skill",
+                ),
+            )
             return CommandResult(
                 handled=True,
                 message="Reloaded local coding resources and project context.",
@@ -570,6 +577,25 @@ def test_skill_chat_items_use_distinct_compact_style() -> None:
     assert "38;2;229;212;239" in output
 
 
+def test_skill_chat_items_expand_with_tool_results_toggle() -> None:
+    item = ChatItem(
+        role="skill",
+        text="Loading skill: review",
+        tool_result_text="✓ read\n# Review\nFull noisy instructions.",
+    )
+    collapsed_console = Console(record=True, width=80)
+    collapsed_console.print(render_chat_item(item, show_tool_results=False))
+    collapsed = collapsed_console.export_text()
+    expanded_console = Console(record=True, width=80)
+    expanded_console.print(render_chat_item(item, show_tool_results=True))
+    expanded = expanded_console.export_text()
+
+    assert "Loading skill: review" in collapsed
+    assert "Full noisy instructions" not in collapsed
+    assert "Loading skill: review" in expanded
+    assert "Full noisy instructions" in expanded
+
+
 def test_branch_summary_chat_items_expand_with_tool_results_toggle() -> None:
     item = ChatItem(
         role="branch_summary",
@@ -701,7 +727,7 @@ def test_tui_state_renders_restored_skill_file_reads_with_skill_style() -> None:
 
     assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
         ("assistant", "Reading skill.", None),
-        ("skill", "Reading skill: review", "✓ read\n# Review\nFull noisy instructions."),
+        ("skill", "Loading skill: review", "✓ read\n# Review\nFull noisy instructions."),
     ]
 
 
@@ -2121,6 +2147,7 @@ async def test_tui_app_reload_appends_command_output_to_transcript() -> None:
                 text="/reload\nReloaded local coding resources and project context.",
             )
         ]
+        assert [skill.name for skill in app.state.skills] == ["reloaded"]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -669,6 +669,42 @@ def test_tui_state_compacts_expanded_skill_messages() -> None:
     ]
 
 
+def test_tui_state_renders_restored_skill_file_reads_with_skill_style() -> None:
+    skill = Skill(
+        name="review",
+        path=Path("/workspace/.tau/skills/review.md"),
+        content="# Review\nFull noisy instructions.",
+        description="Review code",
+    )
+    state = tui_app.TuiState(skills=(skill,))
+
+    state.load_messages(
+        [
+            AssistantMessage(
+                content="Reading skill.",
+                tool_calls=[
+                    ToolCall(
+                        id="call-1",
+                        name="read",
+                        arguments={"path": "/workspace/.tau/skills/review.md"},
+                    )
+                ],
+            ),
+            ToolResultMessage(
+                tool_call_id="call-1",
+                name="read",
+                ok=True,
+                content="# Review\nFull noisy instructions.",
+            ),
+        ]
+    )
+
+    assert [(item.role, item.text, item.tool_result_text) for item in state.items] == [
+        ("assistant", "Reading skill.", None),
+        ("skill", "Reading skill: review", "✓ read\n# Review\nFull noisy instructions."),
+    ]
+
+
 def test_light_theme_tool_success_uses_dark_text_without_background() -> None:
     console = Console(record=True, width=80)
     console.print(

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -68,7 +68,7 @@ def test_command_completion_prioritizes_direct_matches_over_search_terms() -> No
     assert state.selected.apply("/res") == "/resume"
 
 
-def test_skill_command_is_not_registered_for_command_completion() -> None:
+def test_skill_command_is_available_for_command_completion() -> None:
     state = build_completion_state(
         "/ski",
         command_registry=create_default_command_registry(),
@@ -76,7 +76,9 @@ def test_skill_command_is_not_registered_for_command_completion() -> None:
         prompt_templates=(),
     )
 
-    assert state.items == ()
+    assert [item.display for item in state.items] == ["/skill:"]
+    assert state.selected is not None
+    assert state.selected.apply("/ski") == "/skill:"
 
 
 def test_skill_name_completion_preserves_request_text() -> None:


### PR DESCRIPTION
## Issue addressed
Closes #123

## Pi inspiration/reference
- Pi formats skill use as a structured `<skill name="..." location="...">...\</skill>` block in `packages/agent/src/harness/skills.ts`.
- Pi parses that block in `packages/coding-agent/src/core/agent-session.ts` and renders it separately with a dedicated interactive skill component in `skill-invocation-message.ts`.
- Tau already preserved explicit skill invocations as structured user-message content and compacted them into a `skill` TUI role; this PR extends the same presentation concept to agent-initiated reads of loaded skill files.

## Summary
- Adds loaded skill metadata to `TuiState` so the TUI can identify exact `read` tool calls for known skill files.
- Renders those skill-file reads as `skill` transcript items with Tau's existing distinct skill styling.
- Keeps ordinary `read` tool calls rendered as normal tool items.
- Keeps the core `tau_agent` event/tool boundary unchanged; path-to-skill interpretation stays in `tau_coding.tui`.

## Files / areas changed
- `src/tau_coding/tui/state.py`: skill-aware read rendering and restored-history handling.
- `src/tau_coding/tui/app.py`: keeps TUI state skill metadata current across session reload/resume/new-session flows.
- `tests/test_tui_adapter.py`: live event coverage for skill reads and ordinary reads.
- `tests/test_tui_app.py`: restored transcript coverage for skill reads plus existing explicit skill invocation coverage.

## Tests / checks
- `uv run pytest tests/test_tui_adapter.py tests/test_tui_app.py -q` -> 154 passed.
- `uv run ruff check src/tau_coding/tui/state.py src/tau_coding/tui/app.py tests/test_tui_adapter.py tests/test_tui_app.py` -> passed.
- `uv run mypy src/tau_coding/tui/state.py src/tau_coding/tui/app.py` -> passed.
- `uv run pytest tests/test_skills.py tests/test_tui_adapter.py tests/test_tui_app.py -q` -> 168 passed.

## Assumptions
- Exact loaded skill file paths are the right app-layer signal for agent-initiated skill reads, avoiding broad path heuristics like any `SKILL.md` suffix.
- Existing Tau skill role/theme colors satisfy the dedicated visual treatment requirement for explicit `/skill:...` invocations.

## Follow-up work
- If Tau later adds dedicated skill invocation events, this presentation path can consume that metadata directly instead of matching read paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/skill:<name>` slash command for invoking skills.
  * Skills now persist across session and branch transitions.
  * Tool calls reading skill files display as dedicated skill items in chat.
  * Added toggle support for showing/hiding tool result details in skill items.

* **Tests**
  * Enhanced test coverage for skill command registration and UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->