### PR TITLE
Implement #132: add logout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,17 @@ The easiest path is from inside the TUI:
 /login
 /login openai
 /login openai-codex
+/logout
+/logout openai
 /model
 ```
 
 `/login` can save API-key credentials for built-in providers or authenticate an
 OpenAI Codex subscription account with OAuth. Credentials are stored in
 `~/.tau/credentials.json` with private file permissions. Provider metadata lives
-in `~/.tau/providers.json`.
+in `~/.tau/providers.json`. `/logout` removes only credentials saved in Tau's
+`credentials.json`; environment variables and provider configuration are
+unchanged.
 
 You can also configure an OpenAI-compatible provider from the CLI:
 
@@ -203,6 +207,7 @@ Common slash commands:
 | Command | Purpose |
 | --- | --- |
 | `/login [provider]` | Save or refresh provider credentials. |
+| `/logout [provider]` | Remove Tau-saved provider credentials. |
 | `/model` | Choose the active provider/model. |
 | `/scoped-models` | Pick models available for quick cycling. |
 | `/session` | Show session and context information. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,9 @@ authentication headers under runtime control.
 OAuth-backed providers, such as `openai-codex`, store a structured credential
 object in `~/.tau/credentials.json` and refresh expired access tokens before a
 model request. Use `/login openai-codex` to authenticate with a Codex
-subscription account.
+subscription account. Use `/logout` to choose a saved Tau credential to remove,
+or `/logout <provider>` to remove one directly. Logout only edits
+`credentials.json`; environment variables and `providers.json` are unchanged.
 
 For example, Hugging Face organization billing can be configured with:
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -126,6 +126,7 @@ Inside the TUI:
 /model
 /model qwen
 /login
+/logout
 ```
 
 `/model` opens the interactive model picker. The picker includes models from
@@ -133,7 +134,9 @@ configured providers, so selecting a model can also switch the active runtime
 provider. The model flow refreshes provider settings before it validates or
 shows choices. `/login` adds or refreshes a built-in provider, including
 OAuth-backed providers such as `openai-codex`, and refreshes provider settings
-after saving credentials.
+after saving credentials. `/logout` opens a picker for providers with saved Tau
+credentials, while `/logout <provider>` removes a specific saved credential. It
+does not change environment variables, `providers.json`, billing, or defaults.
 
 When Tau loads `~/.tau/providers.json`, it merges the current built-in model
 catalog into built-in provider entries such as Hugging Face. Custom models and

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -99,6 +99,8 @@ class CommandResult:
     tree_picker_requested: bool = False
     login_picker_requested: bool = False
     login_provider: str | None = None
+    logout_picker_requested: bool = False
+    logout_provider: str | None = None
     model_picker_requested: bool = False
     scoped_models_picker_requested: bool = False
     theme_picker_requested: bool = False
@@ -309,6 +311,14 @@ def create_default_command_registry() -> CommandRegistry:
             usage="/login [provider]",
             description="Save an API key for a built-in provider.",
             handler=_login_command,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            name="logout",
+            usage="/logout [provider]",
+            description="Remove saved credentials for a built-in provider.",
+            handler=_logout_command,
         )
     )
     return registry
@@ -649,6 +659,23 @@ def _login_command(context: CommandContext) -> CommandResult:
         return CommandResult(handled=True, login_provider=entry.name)
 
     return CommandResult(handled=True, login_picker_requested=True)
+
+
+def _logout_command(context: CommandContext) -> CommandResult:
+    provider_name = context.args.strip()
+    if provider_name:
+        entry = builtin_provider_entry(provider_name)
+        if entry is None:
+            providers = ", ".join(entry.name for entry in BUILTIN_PROVIDER_CATALOG)
+            return CommandResult(
+                handled=True,
+                message=(
+                    f"Unknown logout provider: {provider_name}\nAvailable providers: {providers}"
+                ),
+            )
+        return CommandResult(handled=True, logout_provider=entry.name)
+
+    return CommandResult(handled=True, logout_picker_requested=True)
 
 
 def _format_session_record(record: CodingSessionRecord) -> str:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -104,6 +104,10 @@ SIDEBAR_MIN_HEIGHT = 24
 ACTIVITY_TICK_SECONDS = 0.15
 ACTIVITY_COLOR_FADE_STEPS = 24
 ACTIVITY_INDICATOR_HEIGHT = 3
+NO_STORED_CREDENTIALS_MESSAGE = (
+    "No stored credentials to remove. /logout only removes credentials saved by /login; "
+    "environment variables and providers.json config are unchanged."
+)
 
 
 class LoginRequiredProvider:
@@ -758,15 +762,17 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
         providers: Sequence[ProviderCatalogEntry],
         *,
         theme: TuiTheme,
+        title: str = "Login",
     ) -> None:
         super().__init__()
         self.providers = tuple(providers)
         self.theme = theme
+        self.title = title
 
     def compose(self) -> ComposeResult:
         """Compose the provider picker."""
         with Vertical(id="login-provider-picker"):
-            yield Static("Login", id="login-provider-title")
+            yield Static(self.title, id="login-provider-title")
             yield ListView(
                 *[
                     ListItem(Label(_login_provider_label(provider), markup=False))
@@ -1926,6 +1932,10 @@ class TauTuiApp(App[None]):
                 self._open_login_picker()
             if command.login_provider is not None:
                 self._open_login(command.login_provider)
+            if command.logout_picker_requested:
+                self._open_logout_picker()
+            if command.logout_provider is not None:
+                self._logout(command.logout_provider)
             if command.model_picker_requested:
                 self._open_model_picker()
             if command.scoped_models_picker_requested:
@@ -2461,6 +2471,52 @@ class TauTuiApp(App[None]):
         self._notify(f"Saved login for {entry.display_name}.")
         self._refresh()
 
+    def _open_logout_picker(self) -> None:
+        providers = _stored_credential_providers(BUILTIN_PROVIDER_CATALOG)
+        if not providers:
+            self._notify(NO_STORED_CREDENTIALS_MESSAGE, severity="warning")
+            return
+        self.push_screen(
+            LoginProviderPickerScreen(
+                providers,
+                theme=self.tui_settings.resolved_theme,
+                title="Logout",
+            ),
+            callback=self._handle_logout_provider_result,
+        )
+
+    def _handle_logout_provider_result(self, provider_name: str | None) -> None:
+        if provider_name is None:
+            return
+        self._logout(provider_name)
+
+    def _logout(self, provider_name: str) -> None:
+        entry = builtin_provider_entry(provider_name)
+        if entry is None:
+            self._notify(f"Unknown provider: {provider_name}", severity="error")
+            return
+
+        credential_store = FileCredentialStore()
+        if not _credential_store_has_entry(credential_store, entry.credential_name):
+            self._notify(NO_STORED_CREDENTIALS_MESSAGE, severity="warning")
+            return
+
+        try:
+            credential_store.delete(entry.credential_name)
+            self.session.reload_provider_settings()
+        except Exception as exc:  # noqa: BLE001 - surface logout failures in the TUI
+            self._notify(f"Could not log out: {exc}", severity="error")
+            return
+
+        if entry.kind == "openai-codex":
+            self._notify(f"Logged out of {entry.display_name}.")
+        else:
+            self._notify(
+                f"Removed stored API key for {entry.display_name}. "
+                "Environment variables and providers.json config are unchanged."
+            )
+        self._refresh()
+
     def _available_model_choices(self) -> tuple[ModelChoice, ...]:
         fallback_choices = (
             ModelChoice(provider_name=self.session.provider_name, model=model)
@@ -2928,6 +2984,27 @@ def _api_key_login_providers(
     providers: Sequence[ProviderCatalogEntry],
 ) -> tuple[ProviderCatalogEntry, ...]:
     return tuple(provider for provider in providers if provider.kind != "openai-codex")
+
+
+def _stored_credential_providers(
+    providers: Sequence[ProviderCatalogEntry],
+) -> tuple[ProviderCatalogEntry, ...]:
+    credential_store = FileCredentialStore()
+    return tuple(
+        provider
+        for provider in providers
+        if _credential_store_has_entry(credential_store, provider.credential_name)
+    )
+
+
+def _credential_store_has_entry(
+    credential_store: FileCredentialStore,
+    credential_name: str,
+) -> bool:
+    return (
+        credential_store.get(credential_name) is not None
+        or credential_store.get_oauth(credential_name) is not None
+    )
 
 
 def _theme_picker_label(theme_name: TuiThemeName, *, current_theme: TuiThemeName) -> str:

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -387,7 +387,7 @@ def _command_argument_completions(
             options=_completion_options(model_names, description="Switch model"),
             sort=True,
         )
-    if command_name == "login":
+    if command_name in {"login", "logout"}:
         return _value_completions(
             text=text,
             start=token_end + 1,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -99,6 +99,7 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "export",
         "hotkeys",
         "login",
+        "logout",
         "model",
         "name",
         "new",
@@ -307,6 +308,28 @@ def test_login_command_requests_provider_login(tmp_path: Path) -> None:
 
     assert result.handled is True
     assert result.login_provider == "openai"
+
+
+def test_logout_command_requests_provider_picker(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/logout")
+
+    assert result.handled is True
+    assert result.logout_picker_requested is True
+
+
+def test_logout_command_requests_provider_logout(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/logout openai")
+
+    assert result.handled is True
+    assert result.logout_provider == "openai"
+
+
+def test_logout_command_rejects_unknown_provider(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/logout local")
+
+    assert result.handled is True
+    assert result.message is not None
+    assert "Unknown logout provider: local" in result.message
 
 
 def test_reload_command_refreshes_session_resources(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -163,6 +163,10 @@ class FakeSession:
             return CommandResult(handled=True, login_picker_requested=True)
         if text.startswith("/login "):
             return CommandResult(handled=True, login_provider=text.removeprefix("/login "))
+        if text == "/logout":
+            return CommandResult(handled=True, logout_picker_requested=True)
+        if text.startswith("/logout "):
+            return CommandResult(handled=True, logout_provider=text.removeprefix("/logout "))
         if text == "/model":
             return CommandResult(handled=True, model_picker_requested=True)
         if text in {"/scoped-models", "/scoped models"}:
@@ -2426,6 +2430,124 @@ async def test_tui_login_provider_does_not_change_default_startup_provider(
     assert session.provider_reload_count == 1
     assert session.provider_name == "openrouter"
     assert tui_app.load_provider_settings().default_provider == "openai"
+
+
+@pytest.mark.anyio
+async def test_tui_logout_without_stored_credentials_shows_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[tuple[str, str | None]] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity")
+        notifications.append((message, severity if isinstance(severity, str) else None))
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/logout"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert notifications == [(tui_app.NO_STORED_CREDENTIALS_MESSAGE, "warning")]
+    assert session.provider_reload_count == 0
+
+
+@pytest.mark.anyio
+async def test_tui_logout_removes_stored_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    credential_path = tmp_path / ".tau" / "credentials.json"
+    FileCredentialStore(credential_path).set("openai", "stored-openai-key")
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/logout openai"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert FileCredentialStore(credential_path).get("openai") is None
+    assert session.provider_reload_count == 1
+    assert notifications == [
+        "Removed stored API key for OpenAI. "
+        "Environment variables and providers.json config are unchanged."
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_logout_removes_oauth_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    credential_path = tmp_path / ".tau" / "credentials.json"
+    FileCredentialStore(credential_path).set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="access-token",
+            refresh="refresh-token",
+            expires=123456,
+            account_id="account-1",
+        ),
+    )
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/logout openai-codex"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert FileCredentialStore(credential_path).get_oauth("openai-codex") is None
+    assert session.provider_reload_count == 1
+    assert notifications == ["Logged out of OpenAI Codex subscription."]
+
+
+@pytest.mark.anyio
+async def test_tui_logout_opens_stored_credential_provider_picker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    FileCredentialStore(tmp_path / ".tau" / "credentials.json").set("anthropic", "stored-key")
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/logout"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginProviderPickerScreen)
+        title = app.screen.query_one("#login-provider-title", Static)
+        assert str(title.render()) == "Logout"
+        provider_list = app.screen.query_one("#login-provider-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in provider_list.children]
+        assert labels == ["Anthropic\n  anthropic"]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -150,6 +150,18 @@ def test_login_argument_completion_uses_available_providers() -> None:
     assert [item.display for item in state.items] == ["openai", "openrouter"]
 
 
+def test_logout_argument_completion_uses_available_providers() -> None:
+    state = build_completion_state(
+        "/logout op",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        provider_names=("openai", "openrouter", "anthropic"),
+    )
+
+    assert [item.display for item in state.items] == ["openai", "openrouter"]
+
+
 def test_thinking_argument_completion_uses_available_modes() -> None:
     state = build_completion_state(
         "/thinking h",


### PR DESCRIPTION
Closes #132

## Issue addressed
- Implements GitHub issue #132: add `/logout` command support for Tau.

## Pi inspiration/reference
- Pi's interactive mode routes `/logout` through the same provider selector family as `/login`.
- Pi deletes only stored auth via auth storage logout/remove, refreshes provider/model state, and tells users that environment variables and config are unchanged.
- Tau adapts this conservatively: only credentials saved in Tau's `~/.tau/credentials.json` are removed.

## Summary
- Added `/logout [provider]` to the slash-command registry.
- Added TUI handling for `/logout` with a picker limited to providers that have saved Tau credentials.
- Added direct `/logout <provider>` support for built-in providers.
- Removes API-key and OAuth credentials via `FileCredentialStore.delete` and refreshes provider settings afterward.
- Shows a Pi-modeled no-credentials message when there is no saved Tau login state to remove.
- Leaves environment variables, `providers.json`, provider defaults, billing, and model config unchanged.

## Files/areas changed
- `src/tau_coding/commands.py`: command result flags and `/logout` registration/dispatch.
- `src/tau_coding/tui/app.py`: logout picker, credential deletion, provider refresh, user-facing messages.
- `src/tau_coding/tui/autocomplete.py`: `/logout` provider argument completions.
- `tests/test_commands.py`: slash-command registry and dispatch coverage.
- `tests/test_tui_app.py`: no-credentials, API-key deletion, OAuth deletion, and picker coverage.
- `tests/test_tui_autocomplete.py`: `/logout` provider completion coverage.
- `README.md`, `docs/providers.md`, `docs/configuration.md`: user documentation for `/logout` scope.

## Tests/checks run
- `uv run pytest tests/test_commands.py tests/test_tui_autocomplete.py tests/test_tui_app.py -q` - 194 passed.
- `uv run ruff check src/tau_coding/commands.py src/tau_coding/tui/app.py src/tau_coding/tui/autocomplete.py tests/test_commands.py tests/test_tui_app.py tests/test_tui_autocomplete.py` - passed.
- `git diff --check` - passed.

## Assumptions
- `/logout <provider>` should mirror Tau's existing `/login [provider]` style while keeping the no-argument picker behavior inspired by Pi.
- Tau should mention `providers.json` rather than Pi's `models.json` because that is Tau's provider config file.

## Follow-up work
- None required for issue #132. Future custom-provider credential forms could extend `/logout` beyond built-in provider catalog entries if Tau later stores custom-provider credentials in `credentials.json`.
