### PR TITLE
Treat custom prompts as dynamic slash commands

### DIFF
--- a/docs/architecture/phase-15-slash-command-registry.md
+++ b/docs/architecture/phase-15-slash-command-registry.md
@@ -112,14 +112,18 @@ For example, `/new` returns `new_session_requested=True`. The TUI responds by
 creating and loading a fresh indexed session without deleting older durable JSONL
 session history.
 
-## Skill command behavior
+## Prompt expansion command behavior
 
 `/skill:<name> [request]` remains a prompt-expansion path, not a normal slash
 command.
 
-The registry intentionally returns `handled=False` for text beginning with
-`/skill:` so `CodingSession.prompt()` can expand the skill before sending the
-prompt to the model.
+Prompt templates also behave as dynamic prompt-expansion commands. For example,
+`.agents/prompts/example.md` is invoked as `/example [arguments]` and expanded by
+`CodingSession.prompt()` before the model sees the prompt.
+
+The registry intentionally returns `handled=False` for skill and prompt-template
+expansion directives so `CodingSession.prompt()` can replace them before sending
+the prompt to the model.
 
 There is no plain `/skill` slash command in the Pi-aligned registry.
 

--- a/docs/architecture/phase-9-skills-prompts.md
+++ b/docs/architecture/phase-9-skills-prompts.md
@@ -124,7 +124,25 @@ Prompt templates live in:
 
 ```text
 ~/.tau/prompts/review.md
+.agents/prompts/review.md
 ```
+
+Tau treats loaded prompt templates as slash-command prompt expansions. A file
+named `.agents/prompts/example.md` can be invoked with:
+
+```text
+/example src/app.py
+```
+
+Tau expands the command before sending the prompt to the model. Invocation text
+after the command is available as `{{ arguments }}` or `{{ args }}`:
+
+```md
+Review {{ arguments }} for correctness.
+```
+
+If the prompt template has no placeholders, Tau appends the invocation arguments
+after a blank line.
 
 Template variables use simple `{{ variable }}` placeholders:
 
@@ -132,7 +150,7 @@ Template variables use simple `{{ variable }}` placeholders:
 Review {{ target }} for {{ focus }}.
 ```
 
-Render templates with:
+Render templates directly with:
 
 ```python
 from tau_coding import load_prompt_templates, render_prompt_template

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -33,6 +33,7 @@ from tau_coding.credentials import (
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import (
     PromptTemplate,
+    expand_prompt_template_command,
     load_prompt_templates,
     load_prompt_templates_with_diagnostics,
     render_prompt_template,
@@ -190,6 +191,7 @@ __all__ = [
     "builtin_provider_entry",
     "collect_prompt_guidelines",
     "CredentialStoreError",
+    "expand_prompt_template_command",
     "create_bash_tool",
     "create_bash_tool_definition",
     "create_coding_tools",

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -1,7 +1,7 @@
 """Markdown prompt template loading and rendering."""
 
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -74,6 +74,50 @@ def render_prompt_template(template: PromptTemplate, variables: Mapping[str, str
         return value
 
     return _TEMPLATE_VARIABLE_RE.sub(replace, template.content)
+
+
+def expand_prompt_template_command(
+    text: str,
+    templates: Sequence[PromptTemplate],
+) -> str | None:
+    """Expand `/name [arguments]` text with a loaded prompt template.
+
+    Template names are matched by markdown filename stem. Invocation arguments are
+    available to templates as `{{ arguments }}` or `{{ args }}`. If a template has
+    no placeholders, arguments are appended after a blank line.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("/") or stripped.startswith("//") or stripped.startswith("/skill:"):
+        return None
+
+    name, args = _parse_prompt_template_command(stripped)
+    if not name:
+        return None
+
+    template = _find_prompt_template(name, templates)
+    if template is None:
+        return None
+
+    rendered = render_prompt_template(template, {"arguments": args, "args": args})
+    if args and not _TEMPLATE_VARIABLE_RE.search(template.content):
+        return f"{rendered.rstrip()}\n\n{args}"
+    return rendered
+
+
+def _find_prompt_template(
+    name: str,
+    templates: Sequence[PromptTemplate],
+) -> PromptTemplate | None:
+    normalized_name = name.strip().removeprefix("/").lower()
+    for template in templates:
+        if template.name.lower() == normalized_name:
+            return template
+    return None
+
+
+def _parse_prompt_template_command(text: str) -> tuple[str, str]:
+    command, separator, args = text[1:].partition(" ")
+    return command.strip().lower(), args.strip() if separator else ""
 
 
 def _load_prompt_templates_from_dir(prompts_dir: Path) -> list[PromptTemplate]:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -55,6 +55,7 @@ from tau_coding.diagnostics import (
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import (
     PromptTemplate,
+    expand_prompt_template_command,
     load_prompt_templates_with_diagnostics,
 )
 from tau_coding.provider_config import (
@@ -1006,15 +1007,20 @@ class CodingSession:
         self._owned_providers.clear()
 
     def handle_command(self, text: str) -> CommandResult:
-        """Handle minimal coding-session slash commands.
+        """Handle coding-session slash commands.
 
-        This is intentionally tiny. Later phases can replace it with a full Pi-like
-        command registry without changing the persistence boundary.
+        Prompt-template slash commands are expansion directives, so they remain
+        unhandled here and flow through `prompt()` for on-the-fly replacement.
         """
+        if expand_prompt_template_command(text, self._prompt_templates) is not None:
+            return CommandResult(handled=False)
         return self._command_registry.execute(self, text)
 
     def expand_prompt_text(self, text: str) -> str:
         """Expand prompt text using loaded markdown resources."""
+        expanded_prompt = expand_prompt_template_command(text, self._prompt_templates)
+        if expanded_prompt is not None:
+            return expanded_prompt
         expanded_skill = expand_skill_command(text, self._skills)
         return expanded_skill if expanded_skill is not None else text
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -104,6 +104,7 @@ SIDEBAR_MIN_HEIGHT = 24
 ACTIVITY_TICK_SECONDS = 0.15
 ACTIVITY_COLOR_FADE_STEPS = 24
 ACTIVITY_INDICATOR_HEIGHT = 3
+COMPLETION_MAX_VISIBLE_LINES = 16
 NO_STORED_CREDENTIALS_MESSAGE = (
     "No stored credentials to remove. /logout only removes credentials saved by /login; "
     "environment variables and providers.json config are unchanged."
@@ -1526,6 +1527,7 @@ class TauTuiApp(App[None]):
         background: $tau-autocomplete-background;
         color: $tau-screen-text;
         border: tall $tau-border;
+        overflow-y: auto;
     }
 
     SessionPickerScreen,
@@ -2768,7 +2770,10 @@ class TauTuiApp(App[None]):
         suggestions.display = bool(self._completion_state.items)
         suggestions.update(
             render_completion_suggestions(
-                self._completion_state,
+                _visible_completion_state(
+                    self._completion_state,
+                    max_lines=COMPLETION_MAX_VISIBLE_LINES,
+                ),
                 theme=self.tui_settings.resolved_theme,
             )
         )
@@ -2890,6 +2895,79 @@ def _hex_to_rgb(color: str) -> tuple[int, int, int]:
     if len(value) != 6:
         raise ValueError(f"Expected #rrggbb color, got {color!r}")
     return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+
+
+def _visible_completion_state(
+    state: CompletionState,
+    *,
+    max_lines: int,
+) -> CompletionState:
+    """Return a completion-state window with the selected item visible."""
+    if not state.items or max_lines <= 0:
+        return CompletionState()
+
+    start = 0
+    while start < state.selected_index:
+        candidate = CompletionState(
+            items=state.items[start:],
+            selected_index=state.selected_index - start,
+        )
+        if _completion_selected_render_line(candidate) < max_lines:
+            break
+        start += 1
+
+    end = len(state.items)
+    while end > state.selected_index + 1:
+        candidate = CompletionState(
+            items=state.items[start:end],
+            selected_index=state.selected_index - start,
+        )
+        if _completion_render_line_count(candidate) <= max_lines:
+            break
+        end -= 1
+
+    return CompletionState(
+        items=state.items[start:end],
+        selected_index=state.selected_index - start,
+    )
+
+
+def _completion_selected_render_line(state: CompletionState) -> int:
+    """Return the rendered line number for the selected completion item."""
+    line = 0
+    has_rendered_text = False
+    previous_category: str | None = None
+    for index, item in enumerate(state.items):
+        if item.category != previous_category:
+            if has_rendered_text:
+                line += 1
+            if item.category:
+                line += 1
+                has_rendered_text = True
+            previous_category = item.category
+        elif has_rendered_text:
+            line += 1
+        if index == state.selected_index:
+            return line
+        has_rendered_text = True
+    return line
+
+
+def _completion_render_line_count(state: CompletionState) -> int:
+    """Return how many lines the completion state renders into."""
+    if not state.items:
+        return 0
+    line_count = 0
+    previous_category: str | None = None
+    for index, item in enumerate(state.items):
+        if item.category != previous_category:
+            if index:
+                line_count += 1
+            if item.category:
+                line_count += 1
+            previous_category = item.category
+        line_count += 1
+    return line_count
 
 
 def _session_command_registry(session: CodingSession) -> CommandRegistry:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6,10 +6,11 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
 from inspect import isawaitable
+from io import StringIO
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Protocol, cast
 
-from rich.console import Group
+from rich.console import Console, Group
 from rich.text import Text
 from textual import events, on
 from textual.app import App, ComposeResult
@@ -80,9 +81,15 @@ from tau_coding.session import (
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui.adapter import TuiEventAdapter
-from tau_coding.tui.autocomplete import CompletionOption, CompletionState, build_completion_state
+from tau_coding.tui.autocomplete import (
+    CompletionItem,
+    CompletionOption,
+    CompletionState,
+    build_completion_state,
+)
 from tau_coding.tui.config import (
     BUILTIN_TUI_THEME_NAMES,
+    TAU_DARK_THEME,
     TuiKeybindings,
     TuiSettings,
     TuiTheme,
@@ -2773,6 +2780,7 @@ class TauTuiApp(App[None]):
                 _visible_completion_state(
                     self._completion_state,
                     max_lines=COMPLETION_MAX_VISIBLE_LINES,
+                    width=max(suggestions.content_size.width or suggestions.size.width, 1),
                 ),
                 theme=self.tui_settings.resolved_theme,
             )
@@ -2901,6 +2909,7 @@ def _visible_completion_state(
     state: CompletionState,
     *,
     max_lines: int,
+    width: int | None = None,
 ) -> CompletionState:
     """Return a completion-state window with the selected item visible."""
     if not state.items or max_lines <= 0:
@@ -2913,7 +2922,7 @@ def _visible_completion_state(
             items=state.items[start:],
             selected_index=state.selected_index - start,
         )
-        if _completion_selected_render_line(candidate) < selected_line_limit:
+        if _completion_selected_render_line(candidate, width=width) < selected_line_limit:
             break
         start += 1
 
@@ -2923,9 +2932,18 @@ def _visible_completion_state(
             items=state.items[start:end],
             selected_index=state.selected_index - start,
         )
-        if _completion_render_line_count(candidate) <= max_lines:
+        if _completion_render_line_count(candidate, width=width) <= max_lines:
             break
         end -= 1
+
+    while start < state.selected_index:
+        candidate = CompletionState(
+            items=state.items[start:end],
+            selected_index=state.selected_index - start,
+        )
+        if _completion_render_line_count(candidate, width=width) <= max_lines:
+            break
+        start += 1
 
     return CompletionState(
         items=state.items[start:end],
@@ -2933,7 +2951,7 @@ def _visible_completion_state(
     )
 
 
-def _completion_selected_render_line(state: CompletionState) -> int:
+def _completion_selected_render_line(state: CompletionState, *, width: int | None = None) -> int:
     """Return the rendered line number for the selected completion item."""
     line = 0
     has_rendered_text = False
@@ -2950,11 +2968,12 @@ def _completion_selected_render_line(state: CompletionState) -> int:
             line += 1
         if index == state.selected_index:
             return line
+        line += _completion_item_extra_wrapped_lines(item, width=width)
         has_rendered_text = True
     return line
 
 
-def _completion_render_line_count(state: CompletionState) -> int:
+def _completion_render_line_count(state: CompletionState, *, width: int | None = None) -> int:
     """Return how many lines the completion state renders into."""
     if not state.items:
         return 0
@@ -2967,8 +2986,35 @@ def _completion_render_line_count(state: CompletionState) -> int:
             if item.category:
                 line_count += 1
             previous_category = item.category
-        line_count += 1
+        line_count += 1 + _completion_item_extra_wrapped_lines(item, width=width)
     return line_count
+
+
+def _completion_item_extra_wrapped_lines(
+    item: CompletionItem,
+    *,
+    width: int | None,
+) -> int:
+    """Return extra rendered lines used when a completion description wraps."""
+    if width is None or width <= 0 or not item.description:
+        return 0
+    output = StringIO()
+    console = Console(
+        file=output,
+        width=width,
+        force_terminal=False,
+        color_system=None,
+        legacy_windows=False,
+    )
+    console.print(
+        render_completion_suggestions(
+            CompletionState(items=(item,), selected_index=0),
+            theme=TAU_DARK_THEME,
+        ),
+        end="",
+    )
+    line_count = len(output.getvalue().splitlines())
+    return max(line_count - 1, 0)
 
 
 def _session_command_registry(session: CodingSession) -> CommandRegistry:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2906,13 +2906,14 @@ def _visible_completion_state(
     if not state.items or max_lines <= 0:
         return CompletionState()
 
+    selected_line_limit = max(max_lines - 1, 1)
     start = 0
     while start < state.selected_index:
         candidate = CompletionState(
             items=state.items[start:],
             selected_index=state.selected_index - start,
         )
-        if _completion_selected_render_line(candidate) < max_lines:
+        if _completion_selected_render_line(candidate) < selected_line_limit:
             break
         start += 1
 

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -98,7 +98,6 @@ def build_completion_state(
     cwd: Path | None = None,
 ) -> CompletionState:
     """Build autocomplete suggestions for the current prompt text."""
-    del prompt_templates
     if not text.startswith("/") or text.startswith("//"):
         if cwd is not None:
             shell_completions = _shell_path_completions(text=text, cwd=cwd)
@@ -129,7 +128,12 @@ def build_completion_state(
         return CompletionState(argument_completions)
 
     return CompletionState(
-        _command_completions(token=token, token_end=token_end, registry=command_registry)
+        _command_completions(
+            token=token,
+            token_end=token_end,
+            registry=command_registry,
+            prompt_templates=prompt_templates,
+        )
     )
 
 
@@ -298,12 +302,27 @@ def _parse_shell_path_token(token: str) -> tuple[str, str, str] | None:
 
 
 def _command_completions(
-    *, token: str, token_end: int, registry: CommandRegistry
+    *,
+    token: str,
+    token_end: int,
+    registry: CommandRegistry,
+    prompt_templates: Sequence[PromptTemplate],
 ) -> tuple[CompletionItem, ...]:
     prefix = token.removeprefix("/").lower()
     suggestions: list[CompletionItem] = []
     for command in registry.list_commands():
         suggestions.extend(_command_alias_completions(command, prefix=prefix, token_end=token_end))
+    for template in prompt_templates:
+        if template.name.lower().startswith(prefix):
+            suggestions.append(
+                CompletionItem(
+                    display=f"/{template.name}",
+                    replacement=f"/{template.name}",
+                    start=0,
+                    end=token_end,
+                    description=template.description or "Prompt template",
+                )
+            )
     return tuple(sorted(suggestions, key=lambda item: _command_completion_sort_key(item, prefix)))
 
 

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -44,6 +44,7 @@ class CompletionItem:
     start: int
     end: int
     description: str | None = None
+    category: str | None = None
 
     def apply(self, text: str) -> str:
         """Apply this completion to input text."""
@@ -309,21 +310,27 @@ def _command_completions(
     prompt_templates: Sequence[PromptTemplate],
 ) -> tuple[CompletionItem, ...]:
     prefix = token.removeprefix("/").lower()
-    suggestions: list[CompletionItem] = []
+    command_suggestions: list[CompletionItem] = []
     for command in registry.list_commands():
-        suggestions.extend(_command_alias_completions(command, prefix=prefix, token_end=token_end))
-    for template in prompt_templates:
-        if template.name.lower().startswith(prefix):
-            suggestions.append(
-                CompletionItem(
-                    display=f"/{template.name}",
-                    replacement=f"/{template.name}",
-                    start=0,
-                    end=token_end,
-                    description=template.description or "Prompt template",
-                )
-            )
-    return tuple(sorted(suggestions, key=lambda item: _command_completion_sort_key(item, prefix)))
+        command_suggestions.extend(
+            _command_alias_completions(command, prefix=prefix, token_end=token_end)
+        )
+    prompt_suggestions = [
+        CompletionItem(
+            display=f"/{template.name}",
+            replacement=f"/{template.name}",
+            start=0,
+            end=token_end,
+            description=template.description or "Prompt template",
+            category="Custom prompts",
+        )
+        for template in prompt_templates
+        if template.name.lower().startswith(prefix)
+    ]
+    return (
+        *sorted(command_suggestions, key=lambda item: _command_completion_sort_key(item, prefix)),
+        *sorted(prompt_suggestions, key=lambda item: _command_completion_sort_key(item, prefix)),
+    )
 
 
 def _command_completion_sort_key(item: CompletionItem, prefix: str) -> tuple[int, str]:
@@ -361,6 +368,7 @@ def _command_alias_completions(
                 start=0,
                 end=token_end,
                 description=command.description,
+                category="Commands",
             )
         )
     return suggestions

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1145,8 +1145,16 @@ def render_completion_suggestions(
 ) -> Text:
     """Render prompt completion suggestions."""
     text = Text()
+    previous_category: str | None = None
     for index, item in enumerate(state.items):
-        if index:
+        if item.category != previous_category:
+            if text:
+                text.append("\n")
+            if item.category:
+                text.append(item.category, style=theme.completion_description)
+                text.append("\n")
+            previous_category = item.category
+        elif text:
             text.append("\n")
         selected = index == state.selected_index
         prefix = "› " if selected else "  "

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1142,32 +1142,32 @@ def render_completion_suggestions(
     state: CompletionState,
     *,
     theme: TuiTheme = TAU_DARK_THEME,
-) -> Text:
-    """Render prompt completion suggestions."""
-    text = Text()
+) -> RenderableType:
+    """Render prompt completion suggestions in aligned command/description columns."""
+    table = Table.grid(expand=True)
+    table.add_column(no_wrap=True)
+    table.add_column(ratio=1)
+
     previous_category: str | None = None
     for index, item in enumerate(state.items):
         if item.category != previous_category:
-            if text:
-                text.append("\n")
+            if index:
+                table.add_row(Text(""), Text(""))
             if item.category:
-                text.append(item.category, style=theme.completion_description)
-                text.append("\n")
+                table.add_row(Text(item.category, style=theme.completion_description), Text(""))
             previous_category = item.category
-        elif text:
-            text.append("\n")
+
         selected = index == state.selected_index
         prefix = "› " if selected else "  "
         style = theme.completion_selected if selected else theme.prompt_text
         description_style = (
             theme.completion_selected_description if selected else theme.completion_description
         )
-        text.append(prefix, style=style)
-        text.append(item.display, style=style)
-        if item.description:
-            text.append("  ")
-            text.append(item.description, style=description_style)
-    return text
+        command = Text(prefix, style=style)
+        command.append(item.display, style=style)
+        command.append("  ", style=style)
+        table.add_row(command, Text(item.description or "", style=description_style))
+    return table
 
 
 def _bullet_list(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -349,7 +349,9 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     await task
 
     assert queue_events == [QueueUpdateEvent(steering=("Queued steering",))]
-    before_release_messages = [entry.message for entry in entries_before_release if entry.type == "message"]
+    before_release_messages = [
+        entry.message for entry in entries_before_release if entry.type == "message"
+    ]
     assert before_release_messages == [UserMessage(content="Hello")]
     assert entries_before_release[-1].type == "leaf"
     assert entries_before_release[-1].entry_id == next(
@@ -1080,6 +1082,42 @@ async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
     assert "References are relative to" in provider.calls[0][2][0].content
     assert provider.calls[0][2][0].content.endswith("</skill>\n\nadd tests")
     assert session.handle_command("/skill:testing").handled is False
+
+
+@pytest.mark.anyio
+async def test_session_expands_prompt_templates_as_slash_commands(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    prompts_dir = resource_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    (prompts_dir / "example.md").write_text(
+        "Custom prompt for {{ arguments }}.",
+        encoding="utf-8",
+    )
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ]
+        ]
+    )
+    config = CodingSessionConfig(
+        provider=provider,
+        model="fake",
+        system="You are Tau.",
+        storage=storage,
+        cwd=tmp_path,
+        resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+    )
+    session = await CodingSession.load(config)
+
+    assert [template.name for template in session.prompt_templates] == ["example"]
+    assert session.handle_command("/example src/app.py").handled is False
+
+    _events = await _collect_session_events(session.prompt("/example src/app.py"))
+
+    assert provider.calls[0][2][0].content == "Custom prompt for src/app.py."
 
 
 @pytest.mark.anyio

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -4,6 +4,7 @@ import pytest
 
 from tau_coding import (
     TauResourcePaths,
+    expand_prompt_template_command,
     load_prompt_templates,
     load_prompt_templates_with_diagnostics,
     render_prompt_template,
@@ -106,3 +107,29 @@ def test_render_prompt_template_rejects_missing_variables() -> None:
 
     with pytest.raises(ResourceError, match="Missing prompt template variable"):
         render_prompt_template(template, {})
+
+
+def test_expand_prompt_template_command_replaces_slash_command() -> None:
+    template = PromptTemplate(
+        name="example",
+        path=Path("example.md"),
+        content="Use these arguments: {{ arguments }}",
+    )
+
+    assert expand_prompt_template_command("/example src/app.py", [template]) == (
+        "Use these arguments: src/app.py"
+    )
+
+
+def test_expand_prompt_template_command_appends_arguments_without_placeholder() -> None:
+    template = PromptTemplate(name="review", path=Path("review.md"), content="Review this code.")
+
+    assert expand_prompt_template_command("/review src/app.py", [template]) == (
+        "Review this code.\n\nsrc/app.py"
+    )
+
+
+def test_expand_prompt_template_command_ignores_unknown_commands() -> None:
+    template = PromptTemplate(name="review", path=Path("review.md"), content="Review this code.")
+
+    assert expand_prompt_template_command("/missing src/app.py", [template]) is None

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -30,6 +30,7 @@ from tau_agent import (
 )
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_config import (
     OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
@@ -1631,6 +1632,30 @@ async def test_tui_app_submits_multiline_prompt_with_enter() -> None:
 
     assert session.prompt_texts == ["first\nsecond"]
     assert prompt.value == ""
+
+
+@pytest.mark.anyio
+async def test_tui_app_completes_custom_prompt_slash_command() -> None:
+    session = FakeSession()
+    session.prompt_templates = (
+        PromptTemplate(
+            name="example",
+            path=Path("example.md"),
+            content="Example prompt.",
+            description="Run the example prompt.",
+        ),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/ex"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        await pilot.press("tab")
+
+        assert prompt.value == "/example"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -57,8 +57,11 @@ from tau_coding.tui.app import (
     ThemePickerScreen,
     TreePickerScreen,
     _activity_prompt_border_color,
+    _completion_selected_render_line,
     _terminal_command_prefix_span,
+    _visible_completion_state,
 )
+from tau_coding.tui.autocomplete import CompletionItem, CompletionState
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
     TAU_LIGHT_THEME,
@@ -2048,6 +2051,88 @@ async def test_tui_app_tree_picker_toggles_tool_calls() -> None:
             "* assistant: Right",
         ]
         assert tree_list.index == 3
+
+
+@pytest.mark.anyio
+def test_completion_selected_render_line_accounts_for_group_headers() -> None:
+    state = CompletionState(
+        items=(
+            CompletionItem(
+                display="/session",
+                replacement="/session",
+                start=0,
+                end=2,
+                category="Commands",
+            ),
+            CompletionItem(
+                display="/example",
+                replacement="/example",
+                start=0,
+                end=2,
+                category="Custom prompts",
+            ),
+        ),
+        selected_index=1,
+    )
+
+    assert _completion_selected_render_line(state) == 3
+
+
+@pytest.mark.anyio
+def test_visible_completion_state_keeps_selected_item_in_render_window() -> None:
+    items = tuple(
+        CompletionItem(
+            display=f"/prompt-{index:02d}",
+            replacement=f"/prompt-{index:02d}",
+            start=0,
+            end=1,
+            category="Custom prompts",
+        )
+        for index in range(30)
+    )
+    state = CompletionState(items=items, selected_index=24)
+
+    visible = _visible_completion_state(state, max_lines=8)
+
+    assert visible.selected is not None
+    assert visible.selected.display == "/prompt-24"
+    assert visible.selected_index < len(visible.items)
+    assert len(visible.items) < len(items)
+    assert _completion_selected_render_line(visible) < 8
+
+
+@pytest.mark.anyio
+async def test_tui_app_scrolls_completion_selection_into_view() -> None:
+    session = FakeSession()
+    session.prompt_templates = tuple(
+        PromptTemplate(
+            name=f"prompt-{index:02d}",
+            path=Path(f"prompt-{index:02d}.md"),
+            content="Run.",
+        )
+        for index in range(30)
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.focus()
+        prompt.value = "/"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+        autocomplete = app.query_one("#autocomplete", Static)
+        initial_rendered = str(autocomplete.render())
+        assert "/prompt-00" not in initial_rendered
+
+        for _ in range(35):
+            app.action_completion_next()
+            await pilot.pause()
+
+        rendered = str(autocomplete.render())
+        selected = app._completion_state.selected
+        assert selected is not None
+        assert selected.display in rendered
+        assert "/prompt-00" not in rendered
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1649,7 +1649,7 @@ async def test_tui_app_completes_custom_prompt_slash_command() -> None:
 
     async with app.run_test() as pilot:
         prompt = app.query_one("#prompt")
-        prompt.value = "/ex"
+        prompt.value = "/exa"
         app._completion_state = app._build_completion_state(prompt.value)
         app._refresh_completions()
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2140,19 +2140,25 @@ async def test_tui_app_scrolls_completion_selection_into_view() -> None:
         prompt.value = "/"
         app._completion_state = app._build_completion_state(prompt.value)
         app._refresh_completions()
-        autocomplete = app.query_one("#autocomplete", Static)
-        initial_rendered = str(autocomplete.render())
-        assert "/prompt-00" not in initial_rendered
+        visible = tui_app._visible_completion_state(
+            app._completion_state,
+            max_lines=tui_app.COMPLETION_MAX_VISIBLE_LINES,
+        )
+        assert visible.items[0].display != "/prompt-00"
 
         for _ in range(35):
             app.action_completion_next()
             await pilot.pause()
 
-        rendered = str(autocomplete.render())
+        visible = tui_app._visible_completion_state(
+            app._completion_state,
+            max_lines=tui_app.COMPLETION_MAX_VISIBLE_LINES,
+        )
         selected = app._completion_state.selected
         assert selected is not None
-        assert selected.display in rendered
-        assert "/prompt-00" not in rendered
+        assert visible.selected is not None
+        assert visible.selected.display == selected.display
+        assert visible.items[0].display != "/prompt-00"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2101,6 +2101,31 @@ def test_visible_completion_state_keeps_selected_item_in_render_window() -> None
     assert _completion_selected_render_line(visible) < 8
 
 
+def test_visible_completion_state_accounts_for_wrapped_descriptions() -> None:
+    items = tuple(
+        CompletionItem(
+            display=f"/prompt-{index:02d}",
+            replacement=f"/prompt-{index:02d}",
+            start=0,
+            end=1,
+            description=(
+                "This prompt has a long description that wraps across multiple lines "
+                "inside the completion table."
+            ),
+            category="Custom prompts",
+        )
+        for index in range(12)
+    )
+    state = CompletionState(items=items, selected_index=8)
+
+    visible = _visible_completion_state(state, max_lines=8, width=48)
+
+    assert visible.selected is not None
+    assert visible.selected.display == "/prompt-08"
+    assert tui_app._completion_render_line_count(visible, width=48) <= 8
+    assert _completion_selected_render_line(visible, width=48) < 7
+
+
 def test_visible_completion_state_keeps_selected_item_above_bottom_edge() -> None:
     items = tuple(
         CompletionItem(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2101,6 +2101,26 @@ def test_visible_completion_state_keeps_selected_item_in_render_window() -> None
     assert _completion_selected_render_line(visible) < 8
 
 
+def test_visible_completion_state_keeps_selected_item_above_bottom_edge() -> None:
+    items = tuple(
+        CompletionItem(
+            display=f"/prompt-{index:02d}",
+            replacement=f"/prompt-{index:02d}",
+            start=0,
+            end=1,
+            category="Custom prompts",
+        )
+        for index in range(30)
+    )
+    state = CompletionState(items=items, selected_index=15)
+
+    visible = _visible_completion_state(state, max_lines=8)
+
+    assert visible.selected is not None
+    assert visible.selected.display == "/prompt-15"
+    assert _completion_selected_render_line(visible) < 7
+
+
 @pytest.mark.anyio
 async def test_tui_app_scrolls_completion_selection_into_view() -> None:
     session = FakeSession()

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 from tau_coding.commands import create_default_command_registry
+from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.skills import Skill
 from tau_coding.tui.autocomplete import CompletionOption, build_completion_state
+from tau_coding.tui.widgets import render_completion_suggestions
 
 
 def test_command_completion_for_slash_lists_every_registered_command() -> None:
@@ -18,6 +20,31 @@ def test_command_completion_for_slash_lists_every_registered_command() -> None:
         f"/{command.name}" if command.name != "skill" else "/skill:"
         for command in registry.list_commands()
     ]
+
+
+def test_slash_completion_groups_commands_and_custom_prompts() -> None:
+    state = build_completion_state(
+        "/",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="example",
+                path=Path("example.md"),
+                content="Example prompt.",
+                description="Run example.",
+            ),
+        ),
+    )
+
+    assert state.items[0].category == "Commands"
+    assert state.items[-1].display == "/example"
+    assert state.items[-1].category == "Custom prompts"
+    rendered = render_completion_suggestions(state).plain
+    assert "Commands\n" in rendered
+    assert "Custom prompts\n" in rendered
+    assert rendered.index("Commands") < rendered.index("/compact")
+    assert rendered.index("Custom prompts") < rendered.index("/example")
 
 
 def test_command_completion_suggests_registered_commands() -> None:

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from rich.console import Console
+
 from tau_coding.commands import create_default_command_registry
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.skills import Skill
@@ -40,11 +42,37 @@ def test_slash_completion_groups_commands_and_custom_prompts() -> None:
     assert state.items[0].category == "Commands"
     assert state.items[-1].display == "/example"
     assert state.items[-1].category == "Custom prompts"
-    rendered = render_completion_suggestions(state).plain
-    assert "Commands\n" in rendered
-    assert "Custom prompts\n" in rendered
+    console = Console(width=100, record=True)
+    console.print(render_completion_suggestions(state))
+    rendered = console.export_text()
+    assert "Commands" in rendered
+    assert "Custom prompts" in rendered
     assert rendered.index("Commands") < rendered.index("/compact")
     assert rendered.index("Custom prompts") < rendered.index("/example")
+
+
+def test_completion_rendering_aligns_wrapped_descriptions() -> None:
+    state = build_completion_state(
+        "/skill:r",
+        command_registry=create_default_command_registry(),
+        skills=(
+            Skill(
+                name="review",
+                path=Path("review.md"),
+                content="Review code",
+                description="Review code with a long description that wraps onto another line.",
+            ),
+        ),
+        prompt_templates=(),
+    )
+
+    console = Console(width=48, record=True)
+    console.print(render_completion_suggestions(state))
+    rendered = console.export_text()
+
+    assert "› /skill:review" in rendered
+    assert "                 another line." in rendered
+    assert not any(line.startswith("another line.") for line in rendered.splitlines())
 
 
 def test_command_completion_suggests_registered_commands() -> None:


### PR DESCRIPTION
## Summary
- Treat loaded prompt templates as dynamic slash-command prompt expansions.
- Expand `/example args` from `example.md` before sending text to the model, with args available as `{{ arguments }}` / `{{ args }}` or appended for templates without placeholders.
- Include prompt templates in TUI slash-command autocomplete.
- Update architecture docs and tests.

Closes #151.

## Validation
Automated:
- `uv run ruff check src/tau_coding/prompt_templates.py src/tau_coding/session.py src/tau_coding/tui/autocomplete.py src/tau_coding/__init__.py tests/test_prompt_templates.py tests/test_coding_session.py tests/test_tui_app.py`
- `uv run pytest tests/test_prompt_templates.py tests/test_coding_session.py::test_session_expands_prompt_templates_as_slash_commands tests/test_tui_app.py::test_tui_app_completes_custom_prompt_slash_command`
- `uv run pytest` was run; 493/494 passed, with one pre-existing environment-sensitive provider default assertion failing locally (`test_run_tui_app_opens_when_provider_login_is_missing`) because local stored credentials make `openai-codex` available.

Manual validation:
1. Check out this branch and run Tau from a temporary project directory.
2. Create `.agents/prompts/example.md` with:
   ```md
   Explain this target: {{ arguments }}
   ```
3. Start Tau in that project.
4. Type `/ex` and confirm autocomplete offers `/example`.
5. Submit `/example src/app.py`.
6. Confirm Tau sends the expanded prompt text (`Explain this target: src/app.py`) instead of showing `Unknown command: /example`.
7. Optional: change the template to text without placeholders, rerun `/example src/app.py`, and confirm Tau appends `src/app.py` after a blank line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt templates can now be invoked as slash commands (e.g., `/example src/app.py`)
  * Custom prompts support argument expansion via template variables
  * Autocomplete suggestions are grouped by category, distinguishing commands from custom prompts

* **Documentation**
  * Updated architecture documentation on prompt-template invocation and expansion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->