### PR TITLE
Implement #146: render interactive bash like tool calls

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1978,20 +1978,32 @@ class TauTuiApp(App[None]):
         if not callable(run_terminal_command):
             self._notify("Terminal commands are not available.", severity="error")
             return
+        item_index = len(self.state.items)
+        self.state.add_item(
+            "tool",
+            f"$ {command.strip()}",
+            always_show_tool_result=True,
+        )
+        self._refresh()
         try:
             result = await run_terminal_command(command, add_to_context=add_to_context)
         except Exception as exc:  # noqa: BLE001 - surface command execution failures in the TUI
+            if item_index < len(self.state.items):
+                self.state.items[item_index].tool_result_text = (
+                    f"✗ bash\nCould not run command: {exc}"
+                )
+                self._refresh()
+                return
             self._notify(f"Could not run command: {exc}", severity="error")
             return
-        self.state.add_item(
-            "tool",
-            f"$ {result.command}",
-            tool_result_text=format_terminal_command_result_block(
-                ok=result.ok,
-                added_to_context=result.added_to_context,
-                output=result.output,
-            ),
-            always_show_tool_result=True,
+        if item_index >= len(self.state.items):
+            return
+        item = self.state.items[item_index]
+        item.text = f"$ {result.command}"
+        item.tool_result_text = format_terminal_command_result_block(
+            ok=result.ok,
+            added_to_context=result.added_to_context,
+            output=result.output,
         )
         self._refresh()
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2841,6 +2841,81 @@ async def test_tui_app_runs_terminal_command_without_context() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("add_to_context", [True, False])
+async def test_tui_app_renders_terminal_command_while_running(add_to_context: bool) -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_run_terminal_command(
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        started.set()
+        await release.wait()
+        return TerminalCommandResult(
+            command=command,
+            output="finished",
+            exit_code=0,
+            ok=True,
+            added_to_context=add_to_context,
+        )
+
+    session.run_terminal_command = fake_run_terminal_command  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        task = asyncio.create_task(
+            app._run_terminal_command("sleep 1", add_to_context=add_to_context)
+        )
+        await started.wait()
+        await pilot.pause()
+
+        assert [(item.role, item.text, item.tool_result_text) for item in app.state.items] == [
+            ("tool", "$ sleep 1", None)
+        ]
+        assert app.state.items[-1].always_show_tool_result is True
+
+        release.set()
+        await task
+
+    context_label = "added to context" if add_to_context else "not added to context"
+    assert app.state.items[-1].tool_result_text == f"✓ bash · {context_label}\nfinished"
+
+
+@pytest.mark.anyio
+async def test_tui_app_marks_failed_terminal_command_as_error() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async def fake_run_terminal_command(
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        return TerminalCommandResult(
+            command=command,
+            output="failed",
+            exit_code=2,
+            ok=False,
+            added_to_context=add_to_context,
+        )
+
+    session.run_terminal_command = fake_run_terminal_command  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "!! false"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.prompt_texts == []
+    assert app.state.items[-1].text == "$ false"
+    assert app.state.items[-1].tool_result_text == "✗ bash · not added to context\nfailed"
+
+
+@pytest.mark.anyio
 async def test_tui_app_renders_terminal_command_output_when_tool_results_are_collapsed() -> None:
     item = ChatItem(
         role="tool",


### PR DESCRIPTION
Closes #146

## Summary
- Render input-bar terminal commands (`!` and `!!`) immediately as TUI tool-style rows while they are running.
- Update the same row after completion with the command output and success/error styling based on the shell result.
- Preserve existing context behavior: `!` adds command output to context, while `!!` keeps it display-only.

## Files / Areas Changed
- `src/tau_coding/tui/app.py`: live terminal-command transcript row insertion and completion update.
- `tests/test_tui_app.py`: deterministic TUI coverage for in-progress rendering, context and non-context modes, collapsed output visibility, output preview limiting, and failed command styling.

## Tests / Checks
- `uv run pytest tests/test_tui_app.py::test_tui_app_runs_terminal_command_and_adds_context tests/test_tui_app.py::test_tui_app_runs_terminal_command_without_context tests/test_tui_app.py::test_tui_app_renders_terminal_command_while_running tests/test_tui_app.py::test_tui_app_marks_failed_terminal_command_as_error tests/test_tui_app.py::test_tui_app_renders_terminal_command_output_when_tool_results_are_collapsed tests/test_tui_app.py::test_tui_app_limits_terminal_command_output_preview -q` - passed, 7 passed.
- `uv run pytest tests/test_coding_session.py::test_terminal_command_can_persist_output_to_context tests/test_coding_session.py::test_terminal_command_can_run_without_context tests/test_coding_session.py::test_parse_terminal_command_prefixes -q` - passed, 3 passed.
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py` - passed.
- `uv run pytest tests/test_tui_app.py -q` - 146 passed, 1 failed. The failure appears unrelated to this change: `test_run_tui_app_opens_when_provider_login_is_missing[asyncio]` expected the default provider name `openai`, but the current environment/path produced `openai-codex`.

## Assumptions
- The existing `TerminalCommandResult.ok` / `exit_code` path is the right source of success versus failure; no output parsing is needed.
- The TUI can treat user-entered bash commands as presentation-only tool rows without adding new `tau_agent` event types.

## Follow-up Work
- None for #146.