### PR TITLE
Fix #150: copy wrapped message lines

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -372,7 +372,7 @@ class CodingSession:
 
     async def tree_choices(self) -> tuple[SessionTreeChoice, ...]:
         """Return branchable session entries for a tree picker."""
-        entries = await self._config.storage.read_all()
+        entries = await self._read_session_entries()
         branch_indents = _tree_branch_indents(entries)
         return tuple(
             SessionTreeChoice(
@@ -394,7 +394,7 @@ class CodingSession:
         replace_instructions: bool = False,
     ) -> str:
         """Move the active leaf to a previous entry, preserving existing history."""
-        entries = await self._config.storage.read_all()
+        entries = await self._read_session_entries()
         by_id = {entry.id: entry for entry in entries}
         if entry_id not in by_id:
             raise ValueError(f"Unknown session entry: {entry_id}")
@@ -473,7 +473,7 @@ class CodingSession:
         format: str | None = None,
     ) -> Path:
         """Export the current session to a user-facing artifact."""
-        entries = await self._config.storage.read_all()
+        entries = await self._read_session_entries()
         session_path = _storage_path(self._config.storage)
         export_format = normalize_export_format(
             format or (destination.suffix.removeprefix(".") if destination else "html")
@@ -1197,7 +1197,7 @@ class CodingSession:
         return persisted_count + len(new_messages)
 
     async def _refresh_persisted_state(self, *, leaf_id: str | None = None) -> None:
-        entries = await self._config.storage.read_all()
+        entries = await self._read_session_entries()
         self._state = SessionState.from_entries(entries, leaf_id=leaf_id)
         if self._config.session_id is not None and self._config.session_manager is not None:
             self._config.session_manager.touch_session(
@@ -1205,6 +1205,10 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
             )
+
+    async def _read_session_entries(self) -> list[SessionEntry]:
+        """Read stored entries, detaching roots imported from external history."""
+        return _detach_missing_parents(await self._config.storage.read_all())
 
     async def _append_session_entry(self, entry: SessionEntry) -> None:
         """Append one durable entry after flushing deferred session metadata."""

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -242,6 +242,8 @@ class CodingSession:
             )
             entries = [info, model, thinking]
             pending_initial_entries = (info, model, thinking)
+        else:
+            entries = _detach_missing_parents(entries)
 
         linear_state = SessionState.from_entries(entries)
         state = (
@@ -1451,6 +1453,17 @@ def _is_context_overflow_error(event: ErrorEvent) -> bool:
         "exceeded the limit",
     )
     return any(marker in normalized for marker in markers)
+
+
+def _detach_missing_parents(entries: list[SessionEntry]) -> list[SessionEntry]:
+    """Return entries with dangling parent pointers detached from external history."""
+    entry_ids = {entry.id for entry in entries}
+    return [
+        entry.model_copy(update={"parent_id": None})
+        if entry.parent_id is not None and entry.parent_id not in entry_ids
+        else entry
+        for entry in entries
+    ]
 
 
 def _last_parent_id_from_state(state: SessionState) -> str | None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1901,9 +1901,12 @@ class TauTuiApp(App[None]):
 
         terminal_command = parse_terminal_command(text)
         if terminal_command is not None:
-            await self._run_terminal_command(
-                terminal_command.command,
-                add_to_context=terminal_command.add_to_context,
+            self.run_worker(
+                self._run_terminal_command(
+                    terminal_command.command,
+                    add_to_context=terminal_command.add_to_context,
+                ),
+                exclusive=True,
             )
             return
 
@@ -1997,24 +2000,29 @@ class TauTuiApp(App[None]):
         if not callable(run_terminal_command):
             self._notify("Terminal commands are not available.", severity="error")
             return
+
         item_index = len(self.state.items)
         self.state.add_item(
             "tool",
             f"$ {command.strip()}",
             always_show_tool_result=True,
         )
+        self._follow_transcript_output()
         self._refresh()
+
         try:
             result = await run_terminal_command(command, add_to_context=add_to_context)
         except Exception as exc:  # noqa: BLE001 - surface command execution failures in the TUI
             if item_index < len(self.state.items):
-                self.state.items[item_index].tool_result_text = (
-                    f"✗ bash\nCould not run command: {exc}"
+                self.state.items[item_index].tool_result_text = format_terminal_command_result_block(
+                    ok=False,
+                    added_to_context=add_to_context,
+                    output=str(exc),
                 )
-                self._refresh()
-                return
             self._notify(f"Could not run command: {exc}", severity="error")
+            self._refresh()
             return
+
         if item_index >= len(self.state.items):
             return
         item = self.state.items[item_index]

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1970,8 +1970,16 @@ class TauTuiApp(App[None]):
         """Add a prompt to the transcript and start the agent worker."""
         self._prompt_run_id += 1
         run_id = self._prompt_run_id
+        self._follow_transcript_output()
         self._refresh()
         self._prompt_worker = self.run_worker(self._run_prompt(text, run_id), exclusive=True)
+
+    def _follow_transcript_output(self) -> None:
+        """Put the transcript back in follow mode for explicit user actions."""
+        if not self.screen_stack:
+            return
+        with suppress(NoMatches):
+            self.query_one("#transcript", TranscriptView).follow_output()
 
     async def _run_terminal_command(self, command: str, *, add_to_context: bool) -> None:
         run_terminal_command = getattr(self.session, "run_terminal_command", None)
@@ -1993,6 +2001,7 @@ class TauTuiApp(App[None]):
             ),
             always_show_tool_result=True,
         )
+        self._follow_transcript_output()
         self._refresh()
 
     def _set_tui_theme(self, theme: TuiThemeName) -> None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1467,6 +1467,8 @@ class TauTuiApp(App[None]):
         border: none;
         background: $tau-transcript-background;
         padding: 0 1 0 0;
+        scrollbar-size-vertical: 0;
+        scrollbar-size-horizontal: 0;
     }
 
     #queued-messages {

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -152,14 +152,6 @@ class TranscriptMessageWidget(Horizontal):
         margin: 0 0 1 0;
     }
 
-    TranscriptMessageWidget > .transcript-markdown-body > MarkdownFence {
-        margin: 0;
-        background: transparent;
-    }
-
-    TranscriptMessageWidget > .transcript-markdown-body > MarkdownFence > Label {
-        padding: 0;
-    }
     """
 
     def __init__(
@@ -235,7 +227,7 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         padding: 0 1 0 0;
     }
 
-    StreamingTranscriptMessageWidget MarkdownParagraph {
+    StreamingTranscriptMessageWidget > MarkdownParagraph {
         margin: 0 0 1 0;
     }
     """
@@ -256,12 +248,13 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         return self._stream
 
     async def append_fragment(self, fragment: str) -> None:
-        """Append streamed markdown without rebuilding the whole transcript."""
+        """Append streamed markdown using the same renderer as finalized messages."""
         if not fragment:
             return
         self.item.text += fragment
         self.selection_text += fragment
-        await self.stream.write(fragment)
+        self._stream = None
+        await self.update(self.item.text)
 
     async def replace_text(self, text: str) -> None:
         """Replace the current markdown text, usually with the final provider message."""
@@ -488,7 +481,7 @@ class TranscriptView(VerticalScroll):
                     theme=self._render_theme,
                 )
             return
-        if text is not None and text != widget.selection_text:
+        if text is not None:
             await widget.replace_text(text)
         self._active_assistant_widget = None
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -543,22 +543,32 @@ def _transcript_plain_body_text(
     text: str,
     body_style: str,
     theme: TuiTheme,
-) -> Text:
-    """Return styled plain transcript text for fast selectable rows."""
+) -> RenderableType:
+    """Return styled transcript text for selectable plain rows."""
     if item.role != "tool":
         return Text(text, style=body_style, overflow="fold", no_wrap=False)
-    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
+
     invocation, separator, result_text = text.partition("\n\n")
-    rendered.append(
-        _render_transcript_tool_invocation(
-            invocation,
-            body_style=body_style,
-            accent_style=_tool_accent_style(item, theme=theme),
-        )
+    invocation_text = _render_transcript_tool_invocation(
+        invocation,
+        body_style=body_style,
+        accent_style=_tool_accent_style(item, theme=theme),
     )
-    if separator:
-        rendered.append(separator)
-        rendered.append(result_text, style=body_style)
+    if not separator:
+        return invocation_text
+
+    patch_body = _render_patch_body(
+        result_text,
+        body_style=body_style,
+        syntax_theme=theme.syntax_theme,
+    )
+    if patch_body is not None:
+        return Group(invocation_text, Text(""), patch_body)
+
+    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
+    rendered.append(invocation_text)
+    rendered.append(separator)
+    rendered.append(result_text, style=body_style)
     return rendered
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -13,6 +13,7 @@ from rich.console import Console, Group, RenderableType
 from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.rule import Rule
+from rich.segment import Segment
 from rich.style import Style
 from rich.syntax import Syntax
 from rich.table import Table
@@ -121,6 +122,12 @@ class CompactSessionInfo(Static):
 _SELECTABLE_MARKDOWN_BLOCKS: dict[type[Any], type[Any]] = {}
 
 
+class NonSelectableStatic(Static):
+    """Static display text that should not participate in mouse selection."""
+
+    ALLOW_SELECT = False
+
+
 class ThemedMarkdownWidget(TextualMarkdown):
     """Textual Markdown widget reserved for Tau transcript streaming."""
 
@@ -165,7 +172,7 @@ def _selectable_markdown_block_class(block_class: type[Any]) -> type[Any]:
             if text is None:
                 return None
             selected_text = _extract_visual_line_selection(
-                [self.render_line(y).text for y in range(self.size.height)],
+                [self.render_line(y) for y in range(self.size.height)],
                 selection,
             )
             if selected_text is None:
@@ -281,7 +288,7 @@ class StreamingTranscriptMessageWidget(Vertical):
     def compose(self) -> Any:
         self._markdown = ThemedMarkdownWidget(self.item.text, theme=self._theme)
         with Horizontal(classes="streaming-message-row"):
-            yield Static("▌", classes="streaming-message-gutter")
+            yield NonSelectableStatic("▌", classes="streaming-message-gutter")
             yield self._markdown
 
     @property
@@ -341,6 +348,19 @@ class TranscriptView(VerticalScroll):
         self._active_thinking_widget: StreamingTranscriptMessageWidget | None = None
         self._hidden_thinking_placeholder_visible = False
 
+    def on_mount(self) -> None:
+        """Follow new transcript content until the user scrolls away."""
+        self.anchor()
+
+    def follow_output(self) -> None:
+        """Return to follow mode for a user-driven turn or explicit jump to bottom."""
+        self.anchor()
+
+    @property
+    def _should_follow_output(self) -> bool:
+        """Return whether new content should keep the viewport pinned to the bottom."""
+        return self.is_vertical_scroll_end or (self.is_anchored and not self._anchor_released)
+
     def update_from_state(
         self,
         state: TuiState,
@@ -350,7 +370,7 @@ class TranscriptView(VerticalScroll):
         """Redraw the transcript from display state."""
         self._render_state = state
         self._render_theme = theme
-        self._redraw(scroll_end=True)
+        self._redraw(scroll_end=self._should_follow_output)
 
     def on_resize(self, event: Resize) -> None:
         """Re-render transcript entries when the terminal width changes."""
@@ -422,7 +442,7 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
         show_tool_results: bool = False,
-        scroll_end: bool = True,
+        scroll_end: bool = False,
     ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
         """Append one transcript item without rebuilding previous blocks."""
         self._render_theme = theme
@@ -445,7 +465,7 @@ class TranscriptView(VerticalScroll):
         self,
         *,
         theme: TuiTheme = TAU_DARK_THEME,
-        scroll_end: bool = True,
+        scroll_end: bool = False,
     ) -> StreamingTranscriptMessageWidget:
         """Create the active assistant message widget if needed."""
         if self._active_assistant_widget is not None:
@@ -467,7 +487,7 @@ class TranscriptView(VerticalScroll):
         delta: str,
         *,
         theme: TuiTheme = TAU_DARK_THEME,
-        scroll_end: bool = True,
+        scroll_end: bool = False,
     ) -> None:
         """Append streamed assistant text to the active message widget."""
         self._active_thinking_widget = None
@@ -483,7 +503,7 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
         show_thinking: bool,
-        scroll_end: bool = True,
+        scroll_end: bool = False,
     ) -> None:
         """Append streamed thinking text or one hidden-thinking placeholder."""
         if not show_thinking:
@@ -570,7 +590,11 @@ def _stylize_strip_range(strip: Strip, *, start: int, end: int, style: Any) -> S
     if end <= start:
         return strip
     before = strip.crop(0, start)
-    selected = strip.crop(start, end).apply_style(style)
+    selected_strip = strip.crop(start, end)
+    selected = Strip(
+        list(Segment.apply_style(selected_strip, post_style=style)),
+        selected_strip.cell_length,
+    )
     after = strip.crop(end, None)
     return Strip.join([before, selected, after])
 
@@ -594,7 +618,7 @@ def _extract_rendered_selection(
     return "\n".join(selected_lines)
 
 
-def _extract_visual_line_selection(lines: list[str], selection: Selection) -> str | None:
+def _extract_visual_line_selection(lines: list[Strip], selection: Selection) -> str | None:
     if not lines:
         return None
     selected_lines: list[str] = []
@@ -603,8 +627,8 @@ def _extract_visual_line_selection(lines: list[str], selection: Selection) -> st
         if span is None:
             continue
         start, end = span
-        line_end = len(line) if end == -1 else max(end, 0)
-        selected_lines.append(line[max(start, 0) : line_end].rstrip())
+        line_end = line.cell_length if end == -1 else max(end, 0)
+        selected_lines.append(line.crop(max(start, 0), line_end).text.rstrip())
     if not selected_lines:
         return None
     return "\n".join(selected_lines)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -149,7 +149,7 @@ class TranscriptMessageWidget(Horizontal):
     }
 
     TranscriptMessageWidget > .transcript-markdown-body > MarkdownParagraph {
-        margin: 0;
+        margin: 0 0 1 0;
     }
 
     TranscriptMessageWidget > .transcript-markdown-body > MarkdownFence {
@@ -233,6 +233,10 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         height: auto;
         margin: 1 1 2 1;
         padding: 0 1 0 0;
+    }
+
+    StreamingTranscriptMessageWidget MarkdownParagraph {
+        margin: 0 0 1 0;
     }
     """
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -134,7 +134,7 @@ class TranscriptMessageWidget(Horizontal):
     TranscriptMessageWidget {
         width: 1fr;
         height: auto;
-        margin: 1 1 2 0;
+        margin: 1 1 1 0;
     }
 
     TranscriptMessageWidget > .transcript-message-gutter {
@@ -148,16 +148,16 @@ class TranscriptMessageWidget(Horizontal):
         padding: 0 1 0 1;
     }
 
-    TranscriptMessageWidget > .transcript-message-body > MarkdownParagraph {
+    TranscriptMessageWidget > .transcript-markdown-body > MarkdownParagraph {
         margin: 0;
     }
 
-    TranscriptMessageWidget > .transcript-message-body > MarkdownFence {
+    TranscriptMessageWidget > .transcript-markdown-body > MarkdownFence {
         margin: 0;
         background: transparent;
     }
 
-    TranscriptMessageWidget > .transcript-message-body > MarkdownFence > Label {
+    TranscriptMessageWidget > .transcript-markdown-body > MarkdownFence > Label {
         padding: 0;
     }
     """
@@ -185,18 +185,36 @@ class TranscriptMessageWidget(Horizontal):
     def compose(self) -> Any:
         gutter = NonSelectableStatic("▌", classes="transcript-message-gutter")
         gutter.styles.color = self._role_style.border
-        body = ThemedMarkdownWidget(
-            self._markdown_text,
-            theme=self._theme,
-            classes="transcript-message-body",
-        )
-        foreground, background = _split_rich_style_colors(self._role_style.body)
-        if foreground:
-            body.styles.color = foreground
-        if background:
-            body.styles.background = background
+        body = self._body_widget()
         yield gutter
         yield body
+
+    def _body_widget(self) -> Static | ThemedMarkdownWidget:
+        if _use_plain_transcript_body(self.item):
+            body = Static(
+                Text(
+                    self.selection_text,
+                    style=self._role_style.body,
+                    overflow="fold",
+                    no_wrap=False,
+                ),
+                expand=True,
+                shrink=True,
+                markup=False,
+                classes="transcript-message-body transcript-plain-body",
+            )
+        else:
+            body = ThemedMarkdownWidget(
+                self._markdown_text,
+                theme=self._theme,
+                classes="transcript-message-body transcript-markdown-body",
+            )
+            foreground, background = _split_rich_style_colors(self._role_style.body)
+            if foreground:
+                body.styles.color = foreground
+            if background:
+                body.styles.background = background
+        return body
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected plain text from this message, not rendered Markdown markup."""
@@ -213,7 +231,7 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
     StreamingTranscriptMessageWidget {
         width: 1fr;
         height: auto;
-        margin: 1 1 2 1;
+        margin: 1 1 1 1;
         padding: 0 1 0 0;
     }
     """
@@ -515,6 +533,11 @@ def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
     foreground = text_style.color.name if text_style.color is not None else None
     background = text_style.bgcolor.name if text_style.bgcolor is not None else None
     return foreground, background
+
+
+def _use_plain_transcript_body(item: ChatItem) -> bool:
+    """Return whether a transcript item can use fast selectable plain text."""
+    return item.role in {"user", "tool", "skill", "error"}
 
 
 def _transcript_item_markdown(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -164,7 +164,12 @@ def _selectable_markdown_block_class(block_class: type[Any]) -> type[Any]:
             text = str(visual) if isinstance(visual, Text | Content) else self.source
             if text is None:
                 return None
-            selected_text = _extract_text_selection(text, selection)
+            selected_text = _extract_visual_line_selection(
+                [self.render_line(y).text for y in range(self.size.height)],
+                selection,
+            )
+            if selected_text is None:
+                selected_text = _extract_text_selection(text, selection)
             if not selected_text:
                 return None
             return selected_text, "\n"
@@ -586,6 +591,22 @@ def _extract_rendered_selection(
         text_start = max(start - line.rendered_prefix_width, 0)
         text_end = len(line.text) if end == -1 else max(end - line.rendered_prefix_width, 0)
         selected_lines.append(line.text[text_start:text_end])
+    return "\n".join(selected_lines)
+
+
+def _extract_visual_line_selection(lines: list[str], selection: Selection) -> str | None:
+    if not lines:
+        return None
+    selected_lines: list[str] = []
+    for line_y, line in enumerate(lines):
+        span = selection.get_span(line_y)
+        if span is None:
+            continue
+        start, end = span
+        line_end = len(line) if end == -1 else max(end, 0)
+        selected_lines.append(line[max(start, 0) : line_end].rstrip())
+    if not selected_lines:
+        return None
     return "\n".join(selected_lines)
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import TimeoutExpired, run
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 from pygments.lexers import get_lexer_by_name  # type: ignore[import-untyped]
 from pygments.util import ClassNotFound  # type: ignore[import-untyped]
@@ -13,18 +13,15 @@ from rich.console import Console, Group, RenderableType
 from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.rule import Rule
-from rich.segment import Segment
 from rich.style import Style
 from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.content import Content
+from textual.containers import Horizontal, VerticalScroll
 from textual.events import Resize
 from textual.geometry import Offset
 from textual.selection import Selection
-from textual.strip import Strip
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets import Static
 from textual.widgets.markdown import MarkdownStream
@@ -44,15 +41,6 @@ TAU_SIDEBAR_LOGO = "τ = 2π"
 class TranscriptLine:
     """Plain transcript line used by compatibility inspection helpers."""
 
-    text: str
-
-
-@dataclass(frozen=True, slots=True)
-class _RenderedSelectionLine:
-    """One rendered transcript line mapped back to copyable body text."""
-
-    rendered_y: int
-    rendered_prefix_width: int
     text: str
 
 
@@ -119,9 +107,6 @@ class CompactSessionInfo(Static):
         self.update(render_compact_session_info(session, theme=theme))
 
 
-_SELECTABLE_MARKDOWN_BLOCKS: dict[type[Any], type[Any]] = {}
-
-
 class NonSelectableStatic(Static):
     """Static display text that should not participate in mouse selection."""
 
@@ -131,68 +116,49 @@ class NonSelectableStatic(Static):
 class ThemedMarkdownWidget(TextualMarkdown):
     """Textual Markdown widget reserved for Tau transcript streaming."""
 
-    def __init__(self, markdown: str | None = None, *, theme: TuiTheme) -> None:
+    def __init__(
+        self,
+        markdown: str | None = None,
+        *,
+        theme: TuiTheme,
+        classes: str | None = None,
+    ) -> None:
         del theme
-        super().__init__(markdown)
-
-    def get_block_class(self, block_name: str) -> type[Any]:
-        """Return Markdown blocks that expose per-cell selection offsets."""
-        return _selectable_markdown_block_class(super().get_block_class(block_name))
+        super().__init__(markdown, classes=classes)
 
 
-def _selectable_markdown_block_class(block_class: type[Any]) -> type[Any]:
-    cached = _SELECTABLE_MARKDOWN_BLOCKS.get(block_class)
-    if cached is not None:
-        return cached
-
-    class SelectableMarkdownBlock(block_class):  # type: ignore[misc]
-        """Markdown block with live Textual selection painting."""
-
-        def render_line(self, y: int) -> Strip:
-            strip = cast(Strip, super().render_line(y)).apply_offsets(0, y)
-            selection = self.text_selection
-            if selection is None:
-                return strip
-            span = selection.get_span(y)
-            if span is None:
-                return strip
-            start, end = span
-            if end == -1:
-                end = strip.cell_length
-            return _stylize_strip_range(
-                strip,
-                start=start,
-                end=end,
-                style=self.screen.get_visual_style("screen--selection").rich_style,
-            )
-
-        def get_selection(self, selection: Selection) -> tuple[str, str] | None:
-            visual = self._render()
-            text = str(visual) if isinstance(visual, Text | Content) else self.source
-            if text is None:
-                return None
-            selected_text = _extract_visual_line_selection(
-                [self.render_line(y) for y in range(self.size.height)],
-                selection,
-            )
-            if selected_text is None:
-                selected_text = _extract_text_selection(text, selection)
-            if not selected_text:
-                return None
-            return selected_text, "\n"
-
-    SelectableMarkdownBlock.__name__ = f"Selectable{block_class.__name__}"
-    _SELECTABLE_MARKDOWN_BLOCKS[block_class] = SelectableMarkdownBlock
-    return SelectableMarkdownBlock
-
-
-class TranscriptMessageWidget(Static):
-    """One selectable transcript message block."""
+class TranscriptMessageWidget(Horizontal):
+    """One selectable transcript message with a non-selectable visual gutter."""
 
     DEFAULT_CSS = """
     TranscriptMessageWidget {
         width: 1fr;
         height: auto;
+        margin: 1 1 2 0;
+    }
+
+    TranscriptMessageWidget > .transcript-message-gutter {
+        width: 1;
+        height: auto;
+    }
+
+    TranscriptMessageWidget > .transcript-message-body {
+        width: 1fr;
+        height: auto;
+        padding: 0 1 0 1;
+    }
+
+    TranscriptMessageWidget > .transcript-message-body > MarkdownParagraph {
+        margin: 0;
+    }
+
+    TranscriptMessageWidget > .transcript-message-body > MarkdownFence {
+        margin: 0;
+        background: transparent;
+    }
+
+    TranscriptMessageWidget > .transcript-message-body > MarkdownFence > Label {
+        padding: 0;
     }
     """
 
@@ -208,70 +174,47 @@ class TranscriptMessageWidget(Static):
             item,
             show_tool_results=show_tool_results,
         )
-        super().__init__(
-            render_chat_item(
-                item,
-                theme=theme,
-                show_tool_results=show_tool_results,
-            ),
-            expand=True,
-            shrink=True,
-            markup=False,
-            classes="transcript-message",
+        self._markdown_text = _transcript_item_markdown(
+            item,
+            show_tool_results=show_tool_results,
         )
+        self._theme = theme
+        self._role_style = _chat_item_role_style(item, theme)
+        super().__init__(classes="transcript-message")
 
-    def render_line(self, y: int) -> Strip:
-        """Render one line with Textual selection offsets and selection styling."""
-        strip = super().render_line(y).apply_offsets(0, y)
-        selection = self.text_selection
-        if selection is None:
-            return strip
-        span = selection.get_span(y)
-        if span is None:
-            return strip
-        start, end = span
-        if end == -1:
-            end = strip.cell_length
-        return _stylize_strip_range(
-            strip,
-            start=start,
-            end=end,
-            style=self.screen.get_visual_style("screen--selection").rich_style,
+    def compose(self) -> Any:
+        gutter = NonSelectableStatic("▌", classes="transcript-message-gutter")
+        gutter.styles.color = self._role_style.border
+        body = ThemedMarkdownWidget(
+            self._markdown_text,
+            theme=self._theme,
+            classes="transcript-message-body",
         )
+        foreground, background = _split_rich_style_colors(self._role_style.body)
+        if foreground:
+            body.styles.color = foreground
+        if background:
+            body.styles.background = background
+        yield gutter
+        yield body
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
-        """Return selected text from this message, not the whole transcript."""
-        selected_text = _extract_rendered_selection(self, selection)
-        if selected_text is None:
-            selected_text = _extract_text_selection(self.selection_text, selection)
+        """Return selected plain text from this message, not rendered Markdown markup."""
+        selected_text = _extract_text_selection(self.selection_text, selection)
         if not selected_text:
             return None
         return selected_text, "\n"
 
 
-class StreamingTranscriptMessageWidget(Vertical):
-    """One assistant or thinking message block that accepts streamed fragments."""
+class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
+    """One assistant or thinking Markdown block that accepts streamed fragments."""
 
     DEFAULT_CSS = """
     StreamingTranscriptMessageWidget {
         width: 1fr;
         height: auto;
-        margin: 1 1 1 0;
-    }
-
-    StreamingTranscriptMessageWidget > .streaming-message-row {
-        height: auto;
-    }
-
-    StreamingTranscriptMessageWidget > .streaming-message-row > .streaming-message-gutter {
-        width: 1;
-        height: auto;
-    }
-
-    StreamingTranscriptMessageWidget > .streaming-message-row > ThemedMarkdownWidget {
-        width: 1fr;
-        height: auto;
-        padding: 0 1 0 1;
+        margin: 1 1 2 1;
+        padding: 0 1 0 0;
     }
     """
 
@@ -280,24 +223,14 @@ class StreamingTranscriptMessageWidget(Vertical):
             raise ValueError("Streaming transcript widgets only support assistant/thinking items")
         self.item = item
         self.selection_text = item.text
-        self._theme = theme
-        self._markdown: ThemedMarkdownWidget | None = None
         self._stream: MarkdownStream | None = None
-        super().__init__(classes="transcript-message")
-
-    def compose(self) -> Any:
-        self._markdown = ThemedMarkdownWidget(self.item.text, theme=self._theme)
-        with Horizontal(classes="streaming-message-row"):
-            yield NonSelectableStatic("▌", classes="streaming-message-gutter")
-            yield self._markdown
+        super().__init__(item.text, theme=theme)
+        self.add_class("transcript-message")
 
     @property
     def stream(self) -> MarkdownStream:
-        markdown = self._markdown
-        if markdown is None:
-            raise RuntimeError("Streaming transcript widget is not mounted")
         if self._stream is None:
-            self._stream = markdown.get_stream(markdown)
+            self._stream = self.get_stream(self)
         return self._stream
 
     async def append_fragment(self, fragment: str) -> None:
@@ -312,9 +245,8 @@ class StreamingTranscriptMessageWidget(Vertical):
         """Replace the current markdown text, usually with the final provider message."""
         self.item.text = text
         self.selection_text = text
-        if self._markdown is not None:
-            self._stream = None
-            await self._markdown.update(text)
+        self._stream = None
+        await self.update(text)
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected text from this streamed message block."""
@@ -322,12 +254,6 @@ class StreamingTranscriptMessageWidget(Vertical):
         if not selected_text:
             return None
         return selected_text, "\n"
-
-    def selection_updated(self, selection: Selection | None) -> None:
-        """Refresh markdown children so Textual can paint live selection spans."""
-        super().selection_updated(selection)
-        if self._markdown is not None:
-            self._markdown.selection_updated(selection)
 
 
 class TranscriptView(VerticalScroll):
@@ -583,103 +509,39 @@ def transcript_item_selection_text(
     return _visible_chat_text(item, show_tool_results=show_tool_results)
 
 
-def _stylize_strip_range(strip: Strip, *, start: int, end: int, style: Any) -> Strip:
-    """Apply a Rich style to a cell range inside a Textual strip."""
-    start = max(start, 0)
-    end = min(end, strip.cell_length)
-    if end <= start:
-        return strip
-    before = strip.crop(0, start)
-    selected_strip = strip.crop(start, end)
-    selected = Strip(
-        list(Segment.apply_style(selected_strip, post_style=style)),
-        selected_strip.cell_length,
-    )
-    after = strip.crop(end, None)
-    return Strip.join([before, selected, after])
+def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
+    """Split the foreground/background colors from a simple Rich style string."""
+    text_style = Style.parse(style)
+    foreground = text_style.color.name if text_style.color is not None else None
+    background = text_style.bgcolor.name if text_style.bgcolor is not None else None
+    return foreground, background
 
 
-def _extract_rendered_selection(
-    widget: TranscriptMessageWidget,
-    selection: Selection,
-) -> str | None:
-    lines = _rendered_selection_lines(widget)
-    if not lines:
-        return None
-    selected_lines: list[str] = []
-    for line in lines:
-        span = selection.get_span(line.rendered_y)
-        if span is None:
-            continue
-        start, end = span
-        text_start = max(start - line.rendered_prefix_width, 0)
-        text_end = len(line.text) if end == -1 else max(end - line.rendered_prefix_width, 0)
-        selected_lines.append(line.text[text_start:text_end])
-    return "\n".join(selected_lines)
+def _transcript_item_markdown(
+    item: ChatItem,
+    *,
+    show_tool_results: bool,
+) -> str:
+    """Return Markdown for a transcript item using native Textual Markdown blocks."""
+    visible_text = _visible_chat_text(item, show_tool_results=show_tool_results)
+    if item.role in {"assistant", "thinking", "status", "branch_summary", "compaction_summary"}:
+        return visible_text
+    return _plain_markdown(visible_text)
 
 
-def _extract_visual_line_selection(lines: list[Strip], selection: Selection) -> str | None:
-    if not lines:
-        return None
-    selected_lines: list[str] = []
-    for line_y, line in enumerate(lines):
-        span = selection.get_span(line_y)
-        if span is None:
-            continue
-        start, end = span
-        line_end = line.cell_length if end == -1 else max(end, 0)
-        selected_lines.append(line.crop(max(start, 0), line_end).text.rstrip())
-    if not selected_lines:
-        return None
-    return "\n".join(selected_lines)
+def _plain_markdown(text: str) -> str:
+    """Represent arbitrary plain text as wrapping Markdown paragraphs."""
+    if not text:
+        return ""
+    return "\n".join(_escape_plain_markdown_line(line) for line in text.splitlines())
 
 
-def _rendered_selection_lines(widget: TranscriptMessageWidget) -> list[_RenderedSelectionLine]:
-    if widget.size.height <= 0:
-        return []
-    rendered_lines = [widget.render_line(y).text for y in range(widget.size.height)]
-    content_bounds = _rendered_content_bounds(rendered_lines)
-    if content_bounds is None:
-        return []
-    first_content_line, last_content_line = content_bounds
-    body_prefix_width = _body_prefix_width(rendered_lines[first_content_line])
-    selection_lines: list[_RenderedSelectionLine] = []
-    for rendered_y in range(first_content_line, last_content_line + 1):
-        line = rendered_lines[rendered_y]
-        prefix_width = _line_prefix_width(line, body_prefix_width)
-        selection_lines.append(
-            _RenderedSelectionLine(
-                rendered_y=rendered_y,
-                rendered_prefix_width=prefix_width,
-                text=line[prefix_width:].rstrip(),
-            )
-        )
-    return selection_lines
-
-
-def _rendered_content_bounds(lines: list[str]) -> tuple[int, int] | None:
-    first = next((index for index, line in enumerate(lines) if line.strip()), None)
-    if first is None:
-        return None
-    last = next(index for index in range(len(lines) - 1, -1, -1) if lines[index].strip())
-    return first, last
-
-
-def _body_prefix_width(first_content_line: str) -> int:
-    if first_content_line.startswith("▌"):
-        if len(first_content_line) > 1 and first_content_line[1] == " ":
-            return 2
-        return 1
-    return len(first_content_line) - len(first_content_line.lstrip(" "))
-
-
-def _line_prefix_width(line: str, body_prefix_width: int) -> int:
-    if line.startswith("▌"):
-        return min(body_prefix_width, len(line))
-    prefix_width = 0
-    while prefix_width < min(body_prefix_width, len(line)) and line[prefix_width] == " ":
-        prefix_width += 1
-    return prefix_width
+def _escape_plain_markdown_line(line: str) -> str:
+    """Escape Markdown syntax while preserving plain, wrapping text."""
+    escaped = line.replace("\\", "\\\\")
+    for character in "`*_{}[]()#+-.!|>":
+        escaped = escaped.replace(character, f"\\{character}")
+    return escaped
 
 
 def _extract_text_selection(text: str, selection: Selection) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -134,7 +134,7 @@ class TranscriptMessageWidget(Horizontal):
     TranscriptMessageWidget {
         width: 1fr;
         height: auto;
-        margin: 1 1 1 0;
+        margin: 1 1 2 0;
     }
 
     TranscriptMessageWidget > .transcript-message-gutter {
@@ -192,11 +192,11 @@ class TranscriptMessageWidget(Horizontal):
     def _body_widget(self) -> Static | ThemedMarkdownWidget:
         if _use_plain_transcript_body(self.item):
             body = Static(
-                Text(
-                    self.selection_text,
-                    style=self._role_style.body,
-                    overflow="fold",
-                    no_wrap=False,
+                _transcript_plain_body_text(
+                    self.item,
+                    text=self.selection_text,
+                    body_style=self._role_style.body,
+                    theme=self._theme,
                 ),
                 expand=True,
                 shrink=True,
@@ -231,7 +231,7 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
     StreamingTranscriptMessageWidget {
         width: 1fr;
         height: auto;
-        margin: 1 1 1 1;
+        margin: 1 1 2 1;
         padding: 0 1 0 0;
     }
     """
@@ -538,6 +538,47 @@ def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
 def _use_plain_transcript_body(item: ChatItem) -> bool:
     """Return whether a transcript item can use fast selectable plain text."""
     return item.role in {"user", "tool", "skill", "error"}
+
+
+def _transcript_plain_body_text(
+    item: ChatItem,
+    *,
+    text: str,
+    body_style: str,
+    theme: TuiTheme,
+) -> Text:
+    """Return styled plain transcript text for fast selectable rows."""
+    if item.role != "tool":
+        return Text(text, style=body_style, overflow="fold", no_wrap=False)
+    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
+    invocation, separator, result_text = text.partition("\n\n")
+    rendered.append(
+        _render_transcript_tool_invocation(
+            invocation,
+            body_style=body_style,
+            accent_style=_tool_accent_style(item, theme=theme),
+        )
+    )
+    if separator:
+        rendered.append(separator)
+        rendered.append(result_text, style=body_style)
+    return rendered
+
+
+def _render_transcript_tool_invocation(
+    text: str,
+    *,
+    body_style: str,
+    accent_style: str | None,
+) -> Text:
+    """Render a selectable tool invocation with status color after the prefix."""
+    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
+    accent_style = accent_style or body_style
+    prefix, name, remainder = _split_tool_invocation(text)
+    rendered.append(prefix, style=body_style)
+    rendered.append(name, style=accent_style)
+    rendered.append(remainder, style=accent_style)
+    return rendered
 
 
 def _transcript_item_markdown(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -731,6 +731,8 @@ def render_chat_item(
             body_style=theme.role_styles["tool"].body,
             accent_style=_tool_accent_style(item, theme=theme),
             show_tool_results=show_tool_results,
+            syntax_theme=theme.syntax_theme,
+            theme=theme,
         )
         if item.role == "tool"
         else _render_chat_body(
@@ -798,12 +800,21 @@ def _render_tool_chat_body(
     body_style: str,
     accent_style: str | None,
     show_tool_results: bool,
-) -> Text:
+    syntax_theme: str,
+    theme: TuiTheme,
+) -> RenderableType:
     text = _render_tool_invocation(item.text, body_style=body_style, accent_style=accent_style)
-    if show_tool_results and item.tool_result_text:
-        text.append("\n\n")
-        text.append(item.tool_result_text, style=body_style)
-    return text
+    if not show_tool_results or not item.tool_result_text:
+        return text
+
+    result_body = _render_chat_body(
+        item.tool_result_text,
+        role=item.role,
+        body_style=body_style,
+        syntax_theme=syntax_theme,
+        theme=theme,
+    )
+    return Group(text, Text(""), result_body)
 
 
 def _render_tool_invocation(text: str, *, body_style: str, accent_style: str | None) -> Text:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -648,6 +648,34 @@ async def test_load_detaches_missing_root_parent_from_imported_branch(tmp_path: 
 
 
 @pytest.mark.anyio
+async def test_tree_branching_detaches_missing_root_parent_from_imported_branch(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(
+        id="root",
+        parent_id="missing-external-parent",
+        message=UserMessage(content="Root"),
+    )
+    assistant = MessageEntry(
+        id="assistant",
+        parent_id="root",
+        message=AssistantMessage(content="Restored"),
+    )
+    await storage.append(root)
+    await storage.append(assistant)
+    await storage.append(LeafEntry(parent_id="assistant", entry_id="assistant"))
+
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+    choices = await session.tree_choices()
+    result = await session.branch_to_entry("root")
+
+    assert [choice.entry_id for choice in choices] == ["root", "assistant"]
+    assert result == "Branched session at root."
+    assert session.messages == (UserMessage(content="Root"),)
+
+
+@pytest.mark.anyio
 async def test_load_restores_active_leaf_branch(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     root = MessageEntry(id="root", message=UserMessage(content="Root"))

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -620,6 +620,32 @@ async def test_load_restores_existing_transcript(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_load_detaches_missing_root_parent_from_imported_branch(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(
+        id="root",
+        parent_id="missing-external-parent",
+        message=UserMessage(content="Root"),
+    )
+    assistant = MessageEntry(
+        id="assistant",
+        parent_id="root",
+        message=AssistantMessage(content="Restored"),
+    )
+    await storage.append(root)
+    await storage.append(assistant)
+    await storage.append(LeafEntry(entry_id="assistant"))
+
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    assert session.messages == (
+        UserMessage(content="Root"),
+        AssistantMessage(content="Restored"),
+    )
+    assert session.state.active_leaf_id == "assistant"
+
+
+@pytest.mark.anyio
 async def test_load_restores_active_leaf_branch(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     root = MessageEntry(id="root", message=UserMessage(content="Root"))

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1070,6 +1070,17 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
         ]
     )
     app = TauTuiApp(session)
+    stream_replacements: list[str] = []
+    original_replace_text = StreamingTranscriptMessageWidget.replace_text
+
+    async def tracking_replace_text(
+        self: StreamingTranscriptMessageWidget,
+        text: str,
+    ) -> None:
+        stream_replacements.append(text)
+        await original_replace_text(self, text)
+
+    StreamingTranscriptMessageWidget.replace_text = tracking_replace_text  # type: ignore[method-assign]
     full_refreshes = 0
 
     original_refresh = app._refresh
@@ -1081,15 +1092,19 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
 
     app._refresh = tracking_refresh  # type: ignore[method-assign]
 
-    async with app.run_test(size=(120, 30)) as pilot:
-        await app._run_prompt("stream")
-        await pilot.pause()
+    try:
+        async with app.run_test(size=(120, 30)) as pilot:
+            await app._run_prompt("stream")
+            await pilot.pause()
 
-        transcript = app.query_one("#transcript", TranscriptView)
-        streamed = app.query_one(StreamingTranscriptMessageWidget)
-        transcript_text = "\n".join(line.text for line in transcript.lines)
+            transcript = app.query_one("#transcript", TranscriptView)
+            streamed = app.query_one(StreamingTranscriptMessageWidget)
+            transcript_text = "\n".join(line.text for line in transcript.lines)
+    finally:
+        StreamingTranscriptMessageWidget.replace_text = original_replace_text  # type: ignore[method-assign]
 
     assert full_refreshes == 1
+    assert stream_replacements == ["alpha beta"]
     assert streamed.selection_text == "alpha beta"
     assert "alpha beta" in transcript_text
 
@@ -3122,6 +3137,31 @@ async def test_tui_app_marks_failed_terminal_command_as_error() -> None:
     assert session.prompt_texts == []
     assert app.state.items[-1].text == "$ false"
     assert app.state.items[-1].tool_result_text == "✗ bash · not added to context\nfailed"
+
+
+@pytest.mark.anyio
+async def test_tui_app_marks_terminal_command_exception_as_failed() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async def fake_run_terminal_command(
+        command: str,
+        *,
+        add_to_context: bool,
+    ) -> TerminalCommandResult:
+        del command, add_to_context
+        raise RuntimeError("boom")
+
+    session.run_terminal_command = fake_run_terminal_command  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "!! false"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert app.state.items[-1].text == "$ false"
+    assert app.state.items[-1].tool_result_text == "✗ bash · not added to context\nboom"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 from textual.containers import VerticalScroll
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
+from textual.strip import Strip
 from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
 
 from tau_agent import (
@@ -878,6 +879,16 @@ def test_chat_items_preserve_malformed_fenced_code() -> None:
     assert 'print("hi")' in output
 
 
+def _strip_style_at(strip: Strip, cell: int) -> object:
+    position = 0
+    for segment in strip:
+        next_position = position + segment.cell_length
+        if position <= cell < next_position:
+            return segment.style
+        position = next_position
+    return None
+
+
 @pytest.mark.anyio
 async def test_transcript_message_widget_extracts_partial_rendered_selection() -> None:
     app = TauTuiApp(
@@ -896,6 +907,30 @@ async def test_transcript_message_widget_extracts_partial_rendered_selection() -
             "beta",
             "\n",
         )
+
+
+@pytest.mark.anyio
+async def test_streaming_transcript_deltas_do_not_force_scroll_end() -> None:
+    app = TauTuiApp(FakeSession(messages=[]))
+
+    async with app.run_test(size=(40, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        forced_scrolls = 0
+        original_scroll_end = transcript.scroll_end
+
+        def tracking_scroll_end(*args: object, **kwargs: object) -> None:
+            nonlocal forced_scrolls
+            forced_scrolls += 1
+            original_scroll_end(*args, **kwargs)
+
+        transcript.scroll_end = tracking_scroll_end  # type: ignore[method-assign]
+
+        await transcript.append_assistant_delta("alpha")
+        await transcript.append_assistant_delta(" beta")
+        await pilot.pause()
+
+    assert forced_scrolls == 0
 
 
 @pytest.mark.anyio
@@ -922,6 +957,29 @@ async def test_streaming_markdown_selection_uses_wrapped_visual_line() -> None:
             "alpha",
             "\n",
         )
+
+
+@pytest.mark.anyio
+async def test_streaming_markdown_selection_visibly_highlights_selected_range() -> None:
+    app = TauTuiApp(FakeSession(messages=[]))
+
+    async with app.run_test(size=(40, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        widget = await transcript.start_assistant_message()
+        await widget.replace_text("alpha beta gamma delta epsilon zeta eta theta")
+        await pilot.pause()
+        block = next(
+            child
+            for child in widget.query("*")
+            if child.__class__.__name__.startswith("SelectableMarkdown")
+        )
+
+        app.screen.selections = {block: Selection(Offset(0, 0), Offset(5, 0))}
+        await pilot.pause()
+
+        line = block.render_line(0)
+        assert _strip_style_at(line, 0) != _strip_style_at(line, 6)
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -64,6 +64,7 @@ from tau_coding.tui.app import (
 from tau_coding.tui.autocomplete import CompletionItem, CompletionState
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
+    TAU_DARK_THEME,
     TAU_LIGHT_THEME,
     TuiKeybindings,
     TuiSettings,
@@ -76,6 +77,7 @@ from tau_coding.tui.widgets import (
     TranscriptView,
     _compact_token_count,
     _syntax_language,
+    _transcript_plain_body_text,
     render_chat_item,
     render_compact_session_info,
     render_session_sidebar,
@@ -562,25 +564,53 @@ def test_tool_chat_items_hide_and_show_result_text() -> None:
     assert "full file contents" in expanded
 
 
+EDIT_TOOL_RESULT_WITH_PATCH = (
+    "✓ edit\n"
+    "Successfully replaced 1 block.\n"
+    "\n"
+    "Patch:\n"
+    "--- a/README.md\n"
+    "+++ b/README.md\n"
+    "@@\n"
+    "-old\n"
+    "+new"
+)
+
+
 def test_expanded_edit_tool_result_renders_patch_as_colored_diff() -> None:
     item = ChatItem(
         role="tool",
         text="→ edit README.md",
-        tool_result_text=(
-            "✓ edit\n"
-            "Successfully replaced 1 block.\n"
-            "\n"
-            "Patch:\n"
-            "--- a/README.md\n"
-            "+++ b/README.md\n"
-            "@@\n"
-            "-old\n"
-            "+new"
-        ),
+        tool_result_text=EDIT_TOOL_RESULT_WITH_PATCH,
     )
 
     console = Console(record=True, width=100, color_system="truecolor")
     console.print(render_chat_item(item, show_tool_results=True))
+
+    plain = console.export_text(clear=False)
+    styled = console.export_text(styles=True)
+    assert "Patch:" in plain
+    assert "-old" in plain
+    assert "+new" in plain
+    assert "\x1b[91;49m-old" in styled
+    assert "\x1b[92;49m+new" in styled
+
+
+def test_transcript_plain_tool_body_renders_patch_as_colored_diff() -> None:
+    item = ChatItem(
+        role="tool",
+        text="→ edit README.md",
+        tool_result_text=EDIT_TOOL_RESULT_WITH_PATCH,
+    )
+    body = _transcript_plain_body_text(
+        item,
+        text=transcript_item_selection_text(item, show_tool_results=True),
+        body_style="#cbd5e1 on #000000",
+        theme=TAU_DARK_THEME,
+    )
+
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(body)
 
     plain = console.export_text(clear=False)
     styled = console.export_text(styles=True)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -9,7 +9,6 @@ from rich.panel import Panel
 from textual.containers import VerticalScroll
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
-from textual.strip import Strip
 from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
 
 from tau_agent import (
@@ -879,18 +878,9 @@ def test_chat_items_preserve_malformed_fenced_code() -> None:
     assert 'print("hi")' in output
 
 
-def _strip_style_at(strip: Strip, cell: int) -> object:
-    position = 0
-    for segment in strip:
-        next_position = position + segment.cell_length
-        if position <= cell < next_position:
-            return segment.style
-        position = next_position
-    return None
-
 
 @pytest.mark.anyio
-async def test_transcript_message_widget_extracts_partial_rendered_selection() -> None:
+async def test_transcript_message_widget_extracts_plain_text_selection() -> None:
     app = TauTuiApp(
         FakeSession(
             messages=[
@@ -903,7 +893,7 @@ async def test_transcript_message_widget_extracts_partial_rendered_selection() -
         await pilot.pause()
         widget = app.query_one(TranscriptMessageWidget)
 
-        assert widget.get_selection(Selection(Offset(8, 1), Offset(12, 1))) == (
+        assert widget.get_selection(Selection(Offset(6, 0), Offset(10, 0))) == (
             "beta",
             "\n",
         )
@@ -932,54 +922,6 @@ async def test_streaming_transcript_deltas_do_not_force_scroll_end() -> None:
 
     assert forced_scrolls == 0
 
-
-@pytest.mark.anyio
-async def test_streaming_markdown_selection_uses_wrapped_visual_line() -> None:
-    app = TauTuiApp(FakeSession(messages=[]))
-
-    async with app.run_test(size=(40, 20)) as pilot:
-        await pilot.pause()
-        transcript = app.query_one("#transcript", TranscriptView)
-        widget = await transcript.start_assistant_message()
-        await widget.replace_text("alpha beta gamma delta epsilon zeta eta theta")
-        await pilot.pause()
-        block = next(
-            child
-            for child in widget.query("*")
-            if child.__class__.__name__.startswith("SelectableMarkdown")
-        )
-
-        assert block.get_selection(Selection(Offset(0, 1), Offset(4, 1))) == (
-            "zeta",
-            "\n",
-        )
-        assert block.get_selection(Selection(Offset(0, 0), Offset(5, 0))) == (
-            "alpha",
-            "\n",
-        )
-
-
-@pytest.mark.anyio
-async def test_streaming_markdown_selection_visibly_highlights_selected_range() -> None:
-    app = TauTuiApp(FakeSession(messages=[]))
-
-    async with app.run_test(size=(40, 20)) as pilot:
-        await pilot.pause()
-        transcript = app.query_one("#transcript", TranscriptView)
-        widget = await transcript.start_assistant_message()
-        await widget.replace_text("alpha beta gamma delta epsilon zeta eta theta")
-        await pilot.pause()
-        block = next(
-            child
-            for child in widget.query("*")
-            if child.__class__.__name__.startswith("SelectableMarkdown")
-        )
-
-        app.screen.selections = {block: Selection(Offset(0, 0), Offset(5, 0))}
-        await pilot.pause()
-
-        line = block.render_line(0)
-        assert _strip_style_at(line, 0) != _strip_style_at(line, 6)
 
 
 @pytest.mark.anyio
@@ -1019,9 +961,9 @@ async def test_tui_transcript_extracts_adjacent_message_selection() -> None:
         messages = list(app.query(TranscriptMessageWidget))
 
         app.screen.selections = {
-            messages[0]: Selection(Offset(8, 1), None),
+            messages[0]: Selection(Offset(6, 0), None),
             messages[1]: SELECT_ALL,
-            messages[2]: Selection(None, Offset(7, 1)),
+            messages[2]: Selection(None, Offset(5, 0)),
         }
 
         assert app.screen.get_selected_text() == "one\nmiddle message\nthird"
@@ -1076,6 +1018,28 @@ def test_transcript_selection_text_tracks_tool_result_visibility() -> None:
     assert transcript_item_selection_text(item, show_tool_results=True) == (
         "→ read README.md\n\n✓ read\nREADME contents"
     )
+
+
+@pytest.mark.anyio
+async def test_tool_transcript_uses_native_markdown_without_custom_selection_painting() -> None:
+    app = TauTuiApp(FakeSession(messages=[]))
+    item = ChatItem(
+        role="tool",
+        text="→ read README.md",
+        tool_result_text="✓ read\nREADME contents",
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        transcript = app.query_one("#transcript", TranscriptView)
+        widget = await transcript.append_item(item, show_tool_results=True)
+        await pilot.pause()
+
+        assert isinstance(widget, TranscriptMessageWidget)
+        assert widget.get_selection(SELECT_ALL) == (
+            "→ read README.md\n\n✓ read\nREADME contents",
+            "\n",
+        )
+        assert list(widget.query("MarkdownFence")) == []
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -899,6 +899,32 @@ async def test_transcript_message_widget_extracts_partial_rendered_selection() -
 
 
 @pytest.mark.anyio
+async def test_streaming_markdown_selection_uses_wrapped_visual_line() -> None:
+    app = TauTuiApp(FakeSession(messages=[]))
+
+    async with app.run_test(size=(40, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        widget = await transcript.start_assistant_message()
+        await widget.replace_text("alpha beta gamma delta epsilon zeta eta theta")
+        await pilot.pause()
+        block = next(
+            child
+            for child in widget.query("*")
+            if child.__class__.__name__.startswith("SelectableMarkdown")
+        )
+
+        assert block.get_selection(Selection(Offset(0, 1), Offset(4, 1))) == (
+            "zeta",
+            "\n",
+        )
+        assert block.get_selection(Selection(Offset(0, 0), Offset(5, 0))) == (
+            "alpha",
+            "\n",
+        )
+
+
+@pytest.mark.anyio
 async def test_tui_transcript_selects_only_one_message() -> None:
     app = TauTuiApp(
         FakeSession(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -562,6 +562,35 @@ def test_tool_chat_items_hide_and_show_result_text() -> None:
     assert "full file contents" in expanded
 
 
+def test_expanded_edit_tool_result_renders_patch_as_colored_diff() -> None:
+    item = ChatItem(
+        role="tool",
+        text="→ edit README.md",
+        tool_result_text=(
+            "✓ edit\n"
+            "Successfully replaced 1 block.\n"
+            "\n"
+            "Patch:\n"
+            "--- a/README.md\n"
+            "+++ b/README.md\n"
+            "@@\n"
+            "-old\n"
+            "+new"
+        ),
+    )
+
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(render_chat_item(item, show_tool_results=True))
+
+    plain = console.export_text(clear=False)
+    styled = console.export_text(styles=True)
+    assert "Patch:" in plain
+    assert "-old" in plain
+    assert "+new" in plain
+    assert "\x1b[91;49m-old" in styled
+    assert "\x1b[92;49m+new" in styled
+
+
 def test_thinking_chat_items_use_distinct_style_and_markdown() -> None:
     console = Console(record=True, width=80)
 


### PR DESCRIPTION
## Issues addressed

Closes #150.
Closes #156.
Closes #157.

## Summary

- Simplify streaming assistant/thinking transcript messages to use a direct Textual Markdown widget, following Toad's `AgentResponse(ConversationMarkdown)` pattern.
- Remove the extra streaming message wrapper/gutter structure so markdown selection is owned by Textual's native Markdown blocks.
- Remove custom Markdown selection painting and wrapped-line extraction in favor of Textual-native Markdown selection behavior.
- Preserve incremental streaming through `MarkdownStream.write(...)` so token deltas do not rebuild the full transcript.
- Add Toad-style transcript anchoring so output follows only while the user remains at the bottom; users can scroll up during generation without being pulled back down.
- Render expanded edit tool patches as syntax-highlighted diffs when Ctrl+O shows tool results.
- Document the larger follow-up plan in #156 for fully migrating remaining Rich `Static` transcript rows to Toad-style native Textual widgets.

## Files/areas changed

- `src/tau_coding/tui/widgets.py`: streaming transcript Markdown simplification, scroll follow mode, selection simplification, colored diff rendering for expanded edit tool results.
- `src/tau_coding/tui/app.py`: re-enable transcript follow mode for explicit user actions.
- `tests/test_tui_app.py`: regression coverage for streaming without forced scroll-end, existing selection/copy behavior, and colored edit diff rendering.

## Tests/checks run and results

- `uv run pytest tests/test_tui_app.py -k 'selection or streaming_transcript or streaming_deltas_update'` - passed.
- `uv run pytest tests/test_tui_app.py -k 'tool_chat_items_hide_and_show_result_text or expanded_edit_tool_result_renders_patch_as_colored_diff'` - passed.
- `uv run pytest tests/test_tui_app.py -q` - one unrelated existing failure remains: `test_run_tui_app_opens_when_provider_login_is_missing[asyncio]` expects provider `openai`, but current runtime selection produced `openai-codex`.

## Notes

- This PR intentionally keeps the previous incremental streaming performance fix intact: `MessageDeltaEvent` still updates the active streaming Markdown widget instead of refreshing the whole transcript.
- #156 tracks the broader follow-up to replace the remaining non-streamed Rich `Static` transcript rows with native Textual widgets for even simpler, more Toad-like selection behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session loading and persisted transcript operations now detach missing parent references to keep session trees, exports, and refreshed state consistent.
  * Terminal command failures now show a properly formatted error result including the exception message.
* **New Features**
  * After prompt submission and tool execution, the transcript reliably returns to “follow output” mode.
* **Improvements**
  * Transcript scrollbars are hidden; streaming updates reduce auto-scrolling for smoother playback.
  * Updated transcript rendering and selection behavior for more accurate selection in markdown/plain views.
  * Terminal command execution is scheduled to keep the UI responsive.
* **Tests**
  * Added/updated regression coverage for session import/branching, selection, streaming refresh behavior, and rendering/command failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
