### PR TITLE
Implement #34: retry transient provider errors

### DIFF
--- a/docs/architecture/provider-retries.md
+++ b/docs/architecture/provider-retries.md
@@ -26,9 +26,9 @@ not wait for the entire retry sleep to finish.
 
 ## Rendering
 
-Transcript and TUI renderers show retry progress as subtle status output. Final
-text mode ignores retry progress and only prints the final assistant response or
-final error.
+Transcript, final-text CLI mode, and TUI renderers show retry progress as subtle
+status output. Final text mode still prints only the final assistant response on
+stdout; retry progress goes to stderr.
 
 ## Boundary
 

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -20,7 +20,12 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.provider import CancellationToken
-from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
+from tau_ai.retry import (
+    is_transient_status,
+    provider_retry_event,
+    retry_delay_seconds,
+    wait_for_retry,
+)
 
 ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_MAX_TOKENS = 4096
@@ -117,6 +122,7 @@ class AnthropicProvider:
                         content_parts: list[str] = []
                         tool_builders: dict[int, _AnthropicToolBuilder] = {}
                         finish_reason: str | None = None
+                        retry_stream = False
 
                         async for line in response.aiter_lines():
                             if signal is not None and signal.is_cancelled():
@@ -180,8 +186,38 @@ class AnthropicProvider:
                                 message = "Provider returned an error"
                                 if isinstance(error, Mapping):
                                     message = _string_or_empty(error.get("message")) or message
-                                yield ProviderErrorEvent(message=message, data=chunk)
+                                error_type = _anthropic_error_type(chunk)
+                                if (
+                                    not emitted_content
+                                    and self._should_retry(attempt, error_type=error_type)
+                                ):
+                                    delay = retry_delay_seconds(
+                                        attempt,
+                                        max_delay_seconds=(
+                                            self._config.max_retry_delay_seconds
+                                        ),
+                                    )
+                                    yield provider_retry_event(
+                                        attempt=attempt,
+                                        max_retries=self._config.max_retries,
+                                        delay_seconds=delay,
+                                        reason=message,
+                                        data={"event": chunk},
+                                    )
+                                    attempt += 1
+                                    if not await wait_for_retry(delay, signal=signal):
+                                        return
+                                    retry_stream = True
+                                    break
+                                yield ProviderErrorEvent(
+                                    message=message,
+                                    retryable=_is_transient_anthropic_error(error_type),
+                                    data={"event": chunk, "attempts": attempt + 1},
+                                )
                                 return
+
+                        if retry_stream:
+                            continue
 
                         tool_calls = [
                             builder.build(index)
@@ -231,10 +267,20 @@ class AnthropicProvider:
             self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
         return self._client
 
-    def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:
+    def _should_retry(
+        self,
+        attempt: int,
+        *,
+        status_code: int | None = None,
+        error_type: str | None = None,
+    ) -> bool:
         if attempt >= self._config.max_retries:
             return False
-        return status_code is None or status_code in {408, 409, 429, 500, 502, 503, 504}
+        if status_code is not None:
+            return is_transient_status(status_code)
+        if error_type is not None:
+            return _is_transient_anthropic_error(error_type)
+        return True
 
 
 class _AnthropicToolBuilder:
@@ -335,6 +381,24 @@ def _loads_object(text: str) -> dict[str, Any] | None:
     except ValueError:
         return None
     return value if isinstance(value, dict) else None
+
+
+def _anthropic_error_type(chunk: Mapping[str, Any]) -> str | None:
+    error = chunk.get("error")
+    if isinstance(error, Mapping):
+        value = error.get("type")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _is_transient_anthropic_error(error_type: str | None) -> bool:
+    return error_type in {
+        "api_error",
+        "overloaded_error",
+        "rate_limit_error",
+        "timeout_error",
+    }
 
 
 def _string_or_empty(value: object) -> str:

--- a/src/tau_ai/events.py
+++ b/src/tau_ai/events.py
@@ -75,6 +75,7 @@ class ProviderErrorEvent(BaseModel):
 
     type: Literal["error"] = "error"
     message: str
+    retryable: bool = False
     data: dict[str, JSONValue] | None = None
 
 

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -26,7 +26,12 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.provider import CancellationToken
-from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
+from tau_ai.retry import (
+    is_transient_status,
+    provider_retry_event,
+    retry_delay_seconds,
+    wait_for_retry,
+)
 
 DEFAULT_OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api"
 
@@ -155,13 +160,45 @@ class OpenAICodexProvider:
                             return
 
                         yield ProviderResponseStartEvent(model=model)
+                        retry_stream = False
                         async for event in _codex_provider_events(response, signal=signal):
                             if isinstance(
                                 event,
                                 ProviderTextDeltaEvent | ProviderToolCallEvent,
                             ):
                                 emitted_content = True
+                            if (
+                                isinstance(event, ProviderErrorEvent)
+                                and event.retryable
+                                and not emitted_content
+                                and self._should_retry(attempt, provider_error=event)
+                            ):
+                                delay = retry_delay_seconds(
+                                    attempt,
+                                    max_delay_seconds=(
+                                        self._config.max_retry_delay_seconds
+                                    ),
+                                )
+                                yield provider_retry_event(
+                                    attempt=attempt,
+                                    max_retries=self._config.max_retries,
+                                    delay_seconds=delay,
+                                    reason=event.message,
+                                    data=event.data,
+                                )
+                                attempt += 1
+                                if not await wait_for_retry(delay, signal=signal):
+                                    return
+                                retry_stream = True
+                                break
+                            if isinstance(event, ProviderErrorEvent):
+                                data = dict(event.data or {})
+                                data["attempts"] = attempt + 1
+                                yield event.model_copy(update={"data": data})
+                                return
                             yield event
+                        if retry_stream:
+                            continue
                         return
                 except httpx.HTTPError as exc:
                     if not emitted_content and self._should_retry(attempt):
@@ -205,9 +242,12 @@ class OpenAICodexProvider:
         *,
         status_code: int | None = None,
         body: str = "",
+        provider_error: ProviderErrorEvent | None = None,
     ) -> bool:
         if attempt >= self._config.max_retries:
             return False
+        if provider_error is not None:
+            return provider_error.retryable
         return status_code is None or _is_retryable_status(status_code, body)
 
 
@@ -367,6 +407,7 @@ async def _codex_provider_events(
         if event_type == "error":
             yield ProviderErrorEvent(
                 message=_error_message(event, fallback="OpenAI Codex returned an error"),
+                retryable=_is_retryable_provider_event(event),
                 data={"event": event},
             )
             return
@@ -374,6 +415,7 @@ async def _codex_provider_events(
         if event_type == "response.failed":
             yield ProviderErrorEvent(
                 message=_response_error_message(event),
+                retryable=_is_retryable_provider_event(event),
                 data={"event": event},
             )
             return
@@ -717,7 +759,51 @@ def _loads_object(value: str) -> dict[str, JSONValue] | None:
 def _is_retryable_status(status_code: int, body: str) -> bool:
     if status_code == 429 and _is_terminal_rate_limit(body):
         return False
-    return status_code in {408, 409, 425, 429} or status_code >= 500
+    return is_transient_status(status_code)
+
+
+def _is_retryable_provider_event(event: Mapping[str, Any]) -> bool:
+    status_code = _event_status_code(event)
+    if status_code is not None:
+        return is_transient_status(status_code)
+    code = _event_error_code(event)
+    if code is None:
+        return False
+    return code.lower() in {
+        "server_error",
+        "service_unavailable",
+        "temporarily_unavailable",
+        "rate_limit_exceeded",
+        "timeout",
+    }
+
+
+def _event_status_code(event: Mapping[str, Any]) -> int | None:
+    for value in _nested_event_values(event, "status", "status_code", "http_status"):
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    return None
+
+
+def _event_error_code(event: Mapping[str, Any]) -> str | None:
+    for value in _nested_event_values(event, "code", "type"):
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _nested_event_values(event: Mapping[str, Any], *names: str) -> list[Any]:
+    values: list[Any] = []
+    for name in names:
+        values.append(event.get(name))
+    for key in ("error", "response"):
+        child = event.get(key)
+        if isinstance(child, Mapping):
+            for name in names:
+                values.append(child.get(name))
+    return values
 
 
 def _is_terminal_rate_limit(body: str) -> bool:

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -20,7 +20,12 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.provider import CancellationToken
-from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
+from tau_ai.retry import (
+    is_transient_status,
+    provider_retry_event,
+    retry_delay_seconds,
+    wait_for_retry,
+)
 
 
 class OpenAICompatibleProvider:
@@ -366,4 +371,4 @@ def _thinking_delta_text(delta: Mapping[str, Any]) -> str:
 
 
 def _is_transient_status(status_code: int) -> bool:
-    return status_code in {408, 409, 425, 429} or status_code >= 500
+    return is_transient_status(status_code)

--- a/src/tau_ai/retry.py
+++ b/src/tau_ai/retry.py
@@ -8,6 +8,7 @@ from tau_ai.provider import CancellationToken
 
 RETRY_POLL_SECONDS = 0.05
 RETRY_BASE_DELAY_SECONDS = 0.25
+TRANSIENT_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
 
 
 def retry_delay_seconds(attempt: int, *, max_delay_seconds: float) -> float:
@@ -16,6 +17,11 @@ def retry_delay_seconds(attempt: int, *, max_delay_seconds: float) -> float:
         return 0.0
     base_delay = min(RETRY_BASE_DELAY_SECONDS, max_delay_seconds)
     return float(min(max_delay_seconds, base_delay * (2**attempt)))
+
+
+def is_transient_status(status_code: int) -> bool:
+    """Return whether an HTTP status usually represents a transient provider error."""
+    return status_code in TRANSIENT_STATUS_CODES
 
 
 def provider_retry_event(

--- a/src/tau_coding/rendering/plain.py
+++ b/src/tau_coding/rendering/plain.py
@@ -1,8 +1,10 @@
 """Pi-style final text renderer for print mode."""
 
 import typer
+from rich.console import Console
+from rich.text import Text
 
-from tau_agent import AgentEvent, ErrorEvent, MessageEndEvent
+from tau_agent import AgentEvent, ErrorEvent, MessageEndEvent, RetryEvent
 
 
 class FinalTextRenderer:
@@ -12,6 +14,7 @@ class FinalTextRenderer:
         self._last_assistant_text = ""
         self._failed = False
         self._error_messages: list[str] = []
+        self._console = Console(stderr=True, highlight=False)
 
     def render(self, event: AgentEvent) -> None:
         """Record events needed for final text output."""
@@ -23,6 +26,10 @@ class FinalTextRenderer:
             if not event.recoverable:
                 self._failed = True
             self._error_messages.append(event.message)
+            return
+
+        if isinstance(event, RetryEvent):
+            self._console.print(Text(f"… {event.message}", style="bright_black"))
 
     def finish(self) -> bool:
         """Print final text or errors and return whether the run succeeded."""

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -97,6 +97,24 @@ def test_final_text_renderer_prints_only_final_message(
     assert captured.out == "Final answer\n"
 
 
+def test_final_text_renderer_shows_retry_status(capsys: pytest.CaptureFixture[str]) -> None:
+    renderer = FinalTextRenderer()
+
+    renderer.render(
+        RetryEvent(
+            attempt=2,
+            max_attempts=3,
+            delay_seconds=0,
+            message="Retrying provider request 2/3 after HTTP 503.",
+        )
+    )
+
+    captured = capsys.readouterr()
+
+    assert "… Retrying provider request 2/3 after HTTP 503." in captured.err
+    assert captured.out == ""
+
+
 def test_final_text_renderer_prints_errors_on_finish(capsys: pytest.CaptureFixture[str]) -> None:
     renderer = FinalTextRenderer()
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -667,6 +667,129 @@ async def test_openai_codex_provider_streams_reasoning_deltas() -> None:
 
 
 @pytest.mark.anyio
+async def test_openai_codex_provider_retries_transient_response_failed_event() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=(
+                    'data: {"type":"response.failed","response":{"status":"failed",'
+                    '"status_code":503,"error":{"code":"service_unavailable",'
+                    '"message":"temporarily unavailable"}}}\n\n'
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert isinstance(events[1], ProviderRetryEvent)
+    assert events[1].attempt == 2
+    assert events[1].max_attempts == 2
+    assert [event.type for event in events] == [
+        "response_start",
+        "retry",
+        "response_start",
+        "text_delta",
+        "response_end",
+    ]
+    assert isinstance(events[-1], ProviderResponseEndEvent)
+    assert events[-1].message.content == "ok"
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_stops_after_max_response_failed_retries() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.failed","response":{"status":"failed",'
+                '"status_code":503,"error":{"message":"temporarily unavailable"}}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert [event.type for event in events] == [
+        "response_start",
+        "retry",
+        "response_start",
+        "error",
+    ]
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].retryable is True
+    assert events[-1].data == {
+        "attempts": 2,
+        "event": {
+            "type": "response.failed",
+            "response": {
+                "status": "failed",
+                "status_code": 503,
+                "error": {"message": "temporarily unavailable"},
+            },
+        }
+    }
+
+
+@pytest.mark.anyio
 async def test_openai_codex_provider_streams_tool_calls() -> None:
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
@@ -1006,3 +1129,107 @@ async def test_anthropic_provider_retries_transient_status_with_event() -> None:
         "text_delta",
         "response_end",
     ]
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_retries_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=(
+                    'data: {"type":"error","error":{"type":"overloaded_error",'
+                    '"message":"overloaded"}}\n\n'
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert isinstance(events[1], ProviderRetryEvent)
+    assert [event.type for event in events] == [
+        "response_start",
+        "retry",
+        "response_start",
+        "text_delta",
+        "response_end",
+    ]
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_does_not_retry_non_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"error","error":{"type":"invalid_request_error",'
+                '"message":"bad request"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=3,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert [event.type for event in events] == ["response_start", "error"]
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].retryable is False
+    assert events[-1].data == {
+        "attempts": 1,
+        "event": {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": "bad request"},
+        },
+    }


### PR DESCRIPTION
Closes #34

## Summary
- Adds provider-neutral retryability on provider error events so adapters can classify transient in-stream failures without moving provider-specific logic into `tau_agent`.
- Retries retryable Anthropic and OpenAI Codex SSE provider errors before any response content/tool output is emitted, preserving bounded retry counts and cancellation-aware backoff.
- Shares transient HTTP status classification, surfaces retry status in final-text CLI mode on stderr, and updates provider retry docs.

## Files / Areas Changed
- `src/tau_ai`: retry helpers, provider error metadata, OpenAI-compatible status sharing, Anthropic stream-error retries, OpenAI Codex response-failure retries.
- `src/tau_coding/rendering/plain.py`: final-text renderer now shows retry status on stderr.
- `tests/test_tau_ai.py`, `tests/test_rendering.py`: deterministic coverage for transient retry, non-transient no-retry, bounded final failure diagnostics, and CLI retry visibility.
- `docs/architecture/provider-retries.md`: renderer behavior updated.

## Tests / Checks
- PASS: `uv run pytest tests/test_tau_ai.py tests/test_agent_loop.py tests/test_rendering.py tests/test_tui_adapter.py`
- PASS: `uv run ruff check src/tau_ai/events.py src/tau_ai/retry.py src/tau_ai/openai_compatible.py src/tau_ai/anthropic.py src/tau_ai/openai_codex.py src/tau_coding/rendering/plain.py tests/test_tau_ai.py tests/test_rendering.py docs/architecture/provider-retries.md`
- PASS: `uv run mypy src/tau_ai/events.py src/tau_ai/retry.py src/tau_ai/openai_compatible.py src/tau_ai/anthropic.py src/tau_ai/openai_codex.py src/tau_coding/rendering/plain.py`
- FAIL, unrelated existing issue: `uv run pytest` has 501 passed and 1 failed in `tests/test_tui_app.py::test_run_tui_app_opens_when_provider_login_is_missing`; it expects default provider `openai`, while current code creates `openai-codex`. The same single test fails in isolation.
- FAIL, unrelated existing issues: `uv run ruff check .` still reports pre-existing `E501` in `tests/test_coding_session.py:352` after my changed-file import ordering was fixed.
- FAIL, unrelated existing issues: `uv run mypy .` reports broad pre-existing type errors across tests and TUI/coding modules; scoped touched source modules pass.

## Assumptions
- Retrying in-stream provider errors is only safe before content/tool data has been emitted; after partial output, Tau surfaces the provider error instead of replaying a potentially duplicated response.
- OpenAI Codex terminal quota/rate-limit body detection remains authoritative for HTTP 429 responses.
- No new user-facing retry config was added; existing `max_retries` and `max_retry_delay_seconds` remain the controls.

## Follow-up Work
- Fix the unrelated TUI default-provider test drift.
- Clean up existing repo-wide ruff/mypy failures so full gates can become required again.