### PR TITLE
Implement #145: Add opt-in terminal alias setup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,10 +128,14 @@ providers or scoped models.
 
 ## Shell Settings
 
-Input-bar terminal commands run in non-interactive shell mode, so aliases from
-files such as `~/.zshrc` or `~/.bashrc` are not loaded automatically. Tau keeps
-that behavior explicit to avoid running arbitrary startup-file side effects
-before every terminal command.
+Tau executes shell commands in non-interactive shell mode. That includes:
+
+- TUI and print-mode terminal commands such as `\! gs` and `\!\! ll`
+- agent-invoked `bash` tool calls
+
+Non-interactive shells do not load aliases from files such as `~/.zshrc` or
+`~/.bashrc` automatically. Tau keeps that behavior explicit to avoid running
+arbitrary startup-file side effects before every command.
 
 To opt in, add a `shellCommandPrefix` to:
 
@@ -139,7 +143,9 @@ To opt in, add a `shellCommandPrefix` to:
 ~/.tau/settings.json
 ```
 
-For example, to enable aliases declared in `~/.zshrc`:
+### zsh users
+
+If your aliases are simple `alias name='command'` lines in `~/.zshrc`, use:
 
 ```json
 {
@@ -147,9 +153,43 @@ For example, to enable aliases declared in `~/.zshrc`:
 }
 ```
 
-Adjust the path to `~/.bashrc` or another file if that is where your aliases
-live. The example imports only lines beginning with `alias `; Tau does not
-source the full startup file for terminal input commands.
+### bash users
+
+If your aliases are in `~/.bashrc`, use:
+
+```json
+{
+  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.bashrc)\""
+}
+```
+
+### dedicated alias file
+
+For the most predictable setup, put Tau-safe aliases in a dedicated file such as
+`~/.tau/aliases.sh`:
+
+```bash
+alias gs='git status'
+alias ll='ls -la'
+```
+
+Then configure:
+
+```json
+{
+  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.tau/aliases.sh)\""
+}
+```
+
+The examples import only lines beginning with `alias `. Tau does not source the
+full startup file. This intentionally avoids side effects such as changing
+directories, printing text, starting background tools, or mutating unrelated
+environment variables before every command.
+
+Tau runs prefixed commands through bash-style non-interactive execution, so
+simple POSIX/bash-compatible alias declarations work best. zsh-specific aliases,
+functions, shell options, or interactive-only startup logic may not work unless
+you rewrite them into bash-compatible setup commands.
 
 Tau also accepts the snake_case key `shell_command_prefix` for consistency with
 other Tau settings.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Important files and directories:
 
 ```text
 ~/.tau/providers.json
+~/.tau/settings.json
 ~/.tau/tui.json
 ~/.tau/sessions/
 ~/.tau/skills/
@@ -124,6 +125,34 @@ requested provider/default/scoped-model change, write atomically, and keep a
 best-effort `providers.json.bak` backup of the previous file. This prevents an
 older running Tau process from saving stale provider settings over newer custom
 providers or scoped models.
+
+## Shell Settings
+
+Input-bar terminal commands run in non-interactive shell mode, so aliases from
+files such as `~/.zshrc` or `~/.bashrc` are not loaded automatically. Tau keeps
+that behavior explicit to avoid running arbitrary startup-file side effects
+before every terminal command.
+
+To opt in, add a `shellCommandPrefix` to:
+
+```text
+~/.tau/settings.json
+```
+
+For example, to enable aliases declared in `~/.zshrc`:
+
+```json
+{
+  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.zshrc)\""
+}
+```
+
+Adjust the path to `~/.bashrc` or another file if that is where your aliases
+live. The example imports only lines beginning with `alias `; Tau does not
+source the full startup file for terminal input commands.
+
+Tau also accepts the snake_case key `shell_command_prefix` for consistency with
+other Tau settings.
 
 ## TUI Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,12 +130,18 @@ providers or scoped models.
 
 Tau executes shell commands in non-interactive shell mode. That includes:
 
-- TUI and print-mode terminal commands such as `\! gs` and `\!\! ll`
+- TUI and print-mode terminal commands such as `! gs` and `!! ll`
 - agent-invoked `bash` tool calls
 
 Non-interactive shells do not load aliases from files such as `~/.zshrc` or
-`~/.bashrc` automatically. Tau keeps that behavior explicit to avoid running
-arbitrary startup-file side effects before every command.
+`~/.bashrc` automatically. This also applies when Tau is launched from terminal
+emulators such as Ghostty: Ghostty may start your interactive shell, but Tau's
+terminal commands still run in a separate non-interactive shell.
+
+Tau keeps shell setup explicit for privacy and safety. It does not automatically
+read, source, grep, or copy aliases from startup files such as `~/.zshrc` or
+`~/.bashrc`, because those files can contain tokens, private paths, or commands
+with interactive side effects.
 
 To opt in, add a `shellCommandPrefix` to:
 
@@ -143,53 +149,55 @@ To opt in, add a `shellCommandPrefix` to:
 ~/.tau/settings.json
 ```
 
-### zsh users
+### Recommended alias setup
 
-If your aliases are simple `alias name='command'` lines in `~/.zshrc`, use:
+Create a small Tau-specific alias file containing only aliases you want Tau to
+use:
 
-```json
-{
-  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.zshrc)\""
-}
+```text
+~/.tau/shell-aliases.bash
 ```
 
-### bash users
-
-If your aliases are in `~/.bashrc`, use:
-
-```json
-{
-  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.bashrc)\""
-}
-```
-
-### dedicated alias file
-
-For the most predictable setup, put Tau-safe aliases in a dedicated file such as
-`~/.tau/aliases.sh`:
+For example:
 
 ```bash
-alias gs='git status'
-alias ll='ls -la'
+alias gst='git status'
+alias ga='git add'
+alias gc='git commit'
 ```
 
-Then configure:
+Then configure Tau to load that file before every terminal command and agent
+`bash` tool call:
 
 ```json
 {
-  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.tau/aliases.sh)\""
+  "shellCommandPrefix": "shopt -s expand_aliases\nsource ~/.tau/shell-aliases.bash"
 }
 ```
 
-The examples import only lines beginning with `alias `. Tau does not source the
-full startup file. This intentionally avoids side effects such as changing
-directories, printing text, starting background tools, or mutating unrelated
-environment variables before every command.
+After saving the file, start a new Tau session and try:
+
+```text
+! gst
+```
+
+Existing in-memory sessions may keep the shell prefix that was loaded when the
+session started. Start a new session if you change `~/.tau/settings.json` while
+Tau is already running.
 
 Tau runs prefixed commands through bash-style non-interactive execution, so
 simple POSIX/bash-compatible alias declarations work best. zsh-specific aliases,
 functions, shell options, or interactive-only startup logic may not work unless
 you rewrite them into bash-compatible setup commands.
+
+### Helping a user set up Ghostty aliases
+
+If a user asks Tau to “set up terminal commands for Ghostty”, Tau should explain
+that the configuration is for Tau's non-interactive terminal commands, not for
+Ghostty itself. Prefer helping the user create or edit `~/.tau/shell-aliases.bash`
+and `~/.tau/settings.json` as shown above. Do not inspect the user's `.zshrc`,
+`.bashrc`, or other shell startup files unless the user explicitly asks Tau to
+read a specific file.
 
 Tau also accepts the snake_case key `shell_command_prefix` for consistency with
 other Tau settings.

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -98,6 +98,13 @@ from tau_coding.session_export import (
     render_session_html,
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
+from tau_coding.shell_config import (
+    ShellConfigError,
+    ShellSettings,
+    load_shell_settings,
+    shell_settings_from_json,
+    shell_settings_path,
+)
 from tau_coding.skills import (
     Skill,
     build_skill_index,
@@ -175,6 +182,8 @@ __all__ = [
     "ResourceError",
     "SessionManager",
     "SessionExportError",
+    "ShellConfigError",
+    "ShellSettings",
     "Skill",
     "SlashCommand",
     "TauPaths",
@@ -232,6 +241,7 @@ __all__ = [
     "FileCredentialStore",
     "jsonl_session_storage",
     "load_provider_settings",
+    "load_shell_settings",
     "load_prompt_templates",
     "load_prompt_templates_with_diagnostics",
     "load_skills",
@@ -251,6 +261,8 @@ __all__ = [
     "resolve_provider_selection",
     "save_default_provider_model",
     "save_provider_settings",
+    "shell_settings_from_json",
+    "shell_settings_path",
     "toggle_saved_scoped_model",
     "export_session_html",
     "upsert_provider",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -46,6 +46,7 @@ from tau_coding.session_export import (
     normalize_export_format,
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
+from tau_coding.shell_config import load_shell_settings
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui import run_tui_app
 
@@ -421,6 +422,7 @@ async def run_openai_print_mode(
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     settings = load_provider_settings()
+    shell_settings = load_shell_settings()
     selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
     provider = create_model_provider(
         selection.provider,
@@ -442,6 +444,7 @@ async def run_openai_print_mode(
             provider_name=selection.provider.name,
             provider_settings=settings,
             runtime_provider_config=selection.provider,
+            shell_command_prefix=shell_settings.shell_command_prefix,
         )
     finally:
         await provider.aclose()
@@ -461,6 +464,7 @@ async def run_print_mode(
     provider_name: str = DEFAULT_PROVIDER_NAME,
     provider_settings: ProviderSettings | None = None,
     runtime_provider_config: ProviderConfig | None = None,
+    shell_command_prefix: str | None = None,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -479,6 +483,7 @@ async def run_print_mode(
             provider_name=provider_name,
             provider_settings=provider_settings,
             runtime_provider_config=runtime_provider_config,
+            shell_command_prefix=shell_command_prefix,
         )
     )
     renderer = create_event_renderer(output)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -181,6 +181,7 @@ class CodingSessionConfig:
     auto_compact_token_threshold: int | None = None
     auto_compact_enabled: bool = True
     thinking_level: ThinkingLevel = DEFAULT_THINKING_LEVEL
+    shell_command_prefix: str | None = None
 
 
 class CodingSession:
@@ -1037,7 +1038,10 @@ class CodingSession:
         if not normalized_command:
             raise ValueError("Terminal command cannot be empty")
 
-        bash_tool = create_bash_tool(cwd=self.cwd)
+        bash_tool = create_bash_tool(
+            cwd=self.cwd,
+            shell_command_prefix=self._config.shell_command_prefix,
+        )
         result = await bash_tool.execute({"command": normalized_command})
         exit_code = None
         if result.data is not None:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -253,7 +253,14 @@ class CodingSession:
             if linear_state.active_leaf_id is not None
             else linear_state
         )
-        tools = config.tools if config.tools is not None else create_coding_tools(cwd=config.cwd)
+        tools = (
+            config.tools
+            if config.tools is not None
+            else create_coding_tools(
+                cwd=config.cwd,
+                shell_command_prefix=config.shell_command_prefix,
+            )
+        )
         resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
         resources = _load_session_resources(resource_paths, config.context_files)
         system = (
@@ -912,6 +919,7 @@ class CodingSession:
                 auto_compact_token_threshold=self._auto_compact_token_threshold,
                 auto_compact_enabled=self._auto_compact_enabled,
                 thinking_level=self._thinking_level,
+                shell_command_prefix=self._config.shell_command_prefix,
             )
         )
         self._config = replacement._config

--- a/src/tau_coding/shell_config.py
+++ b/src/tau_coding/shell_config.py
@@ -1,0 +1,62 @@
+"""Durable shell execution settings for Tau terminal commands."""
+
+from dataclasses import dataclass
+from json import JSONDecodeError, loads
+from pathlib import Path
+from typing import Any
+
+from tau_coding.paths import TauPaths
+
+
+class ShellConfigError(ValueError):
+    """Raised when Tau shell settings are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ShellSettings:
+    """Shell execution settings loaded from Tau home."""
+
+    shell_command_prefix: str | None = None
+
+    def to_json(self) -> dict[str, str]:
+        """Serialize these settings to JSON-compatible data."""
+        if self.shell_command_prefix is None:
+            return {}
+        return {"shellCommandPrefix": self.shell_command_prefix}
+
+
+def shell_settings_path(paths: TauPaths | None = None) -> Path:
+    """Return the durable shell settings path."""
+    return (paths or TauPaths()).home / "settings.json"
+
+
+def load_shell_settings(paths: TauPaths | None = None) -> ShellSettings:
+    """Load durable shell settings, falling back to built-in defaults."""
+    path = shell_settings_path(paths)
+    if not path.exists():
+        return ShellSettings()
+    try:
+        raw = loads(path.read_text(encoding="utf-8"))
+    except JSONDecodeError as exc:
+        raise ShellConfigError(f"Shell settings are not valid JSON: {path}") from exc
+    if not isinstance(raw, dict):
+        raise ShellConfigError("Shell settings must be a JSON object")
+    return shell_settings_from_json(raw)
+
+
+def shell_settings_from_json(data: dict[str, Any]) -> ShellSettings:
+    """Parse shell settings from JSON-compatible data."""
+    allowed_fields = {"shellCommandPrefix", "shell_command_prefix"}
+    unknown_fields = set(data) - allowed_fields
+    if unknown_fields:
+        raise ShellConfigError(f"Unknown shell settings field: {sorted(unknown_fields)[0]}")
+    if "shellCommandPrefix" in data and "shell_command_prefix" in data:
+        raise ShellConfigError("Use only one of shellCommandPrefix or shell_command_prefix")
+
+    raw_prefix = data.get("shellCommandPrefix", data.get("shell_command_prefix"))
+    if raw_prefix is None:
+        return ShellSettings()
+    if not isinstance(raw_prefix, str):
+        raise ShellConfigError("shellCommandPrefix must be a string")
+    prefix = raw_prefix.strip()
+    return ShellSettings(shell_command_prefix=prefix or None)

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -18,6 +18,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from time import monotonic
+from typing import Any
 
 from tau_agent.tools import AgentTool, AgentToolResult, ToolCancellationToken, ToolExecutor
 from tau_agent.types import JSONValue
@@ -422,7 +423,11 @@ def create_edit_tool(*, cwd: str | Path | None = None) -> AgentTool:
     return create_edit_tool_definition(cwd=cwd).to_agent_tool()
 
 
-def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinition:
+def create_bash_tool_definition(
+    *,
+    cwd: str | Path | None = None,
+    shell_command_prefix: str | None = None,
+) -> ToolDefinition:
     """Create a definition for the `bash` tool.
 
     The tool runs a shell command with `cwd` as the subprocess working
@@ -440,12 +445,14 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
     duration, truncation metadata, and full-output path metadata.
     """
     root = Path.cwd() if cwd is None else Path(cwd)
+    prefix = shell_command_prefix.strip() if shell_command_prefix else None
 
     async def execute(
         arguments: Mapping[str, JSONValue],
         signal: ToolCancellationToken | None = None,
     ) -> AgentToolResult:
         command = _str_arg(arguments, "command")
+        shell_command = _prefixed_shell_command(command, prefix)
         timeout = _optional_float_arg(arguments, "timeout")
         if timeout is not None and timeout <= 0:
             raise ToolInputError("timeout must be greater than 0")
@@ -455,15 +462,16 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
         start = monotonic()
         if os.name == "posix":
             process = await asyncio.create_subprocess_shell(
-                command,
+                shell_command,
                 cwd=root,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 start_new_session=True,
+                executable="bash" if prefix else None,
             )
         else:
             process = await asyncio.create_subprocess_shell(
-                command,
+                shell_command,
                 cwd=root,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -527,6 +535,7 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
                 "duration_seconds": round(monotonic() - start, 3),
                 "truncation": truncation.to_json(),
                 "full_output_path": full_output_path,
+                "shell_command_prefix_applied": prefix is not None,
             },
         )
 
@@ -555,9 +564,23 @@ def create_bash_tool_definition(*, cwd: str | Path | None = None) -> ToolDefinit
     )
 
 
-def create_bash_tool(*, cwd: str | Path | None = None) -> AgentTool:
+def create_bash_tool(
+    *,
+    cwd: str | Path | None = None,
+    shell_command_prefix: str | None = None,
+) -> AgentTool:
     """Create an `AgentTool` for executing shell commands with captured output."""
-    return create_bash_tool_definition(cwd=cwd).to_agent_tool()
+    return create_bash_tool_definition(
+        cwd=cwd,
+        shell_command_prefix=shell_command_prefix,
+    ).to_agent_tool()
+
+
+def _prefixed_shell_command(command: str, prefix: str | None) -> str:
+    """Return a shell command with an opt-in setup prefix applied."""
+    if prefix is None:
+        return command
+    return f"{prefix}\n{command}"
 
 
 def format_size(bytes_count: int) -> str:
@@ -582,7 +605,7 @@ async def _communicate_with_cancellation(
     communicate = asyncio.create_task(process.communicate())
     cancel_watch: asyncio.Task[None] | None = None
     try:
-        wait_for = {communicate}
+        wait_for: set[asyncio.Task[Any]] = {communicate}
         if signal is not None:
             cancel_watch = asyncio.create_task(_wait_for_cancel(signal))
             wait_for.add(cancel_watch)
@@ -601,8 +624,11 @@ async def _communicate_with_cancellation(
         try:
             output_bytes, stderr = await communicate
         except asyncio.CancelledError:
-            output_bytes, stderr = b"", None
-        return output_bytes, stderr, not cancelled, cancelled
+            output_bytes = b""
+            stderr_result: bytes | None = None
+        else:
+            stderr_result = stderr
+        return output_bytes, stderr_result, not cancelled, cancelled
     except asyncio.CancelledError:
         _kill_process_tree(process)
         if not communicate.done():

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -91,21 +91,26 @@ class ToolDefinition:
 _file_locks: dict[Path, asyncio.Lock] = {}
 
 
-def create_coding_tools(*, cwd: str | Path | None = None) -> list[AgentTool]:
+def create_coding_tools(
+    *,
+    cwd: str | Path | None = None,
+    shell_command_prefix: str | None = None,
+) -> list[AgentTool]:
     """Create the default coding-tool set for a local project.
 
     The returned tools are ordered as `read`, `write`, `edit`, and `bash`.
     Relative paths used with those tools are resolved against `cwd`; when `cwd`
     is omitted, the process current working directory at factory-call time is
     used. The tools share per-path write/edit locks within this process so
-    concurrent mutations of the same file do not interleave.
+    concurrent mutations of the same file do not interleave. When configured,
+    `shell_command_prefix` is prepended to every bash tool command.
     """
     root = Path.cwd() if cwd is None else Path(cwd)
     return [
         create_read_tool(cwd=root),
         create_write_tool(cwd=root),
         create_edit_tool(cwd=root),
-        create_bash_tool(cwd=root),
+        create_bash_tool(cwd=root, shell_command_prefix=shell_command_prefix),
     ]
 
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -79,6 +79,7 @@ from tau_coding.session import (
     parse_terminal_command,
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
+from tau_coding.shell_config import load_shell_settings
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.autocomplete import (
@@ -775,12 +776,12 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
         super().__init__()
         self.providers = tuple(providers)
         self.theme = theme
-        self.title = title
+        self.title_text = title
 
     def compose(self) -> ComposeResult:
         """Compose the provider picker."""
         with Vertical(id="login-provider-picker"):
-            yield Static(self.title, id="login-provider-title")
+            yield Static(self.title_text, id="login-provider-title")
             yield ListView(
                 *[
                     ListItem(Label(_login_provider_label(provider), markup=False))
@@ -2014,7 +2015,8 @@ class TauTuiApp(App[None]):
             result = await run_terminal_command(command, add_to_context=add_to_context)
         except Exception as exc:  # noqa: BLE001 - surface command execution failures in the TUI
             if item_index < len(self.state.items):
-                self.state.items[item_index].tool_result_text = format_terminal_command_result_block(
+                item = self.state.items[item_index]
+                item.tool_result_text = format_terminal_command_result_block(
                     ok=False,
                     added_to_context=add_to_context,
                     output=str(exc),
@@ -3567,6 +3569,7 @@ async def run_tui_app(
         raise RuntimeError("--resume and --new-session cannot be used together")
 
     provider_settings = load_provider_settings()
+    shell_settings = load_shell_settings()
     manager = session_manager or SessionManager()
     record = _explicit_resume_record(
         manager,
@@ -3615,6 +3618,7 @@ async def run_tui_app(
                 provider_settings=provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=auto_compact_token_threshold,
+                shell_command_prefix=shell_settings.shell_command_prefix,
             )
         )
         app = TauTuiApp(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -310,6 +310,27 @@ async def test_terminal_command_can_run_without_context(tmp_path: Path) -> None:
     assert not any(isinstance(entry, MessageEntry) for entry in entries)
 
 
+@pytest.mark.anyio
+async def test_terminal_command_uses_configured_shell_command_prefix(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            shell_command_prefix="shopt -s expand_aliases\nalias greet='printf terminal-alias'",
+        )
+    )
+
+    result = await session.run_terminal_command("greet", add_to_context=False)
+
+    assert result.ok is True
+    assert result.output == "terminal-alias"
+    assert result.added_to_context is False
+
+
 def test_parse_terminal_command_prefixes() -> None:
     assert parse_terminal_command("! pwd") is not None
     add_request = parse_terminal_command("! pwd")

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1884,6 +1884,38 @@ async def test_session_toggles_and_cycles_scoped_models(
 
 
 @pytest.mark.anyio
+async def test_session_resume_preserves_shell_command_prefix(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    first_cwd = tmp_path / "first"
+    second_cwd = tmp_path / "second"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+    first_record = manager.create_session(cwd=first_cwd, model="fake", title="First")
+    second_record = manager.create_session(cwd=second_cwd, model="fake", title="Second")
+    second_storage = JsonlSessionStorage(second_record.path)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(first_record.path),
+            cwd=first_record.cwd,
+            session_id=first_record.id,
+            session_manager=manager,
+            shell_command_prefix="shopt -s expand_aliases\nalias greet='printf resumed-alias'",
+        )
+    )
+    await second_storage.append(SessionInfoEntry(cwd=str(second_record.cwd)))
+    await second_storage.append(ModelChangeEntry(model="fake"))
+
+    await session.resume(second_record.id)
+    result = await session.run_terminal_command("greet", add_to_context=False)
+
+    assert result.ok is True
+    assert result.output == "resumed-alias"
+
+
+@pytest.mark.anyio
 async def test_session_resumes_indexed_session(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
     first_record = manager.create_session(cwd=tmp_path / "first", model="fake", title="First")

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -331,6 +331,29 @@ async def test_terminal_command_uses_configured_shell_command_prefix(tmp_path: P
     assert result.added_to_context is False
 
 
+@pytest.mark.anyio
+async def test_agent_bash_tool_uses_configured_shell_command_prefix(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            shell_command_prefix="shopt -s expand_aliases\nalias greet='printf agent-alias'",
+        )
+    )
+    bash_tool = next(tool for tool in session.tools if tool.name == "bash")
+
+    result = await bash_tool.execute({"command": "greet"})
+
+    assert result.ok is True
+    assert result.content == "agent-alias"
+    assert result.data is not None
+    assert result.data["shell_command_prefix_applied"] is True
+
+
 def test_parse_terminal_command_prefixes() -> None:
     assert parse_terminal_command("! pwd") is not None
     add_request = parse_terminal_command("! pwd")

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 from pathlib import Path
 from time import monotonic
 
@@ -157,6 +158,27 @@ async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
     assert result.data is not None
     assert result.data["exit_code"] == 0
     assert result.data["timed_out"] is False
+
+
+@pytest.mark.anyio
+async def test_bash_tool_applies_opt_in_shell_command_prefix(tmp_path: Path) -> None:
+    rc_path = tmp_path / ".zshrc"
+    marker = tmp_path / "sourced"
+    rc_path.write_text(
+        "alias greet='printf alias-output'\n"
+        f"touch {shlex.quote(str(marker))}\n",
+        encoding="utf-8",
+    )
+    prefix = f"shopt -s expand_aliases\neval \"$(grep '^alias ' {shlex.quote(str(rc_path))})\""
+    tool = create_bash_tool(cwd=tmp_path, shell_command_prefix=prefix)
+
+    result = await tool.execute({"command": "greet"})
+
+    assert result.ok is True
+    assert result.content == "alias-output"
+    assert result.data is not None
+    assert result.data["shell_command_prefix_applied"] is True
+    assert not marker.exists()
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -161,6 +161,24 @@ async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_create_coding_tools_applies_shell_command_prefix(
+    tmp_path: Path,
+) -> None:
+    tools = create_coding_tools(
+        cwd=tmp_path,
+        shell_command_prefix="shopt -s expand_aliases\nalias greet='printf coding-tool-alias'",
+    )
+    bash_tool = next(tool for tool in tools if tool.name == "bash")
+
+    result = await bash_tool.execute({"command": "greet"})
+
+    assert result.ok is True
+    assert result.content == "coding-tool-alias"
+    assert result.data is not None
+    assert result.data["shell_command_prefix_applied"] is True
+
+
+@pytest.mark.anyio
 async def test_bash_tool_applies_opt_in_shell_command_prefix(tmp_path: Path) -> None:
     rc_path = tmp_path / ".zshrc"
     marker = tmp_path / "sourced"

--- a/tests/test_shell_config.py
+++ b/tests/test_shell_config.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from tau_coding import (
+    ShellConfigError,
+    ShellSettings,
+    TauPaths,
+    load_shell_settings,
+    shell_settings_from_json,
+    shell_settings_path,
+)
+
+
+def test_load_shell_settings_missing_file_uses_defaults(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+
+    assert load_shell_settings(paths) == ShellSettings()
+
+
+def test_load_shell_settings_accepts_pi_style_shell_command_prefix(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    path = shell_settings_path(paths)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '{"shellCommandPrefix": "shopt -s expand_aliases\\nalias gs=\\\"git status\\\""}',
+        encoding="utf-8",
+    )
+
+    settings = load_shell_settings(paths)
+
+    assert settings.shell_command_prefix == 'shopt -s expand_aliases\nalias gs="git status"'
+    assert settings.to_json() == {
+        "shellCommandPrefix": 'shopt -s expand_aliases\nalias gs="git status"'
+    }
+
+
+def test_shell_settings_accepts_tau_style_shell_command_prefix() -> None:
+    settings = shell_settings_from_json({"shell_command_prefix": " alias ll='ls -la' "})
+
+    assert settings.shell_command_prefix == "alias ll='ls -la'"
+
+
+def test_shell_settings_rejects_unknown_fields() -> None:
+    with pytest.raises(ShellConfigError, match="Unknown shell settings field"):
+        shell_settings_from_json({"shell": "bash"})


### PR DESCRIPTION
Issue addressed
- Closes #145

Summary
- Adds Tau shell settings at ~/.tau/settings.json with Pi-compatible shellCommandPrefix plus Tau-style shell_command_prefix parsing.
- Applies the optional prefix only to input-bar terminal commands in print mode and TUI session startup.
- Keeps terminal execution policy in tau_coding and does not source full .zshrc/.bashrc automatically.

Files/areas changed
- src/tau_coding/shell_config.py: new shell settings loader/parser.
- src/tau_coding/tools.py and src/tau_coding/session.py: optional prefix hook for terminal command execution.
- src/tau_coding/cli.py and src/tau_coding/tui/app.py: load shell settings at app/session construction.
- docs/configuration.md: documents the safe alias import setup.
- tests/test_shell_config.py, tests/test_coding_tools.py, tests/test_coding_session.py: focused coverage for config parsing and alias setup behavior.

Tests/checks run
- uv run pytest tests/test_shell_config.py tests/test_coding_tools.py::test_bash_tool_applies_opt_in_shell_command_prefix tests/test_coding_session.py::test_terminal_command_uses_configured_shell_command_prefix tests/test_cli.py::test_run_print_mode_terminal_command_adds_context tests/test_cli.py::test_run_print_mode_terminal_command_can_skip_context - passed.
- uv run pytest tests/test_coding_tools.py tests/test_coding_session.py tests/test_cli.py tests/test_shell_config.py - 104 passed.
- uv run ruff check src/tau_coding/shell_config.py src/tau_coding/tools.py src/tau_coding/session.py src/tau_coding/cli.py src/tau_coding/tui/app.py src/tau_coding/__init__.py tests/test_shell_config.py tests/test_coding_tools.py tests/test_coding_session.py - passed.
- uv run mypy src/tau_coding/shell_config.py src/tau_coding/tools.py src/tau_coding/session.py src/tau_coding/cli.py src/tau_coding/tui/app.py src/tau_coding/__init__.py - passed.
- uv run python -m compileall src/tau_coding/shell_config.py src/tau_coding/tools.py src/tau_coding/session.py src/tau_coding/cli.py src/tau_coding/tui/app.py - passed.

Assumptions
- This intentionally mirrors Pi's documented opt-in shellCommandPrefix pattern instead of automatically sourcing startup files.
- The documented example imports only alias declarations from the selected rc file.

Follow-up work
- A future setup command could write ~/.tau/settings.json interactively if users want a guided alias setup flow.