### PR TITLE
Fix #131: cover credential-backed Codex provider restoration

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from tau_ai import (
 )
 from tau_coding import CodingSessionRecord, SessionManager, cli
 from tau_coding.cli import app, run_print_mode
+from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.paths import TauPaths
 from tau_coding.provider_config import (
     OpenAICompatibleProviderConfig,
@@ -645,6 +646,60 @@ def test_providers_command_lists_default_provider(
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
     assert " \topenrouter\topenai-compatible\topenai/gpt-5.5" in result.stdout
     assert " \thuggingface\topenai-compatible\topenai/gpt-oss-120b" in result.stdout
+
+
+def test_providers_command_restores_codex_with_stored_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_CODEX_ACCESS_TOKEN", raising=False)
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        """
+{
+  "default_provider": "local",
+  "providers": [
+    {
+      "type": "openai-compatible",
+      "name": "openai",
+      "base_url": "https://api.openai.com/v1",
+      "api_key_env": "OPENAI_API_KEY",
+      "credential_name": "openai",
+      "models": ["gpt-5.5"],
+      "default_model": "gpt-5.5"
+    },
+    {
+      "type": "openai-compatible",
+      "name": "local",
+      "base_url": "http://localhost:11434/v1",
+      "api_key_env": "LOCAL_API_KEY",
+      "credential_name": null,
+      "models": ["qwen"],
+      "default_model": "qwen"
+    }
+  ]
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    FileCredentialStore(tau_home / "credentials.json").set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="access-token",
+            refresh="refresh-token",
+            expires=123456,
+            account_id="account-1",
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["providers"])
+
+    assert result.exit_code == 0
+    assert "*\tlocal\topenai-compatible\tqwen" in result.stdout
+    assert " \topenai-codex\topenai-codex\tgpt-5.5" in result.stdout
+    assert "\tOPENAI_CODEX_ACCESS_TOKEN\tstored:openai-codex\t" in result.stdout
 
 
 def test_render_provider_settings_shows_credential_source(


### PR DESCRIPTION
Issue addressed: Closes #131

Summary:
- Investigated the provider/credential mismatch against current Tau and local Pi source.
- Confirmed Tau's current `tau_coding.provider_config.load_provider_settings()` now reconciles stale `providers.json` files by merging built-in catalog metadata and appending credential-backed missing built-in providers such as `openai-codex`.
- Added a CLI regression for the exact reported shape: stale `providers.json` containing only `openai` and `local`, plus stored OAuth credentials for `openai-codex`, then `tau providers` must list Codex with `stored:openai-codex`.

Files/areas changed:
- `tests/test_cli.py`: added coverage for `tau providers` restoring the built-in Codex subscription provider when stored OAuth credentials exist.

Tests/checks run and results:
- `uv run pytest tests/test_cli.py::test_providers_command_restores_codex_with_stored_oauth tests/test_provider_config.py::test_load_provider_settings_restores_builtin_providers_with_stored_credentials tests/test_provider_config.py::test_load_provider_settings_merges_builtin_model_catalog tests/test_provider_config.py::test_load_provider_settings_restores_builtin_credential_name` - passed, 4 tests.
- `uv run pytest tests/test_provider_config.py tests/test_cli.py` - passed, 61 tests.
- `uv run ruff check tests/test_cli.py` - passed.
- `git diff --check` - passed.

Assumptions:
- Pi comparison indicates built-ins are loaded first and user/custom model config is layered on top, so Tau's provider settings load should not allow an older provider file to hide credential-backed built-ins.
- No secrets or real credential values were read into tests; the regression uses synthetic OAuth credentials in a temporary Tau home.

Follow-up work:
- None required for #131 unless we want a separate cleanup to persist restored built-in entries back to `providers.json` after read-time reconciliation.
