### PR TITLE
Improve prompt event immediacy

### DIFF
--- a/docs/architecture/phase-20-2-prompt-immediacy.md
+++ b/docs/architecture/phase-20-2-prompt-immediacy.md
@@ -1,0 +1,76 @@
+# Phase 20.2: Prompt Immediacy Experiment
+
+Phase 20.2 experiments with making submitted prompts appear in the TUI sooner
+while keeping transcript rendering driven by agent events.
+
+## What Changed
+
+`AgentHarness.prompt()` still appends the user message to the harness-owned
+transcript immediately, but `_run()` now emits the prompt's user message events
+before entering the provider/tool agent loop:
+
+```text
+message_start user
+message_end user
+agent_start
+turn_start
+...
+```
+
+Previously, the harness waited for `run_agent_loop()` to emit `turn_start` and
+then replayed the pending user message events. Moving the user message events to
+the front gives event-authoritative UIs an earlier durable transcript boundary
+for the submitted prompt.
+
+`CodingSession.prompt()` and `CodingSession.continue_()` now yield streamed
+events before awaiting message persistence for `MessageEndEvent` events:
+
+```python
+yield event
+if isinstance(event, MessageEndEvent):
+    persisted_count = await self._persist_messages_since(persisted_count)
+```
+
+Persistence is not moved to a background task. It remains awaited inside the
+same async generator, preserving sequential session writes. The difference is
+that the TUI receives and can render the message event before the JSONL append
+and session-state refresh finish.
+
+## Why
+
+Long sessions can make persistence visibly expensive because each completed
+message appends session entries and refreshes the persisted session state. When
+that work happens before yielding the event, a submitted prompt may not appear
+until persistence completes.
+
+This experiment preserves event-authoritative transcript rendering while making
+the event visible to the UI before persistence side effects run.
+
+## Tradeoff
+
+The event order remains deterministic, and persistence remains ordered, but the
+durability timing changes:
+
+- before: message persisted before the TUI saw it
+- after: TUI sees the message immediately before persistence completes
+
+If the process exits in that small window, the TUI may have displayed a message
+that is not present after session reload.
+
+## Pi Comparison
+
+Pi's current harness persists `message_end` before notifying subscribers. This
+Tau phase is therefore an intentional responsiveness experiment rather than a
+straight port of Pi's durability timing.
+
+## Tests
+
+Focused coverage lives in:
+
+```text
+tests/test_agent_harness.py
+tests/test_coding_session.py
+```
+
+The new session test uses a storage implementation that fails on append to prove
+that the user `MessageEndEvent` is yielded before persistence is attempted.

--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -191,6 +191,14 @@ class AgentHarness:
         self._current_signal = signal
         pending_prompt_event = prompt_message
         try:
+            if pending_prompt_event is not None:
+                start = MessageStartEvent(message_role="user")
+                end = MessageEndEvent(message=pending_prompt_event)
+                for prompt_event in (start, end):
+                    await self._notify(prompt_event)
+                    yield prompt_event
+                pending_prompt_event = None
+
             async for event in run_agent_loop(
                 provider=self._config.provider,
                 model=self._config.model,
@@ -205,13 +213,6 @@ class AgentHarness:
             ):
                 await self._notify(event)
                 yield event
-                if pending_prompt_event is not None and event.type == "turn_start":
-                    start = MessageStartEvent(message_role="user")
-                    end = MessageEndEvent(message=pending_prompt_event)
-                    for prompt_event in (start, end):
-                        await self._notify(prompt_event)
-                        yield prompt_event
-                    pending_prompt_event = None
         finally:
             if self._current_signal is signal:
                 self._current_signal = None

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1100,8 +1100,6 @@ class CodingSession:
         overflow_event: ErrorEvent | None = None
         try:
             async for event in self._harness.prompt(expanded_content):
-                if isinstance(event, MessageEndEvent):
-                    persisted_count = await self._persist_messages_since(persisted_count)
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
                         context=context,
@@ -1111,16 +1109,14 @@ class CodingSession:
                     if _is_context_overflow_error(event):
                         overflow_event = event
                 yield event
+                if isinstance(event, MessageEndEvent):
+                    persisted_count = await self._persist_messages_since(persisted_count)
             persisted_count = await self._persist_messages_since(persisted_count)
             if overflow_event is not None:
                 compacted = await self._try_overflow_compact(context=context)
                 if compacted:
                     retry_persisted_count = len(self._harness.messages)
                     async for retry_event in self._harness.continue_():
-                        if isinstance(retry_event, MessageEndEvent):
-                            retry_persisted_count = await self._persist_messages_since(
-                                retry_persisted_count
-                            )
                         if isinstance(retry_event, ErrorEvent) and not retry_event.recoverable:
                             self._last_diagnostic_log_path = (
                                 self._diagnostic_logger.log_error_event(
@@ -1130,6 +1126,10 @@ class CodingSession:
                                 )
                             )
                         yield retry_event
+                        if isinstance(retry_event, MessageEndEvent):
+                            retry_persisted_count = await self._persist_messages_since(
+                                retry_persisted_count
+                            )
                     await self._persist_messages_since(retry_persisted_count)
                 return
             await self._try_auto_compact(context=context, phase="auto_compact_after_prompt")
@@ -1147,8 +1147,6 @@ class CodingSession:
         persisted_count = len(self._harness.messages)
         try:
             async for event in self._harness.continue_():
-                if isinstance(event, MessageEndEvent):
-                    persisted_count = await self._persist_messages_since(persisted_count)
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
                         context=context,
@@ -1156,6 +1154,8 @@ class CodingSession:
                         event=event,
                     )
                 yield event
+                if isinstance(event, MessageEndEvent):
+                    persisted_count = await self._persist_messages_since(persisted_count)
             await self._persist_messages_since(persisted_count)
             await self._try_auto_compact(context=context, phase="auto_compact_after_continue")
         except Exception as exc:

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -33,17 +33,17 @@ async def test_prompt_appends_user_message_and_assistant_response() -> None:
     events = [event async for event in harness.prompt("Hi")]
 
     assert [event.type for event in events] == [
-        "agent_start",
-        "turn_start",
         "message_start",
         "message_end",
+        "agent_start",
+        "turn_start",
         "message_start",
         "message_end",
         "turn_end",
         "agent_end",
     ]
-    assert events[2].message_role == "user"  # type: ignore[attr-defined]
-    assert events[3].message == UserMessage(content="Hi")  # type: ignore[attr-defined]
+    assert events[0].message_role == "user"  # type: ignore[attr-defined]
+    assert events[1].message == UserMessage(content="Hi")  # type: ignore[attr-defined]
     assert harness.messages == (UserMessage(content="Hi"), assistant)
 
 
@@ -148,10 +148,10 @@ async def test_subscribed_listeners_receive_events_and_can_unsubscribe() -> None
     _more_events = [event async for event in harness.continue_()]
 
     assert seen == [
-        "agent_start",
-        "turn_start",
         "message_start",
         "message_end",
+        "agent_start",
+        "turn_start",
         "message_start",
         "message_delta",
         "message_end",
@@ -183,10 +183,10 @@ async def test_cancel_requests_cancellation_for_current_run() -> None:
             harness.cancel()
 
     assert [event.type for event in events] == [
-        "agent_start",
-        "turn_start",
         "message_start",
         "message_end",
+        "agent_start",
+        "turn_start",
         "message_start",
         "message_delta",
         "error",

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -9,6 +9,7 @@ from tau_agent import (
     AgentMessage,
     AgentTool,
     AssistantMessage,
+    MessageEndEvent,
     QueueUpdateEvent,
     ToolCall,
     ToolResultMessage,
@@ -92,6 +93,12 @@ class RaisingProvider:
             yield  # pragma: no cover
 
         return iterator()
+
+
+class FailingAppendStorage(JsonlSessionStorage):
+    async def append(self, entry: object) -> None:
+        del entry
+        raise RuntimeError("append blocked")
 
 
 class WaitingProvider:
@@ -275,6 +282,31 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
     assert entries[-1].type == "leaf"
     assert entries[-1].entry_id == message_entries[-1].id
     assert session.messages == (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
+
+
+@pytest.mark.anyio
+async def test_prompt_yields_user_message_before_persisting_it(tmp_path: Path) -> None:
+    storage = FailingAppendStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Hi")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    stream = session.prompt("Hello")
+    first_event = await anext(stream)
+    second_event = await anext(stream)
+
+    assert first_event.type == "message_start"
+    assert isinstance(second_event, MessageEndEvent)
+    assert second_event.message == UserMessage(content="Hello")
+
+    with pytest.raises(RuntimeError, match="append blocked"):
+        await anext(stream)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Emit a submitted prompt's user message events from `AgentHarness._run()` before entering `run_agent_loop()`.
- Yield session events before awaiting `MessageEndEvent` persistence in `CodingSession.prompt()` / `continue_()`.
- Keep persistence synchronous and ordered; this does not introduce background persistence.
- Document the responsiveness experiment and durability timing tradeoff.

## Why

Long sessions can make JSONL persistence and persisted-state refresh visible before the TUI receives the user `MessageEndEvent`. This keeps transcript rendering event-authoritative while allowing the TUI to render the event before persistence finishes.

Closes #166.

## Testing

- `uv run pytest tests/test_agent_harness.py tests/test_coding_session.py` ✅
- `uv run pytest tests/test_agent_harness.py tests/test_coding_session.py tests/test_tui_app.py` currently has unrelated TUI expectation failures on `origin/main` around theme colors/provider defaults; the focused harness/session tests pass.

## Notes

Pi currently persists `message_end` before subscriber notification. This PR is intentionally an experiment in Tau's TUI responsiveness rather than a direct Pi timing port.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt-related messages now appear earlier in the event stream, allowing the UI to show user input sooner.
  * Streaming interfaces now render a message before persistence and session refresh complete.

* **Bug Fixes**
  * Event ordering has been updated so user message boundaries are emitted before the next agent activity begins.
  * Session handling now better preserves message visibility during prompt and continuation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->