### PR TITLE
Fix #164: allow prompt editing during compaction

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1903,11 +1903,27 @@ class TauTuiApp(App[None]):
             return
 
         text = raw_text.strip()
+        if not text:
+            prompt.text = ""
+            self._completion_state = CompletionState()
+            self._refresh_completions()
+            return
+
+        if self._is_compaction_active():
+            if text.startswith("/compact"):
+                self._notify("A compaction is already running.", severity="warning")
+            else:
+                prompt.text = raw_text
+                prompt.move_cursor(_text_end_location(raw_text))
+                self._notify(
+                    "Compaction is still running. You can keep editing, but wait to submit.",
+                    severity="warning",
+                )
+            return
+
         prompt.text = ""
         self._completion_state = CompletionState()
         self._refresh_completions()
-        if not text:
-            return
 
         terminal_command = parse_terminal_command(text)
         if terminal_command is not None:
@@ -1929,6 +1945,14 @@ class TauTuiApp(App[None]):
             if command.compact_summary is not None:
                 if self._is_compaction_active():
                     self._notify("A compaction is already running.", severity="warning")
+                elif self._is_agent_or_queue_active():
+                    prompt.text = raw_text
+                    prompt.move_cursor(_text_end_location(raw_text))
+                    self._notify(
+                        "Wait for the current agent turn and queued messages to finish before compacting.",
+                        severity="warning",
+                    )
+                    return
                 else:
                     self._compaction_worker = self.run_worker(
                         self._run_compaction(command.compact_summary),
@@ -1984,18 +2008,20 @@ class TauTuiApp(App[None]):
             await self._queue_prompt(text, streaming_behavior=streaming_behavior)
             return
 
-        if self._is_compaction_active():
-            prompt.text = raw_text
-            prompt.move_cursor(_text_end_location(raw_text))
-            self._notify("Compaction is still running. You can keep editing, but wait to submit.", severity="warning")
-            return
-
         self._submit_prompt(text)
 
     def _is_compaction_active(self) -> bool:
         """Return whether a manual compaction worker is still running."""
         worker = self._compaction_worker
         return worker is not None and not worker.is_finished and not worker.is_cancelled
+
+    def _is_agent_or_queue_active(self) -> bool:
+        """Return whether compaction would race an active or queued agent turn."""
+        self._sync_queue_state()
+        worker = self._prompt_worker
+        is_worker_active = worker is not None and not worker.is_finished and not worker.is_cancelled
+        is_session_running = bool(getattr(self.session, "is_running", False))
+        return self.state.running or is_session_running or is_worker_active or self.state.queued_message_count > 0
 
     async def _run_compaction(self, summary: str) -> None:
         """Run manual compaction without disabling prompt editing."""
@@ -2004,6 +2030,8 @@ class TauTuiApp(App[None]):
         self._refresh()
         try:
             compact_message = await self.session.compact(summary)
+        except asyncio.CancelledError:
+            return
         except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
             self._notify(f"Error: {exc}", severity="error")
             return
@@ -2187,8 +2215,26 @@ class TauTuiApp(App[None]):
         self._refresh_chrome()
 
     def action_cancel(self) -> None:
-        """Cancel the active agent turn."""
+        """Cancel the active compaction or agent turn."""
+        if self._cancel_active_compaction(notify=True):
+            return
         self._cancel_active_prompt(notify=True)
+
+    def _cancel_active_compaction(self, *, notify: bool) -> bool:
+        """Cancel the active manual compaction worker and restore visible session state."""
+        worker = self._compaction_worker
+        if worker is None or worker.is_finished or worker.is_cancelled:
+            return False
+
+        worker.cancel()
+        self._compaction_worker = None
+        self.state.clear()
+        self.state.set_skills(self.session.skills)
+        self.state.load_messages(self.session.messages)
+        self._refresh()
+        if notify:
+            self._notify("Cancelled compaction.")
+        return True
 
     def _cancel_active_prompt(self, *, notify: bool, interrupt: bool = False) -> None:
         """Cancel the active prompt worker and ignore any late events from it."""

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1776,6 +1776,7 @@ class TauTuiApp(App[None]):
         self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
+        self._compaction_worker: Worker[None] | None = None
         self._prompt_run_id = 0
         self._completion_state = CompletionState()
         self._activity_frame = 0
@@ -1926,17 +1927,13 @@ class TauTuiApp(App[None]):
             if command.new_session_requested:
                 await self._new_session()
             if command.compact_summary is not None:
-                try:
-                    self.state.clear()
-                    self.state.add_item("status", "Compacting session…")
-                    self._refresh()
-                    compact_message = await self.session.compact(command.compact_summary)
-                    self.state.clear()
-                    self.state.set_skills(self.session.skills)
-                    self.state.load_messages(self.session.messages)
-                    self._notify(compact_message)
-                except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
-                    self._notify(f"Error: {exc}", severity="error")
+                if self._is_compaction_active():
+                    self._notify("A compaction is already running.", severity="warning")
+                else:
+                    self._compaction_worker = self.run_worker(
+                        self._run_compaction(command.compact_summary),
+                        exclusive=False,
+                    )
             if command.export_requested:
                 try:
                     exported_path = await self.session.export(
@@ -1987,7 +1984,36 @@ class TauTuiApp(App[None]):
             await self._queue_prompt(text, streaming_behavior=streaming_behavior)
             return
 
+        if self._is_compaction_active():
+            prompt.text = raw_text
+            prompt.move_cursor(_text_end_location(raw_text))
+            self._notify("Compaction is still running. You can keep editing, but wait to submit.", severity="warning")
+            return
+
         self._submit_prompt(text)
+
+    def _is_compaction_active(self) -> bool:
+        """Return whether a manual compaction worker is still running."""
+        worker = self._compaction_worker
+        return worker is not None and not worker.is_finished and not worker.is_cancelled
+
+    async def _run_compaction(self, summary: str) -> None:
+        """Run manual compaction without disabling prompt editing."""
+        self.state.clear()
+        self.state.add_item("status", "Compacting session…")
+        self._refresh()
+        try:
+            compact_message = await self.session.compact(summary)
+        except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
+            self._notify(f"Error: {exc}", severity="error")
+            return
+        finally:
+            self._compaction_worker = None
+        self.state.clear()
+        self.state.set_skills(self.session.skills)
+        self.state.load_messages(self.session.messages)
+        self._notify(compact_message)
+        self._refresh()
 
     def _submit_prompt(self, text: str) -> None:
         """Add a prompt to the transcript and start the agent worker."""

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1740,6 +1740,151 @@ async def test_tui_app_compact_command_accepts_no_instructions() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("blocked_command", ["/new", "/resume abc123"])
+async def test_tui_app_blocks_session_commands_while_compacting(blocked_command: str) -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    class SlowCompactSession(FakeSession):
+        async def compact(self, summary: str) -> str:
+            self.compact_summaries.append(summary)
+            started.set()
+            await finish.wait()
+            self.messages = (UserMessage(content="Previous conversation summary:\nGenerated summary"),)
+            self.context_token_estimate = 42
+            return "Compacted 2 context entries."
+
+    session = SlowCompactSession(messages=[UserMessage(content="Earlier")])
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/compact Summary of earlier work."
+        await pilot.press("enter")
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        prompt.value = blocked_command
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.new_session_count == 0
+        assert session.resumed_session_ids == []
+        assert prompt.value == blocked_command
+        assert notifications == ["Compaction is still running. You can keep editing, but wait to submit."]
+
+        finish.set()
+        await pilot.pause()
+
+        assert session.compact_summaries == ["Summary of earlier work."]
+
+
+@pytest.mark.anyio
+async def test_tui_app_blocks_compact_command_while_agent_is_running() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        prompt = app.query_one("#prompt")
+        prompt.value = "/compact Summary of earlier work."
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.compact_summaries == []
+        assert prompt.value == "/compact Summary of earlier work."
+        assert notifications == [
+            "Wait for the current agent turn and queued messages to finish before compacting."
+        ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_blocks_compact_command_while_follow_up_is_queued() -> None:
+    session = FakeSession()
+    session.queued_follow_up_messages = ("after this",)
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        app._refresh()
+        prompt = app.query_one("#prompt")
+        prompt.value = "/compact Summary of earlier work."
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.compact_summaries == []
+        assert prompt.value == "/compact Summary of earlier work."
+        assert notifications == [
+            "Wait for the current agent turn and queued messages to finish before compacting."
+        ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_escape_cancels_active_compaction() -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    class SlowCompactSession(FakeSession):
+        async def compact(self, summary: str) -> str:
+            self.compact_summaries.append(summary)
+            started.set()
+            await finish.wait()
+            self.messages = (UserMessage(content="Previous conversation summary:\nGenerated summary"),)
+            self.context_token_estimate = 42
+            return "Compacted 2 context entries."
+
+    session = SlowCompactSession(messages=[UserMessage(content="Earlier")])
+    app = TauTuiApp(session)
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/compact Summary of earlier work."
+        await pilot.press("enter")
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert app._compaction_worker is None
+        assert [(item.role, item.text) for item in app.state.items] == [("user", "Earlier")]
+        assert notifications == ["Cancelled compaction."]
+
+        prompt.value = "/new"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.new_session_count == 1
+        assert session.messages == ()
+        assert not any(item.role == "compaction_summary" for item in app.state.items)
+
+
+@pytest.mark.anyio
 async def test_tui_app_export_command_runs_session_export() -> None:
     session = FakeSession(messages=[UserMessage(content="Earlier")])
     app = TauTuiApp(session)


### PR DESCRIPTION
## Summary

- run manual `/compact` work in a non-exclusive worker
- keep the prompt editor usable while compaction is in progress
- guard prompt submission until compaction finishes, while preserving drafted text

Fixes #164

## Tests

- `uv run pytest tests/test_tui_app.py::test_tui_app_compact_command_runs_session_compaction tests/test_tui_app.py::test_tui_app_compact_command_accepts_no_instructions -q`

Note: full `tests/test_tui_app.py` currently has unrelated failures around theme color expectations and default provider selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual session compaction now runs in the background to keep the interface responsive.

* **Bug Fixes**
  * Blocked prompt submission and session-changing commands while compaction is running, preserving editor input and showing clear notifications.
  * Improved safeguards so compaction won’t start during an active agent turn or queued follow-up streaming.
  * Updated cancellation behavior: cancel now prioritizes active compaction, and pressing Escape cancels compaction and restores the session view.  

* **Tests**
  * Added TUI coverage for compaction concurrency and Escape cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->