### PR TITLE
Improve provider error diagnostic logging

### DIFF
--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from tau_agent.events import AgentEvent, MessageEndEvent, MessageStartEvent, QueueUpdateEvent
 from tau_agent.loop import run_agent_loop
-from tau_agent.messages import AgentMessage, UserMessage
+from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
 from tau_agent.tools import AgentTool
 from tau_ai.provider import ModelProvider
 
@@ -175,6 +175,7 @@ class AgentHarness:
     def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
         """Append a user message and run the agent loop."""
         self._ensure_not_running()
+        self._append_interrupted_tool_results()
         self._running = True
         message = UserMessage(content=content)
         self._messages.append(message)
@@ -183,6 +184,7 @@ class AgentHarness:
     def continue_(self) -> AsyncIterator[AgentEvent]:
         """Continue the agent loop without appending a new user message."""
         self._ensure_not_running()
+        self._append_interrupted_tool_results()
         self._running = True
         return self._run()
 
@@ -213,6 +215,8 @@ class AgentHarness:
                         yield prompt_event
                     pending_prompt_event = None
         finally:
+            if signal.is_cancelled():
+                self._append_interrupted_tool_results()
             if self._current_signal is signal:
                 self._current_signal = None
             self._running = False
@@ -243,3 +247,51 @@ class AgentHarness:
             queue.clear()
             return messages
         return (queue.popleft(),)
+
+    def _append_interrupted_tool_results(self) -> None:
+        """Repair a transcript left mid-tool-call by an interrupted run.
+
+        OpenAI-compatible providers reject a transcript where an assistant tool
+        call is not followed by a matching tool result. If the UI cancels the
+        worker while a tool is still running, the normal loop may not get a
+        chance to append the cancellation result, so repair that gap before the
+        next model request.
+        """
+        assistant_index = _latest_open_tool_call_assistant_index(self._messages)
+        if assistant_index is None:
+            return
+
+        assistant = self._messages[assistant_index]
+        if not isinstance(assistant, AssistantMessage):
+            return
+
+        returned_ids = {
+            message.tool_call_id
+            for message in self._messages[assistant_index + 1 :]
+            if isinstance(message, ToolResultMessage)
+        }
+        for tool_call in assistant.tool_calls:
+            if tool_call.id in returned_ids:
+                continue
+            message = "Tool call interrupted by user"
+            self._messages.append(
+                ToolResultMessage(
+                    tool_call_id=tool_call.id,
+                    name=tool_call.name,
+                    content=message,
+                    ok=False,
+                    error=message,
+                )
+            )
+
+
+def _latest_open_tool_call_assistant_index(messages: Sequence[AgentMessage]) -> int | None:
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, UserMessage):
+            return None
+        if isinstance(message, AssistantMessage):
+            if message.tool_calls:
+                return index
+            return None
+    return None

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -143,11 +143,12 @@ class OpenAICodexProvider:
                                     return
                                 continue
                             yield ProviderErrorEvent(
-                                message=(
-                                    "OpenAI Codex request failed with status "
-                                    f"{response.status_code}"
+                                message=_codex_http_error_message(
+                                    status_code=response.status_code,
+                                    body=body_text,
                                 ),
                                 data={
+                                    "status_code": response.status_code,
                                     "body": body_text,
                                     "attempts": attempt + 1,
                                 },
@@ -642,6 +643,43 @@ def _finish_reason_from_response(event: Mapping[str, Any]) -> str | None:
     if isinstance(status, str):
         return status
     return None
+
+
+def _codex_http_error_message(*, status_code: int, body: str) -> str:
+    prefix = f"OpenAI Codex request failed with status {status_code}"
+    detail = _http_error_detail(body)
+    if detail:
+        return f"{prefix}: {detail}"
+    return prefix
+
+
+def _http_error_detail(body: str) -> str:
+    parsed = _loads_object(body)
+    if parsed is not None:
+        detail = _error_detail_from_mapping(parsed)
+        if detail:
+            return detail
+    return body.strip()[:1000]
+
+
+def _error_detail_from_mapping(value: Mapping[str, Any]) -> str:
+    error = value.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+        code = error.get("code")
+        if isinstance(code, str) and code:
+            return code
+    for key in ("message", "detail", "error"):
+        detail = value.get(key)
+        if isinstance(detail, str) and detail:
+            return detail
+        if isinstance(detail, Mapping):
+            nested = _error_detail_from_mapping(detail)
+            if nested:
+                return nested
+    return ""
 
 
 def _response_error_message(event: Mapping[str, Any]) -> str:

--- a/src/tau_coding/diagnostics.py
+++ b/src/tau_coding/diagnostics.py
@@ -60,12 +60,14 @@ class AgentCallDiagnosticLogger:
         phase: str,
         event: ErrorEvent,
     ) -> Path:
-        """Log an agent error event without provider payload bodies or prompts."""
+        """Log an agent error event with safe provider diagnostic details."""
         entry = _base_entry(context, phase=phase, kind="error_event")
         entry["error"] = {
             "message": event.message,
             "recoverable": event.recoverable,
         }
+        if event.data is not None:
+            entry["error"]["data"] = event.data
         self._append(entry)
         return self.path
 

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -8,6 +8,8 @@ from tau_agent import (
     AssistantMessage,
     MessageEndEvent,
     MessageStartEvent,
+    ToolCall,
+    ToolResultMessage,
     UserMessage,
 )
 from tau_agent.harness import AgentHarness, AgentHarnessConfig
@@ -194,6 +196,81 @@ async def test_cancel_requests_cancellation_for_current_run() -> None:
         "agent_end",
     ]
     assert harness.messages == (UserMessage(content="Hi"),)
+
+
+@pytest.mark.anyio
+async def test_cancelled_tool_run_repairs_transcript_before_next_prompt() -> None:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del arguments, signal
+        return AgentToolResult(tool_call_id="call-1", name="read", ok=True, content="ok")
+
+    tool = AgentTool(
+        name="read",
+        description="Read a file.",
+        input_schema={"type": "object"},
+        executor=executor,
+    )
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(
+                    message=AssistantMessage(content="I'll read it.", tool_calls=[tool_call])
+                ),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Recovered.")),
+            ],
+        ]
+    )
+    harness = AgentHarness(
+        AgentHarnessConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            tools=[tool],
+        )
+    )
+
+    stream = harness.prompt("Read README.md")
+    async for event in stream:
+        if event.type == "tool_execution_start":
+            harness.cancel()
+            await stream.aclose()
+            break
+
+    assert harness.messages == (
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        ToolResultMessage(
+            tool_call_id="call-1",
+            name="read",
+            content="Tool call interrupted by user",
+            ok=False,
+            error="Tool call interrupted by user",
+        ),
+    )
+
+    events = [event async for event in harness.prompt("What happened?")]
+
+    assert events[-1].type == "agent_end"
+    assert provider.calls[1][2] == [
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        ToolResultMessage(
+            tool_call_id="call-1",
+            name="read",
+            content="Tool call interrupted by user",
+            ok=False,
+            error="Tool call interrupted by user",
+        ),
+        UserMessage(content="What happened?"),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -272,6 +272,66 @@ async def test_prompt_logs_error_event_diagnostic_data(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_prompt_repairs_loaded_session_with_interrupted_tool_call(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user_entry = MessageEntry(message=UserMessage(content="Read README.md"))
+    await storage.append(user_entry)
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    assistant_entry = MessageEntry(
+        parent_id=user_entry.id,
+        message=AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+    )
+    await storage.append(assistant_entry)
+    await storage.append(LeafEntry(parent_id=assistant_entry.id, entry_id=assistant_entry.id))
+
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Recovered.")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    await _collect_session_events(session.prompt("What happened?"))
+
+    expected_repair = ToolResultMessage(
+        tool_call_id="call-1",
+        name="read",
+        content="Tool call interrupted by user",
+        ok=False,
+        error="Tool call interrupted by user",
+    )
+    assert provider.calls[0][2] == [
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        expected_repair,
+        UserMessage(content="What happened?"),
+    ]
+
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        expected_repair,
+        UserMessage(content="What happened?"),
+        AssistantMessage(content="Recovered."),
+    ]
+
+
+@pytest.mark.anyio
 async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -238,6 +238,40 @@ async def test_prompt_logs_unexpected_agent_call_exception(tmp_path: Path) -> No
 
 
 @pytest.mark.anyio
+async def test_prompt_logs_error_event_diagnostic_data(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    tau_paths = TauPaths(home=tmp_path / "tau-home", agents_home=tmp_path / "agents-home")
+    provider = FakeProvider(
+        [[ProviderErrorEvent(message="provider failed", data={"status_code": 400, "body": "bad request"})]]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="fake-provider",
+            session_id="session-1",
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    await _collect_session_events(session.prompt("Hello"))
+
+    log_path = tau_paths.agent_calls_log_path
+    assert session.last_diagnostic_log_path == log_path
+    entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert entry["kind"] == "error_event"
+    assert entry["error"] == {
+        "message": "provider failed",
+        "recoverable": False,
+        "data": {"status_code": 400, "body": "bad request"},
+    }
+    assert "Hello" not in log_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
 async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -475,6 +475,86 @@ async def test_openai_compatible_provider_does_not_retry_non_transient_status() 
 
 
 @pytest.mark.anyio
+async def test_openai_codex_provider_includes_http_error_detail_in_message() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"error": {"message": "The requested model does not exist."}},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].message == (
+        "OpenAI Codex request failed with status 400: "
+        "The requested model does not exist."
+    )
+    assert events[-1].data == {
+        "status_code": 400,
+        "body": '{"error":{"message":"The requested model does not exist."}}',
+        "attempts": 1,
+    }
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_includes_plain_http_error_body_in_message() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="bad request details")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].message == (
+        "OpenAI Codex request failed with status 400: bad request details"
+    )
+    assert events[-1].data == {
+        "status_code": 400,
+        "body": "bad request details",
+        "attempts": 1,
+    }
+
+
+@pytest.mark.anyio
 async def test_openai_codex_provider_formats_request_and_streams_text() -> None:
     requests: list[httpx.Request] = []
 


### PR DESCRIPTION
## Summary

- include `ErrorEvent.data` in agent-call diagnostic log entries
- preserve concise transcript-facing error messages while logging provider details such as status/body
- add coverage for provider error diagnostic data without logging prompts

Addresses the logging slice of #116

## Tests

- `uv run pytest tests/test_coding_session.py::test_prompt_logs_error_event_diagnostic_data tests/test_coding_session.py::test_prompt_logs_unexpected_agent_call_exception -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider error diagnostics by including additional structured error details when available.
  * Enhanced OpenAI Codex HTTP error messages by extracting more informative details from JSON/plain-text responses.
  * The agent harness now repairs interrupted tool-call transcripts before continuing, preventing missing tool results.

* **Tests**
  * Added new test coverage for diagnostic logging of provider error `data` and for transcript repair after cancelled tool runs.
  * Added Codex provider tests ensuring HTTP error details are included in emitted error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->