### PR TITLE
Handle missing variables in prompt slash commands

### DIFF
--- a/docs/architecture/phase-9-skills-prompts.md
+++ b/docs/architecture/phase-9-skills-prompts.md
@@ -141,8 +141,10 @@ after the command is available as `{{ arguments }}` or `{{ args }}`:
 Review {{ arguments }} for correctness.
 ```
 
-If the prompt template has no placeholders, Tau appends the invocation arguments
-after a blank line.
+If the prompt template has no `{{ arguments }}` or `{{ args }}` placeholder,
+Tau appends the invocation arguments after a blank line. Other placeholders are
+left blank during slash-command expansion so a custom prompt can include optional
+fields without crashing the TUI.
 
 Template variables use simple `{{ variable }}` placeholders:
 
@@ -162,7 +164,9 @@ text = render_prompt_template(
 )
 ```
 
-Missing variables raise `ResourceError`; extra variables are ignored.
+Missing variables raise `ResourceError`; extra variables are ignored. This strict
+behavior applies to direct rendering. Slash-command expansion is more forgiving
+and renders missing custom variables as blank text.
 
 ## Boundary
 

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -14,6 +14,7 @@ from tau_coding.resources import (
 )
 
 _TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
+_ARGUMENT_TEMPLATE_VARIABLES = {"arguments", "args"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,14 +64,26 @@ def load_prompt_templates_with_diagnostics(
     return sorted(templates_by_name.values(), key=lambda template: template.name), diagnostics
 
 
-def render_prompt_template(template: PromptTemplate, variables: Mapping[str, str]) -> str:
-    """Render a prompt template using `{{ variable }}` placeholders."""
+def render_prompt_template(
+    template: PromptTemplate,
+    variables: Mapping[str, str],
+    *,
+    missing: str | None = None,
+) -> str:
+    """Render a prompt template using `{{ variable }}` placeholders.
+
+    By default, missing variables raise `ResourceError`. Callers that treat
+    templates as user-facing shortcuts can pass `missing` to render absent
+    variables as a fallback string instead.
+    """
 
     def replace(match: re.Match[str]) -> str:
         name = match.group(1)
         value = variables.get(name)
         if value is None:
-            raise ResourceError(f"Missing prompt template variable: {name}")
+            if missing is None:
+                raise ResourceError(f"Missing prompt template variable: {name}")
+            return missing
         return value
 
     return _TEMPLATE_VARIABLE_RE.sub(replace, template.content)
@@ -98,10 +111,21 @@ def expand_prompt_template_command(
     if template is None:
         return None
 
-    rendered = render_prompt_template(template, {"arguments": args, "args": args})
-    if args and not _TEMPLATE_VARIABLE_RE.search(template.content):
+    rendered = render_prompt_template(
+        template,
+        {"arguments": args, "args": args},
+        missing="",
+    )
+    if args and not _template_references_arguments(template.content):
         return f"{rendered.rstrip()}\n\n{args}"
     return rendered
+
+
+def _template_references_arguments(content: str) -> bool:
+    return any(
+        match.group(1) in _ARGUMENT_TEMPLATE_VARIABLES
+        for match in _TEMPLATE_VARIABLE_RE.finditer(content)
+    )
 
 
 def _find_prompt_template(

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -121,6 +121,30 @@ def test_expand_prompt_template_command_replaces_slash_command() -> None:
     )
 
 
+def test_expand_prompt_template_command_blanks_missing_custom_variables() -> None:
+    template = PromptTemplate(
+        name="review",
+        path=Path("review.md"),
+        content="Base branch: {{ base_branch }}\nReview PR {{ arguments }}.",
+    )
+
+    assert expand_prompt_template_command("/review 168", [template]) == (
+        "Base branch: \nReview PR 168."
+    )
+
+
+def test_expand_prompt_template_command_appends_arguments_without_argument_placeholder() -> None:
+    template = PromptTemplate(
+        name="review",
+        path=Path("review.md"),
+        content="Base branch: {{ base_branch }}\nReview this code.",
+    )
+
+    assert expand_prompt_template_command("/review src/app.py", [template]) == (
+        "Base branch: \nReview this code.\n\nsrc/app.py"
+    )
+
+
 def test_expand_prompt_template_command_appends_arguments_without_placeholder() -> None:
     template = PromptTemplate(name="review", path=Path("review.md"), content="Review this code.")
 


### PR DESCRIPTION
## Summary
- render missing custom variables as blank text during prompt-template slash command expansion
- append invocation arguments unless the template explicitly references {{ arguments }} or {{ args }}
- document the forgiving slash-command behavior and add regression tests

## Tests
- uv run pytest tests/test_prompt_templates.py tests/test_coding_session.py::test_session_expands_prompt_templates_as_slash_commands
- uv run pytest *(fails: existing unrelated TUI expectations for theme colors/diff ANSI/provider default)*