### PR TITLE
Hide autocomplete after completed custom command

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -109,10 +109,16 @@ def build_completion_state(
 
     token_end = _first_token_end(text)
     token = text[:token_end]
+    has_argument_text = token_end < len(text)
     if token.startswith("/skill:"):
+        if has_argument_text and _matches_skill_command(token, skills):
+            return CompletionState()
         return CompletionState(_skill_completions(token=token, token_end=token_end, skills=skills))
 
     if ":" in token:
+        return CompletionState()
+
+    if has_argument_text and _matches_prompt_template_command(token, prompt_templates):
         return CompletionState()
 
     argument_completions = _command_argument_completions(
@@ -300,6 +306,18 @@ def _parse_shell_path_token(token: str) -> tuple[str, str, str] | None:
     if any(part in {"", ".", ".."} for part in parent_parts):
         return None
     return parent_text, name_prefix, replacement_prefix
+
+
+def _matches_skill_command(token: str, skills: Sequence[Skill]) -> bool:
+    command_name = token.removeprefix("/skill:").lower()
+    return any(skill.name.lower() == command_name for skill in skills)
+
+
+def _matches_prompt_template_command(
+    token: str, prompt_templates: Sequence[PromptTemplate]
+) -> bool:
+    command_name = token.removeprefix("/").lower()
+    return any(template.name.lower() == command_name for template in prompt_templates)
 
 
 def _command_completions(

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -118,9 +118,6 @@ def build_completion_state(
     if ":" in token:
         return CompletionState()
 
-    if has_argument_text and _matches_prompt_template_command(token, prompt_templates):
-        return CompletionState()
-
     argument_completions = _command_argument_completions(
         text=text,
         token_end=token_end,
@@ -133,6 +130,9 @@ def build_completion_state(
     )
     if argument_completions is not None:
         return CompletionState(argument_completions)
+
+    if has_argument_text and _matches_prompt_template_command(token, prompt_templates):
+        return CompletionState()
 
     return CompletionState(
         _command_completions(

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -131,7 +131,10 @@ def build_completion_state(
     if argument_completions is not None:
         return CompletionState(argument_completions)
 
-    if has_argument_text and _matches_prompt_template_command(token, prompt_templates):
+    if has_argument_text and (
+        _matches_prompt_template_command(token, prompt_templates)
+        or _matches_registered_command(token, command_registry)
+    ):
         return CompletionState()
 
     return CompletionState(
@@ -318,6 +321,11 @@ def _matches_prompt_template_command(
 ) -> bool:
     command_name = token.removeprefix("/").lower()
     return any(template.name.lower() == command_name for template in prompt_templates)
+
+
+def _matches_registered_command(token: str, registry: CommandRegistry) -> bool:
+    command_name = token.removeprefix("/").lower()
+    return registry.get(command_name) is not None
 
 
 def _command_completions(

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -136,7 +136,7 @@ def test_skill_command_is_available_for_command_completion() -> None:
     assert state.selected.apply("/ski") == "/skill:"
 
 
-def test_skill_name_completion_preserves_request_text() -> None:
+def test_skill_name_completion_preserves_request_text_for_incomplete_name() -> None:
     state = build_completion_state(
         "/skill:r fix tests",
         command_registry=create_default_command_registry(),
@@ -154,6 +154,60 @@ def test_skill_name_completion_preserves_request_text() -> None:
     assert [item.display for item in state.items] == ["/skill:review"]
     assert state.selected is not None
     assert state.selected.apply("/skill:r fix tests") == "/skill:review fix tests"
+
+
+def test_skill_name_completion_hides_after_completed_skill_command_space() -> None:
+    state = build_completion_state(
+        "/skill:review fix tests",
+        command_registry=create_default_command_registry(),
+        skills=(
+            Skill(
+                name="review",
+                path=Path("review.md"),
+                content="Review code",
+                description="Review code",
+            ),
+        ),
+        prompt_templates=(),
+    )
+
+    assert state.items == ()
+
+
+def test_custom_prompt_completion_hides_after_completed_prompt_command_space() -> None:
+    state = build_completion_state(
+        "/example fix tests",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="example",
+                path=Path("example.md"),
+                content="Example prompt.",
+                description="Run example.",
+            ),
+        ),
+    )
+
+    assert state.items == ()
+
+
+def test_custom_prompt_completion_reappears_when_deleting_back_to_command_token() -> None:
+    state = build_completion_state(
+        "/exa",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="example",
+                path=Path("example.md"),
+                content="Example prompt.",
+                description="Run example.",
+            ),
+        ),
+    )
+
+    assert [item.display for item in state.items] == ["/example"]
 
 
 def test_completion_selection_wraps() -> None:

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -157,7 +157,20 @@ def test_skill_name_completion_preserves_request_text_for_incomplete_name() -> N
 
 
 def test_skill_name_completion_hides_after_completed_skill_command_space() -> None:
-    state = build_completion_state(
+    trailing_space_state = build_completion_state(
+        "/skill:review ",
+        command_registry=create_default_command_registry(),
+        skills=(
+            Skill(
+                name="review",
+                path=Path("review.md"),
+                content="Review code",
+                description="Review code",
+            ),
+        ),
+        prompt_templates=(),
+    )
+    request_state = build_completion_state(
         "/skill:review fix tests",
         command_registry=create_default_command_registry(),
         skills=(
@@ -171,11 +184,25 @@ def test_skill_name_completion_hides_after_completed_skill_command_space() -> No
         prompt_templates=(),
     )
 
-    assert state.items == ()
+    assert trailing_space_state.items == ()
+    assert request_state.items == ()
 
 
 def test_custom_prompt_completion_hides_after_completed_prompt_command_space() -> None:
-    state = build_completion_state(
+    trailing_space_state = build_completion_state(
+        "/example ",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="example",
+                path=Path("example.md"),
+                content="Example prompt.",
+                description="Run example.",
+            ),
+        ),
+    )
+    request_state = build_completion_state(
         "/example fix tests",
         command_registry=create_default_command_registry(),
         skills=(),
@@ -189,7 +216,26 @@ def test_custom_prompt_completion_hides_after_completed_prompt_command_space() -
         ),
     )
 
-    assert state.items == ()
+    assert trailing_space_state.items == ()
+    assert request_state.items == ()
+
+
+def test_builtin_command_argument_completion_wins_over_custom_prompt_name() -> None:
+    state = build_completion_state(
+        "/model fak",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="model",
+                path=Path("model.md"),
+                content="Choose a model.",
+            ),
+        ),
+        model_names=("fake-model",),
+    )
+
+    assert [item.display for item in state.items] == ["fake-model"]
 
 
 def test_custom_prompt_completion_reappears_when_deleting_back_to_command_token() -> None:

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -220,6 +220,36 @@ def test_custom_prompt_completion_hides_after_completed_prompt_command_space() -
     assert request_state.items == ()
 
 
+def test_builtin_command_completion_hides_after_completed_command_space() -> None:
+    trailing_space_state = build_completion_state(
+        "/compact ",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+    )
+    request_state = build_completion_state(
+        "/compact summarize old context",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+    )
+
+    assert trailing_space_state.items == ()
+    assert request_state.items == ()
+
+
+def test_builtin_command_argument_completion_wins_over_completed_command_hide() -> None:
+    state = build_completion_state(
+        "/model fak",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        model_names=("fake-model",),
+    )
+
+    assert [item.display for item in state.items] == ["fake-model"]
+
+
 def test_builtin_command_argument_completion_wins_over_custom_prompt_name() -> None:
     state = build_completion_state(
         "/model fak",


### PR DESCRIPTION
## Summary
- hide skill autocomplete once a complete `/skill:<name>` token has argument text
- hide custom prompt autocomplete once a complete prompt command has argument text
- add autocomplete tests for completed skill/prompt commands and deleting back to the command token

Fixes #173

## Tests
- uv run pytest tests/test_tui_autocomplete.py -q
- uv run pytest -q
- uv run ruff check src/tau_coding/tui/autocomplete.py tests/test_tui_autocomplete.py
- uv run ruff format --check src/tau_coding/tui/autocomplete.py tests/test_tui_autocomplete.py

Note: full-repo `uv run ruff check .`, `uv run ruff format --check .`, and `uv run mypy` currently fail on pre-existing unrelated issues in files not touched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete now hides suggestions after a skill or custom prompt command has been fully entered.
  * Matching is more accurate when typing skill and prompt template names, including case-insensitive matches.
  * Suggestions reappear correctly when deleting back to just the command token.

* **Tests**
  * Expanded autocomplete coverage for incomplete skill names, completed commands, and prompt deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->