### PR TITLE
Fix #175: restore streaming transcript scrollback

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -344,19 +344,30 @@ class TranscriptView(VerticalScroll):
         self._active_assistant_widget: StreamingTranscriptMessageWidget | None = None
         self._active_thinking_widget: StreamingTranscriptMessageWidget | None = None
         self._hidden_thinking_placeholder_visible = False
+        self._follow_output = True
 
     def on_mount(self) -> None:
         """Follow new transcript content until the user scrolls away."""
-        self.anchor()
+        self.follow_output()
 
     def follow_output(self) -> None:
         """Return to follow mode for a user-driven turn or explicit jump to bottom."""
-        self.anchor()
+        self._follow_output = True
+        self.anchor(False)
+        self.scroll_end(animate=False)
 
     @property
     def _should_follow_output(self) -> bool:
         """Return whether new content should keep the viewport pinned to the bottom."""
-        return self.is_vertical_scroll_end or (self.is_anchored and not self._anchor_released)
+        return self._follow_output or self.is_vertical_scroll_end
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        """Track whether user scrollback has opted out of transcript following."""
+        super().watch_scroll_y(old_value, new_value)
+        if round(new_value) >= self.max_scroll_y:
+            self._follow_output = True
+        elif round(new_value) < round(old_value):
+            self._follow_output = False
 
     def update_from_state(
         self,
@@ -442,6 +453,7 @@ class TranscriptView(VerticalScroll):
         scroll_end: bool = False,
     ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
         """Append one transcript item without rebuilding previous blocks."""
+        should_follow = self._should_follow_output if not scroll_end else True
         self._render_theme = theme
         widget = _transcript_widget(
             item,
@@ -454,7 +466,7 @@ class TranscriptView(VerticalScroll):
         self._hidden_thinking_placeholder_visible = False
         self._last_render_width = self.scrollable_content_region.width
         self.refresh(layout=True)
-        if scroll_end:
+        if should_follow:
             self.scroll_end(animate=False)
         return widget
 
@@ -467,6 +479,7 @@ class TranscriptView(VerticalScroll):
         """Create the active assistant message widget if needed."""
         if self._active_assistant_widget is not None:
             return self._active_assistant_widget
+        should_follow = self._should_follow_output if not scroll_end else True
         widget = StreamingTranscriptMessageWidget(
             ChatItem(role="assistant", text=""),
             theme=theme,
@@ -475,7 +488,7 @@ class TranscriptView(VerticalScroll):
         await self.mount(widget)
         self._active_assistant_widget = widget
         self._last_render_width = self.scrollable_content_region.width
-        if scroll_end:
+        if should_follow:
             self.scroll_end(animate=False)
         return widget
 
@@ -489,9 +502,10 @@ class TranscriptView(VerticalScroll):
         """Append streamed assistant text to the active message widget."""
         self._active_thinking_widget = None
         self._hidden_thinking_placeholder_visible = False
+        should_follow = self._should_follow_output if not scroll_end else True
         widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
         await widget.append_fragment(delta)
-        if scroll_end:
+        if should_follow:
             self.scroll_end(animate=False)
 
     async def append_thinking_delta(
@@ -503,6 +517,7 @@ class TranscriptView(VerticalScroll):
         scroll_end: bool = False,
     ) -> None:
         """Append streamed thinking text or one hidden-thinking placeholder."""
+        should_follow = self._should_follow_output if not scroll_end else True
         if not show_thinking:
             if self._hidden_thinking_placeholder_visible:
                 return
@@ -512,7 +527,7 @@ class TranscriptView(VerticalScroll):
                     text="Thinking… Press Ctrl+T to show thinking tokens.",
                 ),
                 theme=theme,
-                scroll_end=scroll_end,
+                scroll_end=should_follow,
             )
             self._hidden_thinking_placeholder_visible = True
             return
@@ -524,7 +539,7 @@ class TranscriptView(VerticalScroll):
             )
             await self.mount(self._active_thinking_widget)
         await self._active_thinking_widget.append_fragment(delta)
-        if scroll_end:
+        if should_follow:
             self.scroll_end(animate=False)
 
     async def finish_assistant_message(self, text: str | None = None) -> None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -354,7 +354,16 @@ class TranscriptView(VerticalScroll):
         """Return to follow mode for a user-driven turn or explicit jump to bottom."""
         self._follow_output = True
         self.anchor(False)
-        self.scroll_end(animate=False)
+        self._request_follow_scroll(force=True)
+
+    def _request_follow_scroll(self, *, force: bool = False) -> None:
+        """Scroll to the bottom after layout if follow mode is still active."""
+
+        def scroll_if_still_following() -> None:
+            if force or self._follow_output or self.is_vertical_scroll_end:
+                self.scroll_end(animate=False, immediate=True)
+
+        self.call_after_refresh(scroll_if_still_following)
 
     @property
     def _should_follow_output(self) -> bool:
@@ -364,10 +373,10 @@ class TranscriptView(VerticalScroll):
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         """Track whether user scrollback has opted out of transcript following."""
         super().watch_scroll_y(old_value, new_value)
-        if round(new_value) >= self.max_scroll_y:
-            self._follow_output = True
-        elif round(new_value) < round(old_value):
+        if new_value < old_value:
             self._follow_output = False
+        elif new_value >= self.max_scroll_y:
+            self._follow_output = True
 
     def update_from_state(
         self,
@@ -442,7 +451,7 @@ class TranscriptView(VerticalScroll):
             )
         self.refresh(layout=True)
         if scroll_end:
-            self.scroll_end(animate=False)
+            self._request_follow_scroll()
 
     async def append_item(
         self,
@@ -467,7 +476,7 @@ class TranscriptView(VerticalScroll):
         self._last_render_width = self.scrollable_content_region.width
         self.refresh(layout=True)
         if should_follow:
-            self.scroll_end(animate=False)
+            self._request_follow_scroll(force=scroll_end)
         return widget
 
     async def start_assistant_message(
@@ -489,7 +498,7 @@ class TranscriptView(VerticalScroll):
         self._active_assistant_widget = widget
         self._last_render_width = self.scrollable_content_region.width
         if should_follow:
-            self.scroll_end(animate=False)
+            self._request_follow_scroll(force=scroll_end)
         return widget
 
     async def append_assistant_delta(
@@ -506,7 +515,7 @@ class TranscriptView(VerticalScroll):
         widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
         await widget.append_fragment(delta)
         if should_follow:
-            self.scroll_end(animate=False)
+            self._request_follow_scroll(force=scroll_end)
 
     async def append_thinking_delta(
         self,
@@ -540,7 +549,7 @@ class TranscriptView(VerticalScroll):
             await self.mount(self._active_thinking_widget)
         await self._active_thinking_widget.append_fragment(delta)
         if should_follow:
-            self.scroll_end(animate=False)
+            self._request_follow_scroll(force=scroll_end)
 
     async def finish_assistant_message(self, text: str | None = None) -> None:
         """Finalize the active assistant widget after the provider sends the full message."""

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1042,7 +1042,6 @@ def test_chat_items_preserve_malformed_fenced_code() -> None:
     assert 'print("hi")' in output
 
 
-
 @pytest.mark.anyio
 async def test_transcript_message_widget_extracts_plain_text_selection() -> None:
     app = TauTuiApp(
@@ -1064,12 +1063,26 @@ async def test_transcript_message_widget_extracts_plain_text_selection() -> None
 
 
 @pytest.mark.anyio
-async def test_streaming_transcript_deltas_do_not_force_scroll_end() -> None:
-    app = TauTuiApp(FakeSession(messages=[]))
+async def test_streaming_transcript_deltas_do_not_force_scroll_end_during_scrollback() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content=f"message {index}\n" + "line\n" * 4) for index in range(12)
+            ]
+        )
+    )
 
-    async with app.run_test(size=(40, 20)) as pilot:
+    async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
         transcript = app.query_one("#transcript", TranscriptView)
+        transcript.follow_output()
+        await pilot.pause()
+        transcript.scroll_to(
+            y=max(0, transcript.max_scroll_y - 5),
+            animate=False,
+            immediate=True,
+        )
+        await pilot.pause()
         forced_scrolls = 0
         original_scroll_end = transcript.scroll_end
 
@@ -1086,6 +1099,64 @@ async def test_streaming_transcript_deltas_do_not_force_scroll_end() -> None:
 
     assert forced_scrolls == 0
 
+
+@pytest.mark.anyio
+async def test_streaming_transcript_deltas_follow_when_at_bottom() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content=f"message {index}\n" + "line\n" * 4) for index in range(12)
+            ]
+        )
+    )
+
+    async with app.run_test(size=(40, 12)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.follow_output()
+        await pilot.pause()
+        assert transcript.is_vertical_scroll_end
+
+        await transcript.append_assistant_delta("alpha\n" * 20)
+        for _ in range(5):
+            await pilot.pause()
+            if transcript.is_vertical_scroll_end:
+                break
+
+        assert transcript.is_vertical_scroll_end
+
+
+@pytest.mark.anyio
+async def test_streaming_transcript_deltas_preserve_user_scrollback() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content=f"message {index}\n" + "line\n" * 4) for index in range(12)
+            ]
+        )
+    )
+
+    async with app.run_test(size=(40, 12)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.follow_output()
+        await pilot.pause()
+        assert transcript.max_scroll_y > 0
+
+        transcript.scroll_to(
+            y=max(0, transcript.max_scroll_y - 5),
+            animate=False,
+            immediate=True,
+        )
+        await pilot.pause()
+        scrollback_y = transcript.scroll_y
+        assert not transcript.is_vertical_scroll_end
+
+        await transcript.append_assistant_delta("alpha\n" * 20)
+        await pilot.pause()
+
+        assert transcript.scroll_y == scrollback_y
+        assert not transcript.is_vertical_scroll_end
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1160,6 +1160,82 @@ async def test_streaming_transcript_deltas_preserve_user_scrollback() -> None:
 
 
 @pytest.mark.anyio
+async def test_streaming_transcript_deltas_do_not_apply_stale_follow_scroll() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content=f"message {index}\n" + "line\n" * 4) for index in range(12)
+            ]
+        )
+    )
+
+    async with app.run_test(size=(40, 12)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.follow_output()
+        await pilot.pause()
+        assert transcript.is_vertical_scroll_end
+
+        await transcript.append_assistant_delta("alpha\n" * 20)
+        transcript.scroll_to(
+            y=max(0, transcript.max_scroll_y - 5),
+            animate=False,
+            immediate=True,
+        )
+        scrollback_y = transcript.scroll_y
+        assert not transcript.is_vertical_scroll_end
+
+        await pilot.pause()
+
+        assert transcript.scroll_y == scrollback_y
+        assert not transcript.is_vertical_scroll_end
+
+
+@pytest.mark.anyio
+async def test_streaming_transcript_fractional_scrollback_after_refollow_stops_following() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content=f"message {index}\n" + "line\n" * 4) for index in range(12)
+            ]
+        )
+    )
+
+    async with app.run_test(size=(40, 12)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.follow_output()
+        await pilot.pause()
+        assert transcript.is_vertical_scroll_end
+
+        transcript.scroll_to(
+            y=max(0, transcript.max_scroll_y - 5),
+            animate=False,
+            immediate=True,
+        )
+        await pilot.pause()
+        assert not transcript.is_vertical_scroll_end
+
+        transcript.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert transcript.is_vertical_scroll_end
+
+        transcript.scroll_to(
+            y=max(0, transcript.max_scroll_y - 0.6),
+            animate=False,
+            immediate=True,
+        )
+        scrollback_y = transcript.scroll_y
+        assert not transcript.is_vertical_scroll_end
+
+        await transcript.append_assistant_delta("alpha\n" * 20)
+        await pilot.pause()
+
+        assert transcript.scroll_y == scrollback_y
+        assert not transcript.is_vertical_scroll_end
+
+
+@pytest.mark.anyio
 async def test_tui_transcript_selects_only_one_message() -> None:
     app = TauTuiApp(
         FakeSession(


### PR DESCRIPTION
Closes #175

## Issue addressed
- Fixes #175: TUI scrollback regression while assistant messages stream.

## Summary
- Restores transcript follow behavior so streaming output stays pinned only when the transcript was already following the bottom.
- Tracks explicit upward user scrollback and preserves that scroll position while assistant/thinking deltas continue to stream.
- Keeps the fix inside `tau_coding` TUI widgets, preserving the agent/provider architecture boundaries.

## Files / areas changed
- `src/tau_coding/tui/widgets.py`: adds explicit follow-output state to `TranscriptView` and applies the captured follow decision around incremental transcript appends.
- `tests/test_tui_app.py`: updates the old no-forced-scroll assertion and adds deterministic coverage for pinned-bottom follow and user scrollback preservation.

## Checks run
- PASS: `uv run pytest tests/test_tui_app.py::test_streaming_transcript_deltas_do_not_force_scroll_end_during_scrollback tests/test_tui_app.py::test_streaming_transcript_deltas_follow_when_at_bottom tests/test_tui_app.py::test_streaming_transcript_deltas_preserve_user_scrollback tests/test_tui_app.py::test_tui_streaming_deltas_update_active_message_without_full_refresh -q`
- PASS: `git diff --check`
- CAVEAT: `uv run ruff format --check src/tau_coding/tui/widgets.py tests/test_tui_app.py` still reports that `tests/test_tui_app.py` would be reformatted in unrelated existing sections outside this change.
- CAVEAT: `uv run ruff check src/tau_coding/tui/widgets.py tests/test_tui_app.py` still reports pre-existing issues in touched files, including an existing quoted annotation in `widgets.py`, import sorting in `tests/test_tui_app.py`, and older long lines outside this patch.
- CAVEAT: `uv run mypy src/tau_coding/tui/widgets.py tests/test_tui_app.py` still reports broad pre-existing type errors in these files; the run is not clean before this patch.

## Assumptions
- Programmatic `follow_output()` calls represent explicit user/application intent to return to bottom-follow mode.
- Upward scroll movement during streaming represents intentional user scrollback and should suspend auto-follow until the viewport returns to the bottom.

## Follow-up
- Consider separately formatting and typing `tests/test_tui_app.py` so focused lint/type checks can be used without unrelated failures.
