### PR TITLE
Fix #179: defer indexing empty new sessions

### DIFF
--- a/docs/assets/landing.css
+++ b/docs/assets/landing.css
@@ -1,0 +1,327 @@
+/* Landing page styles for docs/index.md.
+   Scoped under .tau-landing so normal MkDocs pages keep the Material theme. */
+
+@import url("https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,800;1,400&family=Space+Grotesk:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+
+.md-content:has(.tau-landing) {
+  max-width: none;
+}
+
+.md-content:has(.tau-landing) .md-content__inner {
+  margin: 0;
+  padding: 0;
+}
+
+.md-content:has(.tau-landing) .md-content__inner > p:has(> link) {
+  display: none;
+}
+
+.md-content:has(.tau-landing) .md-content__inner::before {
+  display: none;
+}
+
+.md-main:has(.tau-landing),
+.md-main__inner:has(.tau-landing) {
+  margin-top: 0;
+}
+
+.md-content:has(.tau-landing) .md-content__button {
+  display: none;
+}
+
+
+  .tau-landing{
+    --ground:#FFFFFF;
+    --grid:#DCE4F2;
+    --grid-strong:#C9D6EE;
+    --ink:#13213C;
+    --ink-soft:#54607A;
+    --accent:#1B3FA0;
+    --red:#D6435B;
+    --paper-edge:#EEF2FA;
+
+    --serif:"Spectral", Georgia, serif;
+    --grotesk:"Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+    --mono:"JetBrains Mono", ui-monospace, monospace;
+    --math:"STIX Two Text","Cambria Math","Times New Roman",serif;
+
+    --cell:28px;
+    --maxw:1080px;
+  }
+
+  .tau-landing, .tau-landing *{box-sizing:border-box;}
+  .tau-landing{
+    margin:0;
+    background:var(--ground);
+    color:var(--ink);
+    font-family:var(--serif);
+    font-weight:400;
+    font-size:18px;
+    line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+    /* notebook grid */
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size:var(--cell) var(--cell), var(--cell) var(--cell);
+    position:relative;
+    width:100vw;
+    margin-left:calc(50% - 50vw);
+    margin-right:calc(50% - 50vw);
+    min-height:100vh;
+    overflow:hidden;
+  }
+  /* faint top-fade so the grid feels like paper, not a screen */
+  .tau-landing::before{
+    content:"";
+    position:fixed; inset:0;
+    background:radial-gradient(120% 80% at 50% -10%, rgba(255,255,255,.85), rgba(255,255,255,0) 60%);
+    pointer-events:none; z-index:0;
+  }
+  /* red margin line of a notebook */
+  .tau-landing::after{
+    content:"";
+    position:fixed; top:0; bottom:0;
+    left:calc(var(--cell) * 3 + 1px);
+    width:1.5px;
+    background:var(--red);
+    opacity:.45;
+    pointer-events:none; z-index:1;
+  }
+  @media (max-width:720px){
+    .tau-landing::after{ left:calc(var(--cell) * 1.5); }
+  }
+
+  .wrap{
+    position:relative; z-index:2;
+    max-width:var(--maxw);
+    margin:0 auto;
+    padding:0 32px;
+  }
+  @media (max-width:720px){ .wrap{ padding:0 22px; } }
+
+  .tau-landing a{color:inherit; text-decoration:none;}
+
+  /* ---- eyebrow / labels ---- */
+  .eyebrow{
+    font-family:var(--grotesk);
+    font-weight:500;
+    font-size:12.5px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:var(--ink-soft);
+  }
+  .tau{ font-family:var(--math); font-style:italic; }
+
+  /* ---- nav ---- */
+  .tau-landing nav{
+    position:relative; z-index:3;
+    display:flex; align-items:baseline; justify-content:space-between;
+    padding:26px 0 0;
+  }
+  .brand{ display:flex; align-items:baseline; gap:12px; }
+  .brand .glyph{
+    font-family:var(--math); font-style:italic;
+    font-size:30px; line-height:1; color:var(--accent);
+  }
+  .brand .name{
+    font-family:var(--grotesk); font-weight:500;
+    letter-spacing:.04em; font-size:18px;
+  }
+  .brand .ver{
+    font-family:var(--mono); font-size:12px; color:var(--ink-soft);
+    border:1px solid var(--grid-strong); border-radius:2px;
+    padding:1px 6px; transform:translateY(-2px);
+  }
+  .navlinks{ display:flex; gap:28px; font-family:var(--grotesk); font-size:14.5px; }
+  .navlinks a{ color:var(--ink-soft); transition:color .2s; }
+  .navlinks a:hover{ color:var(--accent); }
+  @media (max-width:560px){ .navlinks a:not(.gh){ display:none; } }
+
+  /* ---- hero ---- */
+  .tau-landing header{ padding:74px 0 40px; }
+  .hero-grid{
+    display:grid;
+    grid-template-columns:1.02fr .98fr;
+    gap:48px; align-items:center;
+  }
+  @media (max-width:860px){
+    .hero-grid{ grid-template-columns:1fr; gap:30px; }
+    .tau-landing header{ padding:48px 0 24px; }
+  }
+
+  .tau-landing h1{
+    font-family:var(--serif);
+    font-weight:300;
+    font-size:clamp(40px, 7vw, 76px);
+    line-height:1.04;
+    letter-spacing:-0.015em;
+    margin:18px 0 0;
+  }
+  .tau-landing h1 em{ font-style:italic; font-weight:400; color:var(--accent); }
+  .tau-landing h1 .big-tau{
+    font-family:var(--math); font-style:italic; font-weight:400;
+    color:var(--accent);
+  }
+  .lede{
+    margin:24px 0 0; max-width:30em;
+    color:var(--ink); font-weight:400; font-size:19px;
+  }
+  .lede strong{ font-weight:600; }
+
+  .cta-row{ display:flex; flex-wrap:wrap; gap:14px; align-items:center; margin-top:34px; }
+  .install{
+    display:inline-flex; align-items:center; gap:12px;
+    font-family:var(--mono); font-size:14.5px;
+    background:var(--ink); color:#fff;
+    padding:13px 18px; border-radius:4px;
+  }
+  .install .dollar{ color:var(--red); }
+  .install .copy{
+    margin-left:6px; font-family:var(--grotesk); font-size:11px;
+    letter-spacing:.1em; text-transform:uppercase;
+    color:rgba(255,255,255,.55); cursor:pointer; transition:color .2s;
+    background:none; border:none; padding:0;
+  }
+  .install .copy:hover{ color:#fff; }
+  .ghost{
+    font-family:var(--grotesk); font-size:15px; font-weight:500;
+    color:var(--accent);
+    border-bottom:1.5px solid var(--accent);
+    padding-bottom:2px; transition:opacity .2s;
+  }
+  .ghost:hover{ opacity:.65; }
+  .ghost .arr{ font-family:var(--serif); }
+
+  /* ---- canvas figure ---- */
+  .figure{
+    position:relative;
+    border:1px solid var(--grid-strong);
+    border-radius:6px;
+    background:rgba(255,255,255,.6);
+    backdrop-filter:blur(1px);
+    padding:14px;
+    box-shadow:0 1px 0 rgba(19,33,60,.04), 0 24px 48px -28px rgba(19,33,60,.28);
+  }
+  .figure canvas{ display:block; width:100%; height:auto; }
+  .figure .figlabel{
+    position:absolute; top:14px; left:18px;
+    font-family:var(--grotesk); font-size:11px; letter-spacing:.18em;
+    text-transform:uppercase; color:var(--ink-soft);
+  }
+  .figure .figval{
+    position:absolute; bottom:16px; right:18px;
+    font-family:var(--mono); font-size:13px; color:var(--accent);
+  }
+
+  /* ---- definition strip ---- */
+  .strip{
+    border-top:1px solid var(--grid-strong);
+    border-bottom:1px solid var(--grid-strong);
+    margin-top:30px;
+    display:grid; grid-template-columns:repeat(3,1fr);
+  }
+  .strip .cellitem{
+    padding:24px 6px; text-align:center;
+    border-right:1px solid var(--grid-strong);
+  }
+  .strip .cellitem:last-child{ border-right:none; }
+  .strip .num{
+    font-family:var(--math); font-style:italic;
+    font-size:30px; color:var(--accent); line-height:1;
+  }
+  .strip .cap{
+    display:block; margin-top:8px;
+    font-family:var(--grotesk); font-size:12px; letter-spacing:.14em;
+    text-transform:uppercase; color:var(--ink-soft);
+  }
+  @media (max-width:560px){
+    .strip{ grid-template-columns:1fr; }
+    .strip .cellitem{ border-right:none; border-bottom:1px solid var(--grid-strong); }
+    .strip .cellitem:last-child{ border-bottom:none; }
+  }
+
+  /* ---- section scaffolding ---- */
+  .tau-landing section{ padding:88px 0; }
+  .sec-head{ display:flex; align-items:baseline; gap:18px; margin-bottom:44px; }
+  .sec-head .mark{
+    font-family:var(--mono); font-size:13px; color:var(--red);
+    transform:translateY(-2px);
+  }
+  .sec-head h2{
+    font-family:var(--serif); font-weight:400; font-style:italic;
+    font-size:clamp(26px,4vw,38px); margin:0; letter-spacing:-0.01em;
+  }
+
+  /* ---- layers ---- */
+  .layers{ display:grid; grid-template-columns:repeat(3,1fr); gap:1px;
+    background:var(--grid-strong); border:1px solid var(--grid-strong); border-radius:6px; overflow:hidden; }
+  @media (max-width:760px){ .layers{ grid-template-columns:1fr; } }
+  .layer{ background:var(--ground); padding:30px 26px 34px; position:relative; }
+  .layer .pkg{ font-family:var(--mono); font-size:13.5px; color:var(--accent); }
+  .layer h3{ font-family:var(--serif); font-weight:500; font-size:21px; margin:14px 0 8px; }
+  .layer p{ margin:0; font-size:16px; color:var(--ink-soft); line-height:1.55; }
+  .layer .idx{
+    position:absolute; top:24px; right:24px;
+    font-family:var(--math); font-style:italic; font-size:22px; color:var(--grid-strong);
+  }
+
+  /* ---- principles ---- */
+  .principles{ display:grid; grid-template-columns:repeat(2,1fr); gap:36px 56px; }
+  @media (max-width:680px){ .principles{ grid-template-columns:1fr; } }
+  .pr{ border-top:1.5px solid var(--ink); padding-top:18px; }
+  .pr h3{ font-family:var(--serif); font-weight:600; font-size:20px; margin:0 0 8px; }
+  .pr p{ margin:0; font-size:16.5px; color:var(--ink-soft); }
+
+  /* ---- code block ---- */
+  .terminal{
+    border:1px solid var(--grid-strong); border-radius:8px; overflow:hidden;
+    background:#0E1A30;
+    box-shadow:0 28px 60px -34px rgba(19,33,60,.5);
+  }
+  .terminal .bar{
+    display:flex; align-items:center; gap:8px;
+    padding:12px 16px; border-bottom:1px solid rgba(255,255,255,.07);
+  }
+  .terminal .bar span{ width:11px; height:11px; border-radius:50%; background:rgba(255,255,255,.18); }
+  .terminal .bar span:first-child{ background:var(--red); opacity:.8; }
+  .terminal .bar .t{ width:auto; height:auto; border-radius:0; background:none;
+    margin-left:8px; font-family:var(--mono); font-size:12px; color:rgba(255,255,255,.4); }
+  .terminal pre{
+    margin:0; padding:24px 22px; overflow-x:auto;
+    font-family:var(--mono); font-size:14px; line-height:1.85; color:#D7E0F4;
+  }
+  .terminal .pmt{ color:var(--red); }
+  .terminal .cmd{ color:#fff; }
+  .terminal .out{ color:#7F8CAA; }
+  .terminal .key{ color:#8FB4FF; }
+
+  .two{ display:grid; grid-template-columns:.85fr 1.15fr; gap:48px; align-items:center; }
+  @media (max-width:820px){ .two{ grid-template-columns:1fr; gap:28px; } }
+  .two p{ color:var(--ink-soft); }
+  .two h2{ font-family:var(--serif); font-weight:400; font-style:italic;
+    font-size:clamp(26px,4vw,36px); margin:0 0 16px; }
+
+  /* ---- closing ---- */
+  .closing{ text-align:center; padding:110px 0 90px; }
+  .closing .turn{
+    font-family:var(--math); font-style:italic;
+    font-size:clamp(64px,16vw,150px); color:var(--accent); line-height:.9;
+    display:block;
+  }
+  .closing p{ max-width:24em; margin:22px auto 0; color:var(--ink-soft); }
+  .closing .cta-row{ justify-content:center; }
+
+  .tau-landing footer{
+    border-top:1px solid var(--grid-strong);
+    padding:34px 0 60px;
+    display:flex; justify-content:space-between; align-items:center;
+    font-family:var(--grotesk); font-size:13.5px; color:var(--ink-soft);
+    flex-wrap:wrap; gap:14px;
+  }
+  .tau-landing footer a:hover{ color:var(--accent); }
+  footer .l{ display:flex; gap:24px; }
+
+  .tau-landing :focus-visible{ outline:2px solid var(--accent); outline-offset:3px; border-radius:2px; }
+
+  @media (prefers-reduced-motion:reduce){ .tau-landing{ scroll-behavior:auto; } }

--- a/docs/assets/landing.js
+++ b/docs/assets/landing.js
@@ -1,0 +1,112 @@
+(function(){
+  // ---- copy buttons ----
+  function bindCopy(id){
+    var b = document.getElementById(id);
+    if(!b) return;
+    b.addEventListener("click", function(){
+      navigator.clipboard && navigator.clipboard.writeText("uv tool install tau");
+      var t = b.textContent; b.textContent = "copied";
+      setTimeout(function(){ b.textContent = t; }, 1400);
+    });
+  }
+  bindCopy("copyBtn"); bindCopy("copyBtn2");
+
+  // ---- the hero: a radius sweeps the unit circle through one full turn (0 -> tau),
+  //      tracing exactly one period of a sine wave on the notebook grid ----
+  var canvas = document.getElementById("tauCanvas");
+  var ctx = canvas.getContext("2d");
+  var INK   = "#13213C";
+  var BLUE  = "#1B3FA0";
+  var RED   = "#D6435B";
+  var SOFT  = "#9FB0D0";
+  var TAU   = Math.PI * 2;
+
+  var W = canvas.width, H = canvas.height, DPR = 1;
+  function resize(){
+    DPR = Math.min(window.devicePixelRatio || 1, 2);
+    var cssW = canvas.clientWidth || 520;
+    var cssH = cssW * (380/520);
+    canvas.width = Math.round(cssW * DPR);
+    canvas.height = Math.round(cssH * DPR);
+    W = canvas.width; H = canvas.height;
+  }
+  resize();
+  window.addEventListener("resize", resize);
+
+  var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var thetaLabel = document.getElementById("thetaVal");
+
+  function draw(theta){
+    ctx.clearRect(0,0,W,H);
+    ctx.save();
+    ctx.scale(DPR, DPR);
+    var w = W/DPR, h = H/DPR;
+
+    var pad = 26;
+    var cx = pad + (h/2 - pad);          // circle centre x
+    var cy = h/2;                         // baseline / circle centre y
+    var R  = h/2 - pad - 8;               // unit radius in px
+    var waveX0 = cx + R + 18;             // wave starts to the right of circle
+    var waveW  = w - waveX0 - pad;
+
+    // baseline axis
+    ctx.strokeStyle = SOFT; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(pad, cy); ctx.lineTo(w - pad, cy); ctx.stroke();
+
+    // unit circle
+    ctx.strokeStyle = "#C9D6EE"; ctx.lineWidth = 1.4;
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, TAU); ctx.stroke();
+
+    // traced sine wave so far
+    ctx.strokeStyle = BLUE; ctx.lineWidth = 2;
+    ctx.beginPath();
+    for(var i=0; i<=theta; i+=0.02){
+      var x = waveX0 + (i/TAU) * waveW;
+      var y = cy - Math.sin(i) * R;
+      if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    }
+    // close to exact theta
+    var ex = waveX0 + (theta/TAU) * waveW;
+    var ey = cy - Math.sin(theta) * R;
+    ctx.lineTo(ex, ey);
+    ctx.stroke();
+
+    // radius
+    var px = cx + Math.cos(theta) * R;
+    var py = cy - Math.sin(theta) * R;
+    ctx.strokeStyle = INK; ctx.lineWidth = 1.6;
+    ctx.beginPath(); ctx.moveTo(cx, cy); ctx.lineTo(px, py); ctx.stroke();
+
+    // projection line from circle point to wave point
+    ctx.strokeStyle = RED; ctx.lineWidth = 1; ctx.setLineDash([3,4]);
+    ctx.beginPath(); ctx.moveTo(px, py); ctx.lineTo(ex, ey); ctx.stroke();
+    ctx.setLineDash([]);
+
+    // moving points
+    ctx.fillStyle = RED;
+    ctx.beginPath(); ctx.arc(px, py, 4, 0, TAU); ctx.fill();
+    ctx.beginPath(); ctx.arc(ex, ey, 4, 0, TAU); ctx.fill();
+
+    // centre dot
+    ctx.fillStyle = INK;
+    ctx.beginPath(); ctx.arc(cx, cy, 2.4, 0, TAU); ctx.fill();
+
+    ctx.restore();
+
+    if(thetaLabel) thetaLabel.innerHTML = "&#952; = " + theta.toFixed(2);
+  }
+
+  if(reduce){
+    draw(TAU * 0.78);
+  } else {
+    var theta = 0;
+    var speed = TAU / 260; // ~ one turn every ~4.3s at 60fps
+    function frame(){
+      theta += speed;
+      if(theta > TAU) theta = 0;
+      draw(theta);
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+  }
+})();

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,69 +1,161 @@
-# Tau
+---
+title: Tau
+description: A minimalist coding-agent harness in Python.
+hide:
+  - navigation
+  - toc
+  - edit
+---
 
-Tau is a Python implementation of Pi's minimalist coding-agent harness architecture.
+<div class="tau-landing">
+<div class="wrap">
+  <nav>
+    <div class="brand">
+      <span class="glyph">&#964;</span>
+      <span class="name">tau</span>
+      <span class="ver">v0.1</span>
+    </div>
+    <div class="navlinks">
+      <a href="getting-started/">Docs</a>
+      <a href="https://github.com/alejandro-ao/tau/issues/1">Roadmap</a>
+      <a href="#start">Getting started</a>
+      <a class="gh" href="https://github.com/alejandro-ao/tau">GitHub &#8599;</a>
+    </div>
+  </nav>
 
-The project is intentionally built in small, documented phases. Each phase adds one layer to the system while keeping the core agent harness independent from the coding-agent app and from any terminal UI framework.
+  <header>
+    <div class="hero-grid">
+      <div>
+        <p class="eyebrow">A minimalist coding-agent harness</p>
+        <h1>A coding agent<br />small enough to <em>read.</em></h1>
+        <p class="lede">
+          <strong>Tau</strong> is a terminal coding agent in Python &mdash; and a
+          phase-by-phase reference for how one is actually built. Named for
+          <span class="tau">&#964;</span>&#8202;=&#8202;2&#960;: one full turn,
+          nothing hidden.
+        </p>
+        <div class="cta-row">
+          <span class="install">
+            <span><span class="dollar">$</span> uv tool install tau</span>
+            <button class="copy" id="copyBtn" type="button" aria-label="Copy install command">copy</button>
+          </span>
+          <a class="ghost" href="getting-started/">Read the docs <span class="arr">&rarr;</span></a>
+        </div>
+      </div>
 
-## Architecture at a glance
+      <figure class="figure">
+        <span class="figlabel">&#952; sweeps 0 &rarr; &#964;</span>
+        <canvas id="tauCanvas" width="520" height="380" role="img"
+          aria-label="A radius sweeping a unit circle through one full turn, tracing one period of a sine wave on notebook paper."></canvas>
+        <span class="figval" id="thetaVal">&#952; = 0.00</span>
+      </figure>
+    </div>
 
-```text
-tau_ai       provider/model streaming layer
-tau_agent    portable agent harness, loop, tools, events, sessions
-tau_coding   CLI app, resources, skills, extensions, commands, UI integration
-```
+    <div class="strip">
+      <div class="cellitem"><span class="num">&#964;&#8202;=&#8202;6.283&#8230;</span><span class="cap">one full turn</span></div>
+      <div class="cellitem"><span class="num">3</span><span class="cap">small layers</span></div>
+      <div class="cellitem"><span class="num">0</span><span class="cap">magic</span></div>
+    </div>
+  </header>
+</div>
 
-The key design boundary is:
+<div class="wrap">
+  <section id="start">
+    <div class="sec-head">
+      <span class="mark">01</span>
+      <h2>Three layers, each explainable on its own</h2>
+    </div>
+    <div class="layers">
+      <div class="layer">
+        <span class="idx">&#8544;</span>
+        <span class="pkg">tau_ai</span>
+        <h3>The provider</h3>
+        <p>Models stream events. A thin layer turns provider responses into a single, ordered event stream you can follow line by line.</p>
+      </div>
+      <div class="layer">
+        <span class="idx">&#8545;</span>
+        <span class="pkg">tau_agent</span>
+        <h3>The harness</h3>
+        <p>A portable brain: the loop that turns events into tool calls, owns transcript and session state, and stays free of any one app.</p>
+      </div>
+      <div class="layer">
+        <span class="idx">&#8546;</span>
+        <span class="pkg">tau_coding</span>
+        <h3>The agent</h3>
+        <p>Files, shell, sessions, skills, commands, and a terminal UI &mdash; one concrete coding environment built on the harness.</p>
+      </div>
+    </div>
+  </section>
 
-```text
-AgentHarness = reusable brain
-AgentSession = coding-agent environment
-TUI = one possible frontend
-```
+  <section>
+    <div class="two">
+      <div>
+        <p class="eyebrow">The boundary</p>
+        <h2>A reusable brain, a swappable body.</h2>
+        <p>The <span class="tau">&#964;</span> harness is the agent. The session is its environment. The terminal is just one possible face. Keep them apart and the whole thing stays legible.</p>
+      </div>
+      <div class="terminal" aria-hidden="true">
+        <div class="bar"><span></span><span></span><span></span><span class="t">tau &mdash; session</span></div>
+        <pre><span class="pmt">&#964; &rsaquo;</span> <span class="cmd">fix the failing test in parser.py</span>
 
-## Current status
+<span class="out">  reading  </span><span class="key">parser.py</span><span class="out">, </span><span class="key">test_parser.py</span>
+<span class="out">  edit     </span><span class="key">parser.py</span><span class="out">  +4 &minus;1</span>
+<span class="out">  run      </span><span class="key">uv run pytest -q</span>
+<span class="out">  &check; 1 passed in 0.21s</span>
 
-Tau currently has:
+<span class="pmt">&#964; &rsaquo;</span> <span class="cmd">_</span></pre>
+      </div>
+    </div>
+  </section>
 
-- project/package foundation
-- development tooling
-- a `tau` console command that opens the Textual TUI by default
-- non-interactive print-mode prompts
-- provider-neutral message, tool, result, and event models
-- a provider-neutral model streaming interface
-- deterministic fake model provider for tests
-- OpenAI-compatible, Anthropic, and OpenAI Codex subscription provider adapters
-- provider retry events with configurable retry/backoff behavior
-- provider-neutral thinking/reasoning delta events
-- a pure agent loop that streams events, executes tools, drains queued prompts,
-  and grows the transcript
-- a reusable `AgentHarness` that owns transcript state, cancellation, and
-  steering/follow-up queues
-- append-only home-directory sessions
-- skills, prompt templates, and project instruction discovery
-- slash commands with TUI autocomplete
-- provider setup and switching
-- stored Tau credentials with environment-variable fallback
-- context accounting, manual/automatic compaction, and HTML session export
-- a Textual TUI with responsive sidebar, click-anywhere prompt refocus,
-  text selection, selected-message copy, activity status, thinking controls,
-  optional thinking-token display, and queued steering/follow-up prompts while
-  the agent is running
-- beginner-friendly design documentation
+  <section>
+    <div class="sec-head">
+      <span class="mark">02</span>
+      <h2>The philosophy</h2>
+    </div>
+    <div class="principles">
+      <div class="pr">
+        <h3>Small layers beat magic</h3>
+        <p>Every package has one job and can be explained without the others. No framework you have to believe in.</p>
+      </div>
+      <div class="pr">
+        <h3>Explicit over clever</h3>
+        <p>The control flow is on the page. Streaming, tool calls, sessions &mdash; readable top to bottom.</p>
+      </div>
+      <div class="pr">
+        <h3>Built phase by phase</h3>
+        <p>Each commit adds one understandable piece, so the repo doubles as a course in how agents are assembled.</p>
+      </div>
+      <div class="pr">
+        <h3>Usable, not just instructive</h3>
+        <p>It is a real terminal agent you can run today &mdash; the teaching is a side effect of the design, not a toy.</p>
+      </div>
+    </div>
+  </section>
 
-## Where to start
+  <section class="closing">
+    <span class="turn">&#964;</span>
+    <p>Start the loop. Watch a coding agent run with nothing hidden between you and the code.</p>
+    <div class="cta-row">
+      <span class="install">
+        <span><span class="dollar">$</span> uv tool install tau</span>
+        <button class="copy" id="copyBtn2" type="button" aria-label="Copy install command">copy</button>
+      </span>
+      <a class="ghost" href="https://github.com/alejandro-ao/tau">View on GitHub <span class="arr">&rarr;</span></a>
+    </div>
+  </section>
 
-- New to the project? Read [Getting Started](getting-started.md).
-- Installing Tau as a command? Read [Installation](installation.md).
-- Looking for file formats and paths? Read [Configuration and Files](configuration.md).
-- Want reusable prompt templates? Read [Custom Prompts](custom-prompts.md).
-- Want the full plan? Read the [Roadmap](00-roadmap.md).
-- Want the big-picture boundaries? Read [Architecture](01-architecture.md).
-- Want the current core model? Read [Core Types and Events](05-core-types-and-events.md).
-- Want to configure model backends? Read [Providers](providers.md).
-- Want to understand long-session context management? Read
-  [Context Compaction](context-compaction.md).
-- Want to understand the execution engine? Read [Agent Loop](agent-loop.md).
-- Want the reusable stateful brain? Read [Agent Harness](harness.md).
-- Want to build another frontend? Read [Building a Custom TUI](custom-tui.md).
-- Want a summary of the completed pre-extension hardening work? Read
-  [Pre-extension Hardening Summary](architecture/pre-extension-hardening.md).
+  <footer>
+    <div class="brand">
+      <span class="glyph" style="font-size:20px;">&#964;</span>
+      <span class="name">tau</span>
+    </div>
+    <div class="l">
+      <a href="getting-started/">Docs</a>
+      <a href="https://github.com/alejandro-ao/tau">GitHub</a>
+      <a href="https://github.com/alejandro-ao/tau/issues/1">Roadmap</a>
+    </div>
+    <span>A teaching project &middot; inspired by Pi</span>
+  </footer>
+</div>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,12 @@ edit_uri: edit/main/docs/
 
 copyright: Copyright &copy; 2026 Alejandro AO
 
+extra_css:
+  - assets/landing.css
+
+extra_javascript:
+  - assets/landing.js
+
 theme:
   name: material
   palette:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -190,6 +190,7 @@ class CodingSessionConfig:
     auto_compact_token_threshold: int | None = None
     auto_compact_enabled: bool = True
     thinking_level: ThinkingLevel = DEFAULT_THINKING_LEVEL
+    index_on_first_persist: bool = False
 
 
 class CodingSession:
@@ -952,7 +953,7 @@ class CodingSession:
         return f"Resumed session: {record.id}"
 
     async def new_session(self) -> str:
-        """Replace this session's active state with a newly indexed session."""
+        """Replace this session's active state with a pending unindexed session."""
         manager = self._config.session_manager
         if manager is None:
             raise ValueError("Session manager is not available")
@@ -972,7 +973,7 @@ class CodingSession:
                 current=self._thinking_level,
             )
 
-        record = manager.create_session(
+        record = manager.prepare_session(
             cwd=self.cwd,
             model=model,
             provider_name=provider_name,
@@ -989,6 +990,7 @@ class CodingSession:
                 provider_settings=self._provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 thinking_level=thinking_level,
+                index_on_first_persist=True,
             )
         )
         self._config = replacement._config
@@ -1249,6 +1251,21 @@ class CodingSession:
         for entry in self._pending_initial_entries:
             await self._config.storage.append(entry)
         self._pending_initial_entries = ()
+        if self._config.index_on_first_persist:
+            self._index_current_session()
+
+    def _index_current_session(self) -> None:
+        if self._config.session_id is None or self._config.session_manager is None:
+            return
+        existing = self._config.session_manager.get_session(self._config.session_id)
+        if existing is not None:
+            return
+        self._config.session_manager.create_session(
+            cwd=self.cwd,
+            model=self.model,
+            provider_name=self.provider_name,
+            session_id=self._config.session_id,
+        )
 
     async def _try_auto_compact(
         self,

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -113,12 +113,32 @@ class SessionManager:
         session_id: str | None = None,
     ) -> CodingSessionRecord:
         """Create and index a new session record."""
+        record = self.prepare_session(
+            cwd=cwd,
+            model=model,
+            provider_name=provider_name,
+            title=title,
+            session_id=session_id,
+        )
+        self.index_session(record)
+        return record
+
+    def prepare_session(
+        self,
+        *,
+        cwd: Path,
+        model: str,
+        provider_name: str | None = None,
+        title: str | None = None,
+        session_id: str | None = None,
+    ) -> CodingSessionRecord:
+        """Return metadata for a session without adding it to the resume index."""
         now = time()
         resolved_cwd = cwd.resolve()
         record_id = session_id or uuid4().hex
         path = self.paths.project_session_dir(resolved_cwd) / f"{record_id}.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
-        record = CodingSessionRecord(
+        return CodingSessionRecord(
             id=record_id,
             path=path,
             cwd=resolved_cwd,
@@ -128,6 +148,9 @@ class SessionManager:
             created_at=now,
             updated_at=now,
         )
+
+    def index_session(self, record: CodingSessionRecord) -> CodingSessionRecord:
+        """Add a prepared session record to the resume index."""
         self._upsert(record)
         return record
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3556,13 +3556,13 @@ def _create_startup_session_record(
     selection: ProviderSelection,
 ) -> CodingSessionRecord:
     try:
-        return manager.create_session(
+        return manager.prepare_session(
             cwd=cwd,
             model=selection.model,
             provider_name=selection.provider.name,
         )
     except TypeError:
-        return manager.create_session(cwd=cwd, model=selection.model)
+        return manager.prepare_session(cwd=cwd, model=selection.model)
 
 
 def _resolve_tui_startup_selection(
@@ -3693,12 +3693,14 @@ async def run_tui_app(
         runtime_provider_config = None
     session: CodingSession | None = None
     try:
+        index_on_first_persist = False
         if record is None:
             record = _create_startup_session_record(
                 manager,
                 cwd=cwd,
                 selection=selection,
             )
+            index_on_first_persist = manager.get_session(record.id) is None
 
         session = await CodingSession.load(
             CodingSessionConfig(
@@ -3712,6 +3714,7 @@ async def run_tui_app(
                 provider_settings=provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=auto_compact_token_threshold,
+                index_on_first_persist=index_on_first_persist,
             )
         )
         app = TauTuiApp(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2334,9 +2334,73 @@ async def test_session_new_session_uses_default_provider_model(
     assert message.startswith("Started new session: ")
     assert session.provider_name == "openai"
     assert session.model == "gpt-5"
-    assert manager.get_session(session.session_id).provider_name == "openai"  # type: ignore[arg-type]
-    assert manager.get_session(session.session_id).model == "gpt-5"  # type: ignore[arg-type]
+    assert manager.get_session(session.session_id) is None
     assert created == [("openai", "gpt-5")]
+
+
+@pytest.mark.anyio
+async def test_session_new_session_is_indexed_after_first_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    current_record = manager.create_session(cwd=tmp_path, model="fake", provider_name="fake")
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5",),
+                default_model="gpt-5",
+            ),
+        ),
+    )
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level
+        return FakeProvider(
+            [
+                [
+                    ProviderResponseStartEvent(model="gpt-5"),
+                    ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+                ]
+            ]
+        )
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(current_record.path),
+            cwd=current_record.cwd,
+            session_id=current_record.id,
+            session_manager=manager,
+            provider_name="fake",
+            provider_settings=settings,
+        )
+    )
+
+    _message = await session.new_session()
+    pending_id = session.session_id
+
+    assert pending_id is not None
+    assert manager.get_session(pending_id) is None
+    assert all(record.id != pending_id for record in manager.list_sessions(tmp_path))
+
+    _events = await _collect_session_events(session.prompt("Hello"))
+
+    indexed = manager.get_session(pending_id)
+    assert indexed is not None
+    assert indexed.provider_name == "openai"
+    assert indexed.model == "gpt-5"
+    assert indexed.path.exists()
 
 
 @pytest.mark.anyio

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -29,6 +29,25 @@ def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
     assert manager.list_sessions(cwd) == [record]
 
 
+def test_session_manager_prepares_unindexed_session(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+
+    record = manager.prepare_session(cwd=cwd, model="fake", provider_name="fake-provider")
+
+    assert record.provider_name == "fake-provider"
+    assert record.path.name == f"{record.id}.jsonl"
+    assert manager.get_session(record.id) is None
+    assert manager.list_sessions(cwd) == []
+
+    indexed = manager.index_session(record)
+
+    assert indexed == record
+    assert manager.get_session(record.id) == record
+    assert manager.list_sessions(cwd) == [record]
+
+
 def test_session_manager_filters_sessions_by_project_cwd(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
     first_cwd = tmp_path / "first"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4021,14 +4021,14 @@ async def test_run_tui_app_falls_back_to_first_credentialed_provider(
             calls.append("provider_closed")
 
     class FakeManager:
-        def create_session(
+        def prepare_session(
             self,
             *,
             cwd: Path,
             model: str,
             provider_name: str | None = None,
         ) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            calls.append(f"prepare:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -4085,7 +4085,7 @@ async def test_run_tui_app_falls_back_to_first_credentialed_provider(
 
     assert calls == [
         "provider:openai:gpt-5.5",
-        f"create:{tmp_path}:gpt-5.5:openai",
+        f"prepare:{tmp_path}:gpt-5.5:openai",
         "load",
         "run",
         "provider_closed",
@@ -4127,14 +4127,14 @@ async def test_run_tui_app_ignores_latest_directory_provider_model_for_new_sessi
             calls.append(f"latest:{cwd}")
             return latest_record
 
-        def create_session(
+        def prepare_session(
             self,
             *,
             cwd: Path,
             model: str,
             provider_name: str | None = None,
         ) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            calls.append(f"prepare:{cwd}:{model}:{provider_name}")
             return created_record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -4188,7 +4188,7 @@ async def test_run_tui_app_ignores_latest_directory_provider_model_for_new_sessi
 
     assert calls == [
         "provider:openai:gpt-5",
-        f"create:{tmp_path}:gpt-5:openai",
+        f"prepare:{tmp_path}:gpt-5:openai",
         "load",
         "run",
         "provider_closed",
@@ -4237,14 +4237,14 @@ async def test_run_tui_app_does_not_start_new_session_from_scoped_model(
             calls.append(f"latest:{cwd}")
             return latest
 
-        def create_session(
+        def prepare_session(
             self,
             *,
             cwd: Path,
             model: str,
             provider_name: str | None = None,
         ) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            calls.append(f"prepare:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -4298,7 +4298,7 @@ async def test_run_tui_app_does_not_start_new_session_from_scoped_model(
 
     assert calls == [
         "provider:openai:gpt-5.5",
-        f"create:{tmp_path}:gpt-5.5:openai",
+        f"prepare:{tmp_path}:gpt-5.5:openai",
         "load",
         "run",
         "provider_closed",
@@ -4325,14 +4325,14 @@ async def test_run_tui_app_creates_new_session_by_default(
             calls.append("provider_closed")
 
     class FakeManager:
-        def create_session(
+        def prepare_session(
             self,
             *,
             cwd: Path,
             model: str,
             provider_name: str | None = None,
         ) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            calls.append(f"prepare:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -4347,6 +4347,7 @@ async def test_run_tui_app_creates_new_session_by_default(
         async def load(cls, config: object) -> str:
             assert config.provider_name == "local"  # type: ignore[attr-defined]
             assert config.auto_compact_token_threshold == 1000  # type: ignore[attr-defined]
+            assert config.index_on_first_persist is True  # type: ignore[attr-defined]
             calls.append("load")
             return "session"
 
@@ -4390,7 +4391,13 @@ async def test_run_tui_app_creates_new_session_by_default(
         session_manager=FakeManager(),
     )
 
-    assert calls == [f"create:{tmp_path}:local-model:local", "load", "run", "provider_closed"]
+    assert calls == [
+        f"prepare:{tmp_path}:local-model:local",
+        "get:new-session",
+        "load",
+        "run",
+        "provider_closed",
+    ]
 
 
 @pytest.mark.anyio
@@ -4409,14 +4416,14 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     )
 
     class FakeManager:
-        def create_session(
+        def prepare_session(
             self,
             *,
             cwd: Path,
             model: str,
             provider_name: str | None = None,
         ) -> CodingSessionRecord:
-            calls.append(f"create:{cwd}:{model}:{provider_name}")
+            calls.append(f"prepare:{cwd}:{model}:{provider_name}")
             return record
 
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
@@ -4453,7 +4460,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
 
     await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
 
-    assert calls == [f"create:{tmp_path}:gpt-5.5:openai", "load:LoginRequiredProvider", "run"]
+    assert calls == [f"prepare:{tmp_path}:gpt-5.5:openai", "load:LoginRequiredProvider", "run"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- add a prepared/unindexed session path to `SessionManager`
- make TUI startup and `/new` use pending session records instead of immediately indexing empty sessions
- index pending sessions only when the first durable session entries are flushed
- add regression coverage for `/new` staying hidden from resume until the first message persists

Closes #179.

## Tests

- `uv run pytest tests/test_session_manager.py tests/test_coding_session.py::test_load_empty_session_defers_transcript_file tests/test_coding_session.py::test_prompt_persists_user_assistant_and_leaf_entries tests/test_coding_session.py::test_session_touches_session_manager_after_persisting_messages tests/test_coding_session.py::test_session_new_session_uses_default_provider_model tests/test_coding_session.py::test_session_new_session_is_indexed_after_first_message tests/test_tui_app.py::test_run_tui_app_creates_new_session_by_default`
- `uv run pytest tests/test_tui_app.py::test_run_tui_app_falls_back_to_first_credentialed_provider tests/test_tui_app.py::test_run_tui_app_ignores_latest_directory_provider_model_for_new_session tests/test_tui_app.py::test_run_tui_app_does_not_start_new_session_from_scoped_model tests/test_tui_app.py::test_run_tui_app_creates_new_session_by_default tests/test_tui_app.py::test_run_tui_app_opens_when_provider_login_is_missing tests/test_tui_app.py::test_run_tui_app_resumes_explicit_session`
- `uv run mypy src/tau_coding/session.py src/tau_coding/session_manager.py src/tau_coding/tui/app.py`
- `git diff --check`
