### PR TITLE
Configure custom domain twotimespi.dev

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -56,7 +56,7 @@ function remarkRelativeMdLinks() {
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://alejandro-ao.github.io",
+  site: "https://twotimespi.dev",
   base: BASE,
   markdown: {
     remarkPlugins: [remarkRelativeMdLinks],

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+twotimespi.dev


### PR DESCRIPTION
Sets up the docs site to serve from the custom domain **twotimespi.dev**.

- `website/public/CNAME` → `twotimespi.dev` (GitHub Pages reads this to bind the domain; survives re-deploys).
- `site: "https://twotimespi.dev"` in `astro.config.mjs` for canonical URLs and the sitemap. Base is already `/`.

Still required outside the repo: Namecheap DNS records, GitHub Pages custom-domain setting + Enforce HTTPS, and re-enabling the deploy workflow's push trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)