### PR TITLE
feat(openai): route gpt-5.5/5.4/codex to the /v1/responses API

### DIFF
--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -1,8 +1,18 @@
-"""OpenAI-compatible chat completions provider."""
+"""OpenAI-compatible chat completions provider.
 
-from collections.abc import AsyncIterator, Mapping
+Most OpenAI-compatible models are served over `/chat/completions`. Newer
+reasoning models (e.g. ``gpt-5.5``/``gpt-5.4`` and the ``*-codex`` family)
+reject the combination of function tools and ``reasoning_effort`` on that
+endpoint and require ``/v1/responses`` instead. This adapter routes those
+models to the Responses API at request time while leaving every other model on
+the original chat-completions path unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Mapping
 from json import JSONDecodeError, dumps, loads
-from typing import Any
+from typing import Any, Protocol
 
 import httpx
 
@@ -22,9 +32,24 @@ from tau_ai.events import (
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
+# Models that reject function tools + reasoning_effort on /chat/completions and
+# must use the /v1/responses endpoint instead.
+_RESPONSES_ONLY_PREFIXES: tuple[str, ...] = ("gpt-5.5", "gpt-5.4")
+
+
+def _use_responses_api(model: str) -> bool:
+    """Return whether ``model`` must be served over the Responses API."""
+    normalized = model.strip().lower()
+    if "codex" in normalized:
+        return True
+    return any(normalized.startswith(prefix) for prefix in _RESPONSES_ONLY_PREFIXES)
+
 
 class OpenAICompatibleProvider:
-    """Provider adapter for OpenAI-compatible `/chat/completions` APIs."""
+    """Provider adapter for OpenAI-compatible `/chat/completions` APIs.
+
+    Models that require it are transparently served over `/v1/responses`.
+    """
 
     def __init__(
         self,
@@ -51,27 +76,101 @@ class OpenAICompatibleProvider:
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
     ) -> AsyncIterator[ProviderEvent]:
-        """Stream one chat completion response as provider-neutral events."""
-
-        async def iterator() -> AsyncIterator[ProviderEvent]:
-            client = self._get_client()
-            payload = _build_chat_payload(
+        """Stream one model response as provider-neutral events."""
+        if _use_responses_api(model):
+            return self._stream_responses(
                 model=model,
                 system=system,
                 messages=messages,
                 tools=tools,
-                reasoning_effort=self._config.reasoning_effort,
-                reasoning_effort_parameter=self._config.reasoning_effort_parameter,
+                signal=signal,
             )
+        return self._stream_chat_completions(
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            signal=signal,
+        )
+
+    def _stream_chat_completions(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Stream one chat completion response as provider-neutral events."""
+        payload = _build_chat_payload(
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            reasoning_effort=self._config.reasoning_effort,
+            reasoning_effort_parameter=self._config.reasoning_effort_parameter,
+        )
+        return self._stream(
+            model=model,
+            url=f"{self._config.base_url.rstrip('/')}/chat/completions",
+            payload=payload,
+            parser_factory=_ChatStreamParser,
+            signal=signal,
+        )
+
+    def _stream_responses(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Stream one `/v1/responses` response as provider-neutral events."""
+        payload = _build_responses_payload(
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            reasoning_effort=self._config.reasoning_effort,
+        )
+        return self._stream(
+            model=model,
+            url=f"{self._config.base_url.rstrip('/')}/responses",
+            payload=payload,
+            parser_factory=_ResponsesStreamParser,
+            signal=signal,
+        )
+
+    def _stream(
+        self,
+        *,
+        model: str,
+        url: str,
+        payload: Mapping[str, JSONValue],
+        parser_factory: Callable[[], _StreamParser],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Run the shared streaming POST + retry envelope for a given endpoint.
+
+        The per-endpoint differences (SSE chunk handling and final-message
+        assembly) live in the ``_StreamParser`` produced by ``parser_factory``;
+        everything else — HTTP, status/network retries, cancellation, the
+        opening ``response_start`` event — is identical across endpoints.
+        """
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            client = self._get_client()
             headers = {
                 **(dict(self._config.headers or {})),
                 "Authorization": f"Bearer {self._config.api_key}",
             }
-            url = f"{self._config.base_url.rstrip('/')}/chat/completions"
 
             attempt = 0
             while True:
-                emitted_content = False
+                parser = parser_factory()
                 try:
                     async with client.stream(
                         "POST", url, json=payload, headers=headers
@@ -110,9 +209,6 @@ class OpenAICompatibleProvider:
                             return
 
                         yield ProviderResponseStartEvent(model=model)
-                        content_parts: list[str] = []
-                        tool_call_builders: dict[int, _ToolCallBuilder] = {}
-                        finish_reason: str | None = None
 
                         async for line in response.aiter_lines():
                             if signal is not None and signal.is_cancelled():
@@ -121,61 +217,20 @@ class OpenAICompatibleProvider:
                             event = _parse_sse_line(line)
                             if event is None:
                                 continue
-                            if event == "[DONE]":
+
+                            events, stop = parser.feed(event)
+                            for parser_event in events:
+                                yield parser_event
+                            if stop:
                                 break
 
-                            chunk = _loads_object(event)
-                            if chunk is None:
-                                yield ProviderErrorEvent(
-                                    message="Provider returned invalid JSON chunk"
-                                )
-                                return
-
-                            choice = _first_choice(chunk)
-                            if choice is None:
-                                continue
-
-                            finish_reason = choice.get("finish_reason") or finish_reason
-                            delta = choice.get("delta")
-                            if not isinstance(delta, Mapping):
-                                continue
-
-                            content = delta.get("content")
-                            if isinstance(content, str) and content:
-                                emitted_content = True
-                                content_parts.append(content)
-                                yield ProviderTextDeltaEvent(delta=content)
-
-                            thinking = _thinking_delta_text(delta)
-                            if thinking:
-                                emitted_content = True
-                                yield ProviderThinkingDeltaEvent(delta=thinking)
-
-                            for tool_call_delta in _tool_call_deltas(delta):
-                                emitted_content = True
-                                index = int(tool_call_delta.get("index", 0))
-                                builder = tool_call_builders.setdefault(
-                                    index, _ToolCallBuilder()
-                                )
-                                builder.add_delta(tool_call_delta)
-
-                        tool_calls = [
-                            builder.build(index)
-                            for index, builder in sorted(tool_call_builders.items())
-                        ]
-                        for tool_call in tool_calls:
-                            yield ProviderToolCallEvent(tool_call=tool_call)
-
-                        message = AssistantMessage(
-                            content="".join(content_parts),
-                            tool_calls=tool_calls,
-                        )
-                        yield ProviderResponseEndEvent(
-                            message=message, finish_reason=finish_reason
-                        )
+                        if parser.fatal:
+                            return
+                        for parser_event in parser.finalize():
+                            yield parser_event
                         return
                 except httpx.HTTPError as exc:
-                    if not emitted_content and self._should_retry(attempt):
+                    if not parser.emitted_content and self._should_retry(attempt):
                         delay = retry_delay_seconds(
                             attempt,
                             max_delay_seconds=self._config.max_retry_delay_seconds,
@@ -211,6 +266,203 @@ class OpenAICompatibleProvider:
         if attempt >= self._config.max_retries:
             return False
         return status_code is None or _is_transient_status(status_code)
+
+
+class _StreamParser(Protocol):
+    """Per-endpoint SSE handler driven by the shared streaming envelope."""
+
+    # True once any model output (text/thinking/tool args) has been emitted;
+    # the envelope uses it to decide whether a mid-stream drop is retryable.
+    emitted_content: bool
+    # True when the parser already emitted a terminal error event and the
+    # envelope must not call finalize().
+    fatal: bool
+
+    def feed(self, event: str) -> tuple[list[ProviderEvent], bool]:
+        """Consume one SSE ``data:`` payload, returning (events, should_stop)."""
+        ...
+
+    def finalize(self) -> list[ProviderEvent]:
+        """Return the trailing tool-call and response-end events."""
+        ...
+
+
+class _ChatStreamParser:
+    """Parser for OpenAI `/chat/completions` SSE chunks."""
+
+    def __init__(self) -> None:
+        self.emitted_content = False
+        self.fatal = False
+        self._content_parts: list[str] = []
+        self._tool_call_builders: dict[int, _ToolCallBuilder] = {}
+        self._finish_reason: str | None = None
+
+    def feed(self, event: str) -> tuple[list[ProviderEvent], bool]:
+        if event == "[DONE]":
+            return [], True
+
+        chunk = _loads_object(event)
+        if chunk is None:
+            self.fatal = True
+            return [ProviderErrorEvent(message="Provider returned invalid JSON chunk")], True
+
+        choice = _first_choice(chunk)
+        if choice is None:
+            return [], False
+
+        self._finish_reason = choice.get("finish_reason") or self._finish_reason
+        delta = choice.get("delta")
+        if not isinstance(delta, Mapping):
+            return [], False
+
+        events: list[ProviderEvent] = []
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            self.emitted_content = True
+            self._content_parts.append(content)
+            events.append(ProviderTextDeltaEvent(delta=content))
+
+        thinking = _thinking_delta_text(delta)
+        if thinking:
+            self.emitted_content = True
+            events.append(ProviderThinkingDeltaEvent(delta=thinking))
+
+        for tool_call_delta in _tool_call_deltas(delta):
+            self.emitted_content = True
+            index = int(tool_call_delta.get("index", 0))
+            builder = self._tool_call_builders.setdefault(index, _ToolCallBuilder())
+            builder.add_delta(tool_call_delta)
+
+        return events, False
+
+    def finalize(self) -> list[ProviderEvent]:
+        tool_calls = [
+            builder.build(index)
+            for index, builder in sorted(self._tool_call_builders.items())
+        ]
+        events: list[ProviderEvent] = [
+            ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
+        ]
+        events.append(
+            ProviderResponseEndEvent(
+                message=AssistantMessage(
+                    content="".join(self._content_parts), tool_calls=tool_calls
+                ),
+                finish_reason=self._finish_reason,
+            )
+        )
+        return events
+
+
+class _ResponsesStreamParser:
+    """Parser for OpenAI `/v1/responses` SSE events."""
+
+    def __init__(self) -> None:
+        self.emitted_content = False
+        self.fatal = False
+        self._content_parts: list[str] = []
+        self._tool_call_builders: dict[str, _ResponsesToolCallBuilder] = {}
+        self._status: str | None = None
+
+    def feed(self, event: str) -> tuple[list[ProviderEvent], bool]:
+        # The Responses API has no [DONE] sentinel; it ends with a terminal
+        # event (completed/incomplete/failed) handled below.
+        if event == "[DONE]":
+            return [], False
+
+        chunk = _loads_object(event)
+        if chunk is None:
+            return [], False
+
+        chunk_type = chunk.get("type")
+        if not isinstance(chunk_type, str):
+            return [], False
+
+        if chunk_type == "response.output_text.delta":
+            delta = chunk.get("delta")
+            if isinstance(delta, str) and delta:
+                self.emitted_content = True
+                self._content_parts.append(delta)
+                return [ProviderTextDeltaEvent(delta=delta)], False
+
+        elif chunk_type in (
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ):
+            delta = chunk.get("delta")
+            if isinstance(delta, str) and delta:
+                self.emitted_content = True
+                return [ProviderThinkingDeltaEvent(delta=delta)], False
+
+        elif chunk_type == "response.output_item.added":
+            _register_responses_item(
+                self._tool_call_builders,
+                chunk.get("item"),
+                output_index=chunk.get("output_index"),
+            )
+
+        elif chunk_type == "response.function_call_arguments.delta":
+            item_id = chunk.get("item_id")
+            if isinstance(item_id, str):
+                builder = self._tool_call_builders.setdefault(
+                    item_id, _ResponsesToolCallBuilder()
+                )
+                builder.add_arguments_delta(chunk.get("delta"))
+                self.emitted_content = True
+
+        elif chunk_type == "response.function_call_arguments.done":
+            item_id = chunk.get("item_id")
+            if isinstance(item_id, str):
+                builder = self._tool_call_builders.setdefault(
+                    item_id, _ResponsesToolCallBuilder()
+                )
+                builder.set_final(arguments=chunk.get("arguments"))
+
+        elif chunk_type == "response.output_item.done":
+            _finalize_responses_item(
+                self._tool_call_builders,
+                chunk.get("item"),
+                output_index=chunk.get("output_index"),
+            )
+
+        elif chunk_type in ("response.completed", "response.incomplete"):
+            self._status = _responses_finish_reason(chunk)
+            return [], True
+
+        elif chunk_type == "response.failed":
+            self.fatal = True
+            return [_responses_failure_event(chunk)], True
+
+        elif chunk_type == "error":
+            self.fatal = True
+            return [
+                ProviderErrorEvent(
+                    message=_responses_error_message(chunk), data={"event": chunk}
+                )
+            ], True
+
+        return [], False
+
+    def finalize(self) -> list[ProviderEvent]:
+        tool_calls = [
+            builder.build(index)
+            for index, builder in enumerate(_ordered_builders(self._tool_call_builders))
+        ]
+        events: list[ProviderEvent] = [
+            ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
+        ]
+        finish_reason = _normalize_finish_reason(
+            self._status, has_tool_calls=bool(tool_calls)
+        )
+        events.append(
+            ProviderResponseEndEvent(
+                message=AssistantMessage(
+                    content="".join(self._content_parts), tool_calls=tool_calls
+                ),
+                finish_reason=finish_reason,
+            )
+        )
+        return events
 
 
 class _ToolCallBuilder:
@@ -249,6 +501,60 @@ class _ToolCallBuilder:
         )
 
 
+class _ResponsesToolCallBuilder:
+    """Accumulates a streamed Responses-API ``function_call`` output item."""
+
+    def __init__(
+        self,
+        *,
+        call_id: str = "",
+        name: str = "",
+        output_index: int = 0,
+    ) -> None:
+        self.call_id = call_id
+        self.name = name
+        self.output_index = output_index
+        self.arguments_parts: list[str] = []
+        self.arguments_final: str | None = None
+
+    def add_arguments_delta(self, delta: object) -> None:
+        if isinstance(delta, str):
+            self.arguments_parts.append(delta)
+
+    def set_final(
+        self,
+        *,
+        call_id: str | None = None,
+        name: str | None = None,
+        arguments: object = None,
+        output_index: int | None = None,
+    ) -> None:
+        if call_id:
+            self.call_id = call_id
+        if name:
+            self.name = name
+        if isinstance(arguments, str):
+            self.arguments_final = arguments
+        if output_index is not None:
+            self.output_index = output_index
+
+    def build(self, index: int) -> ToolCall:
+        arguments_text = (
+            self.arguments_final
+            if self.arguments_final is not None
+            else "".join(self.arguments_parts)
+        )
+        arguments = _loads_object(arguments_text) if arguments_text else {}
+        if arguments is None:
+            arguments = {"_raw_arguments": arguments_text}
+
+        return ToolCall(
+            id=self.call_id or f"tool-call-{index}",
+            name=self.name,
+            arguments=arguments,
+        )
+
+
 def _build_chat_payload(
     *,
     model: str,
@@ -274,6 +580,186 @@ def _build_chat_payload(
     if tools:
         payload["tools"] = [_tool_to_openai(tool) for tool in tools]
     return payload
+
+
+def _build_responses_payload(
+    *,
+    model: str,
+    system: str,
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+    reasoning_effort: str | None = None,
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "model": model,
+        "stream": True,
+        # Stay stateless: the full transcript is resent every turn, so there is
+        # no need for server-side retention. ``store: false`` also keeps the
+        # path usable for zero-data-retention orgs, which reject ``store: true``.
+        "store": False,
+        "instructions": system,
+        "input": _messages_to_responses_input(messages),
+    }
+    effort = _normalize_responses_effort(reasoning_effort)
+    if effort is not None:
+        # ``summary: auto`` streams ``response.reasoning_summary_text.delta``
+        # events so the agent's thinking is visible, mirroring the reasoning
+        # deltas surfaced on the chat-completions path.
+        payload["reasoning"] = {"effort": effort, "summary": "auto"}
+    if tools:
+        payload["tools"] = [_tool_to_responses(tool) for tool in tools]
+    return payload
+
+
+def _normalize_responses_effort(reasoning_effort: str | None) -> str | None:
+    """Map an internal reasoning level to a Responses-API effort, or drop it."""
+    if reasoning_effort is None:
+        return None
+    normalized = reasoning_effort.strip().lower()
+    if normalized in ("", "none"):
+        return None
+    return normalized
+
+
+def _messages_to_responses_input(
+    messages: list[AgentMessage],
+) -> list[JSONValue]:
+    items: list[JSONValue] = []
+    for message in messages:
+        if isinstance(message, UserMessage):
+            items.append({"role": "user", "content": message.content})
+        elif isinstance(message, AssistantMessage):
+            if message.content:
+                items.append({"role": "assistant", "content": message.content})
+            for tool_call in message.tool_calls:
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tool_call.id,
+                        "name": tool_call.name,
+                        "arguments": dumps(tool_call.arguments),
+                    }
+                )
+        elif isinstance(message, ToolResultMessage):
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message.tool_call_id,
+                    "output": message.content,
+                }
+            )
+    return items
+
+
+def _tool_to_responses(tool: AgentTool) -> dict[str, JSONValue]:
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": dict(tool.input_schema),
+    }
+
+
+def _register_responses_item(
+    builders: dict[str, _ResponsesToolCallBuilder],
+    item: object,
+    *,
+    output_index: object,
+) -> None:
+    if not isinstance(item, Mapping) or item.get("type") != "function_call":
+        return
+    item_id = item.get("id")
+    if not isinstance(item_id, str):
+        return
+    raw_arguments = item.get("arguments")
+    builder = builders.setdefault(item_id, _ResponsesToolCallBuilder())
+    builder.set_final(
+        call_id=_str_or_none(item.get("call_id")),
+        name=_str_or_none(item.get("name")),
+        arguments=raw_arguments if isinstance(raw_arguments, str) and raw_arguments else None,
+        output_index=_int_or_none(output_index),
+    )
+
+
+def _finalize_responses_item(
+    builders: dict[str, _ResponsesToolCallBuilder],
+    item: object,
+    *,
+    output_index: object,
+) -> None:
+    if not isinstance(item, Mapping) or item.get("type") != "function_call":
+        return
+    item_id = item.get("id")
+    if not isinstance(item_id, str):
+        return
+    builder = builders.setdefault(item_id, _ResponsesToolCallBuilder())
+    builder.set_final(
+        call_id=_str_or_none(item.get("call_id")),
+        name=_str_or_none(item.get("name")),
+        arguments=item.get("arguments"),
+        output_index=_int_or_none(output_index),
+    )
+
+
+def _ordered_builders(
+    builders: dict[str, _ResponsesToolCallBuilder],
+) -> list[_ResponsesToolCallBuilder]:
+    return [
+        builder
+        for _, builder in sorted(
+            builders.items(), key=lambda pair: pair[1].output_index
+        )
+    ]
+
+
+def _responses_finish_reason(chunk: Mapping[str, Any]) -> str | None:
+    response = chunk.get("response")
+    if isinstance(response, Mapping):
+        status = response.get("status")
+        if isinstance(status, str):
+            return status
+    return None
+
+
+def _normalize_finish_reason(status: str | None, *, has_tool_calls: bool) -> str:
+    """Map a Responses-API status to chat-completions-style finish reasons."""
+    if has_tool_calls:
+        return "tool_calls"
+    if status == "incomplete":
+        return "length"
+    return "stop"
+
+
+def _responses_failure_event(chunk: Mapping[str, Any]) -> ProviderErrorEvent:
+    message = "Provider response failed"
+    response = chunk.get("response")
+    if isinstance(response, Mapping):
+        error = response.get("error")
+        if isinstance(error, Mapping):
+            error_message = error.get("message")
+            if isinstance(error_message, str) and error_message:
+                message = error_message
+    return ProviderErrorEvent(message=message, data={"event": dict(chunk)})
+
+
+def _responses_error_message(chunk: Mapping[str, Any]) -> str:
+    message = chunk.get("message")
+    if isinstance(message, str) and message:
+        return message
+    error = chunk.get("error")
+    if isinstance(error, Mapping):
+        nested = error.get("message")
+        if isinstance(nested, str) and nested:
+            return nested
+    return "Provider stream error"
+
+
+def _str_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: object) -> int | None:
+    return value if isinstance(value, int) else None
 
 
 def _system_message(system: str) -> dict[str, JSONValue]:

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -378,7 +378,7 @@ class _ResponsesStreamParser:
         if not isinstance(chunk_type, str):
             return [], False
 
-        if chunk_type == "response.output_text.delta":
+        if chunk_type in ("response.output_text.delta", "response.refusal.delta"):
             delta = chunk.get("delta")
             if isinstance(delta, str) and delta:
                 self.emitted_content = True

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -4,7 +4,15 @@ from json import loads
 import httpx
 import pytest
 
-from tau_agent import AgentTool, AgentToolResult, SimpleCancellationToken, ToolCall, UserMessage
+from tau_agent import (
+    AgentTool,
+    AgentToolResult,
+    AssistantMessage,
+    SimpleCancellationToken,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
 from tau_agent.types import JSONValue
 from tau_ai import (
     AnthropicConfig,
@@ -203,7 +211,7 @@ async def test_openai_compatible_provider_includes_configured_reasoning_effort()
 
 
 @pytest.mark.anyio
-async def test_openai_compatible_provider_can_send_responses_reasoning_effort() -> None:
+async def test_openai_compatible_provider_supports_nested_reasoning_effort_parameter() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -225,15 +233,18 @@ async def test_openai_compatible_provider_can_send_responses_reasoning_effort() 
             client=client,
         )
 
+        # A model served over /chat/completions (not gpt-5.5/5.4/codex, which
+        # route to /v1/responses) exercises the nested reasoning.effort payload.
         await _collect(
             provider.stream_response(
-                model="gpt-5.5",
+                model="custom-reasoner",
                 system="You are Tau.",
                 messages=[UserMessage(content="Say ok")],
                 tools=[],
             )
         )
 
+    assert requests[0].url == "https://example.test/v1/chat/completions"
     assert loads(requests[0].content)["reasoning"] == {"effort": "high"}
     assert "reasoning_effort" not in loads(requests[0].content)
 
@@ -1086,3 +1097,405 @@ async def test_anthropic_provider_retries_transient_status_with_event() -> None:
         "text_delta",
         "response_end",
     ]
+
+
+def _weather_tool() -> AgentTool:
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: SimpleCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del signal
+        return AgentToolResult(
+            tool_call_id="call_1", name="get_weather", ok=True, content=str(arguments)
+        )
+
+    return AgentTool(
+        name="get_weather",
+        description="Get current weather for a city.",
+        input_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+        executor=executor,
+    )
+
+
+def test_use_responses_api_routes_only_restricted_models() -> None:
+    from tau_ai.openai_compatible import _use_responses_api
+
+    assert _use_responses_api("gpt-5.5") is True
+    assert _use_responses_api("gpt-5.5-pro") is True
+    assert _use_responses_api("gpt-5.4") is True
+    assert _use_responses_api("gpt-5.3-codex") is True
+    assert _use_responses_api("GPT-5.5") is True
+    assert _use_responses_api("gpt-5.1") is False
+    assert _use_responses_api("gpt-5") is False
+    assert _use_responses_api("gpt-4o") is False
+    assert _use_responses_api("test-model") is False
+
+
+@pytest.mark.anyio
+async def test_responses_api_formats_request_for_restricted_model() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_text.delta","delta":"Sun"}\n\n'
+                'data: {"type":"response.output_text.delta","delta":"ny"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    messages = [
+        UserMessage(content="weather in Paris?"),
+        AssistantMessage(
+            content="",
+            tool_calls=[
+                ToolCall(id="call_1", name="get_weather", arguments={"city": "Paris"})
+            ],
+        ),
+        ToolResultMessage(
+            tool_call_id="call_1", name="get_weather", content='{"temp_c": 19}'
+        ),
+        UserMessage(content="summarize"),
+    ]
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                reasoning_effort="medium",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=messages,
+                tools=[_weather_tool()],
+            )
+        )
+
+    assert [event.type for event in events] == [
+        "response_start",
+        "text_delta",
+        "text_delta",
+        "response_end",
+    ]
+    assert isinstance(events[-1], ProviderResponseEndEvent)
+    assert events[-1].message.content == "Sunny"
+    assert events[-1].finish_reason == "stop"
+
+    request = requests[0]
+    assert request.url == "https://example.test/v1/responses"
+
+    payload = loads(request.content)
+    assert payload["model"] == "gpt-5.5"
+    assert payload["stream"] is True
+    assert payload["store"] is False
+    assert payload["instructions"] == "You are Tau."
+    assert payload["reasoning"] == {"effort": "medium", "summary": "auto"}
+    # Responses-API tools are flat (no nested "function" object).
+    assert payload["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+    # The assistant turn has empty content, so only its function_call appears.
+    assert payload["input"][0] == {"role": "user", "content": "weather in Paris?"}
+    function_call = payload["input"][1]
+    assert function_call["type"] == "function_call"
+    assert function_call["call_id"] == "call_1"
+    assert function_call["name"] == "get_weather"
+    assert loads(function_call["arguments"]) == {"city": "Paris"}
+    assert payload["input"][2] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"temp_c": 19}',
+    }
+    assert payload["input"][3] == {"role": "user", "content": "summarize"}
+
+
+@pytest.mark.anyio
+async def test_responses_api_parses_streamed_tool_call() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_item.added","output_index":0,'
+                '"item":{"id":"fc_1","type":"function_call","call_id":"call_abc",'
+                '"name":"get_weather","arguments":""}}\n\n'
+                'data: {"type":"response.function_call_arguments.delta",'
+                '"item_id":"fc_1","delta":"{\\"city\\":"}\n\n'
+                'data: {"type":"response.function_call_arguments.delta",'
+                '"item_id":"fc_1","delta":"\\"Paris\\"}"}\n\n'
+                'data: {"type":"response.function_call_arguments.done",'
+                '"item_id":"fc_1","arguments":"{\\"city\\":\\"Paris\\"}"}\n\n'
+                'data: {"type":"response.output_item.done","output_index":0,'
+                '"item":{"id":"fc_1","type":"function_call","call_id":"call_abc",'
+                '"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="weather?")],
+                tools=[_weather_tool()],
+            )
+        )
+
+    tool_call_events = [e for e in events if isinstance(e, ProviderToolCallEvent)]
+    assert len(tool_call_events) == 1
+    assert tool_call_events[0].tool_call.id == "call_abc"
+    assert tool_call_events[0].tool_call.name == "get_weather"
+    assert tool_call_events[0].tool_call.arguments == {"city": "Paris"}
+
+    end = events[-1]
+    assert isinstance(end, ProviderResponseEndEvent)
+    assert len(end.message.tool_calls) == 1
+    assert end.message.tool_calls[0].id == "call_abc"
+    assert end.message.tool_calls[0].arguments == {"city": "Paris"}
+    assert end.finish_reason == "tool_calls"
+
+
+@pytest.mark.anyio
+async def test_responses_api_streams_reasoning_summary_as_thinking() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.reasoning_summary_text.delta",'
+                '"delta":"Considering"}\n\n'
+                'data: {"type":"response.output_text.delta","delta":"Answer"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                reasoning_effort="high",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="think")],
+                tools=[],
+            )
+        )
+
+    assert [event.type for event in events] == [
+        "response_start",
+        "thinking_delta",
+        "text_delta",
+        "response_end",
+    ]
+    thinking = next(e for e in events if isinstance(e, ProviderThinkingDeltaEvent))
+    assert thinking.delta == "Considering"
+
+
+@pytest.mark.anyio
+async def test_responses_api_omits_reasoning_when_effort_is_none() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                reasoning_effort="none",
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="hi")],
+                tools=[_weather_tool()],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    # gpt-5.5 rejects tools + reasoning on /chat/completions; with thinking off
+    # the reasoning field is dropped entirely so tools still work over /responses.
+    assert "reasoning" not in payload
+    assert "tools" in payload
+
+
+@pytest.mark.anyio
+async def test_responses_api_surfaces_stream_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.failed","response":{"status":"failed",'
+                '"error":{"message":"model exploded"}}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="hi")],
+                tools=[],
+            )
+        )
+
+    error_events = [e for e in events if isinstance(e, ProviderErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].message == "model exploded"
+    # The raw event is preserved for debugging (code/param/type, etc.).
+    assert error_events[0].data is not None
+    assert error_events[0].data["event"]["type"] == "response.failed"
+
+
+@pytest.mark.anyio
+async def test_responses_api_orders_parallel_tool_calls_by_output_index() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_item.added","output_index":0,'
+                '"item":{"id":"fc_a","type":"function_call","call_id":"call_a",'
+                '"name":"get_weather","arguments":"{\\"city\\":\\"A\\"}"}}\n\n'
+                'data: {"type":"response.output_item.added","output_index":1,'
+                '"item":{"id":"fc_b","type":"function_call","call_id":"call_b",'
+                '"name":"get_weather","arguments":"{\\"city\\":\\"B\\"}"}}\n\n'
+                # Done events arrive out of order to prove sorting by output_index.
+                'data: {"type":"response.output_item.done","output_index":1,'
+                '"item":{"id":"fc_b","type":"function_call","call_id":"call_b",'
+                '"name":"get_weather","arguments":"{\\"city\\":\\"B\\"}"}}\n\n'
+                'data: {"type":"response.output_item.done","output_index":0,'
+                '"item":{"id":"fc_a","type":"function_call","call_id":"call_a",'
+                '"name":"get_weather","arguments":"{\\"city\\":\\"A\\"}"}}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="weather?")],
+                tools=[_weather_tool()],
+            )
+        )
+
+    end = events[-1]
+    assert isinstance(end, ProviderResponseEndEvent)
+    assert [tc.id for tc in end.message.tool_calls] == ["call_a", "call_b"]
+    assert [tc.arguments["city"] for tc in end.message.tool_calls] == ["A", "B"]
+
+
+@pytest.mark.anyio
+async def test_responses_api_surfaces_top_level_error_event() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text='data: {"type":"error","message":"rate limited"}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="hi")],
+                tools=[],
+            )
+        )
+
+    error_events = [e for e in events if isinstance(e, ProviderErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].message == "rate limited"
+
+
+@pytest.mark.anyio
+async def test_responses_api_maps_incomplete_status_to_length() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+                'data: {"type":"response.incomplete","response":{"status":"incomplete"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="hi")],
+                tools=[],
+            )
+        )
+
+    end = events[-1]
+    assert isinstance(end, ProviderResponseEndEvent)
+    assert end.message.content == "partial"
+    assert end.finish_reason == "length"

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1279,6 +1279,50 @@ async def test_responses_api_parses_streamed_tool_call() -> None:
 
 
 @pytest.mark.anyio
+async def test_responses_api_streams_refusal_as_text() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.refusal.delta","delta":"I can"}\n\n'
+                'data: {"type":"response.refusal.delta","delta":"not help with that."}\n\n'
+                'data: {"type":"response.refusal.done",'
+                '"refusal":"I cannot help with that."}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="unsafe request")],
+                tools=[],
+            )
+        )
+
+    assert [event.type for event in events] == [
+        "response_start",
+        "text_delta",
+        "text_delta",
+        "response_end",
+    ]
+    text_deltas = [e.delta for e in events if isinstance(e, ProviderTextDeltaEvent)]
+    assert text_deltas == ["I can", "not help with that."]
+    end = events[-1]
+    assert isinstance(end, ProviderResponseEndEvent)
+    assert end.message.content == "I cannot help with that."
+    assert end.finish_reason == "stop"
+
+
+@pytest.mark.anyio
 async def test_responses_api_streams_reasoning_summary_as_thinking() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary

OpenAI rejects `function tools + reasoning_effort` on `/chat/completions` for **gpt-5.5**, **gpt-5.4** and the **`*-codex`** models, returning HTTP 400 (*"Please use /v1/responses instead"*). Since the default model is gpt-5.5 and the agent always sends tools, every request failed out of the box.

This PR adds a **Responses-API streaming path** to `OpenAICompatibleProvider`, selected per-model at request time. Restricted models (gpt-5.5 / gpt-5.4 prefixes, or any name containing `codex`) use `/v1/responses`; all other models keep the existing `/chat/completions` behaviour unchanged.

## The new path

- Maps transcript messages to the Responses `input` format, including replaying `function_call` / `function_call_output` items across turns.
- Parses the Responses SSE event stream into the same provider-neutral events.
- Sends `store: false` (stateless; full transcript resent each turn) so it also works for zero-data-retention orgs, matching the Codex provider.
- Requests `reasoning.summary: "auto"` so thinking stays visible, and omits reasoning entirely when thinking is off.
- Normalizes finish reasons to chat-completions semantics (`tool_calls` / `stop` / `length`) and preserves the raw event on errors for debuggability.

Both endpoints now share a single streaming/retry envelope (`_stream`); per-endpoint SSE handling and final-message assembly live in small `_ChatStreamParser` / `_ResponsesStreamParser` classes, removing ~170 lines of duplicated transport scaffolding.

## Testing

- **Live API** (end-to-end): multi-turn tool round-trips on both endpoints with `store:false` + streamed reasoning.
- **Unit tests** (mocked transport): routing, request shape, streamed tool-call assembly, parallel tool-call ordering, reasoning summaries, thinking-off, incomplete responses, and both stream-failure and top-level error events.

```
34 passed · mypy clean · ruff clean
```

Backward compatible: non-restricted models are unaffected.
