### PR TITLE
Add `license-files` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.14"
 dependencies = [
     "anyio>=4.0",


### PR DESCRIPTION
This is required to package the license file, and to package `tau-ai` for conda-forge (see [here](https://github.com/conda-forge/staged-recipes/pull/33987)).