### PR TITLE
feat: add support for OpenCode Go provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ wheels/
 website/public/
 website/resources/
 website/.hugo_build.lock
+
+# macOS system files
+.DS_Store
+.AppleDouble
+.LSOverride
+

--- a/dev-notes/opencode-go-support.md
+++ b/dev-notes/opencode-go-support.md
@@ -1,0 +1,73 @@
+# OpenCode Go Support & Model Overrides
+
+## Introduction
+
+Aggregator providers such as OpenCode Go, Hugging Face, and OpenRouter serve models over different APIs. These models carry their own nuances, particularly regarding how reasoning (thinking) is driven, which API payload format is required (OpenAI-compatible vs. Anthropic Messages), and default configuration values. 
+
+Without model-specific overrides, the flat provider-level catalog results in the UI displaying settings and labels that do nothing or are incorrect for specific models. 
+
+This document tracks the research, design, and implementation of `model_overrides` which allows the Tau UI and provider runtime to stay honest and do what it says.
+
+---
+
+## 1. Research: OpenCode Go Analysis
+
+Two sources are used to research OpenCode Go behavior:
+- **models.dev** — `anomalyco/models.dev` (`providers/opencode-go/`)
+- **OpenCode agent** — `anomalyco/opencode` (`packages/core` and `packages/console/app/src/routes/zen/`)
+
+### Two APIs Behind One Base URL
+The OpenCode Go Zen endpoint (`https://opencode.ai/zen/go/v1`) accepts both OpenAI-compatible and Anthropic Messages formats:
+- `POST /zen/go/v1/chat/completions` (OpenAI format, used by GLM, Kimi, DeepSeek, and Mimo models).
+- `POST /zen/go/v1/messages` (Anthropic format, used by Minimax and Qwen models).
+
+Since the base URL is identical, we must dynamically adapt the client runtime configurations based on the selected model to serialize payloads correctly.
+
+### Gaps in Thinking Option Handling
+OpenCode's codebase does not consume `reasoning_options` from models.dev. It relies on named **variants** configured at runtime (`Resource.ZEN_MODELS*` from the Zen config API). The payload converter maps options as follows:
+- `@ai-sdk/openai-compatible` maps `reasoningEffort` -> `reasoning_effort`.
+- `@ai-sdk/anthropic` maps `effort` -> `output_config.effort` and `taskBudget` -> `output_config.task_budget`.
+
+Because of these nuances, models have different configurations:
+- **`glm-5.2`**: Exposes effort levels `high` and `max` (via `reasoning_effort`), defaulting to `max`.
+- **`glm-5.1` / `kimi-k2.6` / `mimo-v2.5`**: Reasoning is always enabled and cannot be customized.
+- **`minimax-m3`**: Simple toggle (on/off) using `adaptive` thinking type via Anthropic format.
+- **`qwen3.7-max`**: Toggle + budget using Anthropic format.
+
+Without individual model configurations, setting a thinking level in the UI would attempt to send parameters the model does not support or fail to enable thinking altogether.
+
+---
+
+## 2. Utility for Other Aggregators (Hugging Face & OpenRouter)
+
+The model overrides system is a generic design that directly benefits other aggregators in [catalog.toml](file:///Users/ilembitov/Projects/tau/src/tau_coding/data/catalog.toml):
+
+1. **Hugging Face (`huggingface` provider)**:
+   Hugging Face is defined in [catalog.toml](file:///Users/ilembitov/Projects/tau/src/tau_coding/data/catalog.toml#L170-L195). It lists multiple heterogeneous models like `zai-org/GLM-5.2` and `deepseek-ai/DeepSeek-V4-Pro`. Using overrides, we can now configure distinct thinking parameter mappings and values without changing Python source files.
+2. **OpenRouter (`openrouter` provider)**:
+   OpenRouter is defined in [catalog.toml](file:///Users/ilembitov/Projects/tau/src/tau_coding/data/catalog.toml#L123-L149). It aggregates models from different vendors (`anthropic/claude-sonnet-4.6`, `google/gemini-3.5-pro`, `z-ai/glm-5.2`, `minimax/minimax-m3`). With `model_overrides`, we can enable thinking options or define specific token limits on a per-model basis for OpenRouter.
+
+---
+
+## 3. How the PR Fixes the Issue
+
+We add `model_overrides` tables directly inside the catalog TOML schema. This resolves the settings gap and keeps the UI honest:
+
+### Declarative Schema
+In [catalog.toml](file:///Users/ilembitov/Projects/tau/src/tau_coding/data/catalog.toml#L265-L315), model-specific overrides are defined:
+```toml
+[providers.model_overrides."glm-5.2"]
+thinking_default = "high"
+thinking_modes = {high = {api_value = "high"}, xhigh = {api_value = "max", label = "max"}}
+```
+
+### Type-Safe Parsing & Validation
+[catalog_loader.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/catalog_loader.py) uses Pydantic validation to verify overrides, matching them against known `models` lists, and serializes them round-trip for user catalog overlays.
+
+### Runtime Routing & Config Swap
+- In [provider_runtime.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/provider_runtime.py), `create_model_provider` dynamically swaps the configuration to `AnthropicProviderConfig` and instantiates `AnthropicProvider` if the model's override has `kind = "anthropic"`.
+- [provider_config.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/provider_config.py) resolves default levels and thinking modes dynamically based on the overrides, translating canonical levels (e.g., `xhigh`) to model-specific API parameters (e.g., `max`).
+
+### Accurate UI Feedback
+- The UI controls read [session.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/session.py) properties like `thinking_is_always_on` and `thinking_level_label`.
+- [widgets.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/tui/widgets.py) and [commands.py](file:///Users/ilembitov/Projects/tau/src/tau_coding/commands.py) update status messages from "unavailable" to "always on" or display custom labels (e.g., "on" instead of "high"), ensuring the user knows exactly what mode is active.

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -11,7 +11,7 @@ import httpx
 from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
 from tau_agent.tools import AgentTool, ToolCall
 from tau_agent.types import JSONValue
-from tau_ai.env import AnthropicConfig
+from tau_ai.env import AnthropicConfig, AnthropicThinkingType
 from tau_ai.events import (
     ProviderErrorEvent,
     ProviderEvent,
@@ -67,6 +67,7 @@ class AnthropicProvider:
                 messages=messages,
                 tools=tools,
                 thinking_budget_tokens=self._config.thinking_budget_tokens,
+                thinking_type=self._config.thinking_type,
             )
             headers = {
                 **(dict(self._config.headers or {})),
@@ -267,9 +268,10 @@ def _build_messages_payload(
     messages: list[AgentMessage],
     tools: list[AgentTool],
     thinking_budget_tokens: int | None = None,
+    thinking_type: AnthropicThinkingType | None = None,
 ) -> dict[str, JSONValue]:
     max_tokens = DEFAULT_MAX_TOKENS
-    if thinking_budget_tokens is not None:
+    if thinking_budget_tokens is not None and thinking_type is None:
         max_tokens = max(max_tokens, thinking_budget_tokens + 1024)
     payload: dict[str, JSONValue] = {
         "model": model,
@@ -278,7 +280,9 @@ def _build_messages_payload(
         "system": system,
         "messages": [_anthropic_message(message) for message in messages],
     }
-    if thinking_budget_tokens is not None:
+    if thinking_type is not None:
+        payload["thinking"] = {"type": thinking_type}
+    elif thinking_budget_tokens is not None:
         payload["thinking"] = {
             "type": "enabled",
             "budget_tokens": thinking_budget_tokens,

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from os import environ
+from typing import Literal
 
 DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
 DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS = 60.0
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES = 2
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS = 1.0
+
+AnthropicThinkingType = Literal["adaptive", "disabled"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +42,7 @@ class AnthropicConfig:
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
     thinking_budget_tokens: int | None = None
+    thinking_type: AnthropicThinkingType | None = None
     provider_name: str = "Anthropic"
 
 

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -15,7 +15,12 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StringConstraints, ValidationError
 
 from tau_coding.paths import TauPaths
-from tau_coding.provider_catalog import ProviderCatalogEntry, ProviderKind
+from tau_coding.provider_catalog import (
+    ProviderCatalogEntry,
+    ProviderKind,
+    ProviderModelOverride,
+    ThinkingMode,
+)
 from tau_coding.thinking import ThinkingLevel, ThinkingParameter
 
 CATALOG_SCHEMA_VERSION = 1
@@ -37,6 +42,22 @@ class CatalogError(ValueError):
     """Raised when a Tau catalog file is invalid."""
 
 
+class _CatalogThinkingMode(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    api_value: str | None = None
+    label: str | None = None
+
+
+class _CatalogModelOverride(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: ProviderKind | None = None
+    thinking_modes: dict[ThinkingLevel, _CatalogThinkingMode] | None = None
+    thinking_default: ThinkingLevel | None = None
+    always_thinking: bool = False
+
+
 class _CatalogProvider(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -54,6 +75,7 @@ class _CatalogProvider(BaseModel):
     thinking_models: tuple[_NonEmptyString, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    model_overrides: dict[_NonEmptyString, _CatalogModelOverride] | None = None
 
 
 class _CatalogFile(BaseModel):
@@ -216,6 +238,35 @@ def _entries_from_raw(raw: dict[str, Any], *, source: str) -> tuple[ProviderCata
     return entries
 
 
+def _model_overrides_from_catalog(
+    overrides: dict[str, _CatalogModelOverride] | None,
+) -> dict[str, ProviderModelOverride] | None:
+    """Convert catalog model overrides into runtime dataclass values."""
+    if not overrides:
+        return None
+    return {
+        model: ProviderModelOverride(
+            kind=override.kind,
+            thinking_modes=_thinking_modes_from_catalog(override.thinking_modes),
+            thinking_default=override.thinking_default,
+            always_thinking=override.always_thinking,
+        )
+        for model, override in overrides.items()
+    }
+
+
+def _thinking_modes_from_catalog(
+    modes: dict[ThinkingLevel, _CatalogThinkingMode] | None,
+) -> dict[ThinkingLevel, ThinkingMode] | None:
+    """Convert catalog thinking modes into runtime dataclass values."""
+    if not modes:
+        return None
+    return {
+        level: ThinkingMode(api_value=mode.api_value, label=mode.label)
+        for level, mode in modes.items()
+    }
+
+
 def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> ProviderCatalogEntry:
     prefix = f"{source}: providers.{provider.name}"
     if provider.default_model not in provider.models:
@@ -226,6 +277,9 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
     for model in provider.context_windows or {}:
         if model not in provider.models:
             raise CatalogError(f"{prefix}.context_windows: {model!r} is not in models")
+    for model in provider.model_overrides or {}:
+        if model not in provider.models:
+            raise CatalogError(f"{prefix}.model_overrides: {model!r} is not in models")
     if provider.thinking_default is not None and (
         provider.thinking_levels is None
         or provider.thinking_default not in provider.thinking_levels
@@ -248,6 +302,7 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
         thinking_models=provider.thinking_models,
         thinking_default=provider.thinking_default,
         thinking_parameter=provider.thinking_parameter,
+        model_overrides=_model_overrides_from_catalog(provider.model_overrides),
     )
 
 
@@ -298,6 +353,40 @@ def _raw_provider_from_entry(entry: ProviderCatalogEntry) -> dict[str, Any]:
         raw["thinking_default"] = entry.thinking_default
     if entry.thinking_parameter is not None:
         raw["thinking_parameter"] = entry.thinking_parameter
+    if entry.model_overrides:
+        raw["model_overrides"] = _raw_model_overrides_from_entry(entry.model_overrides)
+    return raw
+
+
+def _raw_model_overrides_from_entry(
+    overrides: dict[str, ProviderModelOverride],
+) -> dict[str, Any]:
+    """Serialize model overrides back into the raw catalog shape."""
+    raw: dict[str, Any] = {}
+    for model, override in overrides.items():
+        entry: dict[str, Any] = {}
+        if override.kind is not None:
+            entry["kind"] = override.kind
+        if override.thinking_modes:
+            entry["thinking_modes"] = {
+                level: _raw_thinking_mode_from_entry(mode)
+                for level, mode in override.thinking_modes.items()
+            }
+        if override.thinking_default is not None:
+            entry["thinking_default"] = override.thinking_default
+        if override.always_thinking:
+            entry["always_thinking"] = True
+        raw[model] = entry
+    return raw
+
+
+def _raw_thinking_mode_from_entry(mode: ThinkingMode) -> dict[str, Any]:
+    """Serialize a thinking mode, dropping ``None`` fields for compact output."""
+    raw: dict[str, Any] = {}
+    if mode.api_value is not None:
+        raw["api_value"] = mode.api_value
+    if mode.label is not None:
+        raw["label"] = mode.label
     return raw
 
 
@@ -328,6 +417,16 @@ def _catalog_to_toml(raw: dict[str, Any]) -> str:
             lines.append("[providers.context_windows]")
             for model, context_window in context_windows.items():
                 lines.append(f"{_toml_key(model)} = {_toml_value(context_window)}")
+        model_overrides = provider.get("model_overrides")
+        if isinstance(model_overrides, dict) and model_overrides:
+            lines.append("")
+            for model in sorted(model_overrides):
+                override = model_overrides[model]
+                lines.append(f"[providers.model_overrides.{_toml_key(model)}]")
+                for key in ("kind", "thinking_default", "always_thinking", "thinking_modes"):
+                    if key in override:
+                        lines.append(f"{key} = {_toml_value(override[key])}")
+                lines.append("")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
@@ -345,6 +444,9 @@ def _toml_value(value: object) -> str:
         return "true" if value else "false"
     if isinstance(value, int | float):
         return str(value)
+    if isinstance(value, dict):
+        items = [(str(k), v) for k, v in value.items() if v is not None]
+        return "{" + ", ".join(f"{_toml_key(k)} = {_toml_value(v)}" for k, v in sorted(items)) + "}"
     if isinstance(value, list | tuple):
         return "[" + ", ".join(_toml_value(item) for item in value) + "]"
     raise TypeError(f"Unsupported TOML value: {value!r}")

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -28,6 +28,7 @@ from tau_coding.provider_config import (
     ProviderConfig,
     ProviderSettings,
     load_provider_settings,
+    provider_default_thinking_level,
     provider_kind,
     resolve_provider_selection,
     save_provider_settings,
@@ -50,7 +51,6 @@ from tau_coding.session_export import (
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.shell_config import load_shell_settings
-from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui import run_tui_app
 from tau_coding.update_check import (
     UpdateNotice,
@@ -461,7 +461,7 @@ async def run_openai_print_mode(
     provider = create_model_provider(
         selection.provider,
         model=selection.model,
-        thinking_level=DEFAULT_THINKING_LEVEL,
+        thinking_level=provider_default_thinking_level(selection.provider, model=selection.model),
     )
     manager = session_manager or SessionManager()
     record = manager.create_session(cwd=cwd, model=selection.model)

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -652,7 +652,10 @@ def _thinking_command(context: CommandContext) -> CommandResult:
 
 def _thinking_status_lines(session: CommandSession) -> list[str]:
     if tuple(session.available_thinking_levels):
-        return [f"Thinking mode: {session.thinking_level}"]
+        label = getattr(session, "thinking_level_label", session.thinking_level)
+        return [f"Thinking mode: {label}"]
+    if getattr(session, "thinking_is_always_on", False):
+        return ["Thinking mode: always on"]
     lines = ["Thinking mode: unavailable"]
     reason = _thinking_unavailable_reason(session)
     if reason:

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -209,3 +209,106 @@ thinking_parameter = "reasoning_effort"
 "openai/gpt-oss-120b" = 131072
 "openai/gpt-oss-20b" = 131072
 "Qwen/Qwen3-Coder-480B-A35B-Instruct" = 262144
+
+[[providers]]
+name = "opencode-go"
+display_name = "OpenCode Go"
+kind = "openai-compatible"
+base_url = "https://opencode.ai/zen/go/v1"
+api_key_env = "OPENCODE_API_KEY"
+credential_name = "opencode-go"
+models = [
+  "glm-5.2",
+  "glm-5.1",
+  "kimi-k2.7-code",
+  "kimi-k2.6",
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+  "minimax-m3",
+  "minimax-m2.7",
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-plus",
+]
+default_model = "deepseek-v4-pro"
+docs_url = "https://opencode.ai/docs/go"
+thinking_levels = ["off", "low", "medium", "high", "xhigh"]
+thinking_models = [
+  "glm-5.2",
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "minimax-m3",
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-plus",
+]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"glm-5.2" = 1000000
+"glm-5.1" = 202752
+"kimi-k2.7-code" = 262144
+"kimi-k2.6" = 262144
+"deepseek-v4-pro" = 1000000
+"deepseek-v4-flash" = 1000000
+"mimo-v2.5" = 1000000
+"mimo-v2.5-pro" = 1048576
+"minimax-m3" = 1000000
+"minimax-m2.7" = 204800
+"qwen3.7-max" = 1000000
+"qwen3.7-plus" = 1000000
+"qwen3.6-plus" = 1000000
+
+[providers.model_overrides."glm-5.2"]
+thinking_default = "high"
+thinking_modes = {high = {api_value = "high"}, xhigh = {api_value = "max", label = "max"}}
+
+[providers.model_overrides."glm-5.1"]
+always_thinking = true
+
+[providers.model_overrides."kimi-k2.7-code"]
+always_thinking = true
+
+[providers.model_overrides."kimi-k2.6"]
+always_thinking = true
+
+[providers.model_overrides."deepseek-v4-pro"]
+thinking_default = "high"
+thinking_modes = {high = {api_value = "high"}, xhigh = {api_value = "max", label = "max"}}
+
+[providers.model_overrides."deepseek-v4-flash"]
+thinking_default = "high"
+thinking_modes = {high = {api_value = "high"}, xhigh = {api_value = "max", label = "max"}}
+
+[providers.model_overrides."mimo-v2.5"]
+always_thinking = true
+
+[providers.model_overrides."mimo-v2.5-pro"]
+always_thinking = true
+
+[providers.model_overrides."minimax-m3"]
+kind = "anthropic"
+thinking_default = "high"
+thinking_modes = {off = {api_value = "disabled"}, high = {api_value = "adaptive", label = "on"}}
+
+[providers.model_overrides."minimax-m2.7"]
+kind = "anthropic"
+always_thinking = true
+
+[providers.model_overrides."qwen3.7-max"]
+kind = "anthropic"
+thinking_default = "medium"
+thinking_modes = {off = {api_value = "disabled"}, low = {}, medium = {}, high = {}, xhigh = {}}
+
+[providers.model_overrides."qwen3.7-plus"]
+kind = "anthropic"
+thinking_default = "medium"
+thinking_modes = {off = {api_value = "disabled"}, low = {}, medium = {}, high = {}, xhigh = {}}
+
+[providers.model_overrides."qwen3.6-plus"]
+kind = "anthropic"
+thinking_default = "medium"
+thinking_modes = {off = {api_value = "disabled"}, low = {}, medium = {}, high = {}, xhigh = {}}

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -2,12 +2,40 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
 from tau_coding.thinking import ThinkingLevel, ThinkingParameter
 
 ProviderKind = Literal["openai-compatible", "anthropic", "openai-codex"]
+
+
+@dataclass(frozen=True, slots=True)
+class ThinkingMode:
+    """A canonical Tau thinking level's provider-specific behavior."""
+
+    api_value: str | None = None
+    label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderModelOverride:
+    """Built-in model behavior that differs from its provider defaults.
+
+    Some aggregators (for example OpenCode Go) expose models with heterogeneous
+    thinking APIs behind a single provider entry: some models take OpenAI's
+    ``reasoning_effort`` parameter, some are served through Anthropic's Messages
+    API thinking types, and some cannot disable reasoning at all. The
+    declarative TOML catalog describes one thinking configuration per provider,
+    so these per-model behaviors live here as a lookup keyed by
+    ``(provider_name, model)``.
+    """
+
+    kind: ProviderKind | None = None
+    thinking_modes: Mapping[ThinkingLevel, ThinkingMode] | None = None
+    thinking_default: ThinkingLevel | None = None
+    always_thinking: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +56,7 @@ class ProviderCatalogEntry:
     thinking_models: tuple[str, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    model_overrides: dict[str, ProviderModelOverride] | None = None
 
 
 def _load_builtin_catalog() -> tuple[ProviderCatalogEntry, ...]:
@@ -46,3 +75,13 @@ def builtin_provider_entry(name: str) -> ProviderCatalogEntry | None:
         if entry.name == name:
             return entry
     return None
+
+
+def catalog_model_override(provider_name: str, model: str | None) -> ProviderModelOverride | None:
+    """Return built-in per-model metadata for a provider/model pair."""
+    if model is None:
+        return None
+    entry = builtin_provider_entry(provider_name)
+    if entry is None or entry.model_overrides is None:
+        return None
+    return entry.model_overrides.get(model)

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -20,7 +20,7 @@ from tau_ai import (
     AnthropicConfig,
     OpenAICompatibleConfig,
 )
-from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
+from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL, AnthropicThinkingType
 from tau_coding.catalog_loader import effective_catalog, save_user_catalog_entries
 from tau_coding.credentials import FileCredentialStore, credentials_path
 from tau_coding.paths import TauPaths
@@ -28,9 +28,12 @@ from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ProviderCatalogEntry,
     ProviderKind,
+    ThinkingMode,
+    catalog_model_override,
 )
 from tau_coding.thinking import (
     DEFAULT_THINKING_LEVEL,
+    THINKING_LEVELS,
     ThinkingLevel,
     ThinkingParameter,
     anthropic_thinking_budget_for_level,
@@ -1010,12 +1013,58 @@ def provider_thinking_levels(
     model: str | None = None,
 ) -> tuple[ThinkingLevel, ...]:
     """Return thinking levels supported by a provider/model pair."""
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    if override is not None:
+        if override.always_thinking:
+            return ()
+        if override.thinking_modes is not None:
+            return tuple(level for level in THINKING_LEVELS if level in override.thinking_modes)
     if provider.thinking_levels is None:
         return ()
-    selected_model = model or provider.default_model
     if provider.thinking_models and selected_model not in provider.thinking_models:
         return ()
     return provider.thinking_levels
+
+
+def provider_thinking_is_always_on(
+    provider: ProviderConfig,
+    *,
+    model: str | None = None,
+) -> bool:
+    """Return whether built-in metadata declares reasoning as always enabled."""
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    return override.always_thinking if override is not None else False
+
+
+def provider_thinking_level_label(
+    provider: ProviderConfig,
+    level: str,
+    *,
+    model: str | None = None,
+) -> str:
+    """Return the provider-facing display label for a canonical Tau level."""
+    normalized = normalize_thinking_level(level)
+    mode = _thinking_mode(provider, model=model, level=normalized)
+    return mode.label if mode is not None and mode.label is not None else normalized
+
+
+def provider_thinking_level_from_label(
+    provider: ProviderConfig,
+    value: str,
+    *,
+    model: str | None = None,
+) -> ThinkingLevel:
+    """Resolve a provider-facing input label to a canonical Tau level."""
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    if override is not None and override.thinking_modes is not None:
+        label = value.strip().lower()
+        for level, mode in override.thinking_modes.items():
+            if mode.label == label:
+                return level
+    return normalize_thinking_level(value)
 
 
 def provider_thinking_unavailable_reason(
@@ -1025,6 +1074,8 @@ def provider_thinking_unavailable_reason(
 ) -> str | None:
     """Explain why a provider/model pair has no configurable thinking modes."""
     selected_model = model or provider.default_model
+    if provider_thinking_is_always_on(provider, model=selected_model):
+        return f"Reasoning is always enabled for {selected_model}"
     if provider.thinking_levels is None:
         if isinstance(provider, OpenAICodexProviderConfig):
             return (
@@ -1047,6 +1098,10 @@ def provider_default_thinking_level(
     levels = provider_thinking_levels(provider, model=model)
     if not levels:
         return None
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    if override is not None and override.thinking_default in levels:
+        return override.thinking_default
     if provider.thinking_default in levels:
         return provider.thinking_default
     if DEFAULT_THINKING_LEVEL in levels:
@@ -1088,13 +1143,24 @@ def anthropic_config_from_provider(
     provider: AnthropicProviderConfig,
     *,
     credential_reader: CredentialReader | None = None,
+    model: str | None = None,
     thinking_level: ThinkingLevel | None = None,
 ) -> AnthropicConfig:
     """Build Anthropic runtime config from durable settings."""
     api_key = _api_key_from_provider(provider, credential_reader=credential_reader)
-    thinking_budget_tokens = _anthropic_thinking_budget_from_provider(
+    thinking_type = _anthropic_thinking_type_from_provider(
         provider,
+        model=model,
         thinking_level=thinking_level,
+    )
+    thinking_budget_tokens = (
+        None
+        if thinking_type is not None
+        else _anthropic_thinking_budget_from_provider(
+            provider,
+            model=model,
+            thinking_level=thinking_level,
+        )
     )
     return AnthropicConfig(
         api_key=api_key,
@@ -1105,6 +1171,7 @@ def anthropic_config_from_provider(
         max_retries=provider.max_retries,
         max_retry_delay_seconds=provider.max_retry_delay_seconds,
         thinking_budget_tokens=thinking_budget_tokens,
+        thinking_type=thinking_type,
     )
 
 
@@ -1157,29 +1224,79 @@ def _reasoning_effort_from_provider(
             f"Thinking mode {normalized} is not available for "
             f"{provider.name}:{selected_model}. Available modes: {available}"
         )
-    return reasoning_effort_for_level(normalized)
+    api_value = _thinking_api_value(provider, model=model, level=normalized)
+    return api_value if api_value is not None else reasoning_effort_for_level(normalized)
 
 
 def _anthropic_thinking_budget_from_provider(
     provider: AnthropicProviderConfig,
     *,
+    model: str | None = None,
     thinking_level: ThinkingLevel | None,
 ) -> int | None:
     if thinking_level is None or provider.thinking_parameter != "anthropic.thinking":
         return None
 
-    levels = provider_thinking_levels(provider)
+    levels = provider_thinking_levels(provider, model=model)
     if not levels:
         return None
 
     normalized = normalize_thinking_level(thinking_level)
     if normalized not in levels:
+        selected_model = model or provider.default_model
         available = ", ".join(levels)
         raise ProviderConfigError(
             f"Thinking mode {normalized} is not available for "
-            f"{provider.name}:{provider.default_model}. Available modes: {available}"
+            f"{provider.name}:{selected_model}. Available modes: {available}"
         )
     return anthropic_thinking_budget_for_level(normalized)
+
+
+def _anthropic_thinking_type_from_provider(
+    provider: AnthropicProviderConfig,
+    *,
+    model: str | None,
+    thinking_level: ThinkingLevel | None,
+) -> AnthropicThinkingType | None:
+    if thinking_level is None or provider.thinking_parameter != "anthropic.thinking":
+        return None
+    normalized = normalize_thinking_level(thinking_level)
+    levels = provider_thinking_levels(provider, model=model)
+    if not levels:
+        return None
+    if normalized not in levels:
+        selected_model = model or provider.default_model
+        available = ", ".join(levels)
+        raise ProviderConfigError(
+            f"Thinking mode {normalized} is not available for "
+            f"{provider.name}:{selected_model}. Available modes: {available}"
+        )
+    api_value = _thinking_api_value(provider, model=model, level=normalized)
+    if api_value == "adaptive":
+        return "adaptive"
+    if api_value == "disabled":
+        return "disabled"
+    return None
+
+
+def _thinking_api_value(
+    provider: ProviderConfig,
+    *,
+    model: str | None,
+    level: ThinkingLevel,
+) -> str | None:
+    mode = _thinking_mode(provider, model=model, level=level)
+    return mode.api_value if mode is not None else None
+
+
+def _thinking_mode(
+    provider: ProviderConfig, *, model: str | None, level: ThinkingLevel
+) -> ThinkingMode | None:
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    if override is None or override.thinking_modes is None:
+        return None
+    return override.thinking_modes.get(level)
 
 
 def _provider_from_json(data: object) -> ProviderConfig:

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -19,6 +19,7 @@ from tau_coding.oauth import (
     oauth_credential_is_expired,
     refresh_openai_codex_token,
 )
+from tau_coding.provider_catalog import catalog_model_override
 from tau_coding.provider_config import (
     AnthropicProviderConfig,
     OpenAICodexProviderConfig,
@@ -51,11 +52,16 @@ def create_model_provider(
     if model is not None:
         validate_provider_model(provider, model)
     credentials = credential_store or FileCredentialStore()
+    selected_model = model or provider.default_model
+    override = catalog_model_override(provider.name, selected_model)
+    if override is not None and override.kind == "anthropic":
+        provider = _anthropic_provider_config_for_model(provider, selected_model)
     if isinstance(provider, AnthropicProviderConfig):
         return AnthropicProvider(
             anthropic_config_from_provider(
                 provider,
                 credential_reader=credentials,
+                model=selected_model,
                 thinking_level=thinking_level,
             )
         )
@@ -83,9 +89,35 @@ def create_model_provider(
         openai_compatible_config_from_provider(
             provider,
             credential_reader=credentials,
-            model=model,
+            model=selected_model,
             thinking_level=thinking_level,
         )
+    )
+
+
+def _anthropic_provider_config_for_model(
+    provider: ProviderConfig,
+    model: str,
+) -> AnthropicProviderConfig:
+    """Adapt shared connection settings for a model served via Messages API."""
+    if isinstance(provider, AnthropicProviderConfig):
+        return provider
+    return AnthropicProviderConfig(
+        name=provider.name,
+        base_url=provider.base_url,
+        api_key_env=provider.api_key_env,
+        credential_name=provider.credential_name,
+        models=provider.models,
+        default_model=model,
+        context_windows=provider.context_windows,
+        headers=provider.headers,
+        timeout_seconds=provider.timeout_seconds,
+        max_retries=provider.max_retries,
+        max_retry_delay_seconds=provider.max_retry_delay_seconds,
+        thinking_levels=provider.thinking_levels,
+        thinking_models=provider.thinking_models,
+        thinking_default=provider.thinking_default,
+        thinking_parameter="anthropic.thinking",
     )
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -69,6 +69,9 @@ from tau_coding.provider_config import (
     load_provider_settings,
     provider_default_thinking_level,
     provider_has_usable_credentials,
+    provider_thinking_is_always_on,
+    provider_thinking_level_from_label,
+    provider_thinking_level_label,
     provider_thinking_levels,
     provider_thinking_unavailable_reason,
     resolve_provider_selection,
@@ -498,6 +501,36 @@ class CodingSession:
         return provider_thinking_levels(provider, model=self.model)
 
     @property
+    def thinking_is_always_on(self) -> bool:
+        """Return whether the active model's reasoning cannot be disabled."""
+        provider = self._active_provider_config()
+        return provider is not None and provider_thinking_is_always_on(
+            provider,
+            model=self.model,
+        )
+
+    @property
+    def thinking_level_label(self) -> str:
+        """Return the provider-facing label for the active thinking state."""
+        if self.thinking_is_always_on:
+            return "always on"
+        provider = self._active_provider_config()
+        if provider is None:
+            return self._thinking_level
+        return provider_thinking_level_label(
+            provider,
+            self._thinking_level,
+            model=self.model,
+        )
+
+    def resolve_thinking_level(self, value: str) -> ThinkingLevel:
+        """Resolve a provider-facing label to Tau's canonical thinking state."""
+        provider = self._active_provider_config()
+        if provider is None:
+            return normalize_thinking_level(value)
+        return provider_thinking_level_from_label(provider, value, model=self.model)
+
+    @property
     def thinking_unavailable_reason(self) -> str | None:
         """Return why thinking controls are unavailable for the active model."""
         if self.available_thinking_levels:
@@ -780,7 +813,7 @@ class CodingSession:
 
     async def set_thinking_level(self, level: str) -> str:
         """Persist and activate a thinking mode for future turns."""
-        normalized = normalize_thinking_level(level)
+        normalized = self.resolve_thinking_level(level)
         available = self.available_thinking_levels
         if not available:
             raise ValueError(_unavailable_thinking_message(self))
@@ -791,7 +824,7 @@ class CodingSession:
                 f"{self._provider_name}:{self.model}. Available modes: {modes}"
             )
         if normalized == self._thinking_level:
-            return f"Thinking mode: {normalized}"
+            return f"Thinking mode: {self.thinking_level_label}"
 
         previous = self._thinking_level
         self._thinking_level = normalized
@@ -812,7 +845,7 @@ class CodingSession:
 
         self._persist_thinking_level_choice()
         await self._refresh_persisted_state(leaf_id=entry.id)
-        return f"Thinking mode: {normalized}"
+        return f"Thinking mode: {self.thinking_level_label}"
 
     async def cycle_thinking_level(self) -> str:
         """Cycle to the next supported thinking mode and persist it."""

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -69,6 +69,7 @@ from tau_coding.provider_config import (
     ProviderSelection,
     load_provider_settings,
     provider_config_from_catalog_entry,
+    provider_default_thinking_level,
     provider_has_usable_credentials,
     resolve_provider_selection,
     save_provider_settings,
@@ -87,7 +88,6 @@ from tau_coding.session import (
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.shell_config import load_shell_settings
-from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.autocomplete import (
     CompletionItem,
@@ -4144,10 +4144,13 @@ async def run_tui_app(
     startup_message: str | None = None
     runtime_provider_config: ProviderConfig | None = selection.provider
     try:
+        startup_thinking_level = provider_default_thinking_level(
+            selection.provider, model=selection.model
+        )
         provider = create_model_provider(
             selection.provider,
             model=selection.model,
-            thinking_level=DEFAULT_THINKING_LEVEL,
+            thinking_level=startup_thinking_level,
         )
     except RuntimeError:
         login_required_message = (

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1433,7 +1433,12 @@ def _context_file_label(path: Path, *, cwd: Path) -> str:
 def _thinking_level(session: SessionSummarySource) -> str:
     available = getattr(session, "available_thinking_levels", None)
     if available == ():
+        if getattr(session, "thinking_is_always_on", False):
+            return "always on"
         return "unavailable"
+    label = getattr(session, "thinking_level_label", None)
+    if label:
+        return str(label)
     explicit_level = getattr(session, "thinking_level", None)
     if explicit_level:
         return str(explicit_level)

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -11,10 +11,18 @@ from tau_coding.catalog_loader import (
     builtin_catalog,
     builtin_catalog_resource_text,
     effective_catalog,
+    save_user_catalog_entries,
     user_catalog_path,
 )
 from tau_coding.paths import TauPaths
-from tau_coding.provider_catalog import BUILTIN_PROVIDER_CATALOG, builtin_provider_entry
+from tau_coding.provider_catalog import (
+    BUILTIN_PROVIDER_CATALOG,
+    ProviderCatalogEntry,
+    ProviderModelOverride,
+    ThinkingMode,
+    builtin_provider_entry,
+    catalog_model_override,
+)
 from tau_coding.provider_config import load_provider_settings
 
 VALID_PROVIDER = """
@@ -47,7 +55,14 @@ def _write_user_catalog(tau_home: Path, body: str) -> TauPaths:
 
 def test_builtin_catalog_matches_expected_providers() -> None:
     names = [entry.name for entry in BUILTIN_PROVIDER_CATALOG]
-    assert names == ["openai", "openai-codex", "anthropic", "openrouter", "huggingface"]
+    assert names == [
+        "openai",
+        "openai-codex",
+        "anthropic",
+        "openrouter",
+        "huggingface",
+        "opencode-go",
+    ]
 
 
 def test_builtin_catalog_golden_anthropic_entry() -> None:
@@ -77,9 +92,128 @@ def test_builtin_catalog_entries_are_internally_consistent() -> None:
         assert entry.default_model in entry.models
         assert set(entry.thinking_models) <= set(entry.models)
         assert set(entry.context_windows or {}) <= set(entry.models)
+        assert set(entry.model_overrides or {}) <= set(entry.models)
         if entry.thinking_default is not None:
             assert entry.thinking_levels is not None
             assert entry.thinking_default in entry.thinking_levels
+
+
+_LOCAL_OVERRIDE_PROVIDER = """
+[[providers]]
+name = "opencode-go"
+display_name = "OpenCode Go"
+kind = "openai-compatible"
+base_url = "https://opencode.ai/zen/go/v1"
+api_key_env = "OPENCODE_API_KEY"
+credential_name = "opencode-go"
+models = ["glm-5.2", "minimax-m3"]
+default_model = "glm-5.2"
+docs_url = "https://opencode.ai/docs/go"
+thinking_levels = ["off", "low", "medium", "high", "xhigh"]
+thinking_models = ["glm-5.2"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"glm-5.2" = 1000000
+"minimax-m3" = 1000000
+
+[providers.model_overrides."glm-5.2"]
+thinking_default = "high"
+thinking_modes = {high = {api_value = "high"}, xhigh = {api_value = "max", label = "max"}}
+
+[providers.model_overrides."minimax-m3"]
+kind = "anthropic"
+always_thinking = true
+"""
+
+
+def test_builtin_catalog_golden_opencode_go_overrides() -> None:
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+    assert entry.kind == "openai-compatible"
+    assert entry.base_url == "https://opencode.ai/zen/go/v1"
+    assert entry.api_key_env == "OPENCODE_API_KEY"
+    assert entry.default_model == "deepseek-v4-pro"
+    assert entry.model_overrides is not None
+    assert set(entry.model_overrides) == set(entry.models)
+
+    glm = catalog_model_override("opencode-go", "glm-5.2")
+    assert glm is not None
+    assert glm.thinking_default == "high"
+    assert glm.thinking_modes == {
+        "high": ThinkingMode(api_value="high"),
+        "xhigh": ThinkingMode(api_value="max", label="max"),
+    }
+
+    assert catalog_model_override("opencode-go", "glm-5.1").always_thinking is True
+    assert catalog_model_override("opencode-go", "kimi-k2.7-code").thinking_modes is None
+
+    minimax = catalog_model_override("opencode-go", "minimax-m3")
+    assert minimax.kind == "anthropic"
+    assert minimax.thinking_default == "high"
+    assert minimax.thinking_modes == {
+        "off": ThinkingMode(api_value="disabled"),
+        "high": ThinkingMode(api_value="adaptive", label="on"),
+    }
+
+    qwen = catalog_model_override("opencode-go", "qwen3.7-max")
+    assert qwen.kind == "anthropic"
+    assert qwen.thinking_default == "medium"
+    assert qwen.thinking_modes == {
+        "off": ThinkingMode(api_value="disabled"),
+        "low": ThinkingMode(),
+        "medium": ThinkingMode(),
+        "high": ThinkingMode(),
+        "xhigh": ThinkingMode(),
+    }
+
+    # Unknown provider/model pairs resolve to None.
+    assert catalog_model_override("opencode-go", "unknown-model") is None
+    assert catalog_model_override("not-a-provider", "glm-5.2") is None
+    assert catalog_model_override("opencode-go", None) is None
+
+
+def test_user_catalog_model_overrides_round_trip(tmp_path: Path) -> None:
+    paths = _write_user_catalog(tmp_path / ".tau", _LOCAL_OVERRIDE_PROVIDER)
+    catalog = effective_catalog(paths)
+    entry = next(e for e in catalog if e.name == "opencode-go")
+    assert entry.model_overrides is not None
+    assert set(entry.model_overrides) == {"glm-5.2", "minimax-m3"}
+    assert entry.model_overrides["glm-5.2"].thinking_modes == {
+        "high": ThinkingMode(api_value="high"),
+        "xhigh": ThinkingMode(api_value="max", label="max"),
+    }
+    assert entry.model_overrides["minimax-m3"].kind == "anthropic"
+    assert entry.model_overrides["minimax-m3"].always_thinking is True
+
+    # Saving an entry with overrides and reloading preserves them exactly.
+    saved_override = ProviderModelOverride(
+        kind="anthropic",
+        thinking_modes={"off": ThinkingMode(api_value="disabled")},
+        thinking_default="medium",
+    )
+    save_path = save_user_catalog_entries(
+        (
+            ProviderCatalogEntry(
+                name="custom-aggregator",
+                display_name="Custom Aggregator",
+                kind="openai-compatible",
+                base_url="https://example.test/v1",
+                api_key_env="CUSTOM_API_KEY",
+                credential_name="custom-aggregator",
+                models=("a-model", "b-model"),
+                default_model="a-model",
+                docs_url="https://example.test/docs",
+                model_overrides={"a-model": saved_override},
+            ),
+        ),
+        paths=paths,
+    )
+    reloaded = effective_catalog(paths)
+    custom = next(e for e in reloaded if e.name == "custom-aggregator")
+    assert custom.model_overrides == {"a-model": saved_override}
+    assert save_path.exists()
 
 
 def test_builtin_catalog_resource_is_packaged() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -39,6 +39,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "anthropic",
         "openrouter",
         "huggingface",
+        "opencode-go",
     ]
     assert settings.providers[0].default_model == DEFAULT_MODEL
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"
@@ -292,6 +293,7 @@ def test_upsert_openai_compatible_provider_replaces_and_sets_default() -> None:
         "local",
         "openai",
         "openai-codex",
+        "opencode-go",
         "openrouter",
     ]
     assert replaced.get_provider("local").default_model == "llama"


### PR DESCRIPTION
This PR adds OpenCode Go as a provider along with all 13 models it currently offers.

The settings for each models are cross-referenced with [Anomalyco's own model declarations](https://github.com/anomalyco/models.dev/tree/dev/providers/opencode-go/models).

Caveat: OpenCode Go serves different models through different API shapes. Because of that, the PR adds support for model-scoped provider overrides, like transport kind (Anthropic/OpenAI), thinking levels, defaults, display labels, API values, and always-on reasoning. The point is to keep the UI honest: we don't show thinking levels that can't actually be selected, or do something else entirely.

For example, Qwen models send Anthropic-style budgeted thinking and can explicitly disable reasoning, MiniMax M3 uses adaptive/disabled, while DeepSeek/GLM effort models expose only the supported high/max levels.

Always-reasoning models do not show a selector, and Tau sends no fake reasoning control for them.

I tried to keep the changes provider-agnostic, so they can be reused for other mixed-behavior catalogs. For example, DeepSeek R1 on OpenRouter.