### PR TITLE
Fix TUI code block horizontal scrolling

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1477,8 +1477,9 @@ class TauTuiApp(App[None]):
         border: none;
         background: $tau-transcript-background;
         padding: 0 0 0 2;
+        overflow-x: auto;
         scrollbar-size-vertical: 0;
-        scrollbar-size-horizontal: 0;
+        scrollbar-size-horizontal: 1;
     }
 
     #queued-messages {
@@ -1951,7 +1952,8 @@ class TauTuiApp(App[None]):
                     prompt.text = raw_text
                     prompt.move_cursor(_text_end_location(raw_text))
                     self._notify(
-                        "Wait for the current agent turn and queued messages to finish before compacting.",
+                        "Wait for the current agent turn and queued messages to finish "
+                        "before compacting.",
                         severity="warning",
                     )
                     return
@@ -2023,7 +2025,12 @@ class TauTuiApp(App[None]):
         worker = self._prompt_worker
         is_worker_active = worker is not None and not worker.is_finished and not worker.is_cancelled
         is_session_running = bool(getattr(self.session, "is_running", False))
-        return self.state.running or is_session_running or is_worker_active or self.state.queued_message_count > 0
+        return (
+            self.state.running
+            or is_session_running
+            or is_worker_active
+            or self.state.queued_message_count > 0
+        )
 
     async def _run_compaction(self, summary: str) -> None:
         """Run manual compaction without disabling prompt editing."""

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -160,6 +160,7 @@ class ThemedMarkdownWidget(TextualMarkdown):
 
     ThemedMarkdownWidget MarkdownFence {
         background: $tau-markdown-code-block-background;
+        scrollbar-size-horizontal: 1;
     }
 
     ThemedMarkdownWidget MarkdownTableContent {
@@ -285,6 +286,10 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
 
     StreamingTranscriptMessageWidget > MarkdownParagraph {
         margin: 0 0 1 0;
+    }
+
+    StreamingTranscriptMessageWidget MarkdownFence {
+        scrollbar-size-horizontal: 1;
     }
     """
 
@@ -992,7 +997,7 @@ class ThemedCodeBlock(CodeBlock):
     """Rich Markdown code block with Tau's themed background color."""
 
     @classmethod
-    def create(cls, markdown: Markdown, token: Any) -> "ThemedCodeBlock":
+    def create(cls, markdown: Markdown, token: Any) -> ThemedCodeBlock:
         node_info = token.info or ""
         lexer_name = node_info.partition(" ")[0]
         code_block_background = getattr(markdown, "code_block_background", "default")

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -160,6 +160,7 @@ class ThemedMarkdownWidget(TextualMarkdown):
 
     ThemedMarkdownWidget MarkdownFence {
         background: $tau-markdown-code-block-background;
+        overflow-x: auto;
         scrollbar-size-horizontal: 1;
     }
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1511,25 +1511,30 @@ async def test_tui_transcript_reflows_when_terminal_resizes() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_transcript_allows_horizontal_code_block_scrolling() -> None:
-    app = TauTuiApp(
-        FakeSession(
-            messages=[
-                AssistantMessage(
-                    content="```python\n" + "value = '" + ("x" * 140) + "'\n```"
-                )
-            ]
-        )
-    )
+@pytest.mark.parametrize(
+    ("code", "has_horizontal_overflow"),
+    [
+        ("x = 1", False),
+        ("value = '" + ("x" * 140) + "'", True),
+    ],
+)
+async def test_tui_transcript_code_block_scrollbar_matches_overflow(
+    code: str,
+    has_horizontal_overflow: bool,
+) -> None:
+    app = TauTuiApp(FakeSession(messages=[AssistantMessage(content=f"```python\n{code}\n```")]))
 
-    async with app.run_test(size=(64, 30)):
+    async with app.run_test(size=(64, 30)) as pilot:
+        await pilot.pause()
         transcript = app.query_one("#transcript", TranscriptView)
         fence = app.query_one("MarkdownFence")
         assert transcript.styles.overflow_x == "auto"
         assert transcript.styles.scrollbar_size_horizontal == 1
         assert fence.styles.scrollbar_size_horizontal == 1
-        assert fence.styles.overflow_x == "scroll"
+        assert fence.styles.overflow_x == "auto"
         assert fence.allow_horizontal_scroll is True
+        assert (fence.max_scroll_x > 0) is has_horizontal_overflow
+        assert fence.show_horizontal_scrollbar is has_horizontal_overflow
 
 
 def test_tui_app_uses_configured_theme_css_variables() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -64,8 +64,8 @@ from tau_coding.tui.app import (
     TreePickerScreen,
     _activity_prompt_border_color,
     _completion_selected_render_line,
-    _theme_css_variables,
     _terminal_command_prefix_span,
+    _theme_css_variables,
     _visible_completion_state,
 )
 from tau_coding.tui.autocomplete import CompletionItem, CompletionState
@@ -81,9 +81,9 @@ from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
     LeftAlignedMarkdownHeading,
     StreamingTranscriptMessageWidget,
+    ThemedMarkdownWidget,
     TranscriptMessageWidget,
     TranscriptView,
-    ThemedMarkdownWidget,
     _compact_token_count,
     _syntax_language,
     _transcript_plain_body_text,
@@ -92,7 +92,6 @@ from tau_coding.tui.widgets import (
     render_session_sidebar,
     transcript_item_selection_text,
 )
-
 
 ANSI_PATTERN = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
@@ -902,7 +901,9 @@ def test_dark_theme_markdown_bullets_use_theme_bullet_color() -> None:
 def test_markdown_tables_use_highlight_color_for_headers() -> None:
     console = Console(record=True, width=80, color_system="truecolor")
     console.print(
-        render_chat_item(ChatItem(role="assistant", text="| Name | Value |\n| --- | --- |\n| A | B |"))
+        render_chat_item(
+            ChatItem(role="assistant", text="| Name | Value |\n| --- | --- |\n| A | B |")
+        )
     )
 
     output = console.export_text(styles=True)
@@ -1509,6 +1510,28 @@ async def test_tui_transcript_reflows_when_terminal_resizes() -> None:
         assert transcript.scroll_offset.x == 0
 
 
+@pytest.mark.anyio
+async def test_tui_transcript_allows_horizontal_code_block_scrolling() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content="```python\n" + "value = '" + ("x" * 140) + "'\n```"
+                )
+            ]
+        )
+    )
+
+    async with app.run_test(size=(64, 30)):
+        transcript = app.query_one("#transcript", TranscriptView)
+        fence = app.query_one("MarkdownFence")
+        assert transcript.styles.overflow_x == "auto"
+        assert transcript.styles.scrollbar_size_horizontal == 1
+        assert fence.styles.scrollbar_size_horizontal == 1
+        assert fence.styles.overflow_x == "scroll"
+        assert fence.allow_horizontal_scroll is True
+
+
 def test_tui_app_uses_configured_theme_css_variables() -> None:
     app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme="high-contrast"))
 
@@ -1767,7 +1790,9 @@ async def test_tui_app_blocks_session_commands_while_compacting(blocked_command:
             self.compact_summaries.append(summary)
             started.set()
             await finish.wait()
-            self.messages = (UserMessage(content="Previous conversation summary:\nGenerated summary"),)
+            self.messages = (
+                UserMessage(content="Previous conversation summary:\nGenerated summary"),
+            )
             self.context_token_estimate = 42
             return "Compacted 2 context entries."
 
@@ -1794,7 +1819,9 @@ async def test_tui_app_blocks_session_commands_while_compacting(blocked_command:
         assert session.new_session_count == 0
         assert session.resumed_session_ids == []
         assert prompt.value == blocked_command
-        assert notifications == ["Compaction is still running. You can keep editing, but wait to submit."]
+        assert notifications == [
+            "Compaction is still running. You can keep editing, but wait to submit."
+        ]
 
         finish.set()
         await pilot.pause()
@@ -1865,7 +1892,9 @@ async def test_tui_app_escape_cancels_active_compaction() -> None:
             self.compact_summaries.append(summary)
             started.set()
             await finish.wait()
-            self.messages = (UserMessage(content="Previous conversation summary:\nGenerated summary"),)
+            self.messages = (
+                UserMessage(content="Previous conversation summary:\nGenerated summary"),
+            )
             self.context_token_estimate = 42
             return "Compacted 2 context entries."
 


### PR DESCRIPTION
code blocks with long lines in the TUI rendered without a visible way to scroll horizontally, leaving clipped content inaccessible.

This PR adds a scrollbar for codeblocks that are horizontally overflowing.

Before:
<img width="643" height="225" alt="Screenshot 2026-06-30 at 16 39 07" src="https://github.com/user-attachments/assets/18112dac-d035-4a4b-9967-42006eafe9ff" />

After:
<img width="632" height="245" alt="Screenshot 2026-06-30 at 16 39 48" src="https://github.com/user-attachments/assets/744dbd37-6f30-4000-918b-af98ebc3e99b" />

Note: I noticed this when it happened on some output that was more important to see. I just use that ruff screenshot example to make the point.