### PR TITLE
Gate PyPI publishing on version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
+    paths:
+      - pyproject.toml
   release:
     types:
       - published
@@ -15,6 +15,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: pypi-publish
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -33,19 +39,52 @@ jobs:
         with:
           python-version-file: .python-version
 
+      - name: Read package metadata
+        id: package
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import tomllib
+
+          project = tomllib.load(open("pyproject.toml", "rb"))["project"]
+          print(f"name={project['name']}")
+          print(f"version={project['version']}")
+          PY
+
+      - name: Check publish trigger
+        id: trigger
+        run: |
+          SHOULD_PUBLISH=false
+          REASON="This workflow only publishes on an intentional release trigger."
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE="${{ github.event.before }}"
+            CURRENT_VERSION="${{ steps.package.outputs.version }}"
+            PREVIOUS_VERSION=$(git show "${BEFORE}:pyproject.toml" 2>/dev/null | python -c 'import sys, tomllib; print(tomllib.load(sys.stdin.buffer)["project"]["version"])' 2>/dev/null || true)
+
+            if [ -n "$PREVIOUS_VERSION" ] && [ "$PREVIOUS_VERSION" != "$CURRENT_VERSION" ]; then
+              SHOULD_PUBLISH=true
+              REASON="project.version changed from ${PREVIOUS_VERSION} to ${CURRENT_VERSION}."
+            else
+              REASON="project.version did not change; skipping PyPI publish."
+            fi
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            SHOULD_PUBLISH=true
+            REASON="GitHub release was published."
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHOULD_PUBLISH=true
+            REASON="Manual release dispatch was requested."
+          fi
+
+          echo "should_publish=${SHOULD_PUBLISH}" >> "$GITHUB_OUTPUT"
+          echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
+          echo "$REASON"
+
       - name: Check whether version is already on PyPI
         id: pypi
+        if: steps.trigger.outputs.should_publish == 'true'
         run: |
-          NAME=$(python - <<'PY'
-          import tomllib
-          print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])
-          PY
-          )
-          VERSION=$(python - <<'PY'
-          import tomllib
-          print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])
-          PY
-          )
+          NAME="${{ steps.package.outputs.name }}"
+          VERSION="${{ steps.package.outputs.version }}"
           STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/${NAME}/${VERSION}/json")
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -57,9 +96,9 @@ jobs:
           fi
 
       - name: Build package
-        if: steps.pypi.outputs.exists != 'true'
+        if: steps.trigger.outputs.should_publish == 'true' && steps.pypi.outputs.exists != 'true'
         run: uv build
 
       - name: Publish package
-        if: steps.pypi.outputs.exists != 'true'
+        if: steps.trigger.outputs.should_publish == 'true' && steps.pypi.outputs.exists != 'true'
         run: uv publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,18 @@ For user-facing behavior, update the published docs under:
 website/src/content/docs/
 ```
 
+## Release process
+
+Tau is published to PyPI as `tau-ai`. Publishing is a production release action,
+not a side effect of every commit merged to `main`.
+
+To prepare a release, intentionally bump `[project].version` in `pyproject.toml`
+and merge that change through a pull request. The PyPI workflow publishes only
+when it detects that version change, or when a maintainer uses an explicit
+release trigger such as a published GitHub Release or manual workflow dispatch.
+See [dev-notes/release-process.md](dev-notes/release-process.md) for the full
+process.
+
 ## Pull request guidelines
 
 Good Tau pull requests are small, focused, and easy to review. Please include:

--- a/dev-notes/release-process.md
+++ b/dev-notes/release-process.md
@@ -1,0 +1,53 @@
+# Tau release process
+
+Tau is published to PyPI as `tau-ai`. Publishing is intentionally tied to a
+release decision, not to every commit that lands on `main`.
+
+## What runs on ordinary `main` commits
+
+Ordinary commits merged to `main` should run validation workflows, documentation
+builds, and other checks, but they should not create a PyPI release unless the
+package version changes.
+
+The PyPI workflow listens to pushes that touch `pyproject.toml`, but it still
+checks the previous commit before publishing. If `[project].version` did not
+change, the workflow exits without building or uploading a package.
+
+## Version source of truth
+
+The package version lives in `pyproject.toml`:
+
+```toml
+[project]
+version = "0.1.0"
+```
+
+A production release starts by intentionally changing that value.
+
+## How to publish a release
+
+1. Choose the next version number.
+2. Update `[project].version` in `pyproject.toml`.
+3. Open a PR with the version bump and any release notes or documentation
+   updates that should accompany it.
+4. Merge the PR to `main` after checks pass.
+5. The `Publish Python package` workflow detects that the version changed and
+   attempts to publish the new package to PyPI.
+6. Verify the release at <https://pypi.org/project/tau-ai/>.
+
+Maintainers may also publish from an explicit GitHub Release or by manually
+running the workflow. Those paths are reserved for intentional release actions,
+not routine development commits.
+
+## Duplicate-version protection
+
+Before building or uploading, the workflow checks whether the package name and
+version already exist on PyPI. If the version is already present, publishing is
+skipped instead of attempting a duplicate upload.
+
+## Safe failure behavior
+
+If `pyproject.toml` changes without a version bump, or a normal `main` commit
+lands without touching release metadata, the workflow does not publish. This
+keeps package versions meaningful and makes the production release process easy
+to audit.


### PR DESCRIPTION
## Summary
- gate the PyPI workflow so ordinary main commits do not publish packages
- publish from main only when pyproject.toml's project version changes
- document Tau's production release process and duplicate-version protection

Closes #195

## Tests / checks
- uv run pytest *(fails: existing test expects /exit to be unknown, but current code returns Exiting session.)*
- uv run ruff check . *(fails on pre-existing lint issues outside this change)*
- uv run ruff format --check . *(not reached in combined command because ruff check failed)*
- uv run mypy *(not reached in combined command because ruff check failed)*
- uv build
- uv run python workflow smoke check
- git diff --check