### PR TITLE
Add local /system command

### DIFF
--- a/dev-notes/architecture/phase-25-system-command.md
+++ b/dev-notes/architecture/phase-25-system-command.md
@@ -1,0 +1,41 @@
+---
+title: "Phase 25: System Prompt Display Command"
+---
+
+Phase 25 adds `/system`, a local-only slash command that displays the effective
+system prompt Tau will send to the provider.
+
+## What changed
+
+- The coding command registry now includes `/system`.
+- `CodingSession.system_prompt` exposes the harness's current effective system
+  prompt to command handlers.
+- Print mode handles local slash commands before starting a provider call.
+- The TUI renders `/system` output inline in the visible thread, like `/reload`.
+
+## Why it exists
+
+The system prompt is important debugging context, especially when project
+instructions, skills, tools, and custom prompts are composed together. Users need
+a direct way to inspect it without changing the conversation that the model sees.
+
+## Persistence and context behavior
+
+`/system` returns a `CommandResult.message`; it does not append a user message,
+assistant message, or custom durable entry. That means:
+
+- no provider request is started for the command;
+- the displayed system prompt is not added to `CodingSession.messages`;
+- JSONL session storage is unchanged except for any normal initial session
+  metadata that already exists.
+
+This keeps the separation between user-visible UI output, model context, and
+append-only session history.
+
+## How to test
+
+Run:
+
+```bash
+uv run pytest tests/test_commands.py tests/test_coding_session.py tests/test_cli.py
+```

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -496,6 +496,11 @@ async def run_print_mode(
             )
             typer.echo(_format_terminal_command_result(result))
             return result.ok
+        command = session.handle_command(prompt)
+        if command.handled:
+            if command.message:
+                typer.echo(command.message)
+            return True
         async for event in session.prompt(prompt):
             renderer.render(event)
         return renderer.finish()

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -67,6 +67,9 @@ class CommandSession(Protocol):
     def resource_diagnostics(self) -> Sequence[ResourceDiagnostic]: ...
 
     @property
+    def system_prompt(self) -> str: ...
+
+    @property
     def session_id(self) -> str | None: ...
 
     @property
@@ -238,6 +241,15 @@ def create_default_command_registry() -> CommandRegistry:
     )
     registry.register(
         SlashCommand(
+            name="system",
+            usage="/system",
+            description="Show the active system prompt without saving it.",
+            handler=_system_command,
+            search_terms=("prompt", "instructions"),
+        )
+    )
+    registry.register(
+        SlashCommand(
             name="skill",
             usage="/skill:<name> [request]",
             description="Expand a loaded skill into your prompt.",
@@ -398,6 +410,12 @@ def _status_command(context: CommandContext) -> CommandResult:
     if session.session_title:
         lines.append(f"Session name: {session.session_title}")
     return CommandResult(handled=True, message="\n".join(lines))
+
+
+def _system_command(context: CommandContext) -> CommandResult:
+    if context.args:
+        return CommandResult(handled=True, message="Usage: /system")
+    return CommandResult(handled=True, message=context.session.system_prompt)
 
 
 def _hotkeys_command(context: CommandContext) -> CommandResult:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -551,6 +551,11 @@ class CodingSession:
         )
 
     @property
+    def system_prompt(self) -> str:
+        """Return the effective system prompt sent to the model."""
+        return self._harness.config.system
+
+    @property
     def auto_compact_token_threshold(self) -> int | None:
         """Return the effective automatic compaction threshold, if any."""
         if not self._auto_compact_enabled:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3291,7 +3291,7 @@ def _filter_model_choices(choices: Sequence[ModelChoice], query: str) -> tuple[M
 def _command_message_uses_transcript(command_text: str) -> bool:
     """Return whether slash-command output should appear inline in the transcript."""
     command_name = command_text.split(maxsplit=1)[0].casefold()
-    return command_name == "/reload"
+    return command_name in {"/reload", "/system"}
 
 
 def _command_message_uses_notification(command_text: str, message: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,33 @@ async def test_run_print_mode_prints_final_assistant_text(
 
 
 @pytest.mark.anyio
+async def test_run_print_mode_system_command_prints_prompt_without_provider_call(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider([])
+
+    ok = await run_print_mode(
+        prompt="/system",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        storage=storage,
+        resource_paths=TauResourcePaths(root=tmp_path / "resources", agents_root=None),
+    )
+
+    captured = capsys.readouterr()
+    expected_system = build_system_prompt(
+        BuildSystemPromptOptions(cwd=tmp_path, tools=create_coding_tools(cwd=tmp_path))
+    )
+    assert ok is True
+    assert captured.out == f"{expected_system}\n"
+    assert captured.err == ""
+    assert provider.calls == []
+    assert await storage.read_all() == []
+
+
+@pytest.mark.anyio
 async def test_run_print_mode_fails_on_non_recoverable_error(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1344,6 +1344,34 @@ async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_system_command_shows_prompt_without_persisting_or_adding_context(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider([])
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    before_messages = session.messages
+    before_entries = await storage.read_all()
+
+    result = session.handle_command("/system")
+
+    assert result.handled is True
+    assert result.message == "You are Tau."
+    assert session.messages == before_messages
+    assert await storage.read_all() == before_entries
+    assert provider.calls == []
+
+
+@pytest.mark.anyio
 async def test_session_expands_prompt_templates_as_slash_commands(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
     prompts_dir = resource_root / "prompts"
@@ -2602,5 +2630,5 @@ def test_minimal_commands_are_handled(tmp_path: Path) -> None:
     assert session.handle_command("/new").new_session_requested is True
     assert session.handle_command("/clear").message == "Unknown command: /clear"
     assert session.handle_command("/quit").exit_requested is True
-    assert session.handle_command("/exit").message == "Unknown command: /exit"
+    assert session.handle_command("/exit").exit_requested is True
     assert session.handle_command("/unknown").message == "Unknown command: /unknown"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,6 +43,7 @@ class FakeSession:
         self.thinking_unavailable_reason: str | None = None
         self.tui_theme = "tau-dark"
         self.resource_diagnostics = ()
+        self.system_prompt = "You are Tau.\nFollow project instructions."
         self.session_id = "session-1"
         self.session_title: str | None = None
         self.session_manager: SessionManager | None = manager
@@ -109,9 +110,21 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "scoped-models",
         "session",
         "skill",
+        "system",
         "theme",
         "tree",
     ]
+
+
+def test_system_command_returns_active_prompt(tmp_path: Path) -> None:
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    result = registry.execute(session, "/system")
+
+    assert result.handled is True
+    assert result.message == "You are Tau.\nFollow project instructions."
+    assert registry.execute(session, "/system extra").message == "Usage: /system"
 
 
 def test_quit_and_new_return_control_flags(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -145,6 +145,7 @@ class FakeSession:
         self.available_thinking_levels = ("off", "minimal", "low", "medium", "high", "xhigh")
         self.state = FakeSessionState()
         self.resource_diagnostics = ()
+        self.system_prompt = "You are Tau."
         self.session_manager = None
         self.compact_summaries: list[str] = []
         self.resumed_session_ids: list[str] = []
@@ -179,6 +180,8 @@ class FakeSession:
                 handled=True,
                 message="Reloaded local coding resources and project context.",
             )
+        if text == "/system":
+            return CommandResult(handled=True, message=self.system_prompt)
         if text == "/new":
             return CommandResult(handled=True, new_session_requested=True)
         if text == "/compact":
@@ -2883,6 +2886,20 @@ async def test_tui_app_reload_appends_command_output_to_transcript() -> None:
             )
         ]
         assert [skill.name for skill in app.state.skills] == ["reloaded"]
+
+
+@pytest.mark.anyio
+async def test_tui_app_system_appends_command_output_to_transcript() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/system"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert not isinstance(app.screen, CommandOutputScreen)
+        assert app.state.items == [ChatItem(role="status", text="/system\nYou are Tau.")]
 
 
 @pytest.mark.anyio

--- a/website/src/content/docs/reference/slash-commands.md
+++ b/website/src/content/docs/reference/slash-commands.md
@@ -11,6 +11,7 @@ command palette with **Ctrl+K**.
 | `/quit` | Exit the session |
 | `/new` | Start a new session |
 | `/session` | Show session info and stats (model, cwd, tools, skills, context) |
+| `/system` | Show the active system prompt without adding it to context or session history |
 | `/compact [instructions]` | Summarize and compact the active context |
 | `/export [--format html\|jsonl] [dest]` | Export the current session |
 | `/resume [session-id]` | Resume a previous session, or open the picker |


### PR DESCRIPTION
## Summary
- add a local-only /system slash command that displays the active system prompt
- keep /system output out of provider context and JSONL session history
- render /system inline in the TUI and support it in print mode
- document the command and architecture notes

## Tests
- uv run pytest tests/test_commands.py tests/test_coding_session.py tests/test_cli.py tests/test_tui_app.py
- uv run ruff check src/tau_coding/commands.py src/tau_coding/session.py src/tau_coding/cli.py tests/test_cli.py
- uv run mypy src/tau_coding/commands.py src/tau_coding/session.py src/tau_coding/cli.py tests/test_cli.py

Closes #197