### PR TITLE
Check PyPI for Tau updates on startup

### DIFF
--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -1,0 +1,30 @@
+# Startup update check
+
+Tau now performs a small, best-effort update check in CLI startup paths that launch the product experience: the Textual TUI and text print mode.
+
+## What was added
+
+- `tau_coding.update_check` fetches PyPI metadata for the published package (`tau-ai`).
+- Versions are compared with `packaging.version.Version` so PEP 440 releases sort correctly.
+- The result is cached under `~/.tau/cache/update-check.json` and refreshed at most once per day.
+- Failures are quiet no-ops: network errors, malformed JSON, missing fields, and invalid versions do not stop startup.
+- `TAU_NO_UPDATE_CHECK=1` disables the check, and the check is skipped automatically when `CI` is set.
+
+## Where it belongs
+
+This lives in `tau_coding`, not `tau_agent`, because update notification is CLI application behavior. The reusable agent harness remains independent of PyPI, Rich/Textual UI concerns, and Tau's home-directory layout.
+
+## Output policy
+
+- TUI startup passes the notice through the existing startup notification path.
+- Print mode writes the notice to stderr for normal text output.
+- Structured print output (`--output json`) suppresses the notice to avoid corrupting scripted output.
+- Utility commands (`tau --version`, `tau sessions`, `tau export`, `tau providers`, `tau setup`) do not run the update check.
+
+## Testing
+
+Run:
+
+```bash
+uv run pytest tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.14"
 dependencies = [
     "anyio>=4.0",
     "httpx>=0.27",
+    "packaging>=24.0",
     "pydantic>=2.0",
     "rich>=13.0",
     "textual>=1.0",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -49,6 +49,7 @@ from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui import run_tui_app
+from tau_coding.update_check import UpdateNotice, startup_update_notice
 
 app = typer.Typer(
     name="tau",
@@ -221,6 +222,7 @@ def main(
         raise typer.Exit()
 
     if prompt_option is None:
+        notice = _startup_update_notice()
         try:
             anyio.run(
                 run_openai_tui,
@@ -231,6 +233,7 @@ def main(
                 provider,
                 auto_compact_threshold,
                 initial_prompt,
+                notice,
             )
         except RuntimeError as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -239,6 +242,10 @@ def main(
     prompt = prompt_option
     if prompt is None:
         raise AssertionError("prompt option should be set outside TUI mode")
+
+    notice = _startup_update_notice()
+    if notice is not None and output is PrintOutputMode.text:
+        typer.echo(notice.message, err=True)
 
     try:
         ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd(), output, provider)
@@ -256,6 +263,7 @@ async def run_openai_tui(
     provider_name: str | None = None,
     auto_compact_token_threshold: int | None = None,
     initial_prompt: str | None = None,
+    update_notice: UpdateNotice | None = None,
 ) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
     await run_tui_app(
@@ -266,7 +274,12 @@ async def run_openai_tui(
         provider_name=provider_name,
         auto_compact_token_threshold=auto_compact_token_threshold,
         initial_prompt=initial_prompt,
+        startup_notice=update_notice.message if update_notice is not None else None,
     )
+
+
+def _startup_update_notice() -> UpdateNotice | None:
+    return startup_update_notice(__version__)
 
 
 def render_session_list(records: list[CodingSessionRecord]) -> None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3666,6 +3666,7 @@ async def run_tui_app(
     auto_compact_token_threshold: int | None = None,
     initial_prompt: str | None = None,
     session_manager: SessionManager | None = None,
+    startup_notice: str | None = None,
 ) -> None:
     """Create the default provider/session and run the Textual app."""
     if new_session and session_id is not None:
@@ -3685,7 +3686,7 @@ async def run_tui_app(
         model=model,
         explicit_resume=session_id is not None,
     )
-    startup_message: str | None = None
+    startup_message: str | None = startup_notice
     runtime_provider_config: ProviderConfig | None = selection.provider
     try:
         provider = create_model_provider(
@@ -3694,9 +3695,14 @@ async def run_tui_app(
             thinking_level=DEFAULT_THINKING_LEVEL,
         )
     except RuntimeError:
-        startup_message = (
+        login_required_message = (
             "Login required. Run /login to choose a provider, "
             f"or /login {selection.provider.name} to continue with the current provider."
+        )
+        startup_message = (
+            f"{startup_message}\n{login_required_message}"
+            if startup_message
+            else login_required_message
         )
         provider = LoginRequiredProvider(startup_message)
         runtime_provider_config = None

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1767,15 +1767,19 @@ class TauTuiApp(App[None]):
         *,
         tui_settings: TuiSettings | None = None,
         startup_message: str | None = None,
+        startup_notice: str | None = None,
         initial_prompt: str | None = None,
     ) -> None:
         self.tui_settings = tui_settings or TuiSettings()
         self.startup_message = startup_message
+        self.startup_notice = startup_notice
         self.initial_prompt = initial_prompt
         super().__init__()
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
         self.state = TuiState(skills=session.skills)
+        if startup_notice:
+            self.state.add_item("status", startup_notice)
         self.state.load_messages(session.messages)
         self.adapter = TuiEventAdapter(self.state)
         self._prompt_worker: Worker[None] | None = None
@@ -3686,7 +3690,7 @@ async def run_tui_app(
         model=model,
         explicit_resume=session_id is not None,
     )
-    startup_message: str | None = startup_notice
+    startup_message: str | None = None
     runtime_provider_config: ProviderConfig | None = selection.provider
     try:
         provider = create_model_provider(
@@ -3699,11 +3703,7 @@ async def run_tui_app(
             "Login required. Run /login to choose a provider, "
             f"or /login {selection.provider.name} to continue with the current provider."
         )
-        startup_message = (
-            f"{startup_message}\n{login_required_message}"
-            if startup_message
-            else login_required_message
-        )
+        startup_message = login_required_message
         provider = LoginRequiredProvider(startup_message)
         runtime_provider_config = None
     session: CodingSession | None = None
@@ -3737,6 +3737,7 @@ async def run_tui_app(
             session,
             tui_settings=load_tui_settings(),
             startup_message=startup_message,
+            startup_notice=startup_notice,
             initial_prompt=initial_prompt,
         )
         await app.run_async()

--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -68,13 +68,15 @@ def startup_update_notice(
         return None
 
     current_time = (now or _utc_now)()
-    latest_version = _cached_latest_version(cache_path, current_time)
-    if latest_version is None:
+    cached_result = _cached_update_check_result(cache_path, current_time)
+    if cached_result is None:
         try:
             latest_version = fetch_latest_pypi_version(fetcher=fetcher)
         except Exception:  # noqa: BLE001 - update checks must never block startup
             return None
         _write_update_check_cache(cache_path, current_time, latest_version)
+    else:
+        latest_version = cached_result.latest_version
 
     if latest_version is None:
         return None
@@ -119,7 +121,10 @@ def _stable_release_versions(releases: dict[Any, Any]) -> list[Version]:
             continue
         if isinstance(files, list) and not files:
             continue
-        parsed = Version(version_text)
+        try:
+            parsed = Version(version_text)
+        except InvalidVersion:
+            continue
         if parsed.is_prerelease or parsed.is_devrelease:
             continue
         versions.append(parsed)
@@ -135,7 +140,7 @@ def _httpx_fetch_json(url: str, timeout_seconds: float) -> dict[str, Any]:
     return data
 
 
-def _cached_latest_version(cache_path: Path | None, now: datetime) -> str | None:
+def _cached_update_check_result(cache_path: Path | None, now: datetime) -> UpdateCheckResult | None:
     path = cache_path or default_update_check_cache_path()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -144,7 +149,7 @@ def _cached_latest_version(cache_path: Path | None, now: datetime) -> str | None
         return None
     if now - result.checked_at > UPDATE_CHECK_INTERVAL:
         return None
-    return result.latest_version
+    return result
 
 
 def _parse_cached_result(data: Any) -> UpdateCheckResult:

--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -1,0 +1,196 @@
+"""Best-effort PyPI update checks for the Tau CLI."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from os import environ
+from pathlib import Path
+from typing import Any
+
+import httpx
+from packaging.version import InvalidVersion, Version
+
+from tau_coding.paths import TauPaths
+
+PYPI_PACKAGE_NAME = "tau-ai"
+PYPI_JSON_URL = f"https://pypi.org/pypi/{PYPI_PACKAGE_NAME}/json"
+UPDATE_CHECK_INTERVAL = timedelta(days=1)
+UPDATE_CHECK_TIMEOUT_SECONDS = 1.5
+UPDATE_CHECK_ENV_DISABLE = "TAU_NO_UPDATE_CHECK"
+
+Fetcher = Callable[[str, float], dict[str, Any]]
+Clock = Callable[[], datetime]
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateNotice:
+    """A user-facing update notice."""
+
+    current_version: str
+    latest_version: str
+    package_name: str = PYPI_PACKAGE_NAME
+
+    @property
+    def message(self) -> str:
+        """Return concise update guidance."""
+        return (
+            f"Tau {self.latest_version} is available (installed: {self.current_version}). "
+            f"Update with: uv tool upgrade {self.package_name}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateCheckResult:
+    """Cached latest-version lookup result."""
+
+    checked_at: datetime
+    latest_version: str | None
+
+
+def startup_update_notice(
+    current_version: str,
+    *,
+    fetcher: Fetcher | None = None,
+    cache_path: Path | None = None,
+    now: Clock | None = None,
+    env: Mapping[str, str] | None = None,
+) -> UpdateNotice | None:
+    """Return an update notice when PyPI has a newer stable Tau release.
+
+    This function is intentionally best-effort: cache, network, JSON, and version
+    parsing failures all become quiet no-ops so startup can continue.
+    """
+    environment = environ if env is None else env
+    if _update_check_disabled(environment):
+        return None
+
+    current_time = (now or _utc_now)()
+    latest_version = _cached_latest_version(cache_path, current_time)
+    if latest_version is None:
+        try:
+            latest_version = fetch_latest_pypi_version(fetcher=fetcher)
+        except Exception:  # noqa: BLE001 - update checks must never block startup
+            return None
+        _write_update_check_cache(cache_path, current_time, latest_version)
+
+    if latest_version is None:
+        return None
+
+    try:
+        if Version(latest_version) <= Version(current_version):
+            return None
+    except InvalidVersion:
+        return None
+
+    return UpdateNotice(current_version=current_version, latest_version=latest_version)
+
+
+def fetch_latest_pypi_version(*, fetcher: Fetcher | None = None) -> str | None:
+    """Fetch the latest stable Tau version from PyPI."""
+    data = (fetcher or _httpx_fetch_json)(PYPI_JSON_URL, UPDATE_CHECK_TIMEOUT_SECONDS)
+    releases = data.get("releases")
+    if isinstance(releases, dict):
+        versions = _stable_release_versions(releases)
+        if versions:
+            return str(max(versions))
+
+    info = data.get("info")
+    if isinstance(info, dict):
+        version = info.get("version")
+        if isinstance(version, str):
+            parsed = Version(version)
+            if not parsed.is_prerelease and not parsed.is_devrelease:
+                return version
+    return None
+
+
+def default_update_check_cache_path(paths: TauPaths | None = None) -> Path:
+    """Return the on-disk cache path for startup update checks."""
+    return (paths or TauPaths()).home / "cache" / "update-check.json"
+
+
+def _stable_release_versions(releases: dict[Any, Any]) -> list[Version]:
+    versions: list[Version] = []
+    for version_text, files in releases.items():
+        if not isinstance(version_text, str):
+            continue
+        if isinstance(files, list) and not files:
+            continue
+        parsed = Version(version_text)
+        if parsed.is_prerelease or parsed.is_devrelease:
+            continue
+        versions.append(parsed)
+    return versions
+
+
+def _httpx_fetch_json(url: str, timeout_seconds: float) -> dict[str, Any]:
+    response = httpx.get(url, timeout=timeout_seconds, follow_redirects=True)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("PyPI response must be a JSON object")
+    return data
+
+
+def _cached_latest_version(cache_path: Path | None, now: datetime) -> str | None:
+    path = cache_path or default_update_check_cache_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        result = _parse_cached_result(data)
+    except Exception:  # noqa: BLE001 - corrupt caches should be ignored
+        return None
+    if now - result.checked_at > UPDATE_CHECK_INTERVAL:
+        return None
+    return result.latest_version
+
+
+def _parse_cached_result(data: Any) -> UpdateCheckResult:
+    if not isinstance(data, dict):
+        raise ValueError("cache must be a JSON object")
+    checked_at = data.get("checked_at")
+    latest_version = data.get("latest_version")
+    if not isinstance(checked_at, str):
+        raise ValueError("cache missing checked_at")
+    if latest_version is not None and not isinstance(latest_version, str):
+        raise ValueError("cache latest_version must be a string")
+    parsed_checked_at = datetime.fromisoformat(checked_at)
+    if parsed_checked_at.tzinfo is None:
+        parsed_checked_at = parsed_checked_at.replace(tzinfo=UTC)
+    return UpdateCheckResult(checked_at=parsed_checked_at, latest_version=latest_version)
+
+
+def _write_update_check_cache(
+    cache_path: Path | None,
+    checked_at: datetime,
+    latest_version: str | None,
+) -> None:
+    path = cache_path or default_update_check_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "checked_at": checked_at.astimezone(UTC).isoformat(),
+                    "latest_version": latest_version,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+
+
+def _update_check_disabled(env: Mapping[str, str]) -> bool:
+    value = env.get(UPDATE_CHECK_ENV_DISABLE)
+    if value is not None and value.strip().lower() not in {"", "0", "false", "no"}:
+        return True
+    return bool(env.get("CI"))
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from tau_coding.rendering import PrintOutputMode
 from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
+from tau_coding.update_check import UpdateNotice
 
 
 def test_version_command() -> None:
@@ -31,6 +32,81 @@ def test_version_command() -> None:
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "tau 0.1.0"
+
+
+def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_startup_update_notice",
+        lambda: (_ for _ in ()).throw(AssertionError("no update check")),
+    )
+
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "tau 0.1.0"
+
+
+def test_print_mode_writes_update_notice_to_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+    ) -> bool:
+        del prompt, model, cwd, output, provider_name
+        return True
+
+    monkeypatch.setattr(
+        cli,
+        "_startup_update_notice",
+        lambda: UpdateNotice(current_version="0.1.0", latest_version="0.2.0"),
+    )
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["-p", "hello"])
+
+    assert result.exit_code == 0
+    assert "Tau 0.2.0 is available (installed: 0.1.0)" in result.stderr
+
+
+def test_json_print_mode_suppresses_update_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+    ) -> bool:
+        del prompt, model, cwd, output, provider_name
+        return True
+
+    monkeypatch.setattr(
+        cli,
+        "_startup_update_notice",
+        lambda: UpdateNotice(current_version="0.1.0", latest_version="0.2.0"),
+    )
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["-p", "hello", "--output", "json"])
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+
+
+def test_utility_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_startup_update_notice",
+        lambda: (_ for _ in ()).throw(AssertionError("no update check")),
+    )
+    monkeypatch.setattr(cli.SessionManager, "list_sessions", lambda self: [])
+
+    result = CliRunner().invoke(app, ["sessions"])
+
+    assert result.exit_code == 0
+    assert "No sessions found." in result.stdout
 
 
 def test_cli_without_prompt_invokes_tui_runner(
@@ -46,7 +122,9 @@ def test_cli_without_prompt_invokes_tui_runner(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        update_notice: object | None = None,
     ) -> None:
+        del update_notice
         calls.append(
             (
                 model,
@@ -60,6 +138,7 @@ def test_cli_without_prompt_invokes_tui_runner(
         )
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
 
     result = CliRunner().invoke(app, [])
@@ -81,7 +160,9 @@ def test_cli_positional_prompt_invokes_tui_runner(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        update_notice: object | None = None,
     ) -> None:
+        del update_notice
         calls.append(
             (
                 model,
@@ -95,6 +176,7 @@ def test_cli_positional_prompt_invokes_tui_runner(
         )
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
 
     result = CliRunner().invoke(app, ["explain this repo"])
@@ -401,6 +483,7 @@ def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch
     ) -> bool:
         return False
 
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
     monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
 
     result = CliRunner().invoke(app, ["-p", "hello"])
@@ -421,7 +504,9 @@ def test_default_tui_invokes_tui_runner_with_flags(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        update_notice: object | None = None,
     ) -> None:
+        del update_notice
         calls.append(
             (
                 model,
@@ -434,6 +519,7 @@ def test_default_tui_invokes_tui_runner_with_flags(
             )
         )
 
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
 
     result = CliRunner().invoke(
@@ -467,11 +553,13 @@ def test_default_tui_rejects_resume_with_new_session(
         provider_name: str | None,
         auto_compact_token_threshold: int | None,
         initial_prompt: str | None,
+        update_notice: object | None = None,
     ) -> None:
         del model, cwd, session_id, new_session, provider_name, auto_compact_token_threshold
-        del initial_prompt
+        del initial_prompt, update_notice
         raise RuntimeError("--resume and --new-session cannot be used together")
 
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
     monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
 
     result = CliRunner().invoke(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4172,6 +4172,24 @@ async def test_tui_resume_refreshes_context_after_session_swap() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_shows_startup_update_notice() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session, startup_message="Tau 0.2.0 is available")
+    notifications: list[tuple[str, str | None]] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        severity = kwargs.get("severity")
+        notifications.append((message, severity if isinstance(severity, str) else None))
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test():
+        pass
+
+    assert notifications == [("Tau 0.2.0 is available", "warning")]
+
+
+@pytest.mark.anyio
 async def test_tui_app_runs_initial_prompt() -> None:
     session = FakeSession(
         events=[
@@ -4637,6 +4655,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
         def __init__(self, session: str, **kwargs: object) -> None:
             assert session == "session"
             message = str(kwargs["startup_message"])
+            assert "Tau 0.2.0 is available" in message
             assert "Login required. Run /login" in message
             assert "/login openai" in message
             assert "OPENAI_API_KEY" not in message
@@ -4656,7 +4675,12 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
     monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
 
-    await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
+    await tui_app.run_tui_app(
+        cwd=tmp_path,
+        model=None,
+        session_manager=FakeManager(),
+        startup_notice="Tau 0.2.0 is available",
+    )
 
     assert calls == [f"prepare:{tmp_path}:gpt-5.5:openai", "load:LoginRequiredProvider", "run"]
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4172,9 +4172,9 @@ async def test_tui_resume_refreshes_context_after_session_swap() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_shows_startup_update_notice() -> None:
-    session = FakeSession()
-    app = TauTuiApp(session, startup_message="Tau 0.2.0 is available")
+async def test_tui_app_shows_startup_update_notice_in_transcript_only() -> None:
+    session = FakeSession(messages=[UserMessage(content="Earlier prompt")])
+    app = TauTuiApp(session, startup_notice="Tau 0.2.0 is available")
     notifications: list[tuple[str, str | None]] = []
 
     def fake_notify(message: str, **kwargs: object) -> None:
@@ -4183,10 +4183,16 @@ async def test_tui_app_shows_startup_update_notice() -> None:
 
     app._notify = fake_notify  # type: ignore[method-assign]
 
-    async with app.run_test():
-        pass
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "Tau 0.2.0 is available",
+            "Earlier prompt",
+        ]
 
-    assert notifications == [("Tau 0.2.0 is available", "warning")]
+    assert notifications == []
+    assert session.messages == (UserMessage(content="Earlier prompt"),)
 
 
 @pytest.mark.anyio
@@ -4655,7 +4661,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
         def __init__(self, session: str, **kwargs: object) -> None:
             assert session == "session"
             message = str(kwargs["startup_message"])
-            assert "Tau 0.2.0 is available" in message
+            assert "Tau 0.2.0 is available" not in message
             assert "Login required. Run /login" in message
             assert "/login openai" in message
             assert "OPENAI_API_KEY" not in message

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,134 @@
+from datetime import UTC, datetime, timedelta
+
+from tau_coding.update_check import (
+    PYPI_JSON_URL,
+    UPDATE_CHECK_TIMEOUT_SECONDS,
+    fetch_latest_pypi_version,
+    startup_update_notice,
+)
+
+
+def test_startup_update_notice_reports_newer_stable_release(tmp_path) -> None:
+    calls: list[tuple[str, float]] = []
+
+    def fetcher(url: str, timeout: float) -> dict[str, object]:
+        calls.append((url, timeout))
+        return {"releases": {"0.1.0": [{}], "0.2.0": [{}], "0.3.0rc1": [{}]}}
+
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=fetcher,
+        cache_path=tmp_path / "update-check.json",
+        now=lambda: datetime(2026, 1, 1, tzinfo=UTC),
+        env={},
+    )
+
+    assert notice is not None
+    assert notice.current_version == "0.1.0"
+    assert notice.latest_version == "0.2.0"
+    assert "Tau 0.2.0 is available (installed: 0.1.0)" in notice.message
+    assert "uv tool upgrade tau-ai" in notice.message
+    assert calls == [(PYPI_JSON_URL, UPDATE_CHECK_TIMEOUT_SECONDS)]
+
+
+def test_startup_update_notice_is_quiet_when_current(tmp_path) -> None:
+    notice = startup_update_notice(
+        "0.2.0",
+        fetcher=lambda _url, _timeout: {"releases": {"0.2.0": [{}]}},
+        cache_path=tmp_path / "update-check.json",
+        env={},
+    )
+
+    assert notice is None
+
+
+def test_startup_update_notice_uses_fresh_cache(tmp_path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text(
+        '{"checked_at":"2026-01-01T00:00:00+00:00","latest_version":"0.2.0"}\n',
+        encoding="utf-8",
+    )
+
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=lambda _url, _timeout: (_ for _ in ()).throw(AssertionError("no fetch")),
+        cache_path=cache_path,
+        now=lambda: datetime(2026, 1, 1, 12, tzinfo=UTC),
+        env={},
+    )
+
+    assert notice is not None
+    assert notice.latest_version == "0.2.0"
+
+
+def test_startup_update_notice_refreshes_stale_cache(tmp_path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text(
+        '{"checked_at":"2026-01-01T00:00:00+00:00","latest_version":"0.2.0"}\n',
+        encoding="utf-8",
+    )
+
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=lambda _url, _timeout: {"releases": {"0.3.0": [{}]}},
+        cache_path=cache_path,
+        now=lambda: datetime(2026, 1, 1, tzinfo=UTC) + timedelta(days=2),
+        env={},
+    )
+
+    assert notice is not None
+    assert notice.latest_version == "0.3.0"
+
+
+def test_startup_update_notice_ignores_failures(tmp_path) -> None:
+    def broken_fetcher(_url: str, _timeout: float) -> dict[str, object]:
+        raise TimeoutError("offline")
+
+    assert (
+        startup_update_notice(
+            "0.1.0",
+            fetcher=broken_fetcher,
+            cache_path=tmp_path / "update-check.json",
+            env={},
+        )
+        is None
+    )
+
+
+def test_startup_update_notice_can_be_disabled(tmp_path) -> None:
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=lambda _url, _timeout: (_ for _ in ()).throw(AssertionError("no fetch")),
+        cache_path=tmp_path / "update-check.json",
+        env={"TAU_NO_UPDATE_CHECK": "1"},
+    )
+
+    assert notice is None
+
+
+def test_startup_update_notice_skips_ci(tmp_path) -> None:
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=lambda _url, _timeout: (_ for _ in ()).throw(AssertionError("no fetch")),
+        cache_path=tmp_path / "update-check.json",
+        env={"CI": "true"},
+    )
+
+    assert notice is None
+
+
+def test_fetch_latest_pypi_version_falls_back_to_info_version() -> None:
+    latest = fetch_latest_pypi_version(
+        fetcher=lambda _url, _timeout: {"info": {"version": "0.4.0"}}
+    )
+
+    assert latest == "0.4.0"
+
+
+def test_fetch_latest_pypi_version_rejects_malformed_versions() -> None:
+    try:
+        fetch_latest_pypi_version(fetcher=lambda _url, _timeout: {"info": {"version": "wat"}})
+    except Exception as exc:
+        assert exc.__class__.__name__ == "InvalidVersion"
+    else:
+        raise AssertionError("expected InvalidVersion")

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -61,6 +61,24 @@ def test_startup_update_notice_uses_fresh_cache(tmp_path) -> None:
     assert notice.latest_version == "0.2.0"
 
 
+def test_startup_update_notice_uses_fresh_empty_cache(tmp_path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text(
+        '{"checked_at":"2026-01-01T00:00:00+00:00","latest_version":null}\n',
+        encoding="utf-8",
+    )
+
+    notice = startup_update_notice(
+        "0.1.0",
+        fetcher=lambda _url, _timeout: (_ for _ in ()).throw(AssertionError("no fetch")),
+        cache_path=cache_path,
+        now=lambda: datetime(2026, 1, 1, 12, tzinfo=UTC),
+        env={},
+    )
+
+    assert notice is None
+
+
 def test_startup_update_notice_refreshes_stale_cache(tmp_path) -> None:
     cache_path = tmp_path / "update-check.json"
     cache_path.write_text(
@@ -123,6 +141,14 @@ def test_fetch_latest_pypi_version_falls_back_to_info_version() -> None:
     )
 
     assert latest == "0.4.0"
+
+
+def test_fetch_latest_pypi_version_skips_malformed_release_versions() -> None:
+    latest = fetch_latest_pypi_version(
+        fetcher=lambda _url, _timeout: {"releases": {"0.3.0": [{}], "wat": [{}]}}
+    )
+
+    assert latest == "0.3.0"
 
 
 def test_fetch_latest_pypi_version_rejects_malformed_versions() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -443,6 +443,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "textual" },
@@ -460,6 +461,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "textual", specifier = ">=1.0" },

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -14,6 +14,11 @@ tau [OPTIONS] [PROMPT] [COMMAND] [ARGS]
 - A positional `PROMPT` opens the TUI and submits it as the first turn.
 - `-p/--prompt` runs a single prompt in [print mode](../guides/print-mode.md).
 
+On TUI and text print-mode startup, Tau may show a non-blocking notice when a
+newer `tau-ai` release is available on PyPI. Disable it with
+`TAU_NO_UPDATE_CHECK=1`; utility commands such as `tau --version`, `tau sessions`,
+and `tau export` do not run the check.
+
 ## Commands
 
 | Command | What it does |

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -25,6 +25,10 @@ those locations and file formats.
 Tau also reads user-level `.agents` resources: `~/.agents/skills/`,
 `~/.agents/prompts/`, `~/.agents/AGENTS.md`.
 
+Startup update checks cache their latest PyPI result in
+`~/.tau/cache/update-check.json` and refresh at most once per day. Set
+`TAU_NO_UPDATE_CHECK=1` to disable the check; Tau also skips it when `CI` is set.
+
 ## Providers
 
 Provider metadata lives in `~/.tau/providers.json`:


### PR DESCRIPTION
## Summary
- add best-effort PyPI update checks with daily cache and PEP 440 version comparison
- surface update notices in TUI startup and text print mode without affecting utility or structured commands
- document TAU_NO_UPDATE_CHECK and cache behavior

Fixes #193

## Tests
- uv run pytest tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
- uv run mypy src/tau_coding/update_check.py src/tau_coding/cli.py src/tau_coding/tui/app.py
- uv run ruff check src/tau_coding/update_check.py src/tau_coding/cli.py src/tau_coding/tui/app.py tests/test_update_check.py tests/test_cli.py