### PR TITLE
Disable active-line highlighting in TUI prompt

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -199,6 +199,7 @@ class PromptInput(TextArea):
         tui_keybindings: TuiKeybindings | None = None,
         **kwargs: Any,
     ) -> None:
+        kwargs.setdefault("highlight_cursor_line", False)
         super().__init__(**kwargs)
         self.tui_keybindings = tui_keybindings or TuiKeybindings()
         self._base_bindings = self._bindings.copy()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1437,6 +1437,18 @@ async def test_tui_app_mounts_sidebar_and_transcript() -> None:
         assert prompt.soft_wrap is True
 
 
+@pytest.mark.anyio
+async def test_prompt_input_does_not_highlight_active_line() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "Keep the prompt background uniform."
+        await pilot.pause()
+
+        assert prompt.highlight_cursor_line is False
+
+
 def test_terminal_command_prefix_span_detects_shell_mode_prefix() -> None:
     assert _terminal_command_prefix_span("! pwd") == (0, 1)
     assert _terminal_command_prefix_span("!! pwd") == (0, 2)


### PR DESCRIPTION
Textual highlights the active `TextArea` line by default, which makes entered prompt text appear on a different background from the rest of the composer.

This disables active-line highlighting specifically for `PromptInput`, leaving generic `TextArea` behavior unchanged. A regression test covers the setting after text is entered.

Verified with the full test suite (589 passed) and Ruff.

It's subtle but you can see the highlighting of just the text line.

Before:
<img width="201" height="90" alt="Screenshot 2026-07-01 at 12 47 59" src="https://github.com/user-attachments/assets/bc1e3a83-cc5d-45b6-b736-36b406e6dcaf" />

After:
<img width="189" height="89" alt="Screenshot 2026-07-01 at 12 46 59" src="https://github.com/user-attachments/assets/98172914-ca3a-4ba3-ac95-ffecb3ff8bd8" />
