### PR TITLE
docs: add contributor workflows, worktree guide, and prompt templates

### DIFF
--- a/.agents/prompts/add-test.md
+++ b/.agents/prompts/add-test.md
@@ -1,0 +1,23 @@
+---
+description: Add or update tests for a specific area of Tau.
+---
+
+Add or update tests for:
+{{ area }}
+
+## Testing conventions
+
+- Use fake providers and fake tools for deterministic agent-loop tests
+- Keep core tests free of provider-specific assumptions
+- Add regression tests for bugs
+- Prefer focused tests that describe the behavior being protected
+- Tests go in `tests/` alongside the code they protect
+
+## Steps
+
+1. Find existing tests for the area (or create new test files)
+2. Understand what behavior needs testing
+3. Write tests using the existing patterns in the codebase
+4. Run the tests: `uv run pytest tests/`
+5. Ensure all tests pass
+6. Commit: `test: add tests for <area>`

--- a/.agents/prompts/fix-bug.md
+++ b/.agents/prompts/fix-bug.md
@@ -1,0 +1,22 @@
+---
+description: Fix a bug from a GitHub issue with reproduction steps.
+---
+
+Fix the bug described in this GitHub issue:
+{{ issue_url }}
+
+## Workflow
+
+1. Read the issue and understand the bug and reproduction steps
+2. Reproduce the bug locally using `uv run tau`
+3. Identify the root cause in the relevant code file
+4. Write a failing test that captures the bug behavior
+5. Fix the bug — make the minimal change that resolves it
+6. Verify the test passes
+7. Run the full test suite:
+   ```
+   uv run pytest
+   ```
+8. Update `dev-notes/` if the fix is non-trivial
+9. Commit with a clear message: `fix: short description`
+10. Open a PR referencing the issue: `Fixes #<number>`

--- a/.agents/prompts/implement-feature.md
+++ b/.agents/prompts/implement-feature.md
@@ -1,0 +1,28 @@
+---
+description: Implement a feature from a GitHub issue in an isolated worktree.
+---
+
+Implement the feature described in this GitHub issue:
+{{ issue_url }}
+
+## Workflow
+
+1. Read the issue carefully and understand the acceptance criteria
+2. Create a branch following naming conventions: `feat/issue-<number>-short-description`
+3. Implement the feature following Tau's architecture:
+   - Keep `tau_ai`, `tau_agent`, and `tau_coding` separated
+   - Provider/model streaming belongs in `tau_ai`
+   - Agent loop, tools, events, sessions belong in `tau_agent`
+   - CLI, TUI, resources, skills belong in `tau_coding`
+4. Add or update tests for behavior changes
+5. Run checks through `uv`:
+   ```
+   uv run pytest
+   uv run ruff check .
+   uv run ruff format --check .
+   uv run mypy
+   ```
+6. Update `dev-notes/` if the change is substantial
+7. Update `website/src/content/docs/` if user-facing
+8. Commit with a clear message: `feat: short description`
+9. Open a PR referencing the issue: `Fixes #<number>`

--- a/.agents/prompts/update-docs.md
+++ b/.agents/prompts/update-docs.md
@@ -1,0 +1,28 @@
+---
+description: Update website documentation for user-facing changes.
+---
+
+Update the website documentation for:
+{{ change }}
+
+## Documentation lives in `website/src/content/docs/`
+
+Choose the right location:
+- `guides/` — how-to guides for features
+- `reference/` — CLI, configuration, tools reference
+- `internals/` — architecture and design docs
+- `concepts.md` — high-level concepts
+
+## Steps
+
+1. Read the existing docs for the area
+2. Update or add the relevant page
+3. Keep language clear and beginner-friendly
+4. Include code examples where helpful
+5. Test the docs site builds:
+   ```
+   cd website
+   bun install
+   bun run build
+   ```
+6. Commit: `docs: update <area> for <change>`

--- a/.agents/prompts/write-dev-notes.md
+++ b/.agents/prompts/write-dev-notes.md
@@ -1,0 +1,29 @@
+---
+description: Write developer notes for a completed phase or feature.
+---
+
+Write developer notes for:
+{{ phase_or_feature }}
+
+## Notes should go in `dev-notes/`
+
+Use the appropriate subdirectory:
+- `dev-notes/architecture/` — for phase implementation notes
+- `dev-notes/design/` — for high-level design docs
+- `dev-notes/adr/` — for architecture decision records
+
+## Each note should explain
+
+1. **What was added** — the concrete changes
+2. **Why it exists** — the motivation and problem it solves
+3. **How it maps to Tau's architecture** — which layer(s) it touches
+4. **How to test or use it** — verification steps
+
+## Format
+
+Use Markdown with a clear title. Follow the pattern of existing phase notes in `dev-notes/architecture/`.
+
+## After writing
+
+- Run `uv run ruff check .` to ensure no formatting issues
+- Commit: `docs: add notes for <phase_or_feature>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,102 @@ uv run tau
 uv run tau -p "explain this repo"
 ```
 
+## Contributor workflow
+
+### Starting from a GitHub issue
+
+1. Pick an issue from the [issue tracker](https://github.com/huggingface/tau/issues)
+2. Create a branch with a descriptive name:
+
+```bash
+# Feature
+ git checkout -b feat/issue-123-short-description
+
+# Bug fix
+ git checkout -b fix/issue-456-short-description
+
+# Documentation
+ git checkout -b docs/issue-789-short-description
+```
+
+3. Make your changes, following the guidelines below
+4. Open a pull request referencing the issue: `Fixes #123`
+
+### Using Git worktrees (optional)
+
+Worktrees let you work on multiple issues simultaneously without stashing or switching branches:
+
+```bash
+# Create a worktree for a new feature (from the repo root)
+ git worktree add ../tau-feat-123 -b feat/issue-123-short-description
+
+# Work inside it
+cd ../tau-feat-123
+uv sync --dev
+uv run pytest
+
+# When done, clean up
+cd /path/to/tau
+ git worktree remove ../tau-feat-123
+```
+
+This keeps your main checkout clean while you work on parallel features, bugfixes, or documentation.
+
+### Using contributor prompts
+
+Tau ships with reusable prompt templates in `.agents/prompts/` for common contributor tasks. Inside Tau, invoke them with a `/` prefix:
+
+| Prompt | Description |
+|--------|-------------|
+| `/implement-feature` | Implement a feature from a GitHub issue |
+| `/fix-bug` | Fix a bug with reproduction steps |
+| `/add-test` | Add or update tests for an area |
+| `/write-dev-notes` | Write developer notes for a phase |
+| `/update-docs` | Update website documentation |
+
+Example usage inside Tau:
+
+```text
+/implement-feature https://github.com/huggingface/tau/issues/123
+/fix-bug https://github.com/huggingface/tau/issues/456
+/add-test tau_coding/provider_config.py
+```
+
+These prompts guide the coding agent to follow Tau's conventions, including layer separation, testing, and documentation expectations.
+
+### Using `gh` CLI for issues and PRs
+
+The GitHub CLI (`gh`) makes it easy to work with issues and pull requests:
+
+```bash
+# List open issues
+gh issue list --repo huggingface/tau
+
+# View an issue
+gh issue view 123 --repo huggingface/tau
+
+# Create a PR from your branch
+gh pr create --title "feat: description" --body "Fixes #123"
+
+# Check PR status
+gh pr status --repo huggingface/tau
+
+# View PR checks
+gh pr checks 207 --repo huggingface/tau
+```
+
+### Recommended development sequence
+
+1. **Read the issue** — `gh issue view 123 --repo huggingface/tau`
+2. **Set up your environment** — `uv sync --dev`
+3. **Create a branch or worktree** — follow naming conventions above
+4. **Implement changes** — follow layer boundaries below
+5. **Write tests** — use fake providers/tools for deterministic tests
+6. **Run checks** — `uv run pytest`, `uv run ruff check .`, `uv run mypy`
+7. **Update docs** — `dev-notes/` for substantial changes, `website/` for user-facing
+8. **Commit** — one coherent change per commit
+9. **Push and open a PR** — `git push origin feat/issue-123-desc` then `gh pr create`
+
 ## Checks before submitting
 
 Run the relevant focused tests while developing, then run the full checks before opening a pull request when practical:

--- a/website/src/content/docs/contributing.md
+++ b/website/src/content/docs/contributing.md
@@ -58,6 +58,17 @@ bun run build    # static output in website/dist/
 User-facing docs live in `website/src/content/docs/`; the landing and "Why Tau?"
 pages are standalone routes in `website/src/pages/`.
 
+## Contributor workflow
+
+For a complete contributor guide — including Git worktrees, branch naming
+conventions, and reusable prompt templates — see
+[CONTRIBUTING.md](https://github.com/huggingface/tau/blob/main/CONTRIBUTING.md)
+in the repository root.
+
+Tau ships with contributor prompt templates in `.agents/prompts/` for common
+tasks like implementing features, fixing bugs, writing dev notes, and updating
+docs. These help coding agents follow Tau's conventions automatically.
+
 ## Documentation expectations
 
 Each substantial phase should leave beginner-friendly notes in `dev-notes/`


### PR DESCRIPTION
## Summary

Adds first-class contributor workflow support for developing Tau with custom prompts and Git worktrees, as requested in #203.

## Changes

### New:  — Contributor prompt templates

Five reusable prompt templates for common contributor tasks:

| Prompt | Description |
|--------|-------------|
| `/implement-feature` | Implement a feature from a GitHub issue |
| `/fix-bug` | Fix a bug with reproduction steps |
| `/add-test` | Add or update tests for an area |
| `/write-dev-notes` | Write developer notes for a phase |
| `/update-docs` | Update website documentation |

Each prompt reinforces Tau's architecture conventions:
- Layer separation (`tau_ai`, `tau_agent`, `tau_coding`)
- Testing with fake providers/tools
- Running commands through `uv`
- Updating `dev-notes/` and website docs

### Updated: `CONTRIBUTING.md` — Contributor workflow section

New section covering:
- Starting from a GitHub issue
- Branch naming conventions (`feat/`, `fix/`, `docs/`)
- Git worktree usage for parallel development
- Using contributor prompts with examples
- Using `gh` CLI for issues and PRs
- Recommended 9-step development sequence

### Updated: `website/src/content/docs/contributing.md`

Brief reference to the contributor workflow and prompt templates.

## Acceptance Criteria

- [x] Clear documentation for using Git worktrees
- [x] Workflow includes creating worktree, branch, running tests, cleanup
- [x] Reusable custom prompts for contributors
- [x] Prompts reinforce Tau's architecture and guidelines
- [x] Beginner-friendly workflow (issue → PR)
- [x] No scripts added (optional per issue)
- [x] Documentation references updated

## Testing

Documentation-only change. No code changes, no tests needed.

Refs: #203