### PR TITLE
Guard Markdown selection until blocks are mounted

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -117,6 +117,17 @@ class NonSelectableStatic(Static):
 class TauMarkdownBlock(MarkdownBlock):
     """Markdown block that applies Tau's themed inline link color."""
 
+    @property
+    def allow_select(self) -> bool:
+        """Only allow native selection once Textual has mounted the block.
+
+        Textual may hit freshly-created Markdown blocks during a mouse-down before
+        they have a parent. Its selection startup path assumes selected content
+        widgets have a parent container, so an unmounted selectable Markdown block
+        can crash with ``container is None``.
+        """
+        return self.parent is not None and super().allow_select
+
     def _token_to_content(self, token: Any) -> Any:
         content = super()._token_to_content(token)
         markdown = self._markdown

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -11,6 +11,7 @@ from textual.containers import VerticalScroll
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
 from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
+from textual.widgets import Markdown as TextualMarkdown
 
 from tau_agent import (
     AgentEndEvent,
@@ -81,6 +82,7 @@ from tau_coding.tui.config import (
 from tau_coding.tui.state import ChatItem
 from tau_coding.tui.widgets import (
     LeftAlignedMarkdownHeading,
+    TauMarkdownBlock,
     StreamingTranscriptMessageWidget,
     ThemedMarkdownWidget,
     TranscriptMessageWidget,
@@ -1435,6 +1437,16 @@ async def test_tui_app_mounts_sidebar_and_transcript() -> None:
         prompt = app.query_one("#prompt")
         assert isinstance(prompt, TextArea)
         assert prompt.soft_wrap is True
+
+
+def test_tau_markdown_block_is_not_selectable_until_mounted() -> None:
+    markdown = TextualMarkdown("example")
+    block = TauMarkdownBlock(
+        markdown,
+        type("Token", (), {"map": (0, 1), "level": 0, "type": "paragraph_open"})(),
+    )
+
+    assert block.allow_select is False
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1450,6 +1450,20 @@ def test_tau_markdown_block_is_not_selectable_until_mounted() -> None:
 
 
 @pytest.mark.anyio
+async def test_tau_markdown_block_remains_selectable_after_mount() -> None:
+    app = TauTuiApp(
+        FakeSession([AssistantMessage(content="Read [docs](https://example.com).")]),
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        block = app.query_one(TauMarkdownBlock)
+        assert block.parent is not None
+        assert block.allow_select is True
+
+
+@pytest.mark.anyio
 async def test_tui_app_disables_text_selection_while_agent_is_running() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
## Summary
- Prevent TauMarkdownBlock from participating in native text selection until it has a parent container
- Add regression coverage for unmounted Markdown blocks

## Tests
- uv run pytest tests/test_tui_app.py -q
- uv run pytest -q