### PR TITLE
Implement #201: refocus system prompt on projects

### DIFF
--- a/dev-notes/architecture/phase-10-system-prompt.md
+++ b/dev-notes/architecture/phase-10-system-prompt.md
@@ -14,7 +14,8 @@ src/tau_coding/system_prompt.py
 
 Tau can now build a deterministic Pi-style system prompt from:
 
-- Tau's default coding-agent identity
+- a short project-first coding-agent identity
+- minimal Tau architecture boundaries
 - enabled tools
 - tool prompt snippets
 - tool prompt guidelines
@@ -32,11 +33,17 @@ Earlier phases added tools, skills, prompt templates, and coding sessions. Befor
 
 ## Default prompt shape
 
-The default prompt starts with Tau's identity:
+The default prompt starts with a project-focused identity:
 
 ```text
-You are an expert coding assistant operating inside Tau, a coding agent harness.
+You are a coding assistant in the user's current project.
 ```
+
+It treats the user's task, repository files, and project instructions as the
+primary sources of truth. Tau-specific guidance is limited to the operational
+package boundaries (`tau_coding`, `tau_agent`, `tau_ai`) and points to
+`website/src/content/docs/internals/architecture.md` for deeper architecture
+context instead of embedding product history in the model prompt.
 
 It then includes an available-tools section using each tool's `prompt_snippet`:
 

--- a/src/tau_coding/system_prompt.py
+++ b/src/tau_coding/system_prompt.py
@@ -49,11 +49,12 @@ def build_system_prompt(options: BuildSystemPromptOptions) -> str:
         return prompt
 
     prompt = (
-        "You are an expert coding assistant operating inside Tau, a coding agent harness. "
-        "You help users by reading files, executing commands, editing code, and writing new files."
+        "You are a coding assistant in the user's current project. "
+        "Follow the user's task, repository files, and project instructions first."
+        "\n\nTau boundary, when relevant: tau_coding=app/UI/resources; "
+        "tau_agent=portable harness; tau_ai=model streaming. Deeper Tau context: "
+        "website/src/content/docs/internals/architecture.md."
         f"\n\nAvailable tools:\n{format_available_tools(options.tools)}"
-        "\n\nIn addition to the tools above, you may have access to other custom tools "
-        "depending on the project."
         f"\n\nGuidelines:\n{format_guidelines(options.tools, options.extra_guidelines)}"
     )
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -30,7 +30,12 @@ def test_default_prompt_includes_tools_guidelines_date_and_cwd(tmp_path: Path) -
         )
     )
 
-    assert "You are an expert coding assistant operating inside Tau" in prompt
+    assert "coding assistant in the user's current project" in prompt
+    assert "project instructions first" in prompt
+    assert "tau_coding=app/UI/resources" in prompt
+    assert "website/src/content/docs/internals/architecture.md" in prompt
+    assert "You are an expert coding assistant operating inside Tau" not in prompt
+    assert "In addition to the tools above" not in prompt
     assert "Available tools:\n- read: Read file contents" in prompt
     assert "- Use bash for file operations like ls, rg, find" in prompt
     assert "- Use read to examine files instead of cat or sed." in prompt


### PR DESCRIPTION
Closes #201

## Summary
- Refocus the default Tau-generated system prompt on the user's current project, repository files, and project instructions.
- Keep only a compact Tau architecture boundary reminder in the prompt and point deeper Tau context to the internals architecture docs.
- Update the Phase 10 system prompt note and prompt-rendering tests to cover the new shape.

## Files / areas changed
- `src/tau_coding/system_prompt.py`: shorter project-first default prompt copy.
- `tests/test_system_prompt.py`: assertions for project-first wording, compact Tau boundary, and removed Tau-centered copy.
- `dev-notes/architecture/phase-10-system-prompt.md`: documentation for the revised default prompt shape.

## Checks run
- `uv run pytest tests/test_system_prompt.py tests/test_cli.py tests/test_coding_session.py` - 106 passed.
- `uv run ruff check src/tau_coding/system_prompt.py tests/test_system_prompt.py` - passed.

## Assumptions
- The existing `website/src/content/docs/internals/architecture.md` page is the stable built-in documentation target for deeper Tau architecture context.
- A default-prompt copy change in `tau_coding` is sufficient; `tau_agent` remains independent of CLI, Rich, Textual, and resource loading.

## Follow-up
- None required for this issue.