### PR TITLE
Bug fix: Branched session compactions include additional messages

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Final, Literal, cast
+from typing import Literal
 
 from tau_agent import (
     AgentEvent,
@@ -103,7 +103,6 @@ from tau_coding.thinking import (
 from tau_coding.tools import create_bash_tool, create_coding_tools
 
 StreamingBehavior = Literal["steer", "follow_up"]
-_UNSET_LEAF_ID: Final[object] = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -1234,20 +1233,12 @@ class CodingSession:
             leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
             await self._append_session_entry(leaf)
 
-        await self._refresh_persisted_state()
+        await self._refresh_persisted_state(leaf_id=self._last_parent_id)
         return persisted_count + len(new_messages)
 
-    async def _refresh_persisted_state(
-        self,
-        *,
-        leaf_id: str | None | object = _UNSET_LEAF_ID,
-    ) -> None:
+    async def _refresh_persisted_state(self, *, leaf_id: str | None) -> None:
         entries = await self._read_session_entries()
-        self._state = (
-            SessionState.from_entries(entries)
-            if leaf_id is _UNSET_LEAF_ID
-            else SessionState.from_entries(entries, leaf_id=cast(str | None, leaf_id))
-        )
+        self._state = SessionState.from_entries(entries, leaf_id=leaf_id)
         if self._config.session_id is not None and self._config.session_manager is not None:
             self._config.session_manager.touch_session(
                 self._config.session_id,

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -947,6 +947,60 @@ async def test_session_branches_to_previous_entry_without_destroying_history(
 
 
 @pytest.mark.anyio
+async def test_persist_after_branch_keeps_state_on_active_branch(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="New answer")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Branch summary")),
+            ],
+        ]
+    )
+    root = MessageEntry(id="root", message=UserMessage(content="Root"))
+    answer = MessageEntry(id="answer", parent_id="root", message=AssistantMessage(content="Answer"))
+    abandoned = MessageEntry(
+        id="abandoned",
+        parent_id="answer",
+        message=UserMessage(content="Abandoned follow-up"),
+    )
+    abandoned_answer = MessageEntry(
+        id="abandoned-answer",
+        parent_id="abandoned",
+        message=AssistantMessage(content="Abandoned answer"),
+    )
+    await storage.append(root)
+    await storage.append(answer)
+    await storage.append(abandoned)
+    await storage.append(abandoned_answer)
+    await storage.append(LeafEntry(entry_id="abandoned-answer"))
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+
+    await session.branch_to_entry("answer")
+    _events = await _collect_session_events(session.prompt("New follow-up"))
+
+    assert session.state.messages == (
+        UserMessage(content="Root"),
+        AssistantMessage(content="Answer"),
+        UserMessage(content="New follow-up"),
+        AssistantMessage(content="New answer"),
+    )
+    assert "abandoned" not in session.state.context_entry_ids
+    assert "abandoned-answer" not in session.state.context_entry_ids
+
+    await session.compact()
+    compactions = [entry for entry in await storage.read_all() if entry.type == "compaction"]
+    assert len(compactions) == 1
+    assert "abandoned" not in compactions[0].replaces_entry_ids
+    assert "abandoned-answer" not in compactions[0].replaces_entry_ids
+    assert "Abandoned" not in provider.calls[1][2][0].content
+
+
+@pytest.mark.anyio
 async def test_session_branches_to_before_selected_user_message_with_prefill(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
When you branch a session back to an earlier point, the messages from the abandoned branch aren't actually gone from the model's world — they silently come back. The transcript looks right, the model answers as if the branch never happened, but as soon as a compaction runs (manual `/compact`, or auto-compact just crossing the threshold in a long session), the summary is generated from the abandoned branch *plus* the active one. From then on, content you explicitly branched away from is permanently baked into the conversation: ask about something that only existed on the dead branch, and the model knows it.

The cause is a state split. What's sent to the provider each turn comes from the in-memory harness transcript, which branching rebuilds correctly — that's why everything looks fine. But compaction plans from a second copy of state, `self._state`, and the refresh that runs after every persisted message (`_persist_messages_since`) rebuilt that copy by replaying the *entire* session file linearly instead of just the active branch's root-to-leaf path. Branching is non-destructive, so the file still contains the dead branch, and the first message persisted after a branch quietly merged it back into `self._state`. The fix makes that refresh branch-aware: it passes the leaf pointer the persist loop just wrote (`leaf_id=self._last_parent_id`), the same replay that `load()` and `branch_to_entry` already use. Every caller of `_refresh_persisted_state` now supplies a leaf id, so the replay-all default is removed entirely — the linear mode in `memory.py` stays as-is for `load()`'s legacy fallback. The regression test walks the full symptom (branch, prompt, compact) and failed before the fix.

**To reproduce in the TUI** (on `main`, without this fix):

1. Start `tau` and send two turns, e.g. "My favorite color is blue" and then "My secret codeword is OTTER".
2. Run `/tree`, highlight the assistant answer to the *first* turn, and press Enter (plain branch, no summarize) — the OTTER turn is abandoned and disappears from the transcript.
3. Send one new prompt, then ask for the codeword: the model correctly doesn't know it.
4. Run `/compact` and ask again — now it does. The compaction entry in the session JSONL (under `~/.tau/sessions/`) also lists the abandoned messages' ids in `replaces_entry_ids`.

This is the compaction summary BEFORE the fix. You can see it includes the OTTER codeword when it shouldn't.
<img width="1326" height="1105" alt="Screenshot 2026-07-03 at 09 52 59" src="https://github.com/user-attachments/assets/825f1999-51ca-4fe6-a99d-6a4ce06874a1" />

AFTER:
<img width="847" height="1026" alt="Screenshot 2026-07-03 at 10 13 26" src="https://github.com/user-attachments/assets/a7a754ba-0498-4396-a26e-62f25e84d113" />
