### PR TITLE
Implement #202: auto-name sessions from first message

### DIFF
--- a/dev-notes/architecture/auto-session-naming.md
+++ b/dev-notes/architecture/auto-session-naming.md
@@ -1,0 +1,36 @@
+# Automatic session naming
+
+Tau automatically gives a new managed session a short title based on the first user message.
+
+## What was added
+
+- New managed sessions are named automatically after the first user message is durably persisted.
+- Tau asks the currently selected provider/model for a concise title of at most four words.
+- The title is sanitized before it is stored in session metadata.
+- If the provider call fails or returns unusable text, Tau falls back to a local title derived from the first message.
+- `/name` remains the manual override and Tau does not replace an existing session title.
+
+## Why it exists
+
+Session ids are useful for exact references, but they are hard to scan in `/resume`, `tau sessions`, and id completions. Automatic names make saved sessions easier to recognize without requiring users to pause and name each one manually.
+
+## How it differs from Pi
+
+This is one of Tau's small intentional product divergences from Pi's minimalist baseline. Pi-style session persistence focuses on durable transcripts and explicit user actions. Tau adds automatic session metadata to improve resume/discovery workflows.
+
+The divergence is kept in `tau_coding` because it is application metadata behavior, not reusable agent-harness behavior. `tau_agent` still only owns the portable agent loop, messages, tools, and events.
+
+## Model choice
+
+Tau uses the session's currently selected provider/model for the naming request. There is no separate title model setting yet. This keeps the implementation simple and follows the active session configuration, but it does mean the first turn may make a short extra model call before the main assistant response.
+
+## Persistence behavior
+
+Naming happens only after the first user message has been persisted. This preserves deferred indexing for newly prepared sessions: a session that is cancelled before its first durable message should not appear in the resume index just because naming started.
+
+## How to test
+
+```bash
+uv run pytest tests/test_coding_session.py -q
+uv run ruff check src/tau_coding/session.py tests/test_coding_session.py website/content/guides/sessions.md
+```

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import string
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -107,6 +108,10 @@ from tau_coding.thinking import (
 from tau_coding.tools import create_bash_tool, create_coding_tools
 
 StreamingBehavior = Literal["steer", "follow_up"]
+SESSION_NAME_SYSTEM_PROMPT = (
+    "You write concise coding-agent session names. Reply with only a short title, "
+    "maximum four words, no quotes, no punctuation-only output."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,6 +253,7 @@ class CodingSession:
             credentials_path(self._resource_paths.paths) if self._resource_paths.paths else None
         )
         self._last_diagnostic_log_path: Path | None = None
+        self._pending_auto_session_title: str | None = None
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -1230,6 +1236,7 @@ class CodingSession:
             )
 
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
+        await self._try_auto_name_session(expanded_content, context=context)
         persisted_count = len(self._harness.messages)
         overflow_event: ErrorEvent | None = None
         try:
@@ -1432,8 +1439,10 @@ class CodingSession:
             cwd=self.cwd,
             model=self.model,
             provider_name=self.provider_name,
+            title=self._pending_auto_session_title,
             session_id=self._config.session_id,
         )
+        self._pending_auto_session_title = None
 
     async def _try_auto_compact(
         self,
@@ -1470,6 +1479,76 @@ class CodingSession:
                 exc=exc,
             )
             return False
+
+    async def _try_auto_name_session(
+        self,
+        first_message: str,
+        *,
+        context: AgentCallDiagnosticContext,
+    ) -> None:
+        if not self._should_auto_name_session():
+            return
+        try:
+            title = await self._generate_session_name(first_message)
+        except Exception as exc:  # noqa: BLE001 - naming must not interrupt the agent turn
+            self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
+                context=context,
+                phase="auto_name_session",
+                exc=exc,
+            )
+            title = _fallback_session_name(first_message)
+        if title is None:
+            title = _fallback_session_name(first_message)
+        if title is None:
+            return
+        self._set_auto_session_title(title)
+
+    def _should_auto_name_session(self) -> bool:
+        if self._config.session_id is None or self._config.session_manager is None:
+            return False
+        record = self._config.session_manager.get_session(self._config.session_id)
+        if record is not None and record.title:
+            return False
+        return not any(isinstance(message, UserMessage) for message in self._harness.messages)
+
+    async def _generate_session_name(self, first_message: str) -> str | None:
+        prompt = (
+            "Create a concise session name for this first user message. "
+            "Use at most four words.\n\n"
+            f"User message:\n{first_message}"
+        )
+        text_parts: list[str] = []
+        final_text: str | None = None
+        async for event in self._harness.config.provider.stream_response(
+            model=self.model,
+            system=SESSION_NAME_SYSTEM_PROMPT,
+            messages=[UserMessage(content=prompt)],
+            tools=[],
+        ):
+            if isinstance(event, ProviderTextDeltaEvent):
+                text_parts.append(event.delta)
+            elif isinstance(event, ProviderResponseEndEvent):
+                final_text = event.message.content
+            elif isinstance(event, ProviderErrorEvent):
+                details = f": {event.data}" if event.data is not None else ""
+                raise RuntimeError(f"Session naming failed: {event.message}{details}")
+        return _sanitize_session_name(final_text if final_text is not None else "".join(text_parts))
+
+    def _set_auto_session_title(self, title: str) -> None:
+        if self._config.session_id is None or self._config.session_manager is None:
+            return
+        existing = self._config.session_manager.get_session(self._config.session_id)
+        if existing is None and self._config.index_on_first_persist:
+            self._pending_auto_session_title = title
+            return
+        if existing is not None and existing.title:
+            return
+        self._config.session_manager.touch_session(
+            self._config.session_id,
+            model=self.model,
+            provider_name=self.provider_name,
+            title=title,
+        )
 
     def _provider_is_usable(self, provider: ProviderConfig) -> bool:
         return provider_has_usable_credentials(
@@ -1983,6 +2062,21 @@ def _unavailable_thinking_message(session: CodingSession) -> str:
     if reason:
         return f"{message}: {reason}"
     return message
+
+
+def _sanitize_session_name(text: str) -> str | None:
+    cleaned = " ".join(text.split()).strip()
+    cleaned = cleaned.strip("\"'`“”‘’")
+    cleaned = cleaned.strip(string.punctuation + " ")
+    words = [word.strip(string.punctuation + "\"'`“”‘’") for word in cleaned.split()]
+    words = [word for word in words if word]
+    if not words:
+        return None
+    return " ".join(words[:4])
+
+
+def _fallback_session_name(first_message: str) -> str | None:
+    return _sanitize_session_name(first_message)
 
 
 def _terminal_command_context_message(command: str, output: str) -> str:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -253,7 +253,6 @@ class CodingSession:
             credentials_path(self._resource_paths.paths) if self._resource_paths.paths else None
         )
         self._last_diagnostic_log_path: Path | None = None
-        self._pending_auto_session_title: str | None = None
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -1236,8 +1235,8 @@ class CodingSession:
             )
 
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
-        await self._try_auto_name_session(expanded_content, context=context)
         persisted_count = len(self._harness.messages)
+        auto_name_attempted = False
         overflow_event: ErrorEvent | None = None
         try:
             events = self._harness.prompt(expanded_content)
@@ -1245,6 +1244,9 @@ class CodingSession:
             async for event in events:
                 if isinstance(event, MessageEndEvent):
                     persisted_count = await self._persist_messages_since(persisted_count)
+                    if not auto_name_attempted and isinstance(event.message, UserMessage):
+                        auto_name_attempted = True
+                        await self._try_auto_name_session(event.message.content, context=context)
                 if isinstance(event, ToolExecutionEndEvent):
                     self._invalidate_context_usage_cache()
                 if isinstance(event, ErrorEvent) and not event.recoverable:
@@ -1439,10 +1441,8 @@ class CodingSession:
             cwd=self.cwd,
             model=self.model,
             provider_name=self.provider_name,
-            title=self._pending_auto_session_title,
             session_id=self._config.session_id,
         )
-        self._pending_auto_session_title = None
 
     async def _try_auto_compact(
         self,
@@ -1509,7 +1509,7 @@ class CodingSession:
         record = self._config.session_manager.get_session(self._config.session_id)
         if record is not None and record.title:
             return False
-        return not any(isinstance(message, UserMessage) for message in self._harness.messages)
+        return sum(isinstance(message, UserMessage) for message in self._harness.messages) == 1
 
     async def _generate_session_name(self, first_message: str) -> str | None:
         prompt = (
@@ -1538,9 +1538,6 @@ class CodingSession:
         if self._config.session_id is None or self._config.session_manager is None:
             return
         existing = self._config.session_manager.get_session(self._config.session_id)
-        if existing is None and self._config.index_on_first_persist:
-            self._pending_auto_session_title = title
-            return
         if existing is not None and existing.title:
             return
         self._config.session_manager.touch_session(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1600,6 +1600,10 @@ async def test_session_touches_session_manager_after_persisting_messages(tmp_pat
         [
             [
                 ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Greeting")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
                 ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
             ]
         ]
@@ -1621,6 +1625,158 @@ async def test_session_touches_session_manager_after_persisting_messages(tmp_pat
     updated = manager.get_session(record.id)
     assert updated is not None
     assert updated.updated_at >= record.updated_at
+
+
+@pytest.mark.anyio
+async def test_session_auto_names_first_unnamed_managed_session(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(
+                    message=AssistantMessage(content='"Fix broken CLI output now"')
+                ),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Please fix the broken CLI output."))
+
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Fix broken CLI output"
+    assert provider.calls[0][0] == "fake"
+    assert provider.calls[0][3] == []
+    assert "Please fix the broken CLI output." in provider.calls[0][2][0].content
+    assert provider.calls[1][2] == [UserMessage(content="Please fix the broken CLI output.")]
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_falls_back_when_provider_fails(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderErrorEvent(message="naming failed"),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Investigate flaky session restore tests"))
+
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Investigate flaky session restore"
+    assert session.messages == (
+        UserMessage(content="Investigate flaky session restore tests"),
+        AssistantMessage(content="Done"),
+    )
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_falls_back_when_provider_returns_unusable_title(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="!!!")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Debug failing model picker"))
+
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Debug failing model picker"
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_does_not_overwrite_manual_name(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake", title="Manual name")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Rename this automatically"))
+
+    unchanged = manager.get_session(record.id)
+    assert unchanged is not None
+    assert unchanged.title == "Manual name"
+    assert len(provider.calls) == 1
 
 
 @pytest.mark.anyio
@@ -2928,6 +3084,10 @@ async def test_session_new_session_is_indexed_after_first_message(
             [
                 [
                     ProviderResponseStartEvent(model="gpt-5"),
+                    ProviderResponseEndEvent(message=AssistantMessage(content="Greeting")),
+                ],
+                [
+                    ProviderResponseStartEvent(model="gpt-5"),
                     ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
                 ]
             ]
@@ -2961,6 +3121,7 @@ async def test_session_new_session_is_indexed_after_first_message(
     assert indexed is not None
     assert indexed.provider_name == "openai"
     assert indexed.model == "gpt-5"
+    assert indexed.title == "Greeting"
     assert indexed.path.exists()
 
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -79,6 +79,10 @@ class SwitchableFakeProvider:
 
 
 class RaisingProvider:
+    def __init__(self, fail_on_call: int = 1) -> None:
+        self.fail_on_call = fail_on_call
+        self.call_count = 0
+
     def stream_response(
         self,
         *,
@@ -89,10 +93,14 @@ class RaisingProvider:
         signal: CancellationToken | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         del model, system, messages, tools, signal
+        self.call_count += 1
+        should_fail = self.call_count == self.fail_on_call
 
         async def iterator() -> AsyncIterator[ProviderEvent]:
-            raise RuntimeError("provider exploded")
-            yield  # pragma: no cover
+            if should_fail:
+                raise RuntimeError("provider exploded")
+            yield ProviderResponseStartEvent(model="fake")
+            yield ProviderResponseEndEvent(message=AssistantMessage(content="Generated title"))
 
         return iterator()
 
@@ -1777,6 +1785,46 @@ async def test_session_auto_name_does_not_overwrite_manual_name(tmp_path: Path) 
     assert unchanged is not None
     assert unchanged.title == "Manual name"
     assert len(provider.calls) == 1
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_does_not_index_new_session_before_first_persist(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.prepare_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Generated title")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=record.cwd,
+            session_id=record.id,
+            session_manager=manager,
+            index_on_first_persist=True,
+        )
+    )
+
+    stream = session.prompt("Stop before the first persisted message")
+    _first_event = await anext(stream)
+    await stream.aclose()
+
+    assert manager.get_session(record.id) is None
+    assert await storage.read_all() == []
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1613,7 +1613,7 @@ async def test_session_touches_session_manager_after_persisting_messages(tmp_pat
             [
                 ProviderResponseStartEvent(model="fake"),
                 ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
-            ]
+            ],
         ]
     )
     config = CodingSessionConfig(
@@ -3137,7 +3137,7 @@ async def test_session_new_session_is_indexed_after_first_message(
                 [
                     ProviderResponseStartEvent(model="gpt-5"),
                     ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
-                ]
+                ],
             ]
         )
 

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -49,11 +49,17 @@ If a summary request fails, Tau falls back to a deterministic summary.
 
 ## Renaming
 
+New sessions are automatically given a short name from the first message when
+Tau can generate one. The name appears anywhere session names are already shown,
+including the `/resume` picker and id completions. If naming fails, the session
+continues normally and Tau falls back to a short local name when possible.
+
 ```text
 /name My refactor session
 ```
 
-The new name appears in the `/resume` picker and id completions.
+Use `/name` at any time to manually override the automatic name. Tau will not
+replace a name you set yourself.
 
 ## Exporting
 

--- a/website/content/internals/design-principles.md
+++ b/website/content/internals/design-principles.md
@@ -38,6 +38,16 @@ you can resume and branch; compaction changes the *active* context without
 rewriting the record. The format is plain enough to read by hand.
 → [Sessions]({{< relref "../guides/sessions.md" >}})
 
+## Small product divergences are explicit
+
+Tau mostly follows Pi's minimalist separation of agent brain, coding session,
+and frontend. A few user-facing conveniences intentionally diverge from that
+baseline. One example is automatic session naming: Tau asks the active
+provider/model for a short title after the first user message is persisted, then
+stores that title as session metadata. This remains in `tau_coding`, not the
+portable `tau_agent` harness, because it is application workflow rather than
+agent-loop behavior.
+
 ## Documentation follows implementation
 
 Tau was built in small, documented phases so a reader can trace how the system


### PR DESCRIPTION
Closes #202

## Summary
- Added automatic session naming for new managed sessions based on the first user message.
- Uses the currently selected provider/model for a short title request, sanitizes output to at most four words, and falls back to a local first-message title if naming fails or returns unusable text.
- Preserves `/name` as the manual override and skips auto-naming when a session already has a title.

## Files / Areas Changed
- `src/tau_coding/session.py`: auto-name trigger, provider title request, sanitization, fallback, and session metadata update.
- `tests/test_coding_session.py`: deterministic fake-provider coverage for generated names, failure fallback, unusable-title fallback, manual-name preservation, and first-message indexing.
- `website/src/content/docs/guides/sessions.md`: user-facing docs for automatic names and `/name` override behavior.

## Tests / Checks
- `uv run pytest tests/test_coding_session.py -q` -> 71 passed
- `uv run ruff check src/tau_coding/session.py tests/test_coding_session.py website/src/content/docs/guides/sessions.md` -> passed
- `git diff --check` -> passed

## Assumptions
- A short secondary provider call before the first main agent turn is acceptable for the smallest implementation; failures are swallowed and fall back locally.
- Auto-naming belongs in `tau_coding` because it is session app metadata behavior, not reusable harness behavior.

## Follow-up Work
- Consider a configuration switch if users want to disable the extra model call.
- Consider making naming asynchronous if first-token latency becomes a concern.
