### PR TITLE
Bug fix: Branching with summary discards all pre-branch context

### DIFF
--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -65,10 +65,6 @@ class SessionState:
         custom_entries: list[CustomEntry] = []
         compaction_entries: list[CompactionEntry] = []
 
-        latest_branch_summary_index = _latest_branch_summary_index(replay_entries)
-        if latest_branch_summary_index is not None:
-            replay_entries = replay_entries[latest_branch_summary_index:]
-
         for entry in replay_entries:
             match entry.type:
                 case "message":
@@ -105,14 +101,6 @@ class SessionState:
             context_entry_ids=tuple(entry_id for entry_id, _message in message_rows),
             entries=tuple(replay_entries),
         )
-
-
-def _latest_branch_summary_index(entries: list[SessionEntry]) -> int | None:
-    """Return the index of the most recent branch summary on a replay path."""
-    for index in range(len(entries) - 1, -1, -1):
-        if entries[index].type == "branch_summary":
-            return index
-    return None
 
 
 def _apply_compaction(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1074,6 +1074,47 @@ async def test_session_branch_restores_model_from_selected_path(tmp_path: Path) 
 
 
 @pytest.mark.anyio
+async def test_session_branch_with_summary_keeps_pre_branch_model_and_messages(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    first_model = ModelChangeEntry(id="model-a", model="first-model")
+    left = MessageEntry(
+        id="left",
+        parent_id="model-a",
+        message=UserMessage(content="Before switch"),
+    )
+    second_model = ModelChangeEntry(
+        id="model-b",
+        parent_id="left",
+        model="second-model",
+    )
+    right = MessageEntry(
+        id="right",
+        parent_id="model-b",
+        message=AssistantMessage(content="After switch"),
+    )
+    await storage.append(first_model)
+    await storage.append(left)
+    await storage.append(second_model)
+    await storage.append(right)
+    await storage.append(LeafEntry(entry_id="right"))
+    session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+
+    assert session.model == "second-model"
+
+    await session.branch_to_entry("left", summarize=True)
+
+    assert session.state.model == "first-model"
+    assert session.model == "first-model"
+    assert len(session.messages) == 2
+    assert session.messages[0] == UserMessage(content="Before switch")
+    assert session.messages[1].content.startswith(
+        "The following is a summary of a branch that this conversation came back from:"
+    )
+
+
+@pytest.mark.anyio
 async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
@@ -1115,13 +1156,14 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
     assert "<conversation>" in provider.calls[0][2][0].content
     assert "Use this EXACT format:" in provider.calls[0][2][0].content
     assert "Abandoned follow-up" in provider.calls[0][2][0].content
-    assert len(session.messages) == 1
-    assert session.messages[0].role == "user"
-    assert isinstance(session.messages[0].content, str)
-    assert session.messages[0].content.startswith(
+    assert len(session.messages) == 2
+    assert session.messages[0] == UserMessage(content="Root")
+    assert session.messages[1].role == "user"
+    assert isinstance(session.messages[1].content, str)
+    assert session.messages[1].content.startswith(
         "The following is a summary of a branch that this conversation came back from:"
     )
-    assert "The abandoned branch went left." in session.messages[0].content
+    assert "The abandoned branch went left." in session.messages[1].content
 
 
 @pytest.mark.anyio
@@ -1220,8 +1262,9 @@ async def test_session_branch_with_summary_falls_back_when_model_summary_is_unav
     assert summary.type == "branch_summary"
     assert "Automatically compacted 2 prior message(s)." in summary.summary
     assert "Abandoned follow-up" in summary.summary
-    assert len(session.messages) == 1
-    assert "Abandoned follow-up" in session.messages[0].content
+    assert len(session.messages) == 2
+    assert session.messages[0] == UserMessage(content="Root")
+    assert "Abandoned follow-up" in session.messages[1].content
 
 
 @pytest.mark.anyio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -198,6 +198,7 @@ def test_session_state_replays_branch_summary_as_context_summary() -> None:
     state = SessionState.from_entries([root, summary], leaf_id="branch-summary")
 
     assert state.messages == (
+        UserMessage(content="Root"),
         UserMessage(
             content=(
                 "The following is a summary of a branch that this conversation came back from:\n"
@@ -207,7 +208,7 @@ def test_session_state_replays_branch_summary_as_context_summary() -> None:
             )
         ),
     )
-    assert state.context_entry_ids == ("branch-summary",)
+    assert state.context_entry_ids == ("root", "branch-summary")
 
 
 def test_path_to_entry_returns_root_to_leaf_branch() -> None:


### PR DESCRIPTION
Branching a session back with a summary is supposed to return you to an earlier point with a digest of the path you abandoned. Instead it does the opposite: everything **before** the branch point — the conversation you branched back to keep working from — vanishes from the model's context, and only the summary of the *abandoned* messages survives. In a long session, branching back one turn with summary wipes hours of context in a single keypress. Model and thinking-level switches made before the branch point are silently reset to the session's startup values too, because the `model_change`/`thinking_level_change` entries get discarded along with the messages.

The cause is two halves that are individually deliberate but incoherent together. `branch_to_entry` builds the summary from only the messages *after* the branch point on the old path, and writes the `BranchSummaryEntry` as a child of the branch-point entry — correct, and the summary preamble even says it describes work done "before returning here", implying the pre-branch context survives. But `SessionState.from_entries` then truncated the replay path at the latest branch summary (`replay_entries[latest_branch_summary_index:]`), throwing away every entry before it: all prior `MessageEntry`s plus `model_change`, `thinking_level_change`, and `session_info`. The truncation was pure destruction with no purpose it could actually serve — abandoned messages are never on the replay path anyway, since `path_to_entry` walks parent links from the leaf and the abandoned suffix lives in a sibling subtree. The fix deletes the truncation. The summary entry, being a child of the branch point, already lands in path order right after the retained context, and the existing `branch_summary` replay arm already renders it as a context message — so after branching, context is now everything up to the branch point followed by the summary of the abandoned suffix, and pre-branch model/thinking selections replay intact. The regression test walks the full symptom (mid-session model switch, branch back with summary) and failed before the fix.

**To reproduce in the TUI** (on `main`, without this fix):

1. Start `tau` and send two turns, e.g. "My favorite color is blue" and then "My secret codeword is OTTER".
2. Switch to a different model with `/model`, then send one more turn: "My favourite drink is apple juice. Just acknowledge."
3. Run `/tree`, highlight the assistant's answer to the *OTTER* turn, and press `s` (branch with summary) — the apple-juice turn is the abandoned suffix.
4. The transcript collapses to a single summary message covering only the apple-juice turn. Ask for the codeword or the favorite color: the model has no idea — both turns are gone from context, even though you branched back specifically to keep them.
5. Run `/model`: you're back on the session's startup model, not the one you switched to in step 2.

The session JSONL (under `~/.tau/sessions/`) still contains every pre-branch entry — nothing was deleted from disk; the loss was purely in replay.

Closely related to #223, which fixes the opposite failure in the other replay mode: there, linear replay after persisting a message retained *too much* (abandoned-branch messages leaking back into `self._state`); here, path replay retained *too little*. The two fixes touch different files and compose — note that this one is best merged together with (or after) #223, since with the truncation gone, linear replay no longer coincidentally hides abandoned messages behind the summary, which #223 fixes properly by making the post-persist refresh branch-aware.
