### PR TITLE
Render assistant and thinking messages without a role block

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -192,6 +192,11 @@ class ThemedMarkdownWidget(TextualMarkdown):
         super().__init__(markdown, classes=classes)
 
 
+# Roles rendered as free-flowing text with no left accent or role background,
+# matching how they appear while streaming.
+_BORDERLESS_TRANSCRIPT_ROLES = frozenset({"assistant", "thinking"})
+
+
 class TranscriptMessageWidget(Horizontal):
     """One selectable transcript message rendered as a full-height role block."""
 
@@ -235,12 +240,13 @@ class TranscriptMessageWidget(Horizontal):
         super().__init__(classes="transcript-message")
         foreground, background = _split_rich_style_colors(self._role_style.body)
         self._body_foreground = foreground
-        self._body_background = background
-        # A real left border spans wrapped/multi-line content, unlike a one-line
-        # gutter child; the container background makes the block rectangular.
-        self.styles.border_left = ("tall", self._role_style.border)
-        if background:
-            self.styles.background = background
+        if item.role in _BORDERLESS_TRANSCRIPT_ROLES:
+            self._body_background = None
+        else:
+            self._body_background = background
+            self.styles.border_left = ("tall", self._role_style.border)
+            if background:
+                self.styles.background = background
 
     def compose(self) -> Any:
         yield self._body_widget()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1144,6 +1144,25 @@ async def test_streaming_transcript_applies_role_foreground() -> None:
 
 
 @pytest.mark.anyio
+async def test_assistant_message_renders_without_role_block() -> None:
+    app = TauTuiApp(
+        FakeSession([AssistantMessage(content="line one\nline two")]),
+        tui_settings=TuiSettings(theme="high-contrast"),
+    )
+
+    async with app.run_test(size=(60, 30)) as pilot:
+        await pilot.pause()
+        widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "assistant")
+        body = widget.query_one(".transcript-message-body")
+
+        # Assistant output flows as plain prose: no left accent and no role
+        # background, so it reads the same while streaming and once finalized.
+        assert not widget.styles.has_rule("border_left")
+        assert widget.styles.background.a == 0
+        assert body.styles.background.a == 0
+
+
+@pytest.mark.anyio
 async def test_streaming_transcript_deltas_do_not_force_scroll_end_during_scrollback() -> None:
     app = TauTuiApp(
         FakeSession(


### PR DESCRIPTION
Currently, the most recent assistant reply has no border (also no border when streaming). But older assistant replies have a border. So sending the next message made the previous reply visibly "pop" a border. Assistant (and thinking) output is also the transcript's main content and reads better as free-flowing prose than as a framed block (aligns with the way Pi does it better).

This skips the left accent border and role background for the `assistant` and `thinking` roles, via a small `_BORDERLESS_TRANSCRIPT_ROLES` set checked in `TranscriptMessageWidget.__init__`. Text foreground still follows the role config. Every other role (user, tool, skill, error, status, summaries) keeps the block from #214. A nice side effect: streaming and finalized assistant messages now look identical, so the border no longer appears when you send a message.

Added a regression test asserting a finalized assistant message has no `border_left` rule and a transparent widget/body background.

Before:
<img width="981" height="644" alt="Screenshot 2026-07-03 at 11 02 33" src="https://github.com/user-attachments/assets/7b0991e7-791a-4c34-b884-7a59e645a36e" />


After:
<img width="980" height="520" alt="Screenshot 2026-07-03 at 11 17 39" src="https://github.com/user-attachments/assets/121b4693-fc4f-4cb3-be87-2489aa391347" />

Pi example showing the assistant thinking and messages just blend into the background (mirroring that style):
<img width="876" height="562" alt="Screenshot 2026-07-03 at 11 21 20" src="https://github.com/user-attachments/assets/48a192fc-ca60-4f0f-9d90-5b1819e89bce" />
