### PR TITLE
Bug fix: Cancelling mid-tool-call permanently corrupts the session transcript

### DIFF
--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -12,7 +12,7 @@ from typing import Literal
 from tau_agent.events import AgentEvent, MessageEndEvent, MessageStartEvent, QueueUpdateEvent
 from tau_agent.loop import run_agent_loop
 from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
-from tau_agent.tools import AgentTool
+from tau_agent.tools import AgentTool, ToolCall
 from tau_ai.provider import ModelProvider
 
 EventListener = Callable[[AgentEvent], Awaitable[None] | None]
@@ -177,7 +177,7 @@ class AgentHarness:
     def prompt(self, content: str) -> AsyncIterator[AgentEvent]:
         """Append a user message and run the agent loop."""
         self._ensure_not_running()
-        self._append_interrupted_tool_results()
+        self.repair_interrupted_tool_calls()
         self._running = True
         message = UserMessage(content=content)
         self._messages.append(message)
@@ -186,7 +186,7 @@ class AgentHarness:
     def continue_(self) -> AsyncIterator[AgentEvent]:
         """Continue the agent loop without appending a new user message."""
         self._ensure_not_running()
-        self._append_interrupted_tool_results()
+        self.repair_interrupted_tool_calls()
         self._running = True
         return self._run()
 
@@ -218,7 +218,7 @@ class AgentHarness:
                     pending_prompt_event = None
         finally:
             if signal.is_cancelled():
-                self._append_interrupted_tool_results()
+                self.repair_interrupted_tool_calls()
             if self._current_signal is signal:
                 self._current_signal = None
             self._running = False
@@ -250,50 +250,52 @@ class AgentHarness:
             return messages
         return (queue.popleft(),)
 
-    def _append_interrupted_tool_results(self) -> None:
-        """Repair a transcript left mid-tool-call by an interrupted run.
+    def repair_interrupted_tool_calls(self) -> tuple[int, ...]:
+        """Repair a transcript holding assistant tool calls with no tool results.
 
         OpenAI-compatible providers reject a transcript where an assistant tool
         call is not followed by a matching tool result. If the UI cancels the
         worker while a tool is still running, the normal loop may not get a
-        chance to append the cancellation result, so repair that gap before the
-        next model request.
+        chance to append the cancellation result — and a transcript restored
+        from storage may hold that gap anywhere, including before later user
+        messages. Insert synthetic failed results directly after each unpaired
+        call block so the next model request is valid.
+
+        Returns the transcript indices where results were inserted, in
+        ascending order, so callers tracking persisted positions can stay
+        aligned.
         """
-        assistant_index = _latest_open_tool_call_assistant_index(self._messages)
-        if assistant_index is None:
-            return
-
-        assistant = self._messages[assistant_index]
-        if not isinstance(assistant, AssistantMessage):
-            return
-
+        insertions: list[int] = []
         returned_ids = {
             message.tool_call_id
-            for message in self._messages[assistant_index + 1 :]
+            for message in self._messages
             if isinstance(message, ToolResultMessage)
         }
-        for tool_call in assistant.tool_calls:
-            if tool_call.id in returned_ids:
+        index = 0
+        while index < len(self._messages):
+            message = self._messages[index]
+            index += 1
+            if not isinstance(message, AssistantMessage) or not message.tool_calls:
                 continue
-            message = "Tool call interrupted by user"
-            self._messages.append(
-                ToolResultMessage(
-                    tool_call_id=tool_call.id,
-                    name=tool_call.name,
-                    content=message,
-                    ok=False,
-                    error=message,
-                )
-            )
+            while index < len(self._messages) and isinstance(
+                self._messages[index], ToolResultMessage
+            ):
+                index += 1
+            for tool_call in message.tool_calls:
+                if tool_call.id in returned_ids:
+                    continue
+                self._messages.insert(index, _interrupted_tool_result_message(tool_call))
+                insertions.append(index)
+                index += 1
+        return tuple(insertions)
 
 
-def _latest_open_tool_call_assistant_index(messages: Sequence[AgentMessage]) -> int | None:
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if isinstance(message, UserMessage):
-            return None
-        if isinstance(message, AssistantMessage):
-            if message.tool_calls:
-                return index
-            return None
-    return None
+def _interrupted_tool_result_message(tool_call: ToolCall) -> ToolResultMessage:
+    message = "Tool call interrupted by user"
+    return ToolResultMessage(
+        tool_call_id=tool_call.id,
+        name=tool_call.name,
+        content=message,
+        ok=False,
+        error=message,
+    )

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -221,6 +221,7 @@ class CodingSession:
         self._config = config
         self._state = state
         self._harness = harness
+        self._persisted_message_count = len(harness.messages)
         self._last_parent_id = last_parent_id
         self._pending_initial_entries = pending_initial_entries
         self._skills = skills
@@ -455,6 +456,7 @@ class CodingSession:
 
         await self._refresh_persisted_state(leaf_id=target_id)
         self._harness.replace_messages(self._state.messages)
+        self._persisted_message_count = len(self._harness.messages)
         self._harness.config.model = self._state.model or self._config.model
         self._thinking_level = _state_thinking_level(self._state, self._config.thinking_level)
         self._sync_thinking_level_to_active_model()
@@ -953,6 +955,7 @@ class CodingSession:
         self._config = replacement._config
         self._state = replacement._state
         self._harness = replacement._harness
+        self._persisted_message_count = replacement._persisted_message_count
         self._last_parent_id = replacement._last_parent_id
         self._skills = replacement._skills
         self._prompt_templates = replacement._prompt_templates
@@ -1012,6 +1015,7 @@ class CodingSession:
         self._config = replacement._config
         self._state = replacement._state
         self._harness = replacement._harness
+        self._persisted_message_count = replacement._persisted_message_count
         self._last_parent_id = replacement._last_parent_id
         self._skills = replacement._skills
         self._prompt_templates = replacement._prompt_templates
@@ -1029,6 +1033,8 @@ class CodingSession:
 
     async def compact(self, instructions: str | None = None) -> str:
         """Generate a manual compaction summary and rebuild active context."""
+        self._repair_transcript()
+        await self._flush_transcript()
         plan = self._manual_compaction_plan()
         summary = await self._generate_compaction_summary(
             plan.messages_to_summarize,
@@ -1086,7 +1092,7 @@ class CodingSession:
             exit_code = raw_exit_code if isinstance(raw_exit_code, int) else None
 
         if add_to_context:
-            before_count = len(self._harness.messages)
+            self._repair_transcript()
             self._harness.append_message(
                 UserMessage(
                     content=_terminal_command_context_message(
@@ -1095,7 +1101,7 @@ class CodingSession:
                     )
                 )
             )
-            await self._persist_messages_since(before_count)
+            await self._flush_transcript()
 
         return TerminalCommandResult(
             command=normalized_command,
@@ -1136,42 +1142,45 @@ class CodingSession:
                 "CodingSession is already running; pass streaming_behavior to queue a message."
             )
 
+        self._repair_transcript()
+        await self._flush_transcript()
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
-        persisted_count = len(self._harness.messages)
         overflow_event: ErrorEvent | None = None
         try:
-            async for event in self._harness.prompt(expanded_content):
-                if isinstance(event, MessageEndEvent):
-                    persisted_count = await self._persist_messages_since(persisted_count)
-                if isinstance(event, ErrorEvent) and not event.recoverable:
-                    self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
-                        context=context,
-                        phase="agent_loop",
-                        event=event,
-                    )
-                    if _is_context_overflow_error(event):
-                        overflow_event = event
-                yield event
-            persisted_count = await self._persist_messages_since(persisted_count)
+            try:
+                async for event in self._harness.prompt(expanded_content):
+                    if isinstance(event, MessageEndEvent):
+                        await self._flush_transcript()
+                    if isinstance(event, ErrorEvent) and not event.recoverable:
+                        self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
+                            context=context,
+                            phase="agent_loop",
+                            event=event,
+                        )
+                        if _is_context_overflow_error(event):
+                            overflow_event = event
+                    yield event
+            finally:
+                await self._flush_transcript()
             if overflow_event is not None:
                 compacted = await self._try_overflow_compact(context=context)
                 if compacted:
-                    retry_persisted_count = len(self._harness.messages)
-                    async for retry_event in self._harness.continue_():
-                        if isinstance(retry_event, MessageEndEvent):
-                            retry_persisted_count = await self._persist_messages_since(
-                                retry_persisted_count
-                            )
-                        if isinstance(retry_event, ErrorEvent) and not retry_event.recoverable:
-                            self._last_diagnostic_log_path = (
-                                self._diagnostic_logger.log_error_event(
-                                    context=context,
-                                    phase="agent_loop_retry",
-                                    event=retry_event,
+                    self._repair_transcript()
+                    try:
+                        async for retry_event in self._harness.continue_():
+                            if isinstance(retry_event, MessageEndEvent):
+                                await self._flush_transcript()
+                            if isinstance(retry_event, ErrorEvent) and not retry_event.recoverable:
+                                self._last_diagnostic_log_path = (
+                                    self._diagnostic_logger.log_error_event(
+                                        context=context,
+                                        phase="agent_loop_retry",
+                                        event=retry_event,
+                                    )
                                 )
-                            )
-                        yield retry_event
-                    await self._persist_messages_since(retry_persisted_count)
+                            yield retry_event
+                    finally:
+                        await self._flush_transcript()
                 return
             await self._try_auto_compact(context=context, phase="auto_compact_after_prompt")
         except Exception as exc:
@@ -1185,19 +1194,22 @@ class CodingSession:
     async def continue_(self) -> AsyncIterator[AgentEvent]:
         """Continue the agent from restored state and persist new messages."""
         context = self._diagnostic_context()
-        persisted_count = len(self._harness.messages)
+        self._repair_transcript()
+        await self._flush_transcript()
         try:
-            async for event in self._harness.continue_():
-                if isinstance(event, MessageEndEvent):
-                    persisted_count = await self._persist_messages_since(persisted_count)
-                if isinstance(event, ErrorEvent) and not event.recoverable:
-                    self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
-                        context=context,
-                        phase="agent_loop",
-                        event=event,
-                    )
-                yield event
-            await self._persist_messages_since(persisted_count)
+            try:
+                async for event in self._harness.continue_():
+                    if isinstance(event, MessageEndEvent):
+                        await self._flush_transcript()
+                    if isinstance(event, ErrorEvent) and not event.recoverable:
+                        self._last_diagnostic_log_path = self._diagnostic_logger.log_error_event(
+                            context=context,
+                            phase="agent_loop",
+                            event=event,
+                        )
+                    yield event
+            finally:
+                await self._flush_transcript()
             await self._try_auto_compact(context=context, phase="auto_compact_after_continue")
         except Exception as exc:
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -1216,26 +1228,41 @@ class CodingSession:
             run_id=new_agent_call_run_id(),
         )
 
-    async def _persist_messages_since(self, persisted_count: int) -> int:
-        """Persist completed harness messages after ``persisted_count``.
+    def _repair_transcript(self) -> None:
+        """Repair unpaired tool calls while keeping the persisted baseline aligned.
+
+        Repairs inserted below the persisted boundary shift already-persisted
+        messages up by one; count them as persisted because the append-only
+        session tree cannot accept mid-history inserts — they are re-created
+        in memory on every load instead. Repairs at or beyond the boundary
+        flush to storage like any other new message.
+        """
+        for index in self._harness.repair_interrupted_tool_calls():
+            if index < self._persisted_message_count:
+                self._persisted_message_count += 1
+
+    async def _flush_transcript(self) -> None:
+        """Persist harness messages that have not reached durable storage yet.
 
         Message lifecycle events are the durable-message boundary. Each persisted
         message advances the append-only tree and records a leaf pointer so tree
         navigation can observe the current branch while a run is still active.
+        The persisted counter advances per message so an interrupted flush never
+        re-persists messages that already reached storage.
         """
-        new_messages = self._harness.messages[persisted_count:]
-        if not new_messages:
-            return persisted_count
+        if self._persisted_message_count >= len(self._harness.messages):
+            return
 
-        for message in new_messages:
+        while self._persisted_message_count < len(self._harness.messages):
+            message = self._harness.messages[self._persisted_message_count]
             entry = MessageEntry(parent_id=self._last_parent_id, message=message)
             await self._append_session_entry(entry)
             self._last_parent_id = entry.id
             leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
             await self._append_session_entry(leaf)
+            self._persisted_message_count += 1
 
         await self._refresh_persisted_state()
-        return persisted_count + len(new_messages)
 
     async def _refresh_persisted_state(
         self,
@@ -1456,6 +1483,7 @@ class CodingSession:
 
         await self._refresh_persisted_state(leaf_id=compaction.id)
         self._harness.replace_messages(self._state.messages)
+        self._persisted_message_count = len(self._harness.messages)
         return compaction
 
 

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -273,6 +273,35 @@ async def test_cancelled_tool_run_repairs_transcript_before_next_prompt() -> Non
     ]
 
 
+def test_repair_inserts_interrupted_results_before_later_user_messages() -> None:
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=FakeProvider([]), model="fake", system="You are Tau."),
+        messages=[
+            UserMessage(content="Read README.md"),
+            AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+            UserMessage(content="Are you still there?"),
+        ],
+    )
+
+    insertions = harness.repair_interrupted_tool_calls()
+
+    assert insertions == (2,)
+    assert harness.messages == (
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        ToolResultMessage(
+            tool_call_id="call-1",
+            name="read",
+            content="Tool call interrupted by user",
+            ok=False,
+            error="Tool call interrupted by user",
+        ),
+        UserMessage(content="Are you still there?"),
+    )
+    assert harness.repair_interrupted_tool_calls() == ()
+
+
 @pytest.mark.anyio
 async def test_harness_rejects_overlapping_prompt_runs() -> None:
     provider = FakeProvider(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 
 import pytest
@@ -8,12 +8,15 @@ import pytest
 from tau_agent import (
     AgentMessage,
     AgentTool,
+    AgentToolResult,
     AssistantMessage,
+    JSONValue,
     QueueUpdateEvent,
     ToolCall,
     ToolResultMessage,
     UserMessage,
 )
+from tau_agent.harness import AgentHarness, AgentHarnessConfig
 from tau_agent.session import (
     CompactionEntry,
     JsonlSessionStorage,
@@ -337,6 +340,173 @@ async def test_prompt_repairs_loaded_session_with_interrupted_tool_call(
         UserMessage(content="What happened?"),
         AssistantMessage(content="Recovered."),
     ]
+
+
+@pytest.mark.anyio
+async def test_prompt_repairs_loaded_session_with_user_message_after_tool_call(
+    tmp_path: Path,
+) -> None:
+    """A user message persisted after an unpaired tool call must not brick the session."""
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user_entry = MessageEntry(message=UserMessage(content="Run the tool"))
+    await storage.append(user_entry)
+    tool_call = ToolCall(id="call-1", name="slow", arguments={})
+    assistant_entry = MessageEntry(
+        parent_id=user_entry.id,
+        message=AssistantMessage(content="Running.", tool_calls=[tool_call]),
+    )
+    await storage.append(assistant_entry)
+    follow_up_entry = MessageEntry(
+        parent_id=assistant_entry.id,
+        message=UserMessage(content="Are you still there?"),
+    )
+    await storage.append(follow_up_entry)
+    await storage.append(LeafEntry(parent_id=follow_up_entry.id, entry_id=follow_up_entry.id))
+
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Recovered.")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    await _collect_session_events(session.prompt("What happened?"))
+
+    expected_repair = ToolResultMessage(
+        tool_call_id="call-1",
+        name="slow",
+        content="Tool call interrupted by user",
+        ok=False,
+        error="Tool call interrupted by user",
+    )
+    assert provider.calls[0][2] == [
+        UserMessage(content="Run the tool"),
+        AssistantMessage(content="Running.", tool_calls=[tool_call]),
+        expected_repair,
+        UserMessage(content="Are you still there?"),
+        UserMessage(content="What happened?"),
+    ]
+
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Run the tool"),
+        AssistantMessage(content="Running.", tool_calls=[tool_call]),
+        UserMessage(content="Are you still there?"),
+        UserMessage(content="What happened?"),
+        AssistantMessage(content="Recovered."),
+    ]
+
+
+@pytest.mark.anyio
+async def test_cancelled_tool_run_persists_repairs_for_later_reload(tmp_path: Path) -> None:
+    """Hard-cancelling a run mid-tool-call must not corrupt the durable transcript."""
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    started = asyncio.Event()
+
+    async def executor(
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+    ) -> AgentToolResult:
+        del arguments, signal
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("tool should have been cancelled")
+
+    tool = AgentTool(
+        name="slow",
+        description="Block until cancelled.",
+        input_schema={"type": "object"},
+        executor=executor,
+    )
+    tool_call = ToolCall(id="call-1", name="slow", arguments={})
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(
+                    message=AssistantMessage(content="Running.", tool_calls=[tool_call])
+                ),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Second answer")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            tools=[tool],
+        )
+    )
+
+    async def drive() -> None:
+        async for _event in session.prompt("Run the slow tool"):
+            pass
+
+    task = asyncio.create_task(drive())
+    await started.wait()
+    session.cancel()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await _collect_session_events(session.prompt("Did it work?"))
+
+    interrupted_result = ToolResultMessage(
+        tool_call_id="call-1",
+        name="slow",
+        content="Tool call interrupted by user",
+        ok=False,
+        error="Tool call interrupted by user",
+    )
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Run the slow tool"),
+        AssistantMessage(content="Running.", tool_calls=[tool_call]),
+        interrupted_result,
+        UserMessage(content="Did it work?"),
+        AssistantMessage(content="Second answer"),
+    ]
+
+    reload_provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Still alive")),
+            ]
+        ]
+    )
+    reloaded = await CodingSession.load(
+        CodingSessionConfig(
+            provider=reload_provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+    await _collect_session_events(reloaded.prompt("And after a restart?"))
+    replayed = reload_provider.calls[0][2]
+    assistant_index = replayed.index(AssistantMessage(content="Running.", tool_calls=[tool_call]))
+    assert replayed[assistant_index + 1] == interrupted_result
 
 
 @pytest.mark.anyio
@@ -2629,7 +2799,9 @@ def test_minimal_commands_are_handled(tmp_path: Path) -> None:
     session = CodingSession(
         _config(tmp_path, FakeProvider([]), JsonlSessionStorage(tmp_path / "session.jsonl")),
         state=object(),  # type: ignore[arg-type]
-        harness=object(),  # type: ignore[arg-type]
+        harness=AgentHarness(
+            AgentHarnessConfig(provider=FakeProvider([]), model="fake", system="You are Tau.")
+        ),
         last_parent_id=None,
     )
 


### PR DESCRIPTION
Press Esc while a tool call is running and the session file is quietly corrupted. Nothing looks wrong at the time — the live session keeps answering normally — but the assistant message carrying the `tool_calls` reached disk while its tool result never does, and the next prompt's user message is persisted directly after it. On the next restart, resuming that session is fatal: the provider rejects the transcript with a 400 (*"an assistant message with 'tool_calls' must be followed by tool messages"*), the 400 is non-retryable, and every subsequent prompt fails the same way. The session is permanently bricked on disk. Running a `!command` while a turn is in flight triggers the same corruption through Textual's `exclusive=True` worker semantics, without pressing Esc at all.

Three defects chain together. `CodingSession.prompt` set its persistence baseline at run start (`persisted_count = len(self._harness.messages)`), so anything a previous aborted run left in memory — the synthetic interrupted tool results the harness appends on cancel — sat below the baseline and was skipped forever. The end-of-run flush wasn't in a `finally`, and the TUI cancel path hard-kills the worker right after `session.cancel()`, so those repairs never reached storage when the cancel happened. And the harness's unpaired-tool-call repair scanned back only to the first user message, so once the next prompt persisted its user message, the on-disk shape `[assistant(tool_calls), user]` was unfixable on reload. The fix addresses all three: the persisted-message baseline becomes session instance state and stragglers are flushed at the start of every prompt, continue, terminal command, and compaction; the run loops flush inside `try/finally` so hard cancellation persists repairs immediately; and `repair_interrupted_tool_calls` now scans the whole transcript and inserts synthetic results in place, even past user messages. That last part also un-bricks sessions corrupted before this fix — mid-history repairs can't be inserted into the append-only session tree, so they're re-created in memory on every load instead. The regression test walks the full symptom (blocking tool, `session.cancel()` plus hard task cancel mirroring the TUI worker, second prompt, reload from the same JSONL) and failed before the fix.

**To reproduce in the TUI** (on `main`, without this fix):

1. Start `tau` and send a prompt that triggers a slow tool call, e.g. "Use the bash tool to run `sleep 60`." Wait until the tool is executing.
2. Press Esc mid-tool-call, then send another prompt (e.g. "What happened?") and let it finish — everything still works, because the in-memory transcript was repaired.
3. Quit, relaunch, and resume the session (Ctrl+R or `--resume`), then send any prompt: provider 400, on this and every later prompt in the session.

Both images below are the view after doing step 3 above.

Before:
<img width="1043" height="507" alt="Screenshot 2026-07-03 at 11 55 51" src="https://github.com/user-attachments/assets/9f4863e9-59b8-4381-b0bd-bcc06d9a9410" />

After:
<img width="1012" height="427" alt="Screenshot 2026-07-03 at 11 57 06" src="https://github.com/user-attachments/assets/feef8f9a-ed6a-4a78-8041-11512b80f109" />
