### PR TITLE
chore: release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -149,7 +149,7 @@ from tau_coding.tools import (
     create_write_tool_definition,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "__version__",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,7 @@ def test_version_command() -> None:
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.0"
+    assert result.stdout.strip() == "tau 0.1.1"
 
 
 def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,7 +51,7 @@ def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPa
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.0"
+    assert result.stdout.strip() == "tau 0.1.1"
 
 
 def test_print_mode_writes_update_notice_to_stderr(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump tau-ai package version to 0.1.1
- Update CLI version expectations and lockfile

## Changes since the last PyPI publish (`0.1.0`)

Last PyPI publish: `tau-ai 0.1.0` on 2026-06-28.

### Agent/provider behavior

- Route OpenAI `gpt-5.5`, `gpt-5.4`, and Codex models to the `/v1/responses` API (#183)
- Add local system prompt command (#198)
- Validate conflicting session flags in the CLI
- Check PyPI for Tau updates on startup (#200)

### TUI fixes and improvements

- Render transcript messages as full-height role blocks (#214)
- Guard Markdown selection until blocks are mounted (#213)
- Disable TUI text selection while streaming (#212)
- Disable active-line highlighting in prompt (#208)
- Fix autocomplete suggestion viewport sizing
- Implement prompt history recall with the Up key (#178)
- Fix code block horizontal scrolling (#190)
- Restore streaming transcript scrollback (#177)
- Add `/exit` alias for `/quit`

### Packaging, release, and CI

- Lower Python requirement to 3.12 (#220)
- Stabilize CI checks (#224)
- Add CI workflow
- Add CODEOWNERS
- Publish package only on GitHub Release
- Gate PyPI publish on intentional version changes
- Add `license-files` metadata
- Add MIT license
- Ignore `.mypy_cache`

### Documentation and website

- Add contributing guidelines
- Refresh provider and shortcut docs
- Update quickstart provider login docs
- Update docs to install `tau-ai` from PyPI
- Refresh README and restore header image
- Link landing logos to home
- Uniformize landing nav links
- Adjust Tau roll animation label spacing

## Checks

- `uv run pytest` — 604 passed
- `uv run ruff check .`
- `uv run mypy`
