### PR TITLE
Fix: Avoid unavailable models and surface provider error details (#226)

### DIFF
--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -196,12 +196,16 @@ class OpenAICompatibleProvider:
                                 if not await wait_for_retry(delay, signal=signal):
                                     return
                                 continue
+                            # Fix for issue #226 by legacy7838-create: Include provider detail in error message
+                            body_text = body.decode(errors="replace")
+                            detail = _http_error_detail(body_text)
+                            prefix = f"Provider request failed with status {response.status_code}"
+                            msg = f"{prefix}: {detail}" if detail else prefix
+                            
                             yield ProviderErrorEvent(
-                                message=(
-                                    f"Provider request failed with status {response.status_code}"
-                                ),
+                                message=msg,
                                 data={
-                                    "body": body.decode(errors="replace"),
+                                    "body": body_text,
                                     "attempts": attempt + 1,
                                 },
                             )
@@ -716,6 +720,24 @@ def _normalize_finish_reason(status: str | None, *, has_tool_calls: bool) -> str
         return "length"
     return "stop"
 
+
+# Fix for issue #226 by legacy7838-create: Parse JSON error details from provider
+def _http_error_detail(body: str) -> str:
+    parsed = _loads_object(body)
+    if parsed is not None:
+        error = parsed.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+            code = error.get("code")
+            if isinstance(code, str) and code:
+                return code
+        for key in ("message", "detail", "error"):
+            detail = parsed.get(key)
+            if isinstance(detail, str) and detail:
+                return detail
+    return body.strip()[:1000]
 
 def _responses_failure_event(chunk: Mapping[str, Any]) -> ProviderErrorEvent:
     message = "Provider response failed"

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -659,6 +659,15 @@ def resolve_provider_selection(
     selected_model = model or provider.default_model
     if not selected_model:
         raise ProviderConfigError(f"Provider {provider.name} does not define a default model")
+
+    # Fix for issue #226 by legacy7838-create: Prevent unavailable auto-selected models
+    if provider.models and selected_model not in provider.models:
+        models_list = ", ".join(provider.models)
+        raise ProviderConfigError(
+            f"Model '{selected_model}' is not available for provider '{provider.name}'. "
+            f"Available models: {models_list}"
+        )
+
     return ProviderSelection(provider=provider, model=selected_model)
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -648,6 +648,12 @@ class CodingSession:
 
     def set_model(self, model: str) -> None:
         """Switch the active model for future turns and make it the default."""
+        # Fix for issue #226 by legacy7838-create: Prevent unavailable mid-session models
+        available = set(self.available_models)
+        if available and model not in available:
+            models_list = ", ".join(sorted(available))
+            raise ValueError(f"Unknown model for provider {self.provider_name}: {model}\nAvailable models: {models_list}")
+
         self._harness.config.model = model
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -269,6 +269,22 @@ def test_resolve_provider_selection_rejects_unknown_provider() -> None:
         resolve_provider_selection(ProviderSettings(), provider_name="missing")
 
 
+def test_resolve_provider_selection_rejects_unavailable_model() -> None:
+    settings = ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost",
+                api_key_env="LOCAL_KEY",
+                models=("qwen", "llama"),
+                default_model="qwen",
+            ),
+        ),
+    )
+    with pytest.raises(ProviderConfigError, match="Model 'gpt-5' is not available for provider 'local'"):
+        resolve_provider_selection(settings, model="gpt-5")
+
 def test_openai_compatible_config_from_provider_uses_configured_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Hi! I'm happy to help fix this issue. This PR addresses both parts of #226:

1. **Model Validation**: Added a guard in `resolve_provider_selection()` and `CodingSession.set_model()` to ensure the requested model is actually in `provider.models`. This prevents Tau from sending doomed requests (like `gpt-5` on Codex).
2. **Actionable Errors**: Ported `_http_error_detail` into `openai_compatible.py` so that HTTP 400s surface the actual JSON error message from the provider instead of a generic "Status 400" message.

I've also added tests to `test_provider_config.py` to cover the new model validation guard. Let me know if you need any adjustments!

Resolves #226