### PR TITLE
feat: enable HF thinking mode switching

### DIFF
--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -225,7 +225,7 @@ BUILTIN_PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
             "openai/gpt-oss-20b": 131_072,
             "Qwen/Qwen3-Coder-480B-A35B-Instruct": 262_144,
         },
-        thinking_levels=("low", "medium", "high"),
+        thinking_levels=("off", "low", "medium", "high"),
         thinking_models=(
             "openai/gpt-oss-120b",
             "openai/gpt-oss-20b",

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -87,11 +87,18 @@ def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:
         == "openrouter:anthropic/claude-sonnet-4.6 is not declared in thinking_models"
     )
     assert provider_thinking_levels(huggingface, model="openai/gpt-oss-120b") == (
+        "off",
         "low",
         "medium",
         "high",
     )
+    assert provider_default_thinking_level(huggingface, model="openai/gpt-oss-120b") == "medium"
     assert provider_thinking_unavailable_reason(huggingface, model="openai/gpt-oss-120b") is None
+    assert provider_thinking_levels(huggingface, model="Qwen/Qwen3-Coder-Next") == ()
+    assert (
+        provider_thinking_unavailable_reason(huggingface, model="Qwen/Qwen3-Coder-Next")
+        == "huggingface:Qwen/Qwen3-Coder-Next is not declared in thinking_models"
+    )
     assert provider_thinking_levels(codex, model="gpt-5.5") == (
         "off",
         "minimal",
@@ -539,6 +546,34 @@ def test_openai_compatible_config_from_provider_sets_reasoning_parameter(
 
     assert config.reasoning_effort == "high"
     assert config.reasoning_effort_parameter == expected
+
+
+def test_huggingface_config_maps_thinking_modes_to_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "test-key")
+    provider = ProviderSettings().get_provider("huggingface")
+
+    off_config = openai_compatible_config_from_provider(
+        provider,
+        model="openai/gpt-oss-120b",
+        thinking_level="off",
+    )
+    high_config = openai_compatible_config_from_provider(
+        provider,
+        model="openai/gpt-oss-120b",
+        thinking_level="high",
+    )
+    unsupported_config = openai_compatible_config_from_provider(
+        provider,
+        model="Qwen/Qwen3-Coder-Next",
+        thinking_level="high",
+    )
+
+    assert off_config.reasoning_effort == "none"
+    assert high_config.reasoning_effort == "high"
+    assert high_config.reasoning_effort_parameter == "reasoning_effort"
+    assert unsupported_config.reasoning_effort is None
 
 
 def test_provider_settings_from_json_loads_headers() -> None:

--- a/website/src/content/docs/guides/providers-and-models.md
+++ b/website/src/content/docs/guides/providers-and-models.md
@@ -85,6 +85,16 @@ Provider entries support `headers`, `timeout_seconds`, `max_retries`, and
 `max_retry_delay_seconds`. For the full JSON shape (and `thinking_levels` for
 custom models), see [Configuration](../reference/configuration.md#providers).
 
+## Thinking modes
+
+For models that declare reasoning support, Tau exposes thinking mode switching
+through the TUI and slash-command flow. The built-in Hugging Face Inference
+Providers entry enables `off`, `low`, `medium`, and `high` for supported
+reasoning models such as `openai/gpt-oss-120b`, `openai/gpt-oss-20b`,
+`Qwen/Qwen3-235B-A22B-Thinking-2507`, and `deepseek-ai/DeepSeek-R1`. Other
+Hugging Face models stay hidden from thinking controls until they are declared
+as supporting reasoning.
+
 :::tip[Org billing example]
 Hugging Face organization billing is just a header on the provider entry:
 


### PR DESCRIPTION
## Closing in favor of PR #241

This functionality is now available as part of **PR #241** ([Make the provider catalog config-driven](https://github.com/huggingface/tau/pull/241)), which introduced TOML-based provider catalog support.

The catalog-driven architecture provides a cleaner foundation for provider configuration including thinking modes. If the HF thinking mode switching is still needed after the catalog refactor, please open a new issue to track that specific feature request.

Closing in favor of PR #241.