### PR TITLE
feat: make providers config-driven

### DIFF
--- a/dev-notes/architecture/config-driven-provider-catalog.md
+++ b/dev-notes/architecture/config-driven-provider-catalog.md
@@ -1,0 +1,72 @@
+---
+title: "Config-driven provider catalog"
+---
+
+Issue: https://github.com/huggingface/tau/issues/238
+
+## What changed
+
+Tau's provider catalog is now data-driven. Bundled provider definitions live in:
+
+```text
+src/tau_coding/data/provider_catalog.json
+```
+
+At runtime, Tau also reads optional local catalog files:
+
+```text
+~/.tau/provider-catalog.json
+<project>/.tau/provider-catalog.json
+```
+
+The load order is bundled catalog, user catalog, then project catalog. Later
+entries override earlier entries with the same provider `name`.
+
+## Why it exists
+
+Before this change, adding a built-in provider or changing a provider's model
+metadata required editing Python source. That made provider support PR-driven.
+The catalog file keeps source code responsible for validation and runtime
+boundaries, while provider metadata can be edited as config.
+
+## Architecture boundary
+
+The implementation stays in `tau_coding` because it deals with Tau home,
+project-local files, login lists, and provider preferences. The reusable
+`tau_agent` harness still receives only a ready model provider and model name.
+The `tau_ai` layer remains focused on provider-neutral runtime adapters.
+
+## Catalog shape
+
+```json
+{
+  "providers": [
+    {
+      "name": "local-gateway",
+      "display_name": "Local Gateway",
+      "kind": "openai-compatible",
+      "base_url": "http://localhost:11434/v1",
+      "api_key_env": "LOCAL_GATEWAY_API_KEY",
+      "credential_name": "local-gateway",
+      "models": ["qwen-coder"],
+      "default_model": "qwen-coder",
+      "docs_url": "https://example.test/local-gateway"
+    }
+  ]
+}
+```
+
+Supported `kind` values are `openai-compatible`, `anthropic`, and
+`openai-codex`. For user-defined providers, `openai-compatible` is the intended
+first path.
+
+## How to test
+
+```bash
+uv run pytest tests/test_provider_config.py
+uv run pytest tests/test_provider_runtime.py
+```
+
+The provider config tests cover bundled catalog loading, user-defined provider
+loading, project overrides, invalid catalog validation, and conversion from
+catalog entries to durable provider settings.

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -43,7 +43,10 @@ from tau_coding.prompt_templates import (
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ProviderCatalogEntry,
+    ProviderCatalogError,
     builtin_provider_entry,
+    load_provider_catalog,
+    provider_catalog_entry,
 )
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
@@ -177,6 +180,7 @@ __all__ = [
     "ProjectContextFile",
     "PromptTemplate",
     "ProviderCatalogEntry",
+    "ProviderCatalogError",
     "ProviderConfig",
     "ProviderConfigError",
     "ProviderSelection",
@@ -248,9 +252,11 @@ __all__ = [
     "load_shell_settings",
     "load_prompt_templates",
     "load_prompt_templates_with_diagnostics",
+    "load_provider_catalog",
     "load_skills",
     "load_skills_with_diagnostics",
     "openai_compatible_config_from_provider",
+    "provider_catalog_entry",
     "provider_config_from_catalog_entry",
     "provider_default_thinking_level",
     "provider_has_usable_credentials",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -63,7 +63,10 @@ app = typer.Typer(
 
 def providers_command() -> None:
     """List configured model providers."""
-    render_provider_settings(load_provider_settings(), credential_reader=FileCredentialStore())
+    render_provider_settings(
+        load_provider_settings(cwd=Path.cwd()),
+        credential_reader=FileCredentialStore(),
+    )
 
 
 def setup_command(
@@ -78,7 +81,7 @@ def setup_command(
     set_default: bool = True,
 ) -> None:
     """Create or update an OpenAI-compatible provider entry."""
-    settings = load_provider_settings()
+    settings = load_provider_settings(cwd=Path.cwd())
     provider = OpenAICompatibleProviderConfig(
         name=provider_name,
         base_url=base_url.rstrip("/"),
@@ -439,7 +442,7 @@ async def run_openai_print_mode(
     session_manager: SessionManager | None = None,
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
-    settings = load_provider_settings()
+    settings = load_provider_settings(cwd=cwd)
     shell_settings = load_shell_settings()
     selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
     provider = create_model_provider(

--- a/src/tau_coding/data/__init__.py
+++ b/src/tau_coding/data/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled Tau coding data files."""

--- a/src/tau_coding/data/provider_catalog.json
+++ b/src/tau_coding/data/provider_catalog.json
@@ -1,0 +1,238 @@
+{
+  "providers": [
+    {
+      "name": "openai",
+      "display_name": "OpenAI",
+      "kind": "openai-compatible",
+      "base_url": "https://api.openai.com/v1",
+      "api_key_env": "OPENAI_API_KEY",
+      "credential_name": "openai",
+      "models": [
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+        "gpt-5.1",
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-4.1",
+        "gpt-4.1-mini"
+      ],
+      "default_model": "gpt-5.5",
+      "docs_url": "https://platform.openai.com/docs",
+      "context_windows": {
+        "gpt-5.5": 272000,
+        "gpt-5.5-pro": 1050000,
+        "gpt-5.4": 272000,
+        "gpt-5.4-mini": 400000,
+        "gpt-5.3-codex": 400000,
+        "gpt-5.2": 400000,
+        "gpt-5.1": 400000,
+        "gpt-5": 400000,
+        "gpt-5-mini": 400000,
+        "gpt-4.1": 1047576,
+        "gpt-4.1-mini": 1047576
+      },
+      "thinking_levels": [
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "thinking_models": [
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+        "gpt-5.1",
+        "gpt-5",
+        "gpt-5-mini"
+      ],
+      "thinking_default": "medium",
+      "thinking_parameter": "reasoning_effort"
+    },
+    {
+      "name": "openai-codex",
+      "display_name": "OpenAI Codex subscription",
+      "kind": "openai-codex",
+      "base_url": "https://chatgpt.com/backend-api",
+      "api_key_env": "OPENAI_CODEX_ACCESS_TOKEN",
+      "credential_name": "openai-codex",
+      "models": [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2"
+      ],
+      "default_model": "gpt-5.5",
+      "docs_url": "https://chatgpt.com/codex",
+      "context_windows": {
+        "gpt-5.5": 272000,
+        "gpt-5.4": 272000,
+        "gpt-5.4-mini": 400000,
+        "gpt-5.3-codex": 400000,
+        "gpt-5.3-codex-spark": 400000,
+        "gpt-5.2": 400000
+      },
+      "thinking_levels": [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "thinking_models": [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2"
+      ],
+      "thinking_default": "medium",
+      "thinking_parameter": "reasoning.effort"
+    },
+    {
+      "name": "anthropic",
+      "display_name": "Anthropic",
+      "kind": "anthropic",
+      "base_url": "https://api.anthropic.com/v1",
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "credential_name": "anthropic",
+      "models": [
+        "claude-sonnet-4-6",
+        "claude-opus-4-8",
+        "claude-haiku-4-5"
+      ],
+      "default_model": "claude-sonnet-4-6",
+      "docs_url": "https://docs.anthropic.com",
+      "context_windows": {
+        "claude-sonnet-4-6": 1000000,
+        "claude-opus-4-8": 200000,
+        "claude-haiku-4-5": 200000
+      },
+      "thinking_levels": [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "thinking_models": [
+        "claude-sonnet-4-6",
+        "claude-opus-4-8"
+      ],
+      "thinking_default": "medium",
+      "thinking_parameter": "anthropic.thinking"
+    },
+    {
+      "name": "openrouter",
+      "display_name": "OpenRouter",
+      "kind": "openai-compatible",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "credential_name": "openrouter",
+      "models": [
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "openai/gpt-5.3-codex",
+        "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-opus-4.8",
+        "google/gemini-3.5-pro",
+        "moonshotai/kimi-k2.7-code",
+        "moonshotai/kimi-k2-instruct",
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
+        "z-ai/glm-5.2",
+        "z-ai/glm-4.5",
+        "minimax/minimax-m3",
+        "qwen/qwen3-coder-plus",
+        "qwen/qwen3-coder",
+        "qwen/qwen3-235b-a22b-thinking-2507",
+        "mistralai/codestral-2508",
+        "meta-llama/llama-4-maverick"
+      ],
+      "default_model": "openai/gpt-5.5",
+      "docs_url": "https://openrouter.ai/docs",
+      "context_windows": {
+        "openai/gpt-5.5": 1050000,
+        "openai/gpt-5.4": 1050000,
+        "openai/gpt-5.3-codex": 400000,
+        "anthropic/claude-sonnet-4.6": 1000000,
+        "qwen/qwen3-coder-plus": 1000000,
+        "mistralai/codestral-2508": 256000
+      },
+      "thinking_levels": [
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "thinking_models": [
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "openai/gpt-5.3-codex",
+        "qwen/qwen3-235b-a22b-thinking-2507"
+      ],
+      "thinking_default": "medium",
+      "thinking_parameter": "reasoning_effort"
+    },
+    {
+      "name": "huggingface",
+      "display_name": "Hugging Face Inference Providers",
+      "kind": "openai-compatible",
+      "base_url": "https://router.huggingface.co/v1",
+      "api_key_env": "HF_TOKEN",
+      "credential_name": "huggingface",
+      "models": [
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+        "Qwen/Qwen3-Coder-Next",
+        "Qwen/Qwen3-235B-A22B-Thinking-2507",
+        "Qwen/Qwen2.5-Coder-32B-Instruct",
+        "moonshotai/Kimi-K2.7-Code",
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "deepseek-ai/DeepSeek-R1",
+        "moonshotai/Kimi-K2-Instruct",
+        "zai-org/GLM-5.2",
+        "zai-org/GLM-4.5",
+        "MiniMaxAI/MiniMax-M3",
+        "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+        "mistralai/Codestral-22B-v0.1",
+        "bigcode/starcoder2-15b"
+      ],
+      "default_model": "openai/gpt-oss-120b",
+      "docs_url": "https://huggingface.co/inference/get-started",
+      "context_windows": {
+        "openai/gpt-oss-120b": 131072,
+        "openai/gpt-oss-20b": 131072,
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct": 262144
+      },
+      "thinking_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "thinking_models": [
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+        "Qwen/Qwen3-235B-A22B-Thinking-2507",
+        "deepseek-ai/DeepSeek-R1"
+      ],
+      "thinking_default": "medium",
+      "thinking_parameter": "reasoning_effort"
+    }
+  ]
+}

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -1,18 +1,35 @@
-"""Built-in provider catalog for Tau login/setup flows."""
+"""Config-driven provider catalog for Tau login/setup flows."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import dataclass, replace
+from importlib.resources import files
+from json import loads
+from pathlib import Path
+from typing import Any, Literal
 
-from tau_coding.thinking import ThinkingLevel, ThinkingParameter
+from tau_coding.thinking import (
+    ThinkingLevel,
+    ThinkingParameter,
+    normalize_thinking_level,
+    normalize_thinking_levels,
+)
 
 ProviderKind = Literal["openai-compatible", "anthropic", "openai-codex"]
+SUPPORTED_PROVIDER_KINDS: tuple[ProviderKind, ...] = (
+    "openai-compatible",
+    "anthropic",
+    "openai-codex",
+)
+
+
+class ProviderCatalogError(ValueError):
+    """Raised when a provider catalog file is invalid."""
 
 
 @dataclass(frozen=True, slots=True)
 class ProviderCatalogEntry:
-    """A built-in provider Tau can present during login."""
+    """A provider Tau can present during login or use as a built-in default."""
 
     name: str
     display_name: str
@@ -29,218 +46,329 @@ class ProviderCatalogEntry:
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
 
+    def to_json(self) -> dict[str, Any]:
+        """Serialize this catalog entry to JSON-compatible data."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "kind": self.kind,
+            "base_url": self.base_url,
+            "api_key_env": self.api_key_env,
+            "credential_name": self.credential_name,
+            "models": list(self.models),
+            "default_model": self.default_model,
+            "docs_url": self.docs_url,
+            "context_windows": dict(self.context_windows or {}),
+            "thinking_levels": (
+                list(self.thinking_levels) if self.thinking_levels is not None else None
+            ),
+            "thinking_models": list(self.thinking_models),
+            "thinking_default": self.thinking_default,
+            "thinking_parameter": self.thinking_parameter,
+        }
 
-BUILTIN_PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
-    ProviderCatalogEntry(
-        name="openai",
-        display_name="OpenAI",
-        kind="openai-compatible",
-        base_url="https://api.openai.com/v1",
-        api_key_env="OPENAI_API_KEY",
-        credential_name="openai",
-        models=(
-            "gpt-5.5",
-            "gpt-5.5-pro",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.3-codex",
-            "gpt-5.2",
-            "gpt-5.1",
-            "gpt-5",
-            "gpt-5-mini",
-            "gpt-4.1",
-            "gpt-4.1-mini",
-        ),
-        default_model="gpt-5.5",
-        docs_url="https://platform.openai.com/docs",
-        context_windows={
-            "gpt-5.5": 272_000,
-            "gpt-5.5-pro": 1_050_000,
-            "gpt-5.4": 272_000,
-            "gpt-5.4-mini": 400_000,
-            "gpt-5.3-codex": 400_000,
-            "gpt-5.2": 400_000,
-            "gpt-5.1": 400_000,
-            "gpt-5": 400_000,
-            "gpt-5-mini": 400_000,
-            "gpt-4.1": 1_047_576,
-            "gpt-4.1-mini": 1_047_576,
-        },
-        thinking_levels=("off", "low", "medium", "high", "xhigh"),
-        thinking_models=(
-            "gpt-5.5",
-            "gpt-5.5-pro",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.3-codex",
-            "gpt-5.2",
-            "gpt-5.1",
-            "gpt-5",
-            "gpt-5-mini",
-        ),
-        thinking_default="medium",
-        thinking_parameter="reasoning_effort",
-    ),
-    ProviderCatalogEntry(
-        name="openai-codex",
-        display_name="OpenAI Codex subscription",
-        kind="openai-codex",
-        base_url="https://chatgpt.com/backend-api",
-        api_key_env="OPENAI_CODEX_ACCESS_TOKEN",
-        credential_name="openai-codex",
-        models=(
-            "gpt-5.5",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.3-codex",
-            "gpt-5.3-codex-spark",
-            "gpt-5.2",
-        ),
-        default_model="gpt-5.5",
-        docs_url="https://chatgpt.com/codex",
-        context_windows={
-            "gpt-5.5": 272_000,
-            "gpt-5.4": 272_000,
-            "gpt-5.4-mini": 400_000,
-            "gpt-5.3-codex": 400_000,
-            "gpt-5.3-codex-spark": 400_000,
-            "gpt-5.2": 400_000,
-        },
-        thinking_levels=("off", "minimal", "low", "medium", "high", "xhigh"),
-        thinking_models=(
-            "gpt-5.5",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.3-codex",
-            "gpt-5.3-codex-spark",
-            "gpt-5.2",
-        ),
-        thinking_default="medium",
-        thinking_parameter="reasoning.effort",
-    ),
-    ProviderCatalogEntry(
-        name="anthropic",
-        display_name="Anthropic",
-        kind="anthropic",
-        base_url="https://api.anthropic.com/v1",
-        api_key_env="ANTHROPIC_API_KEY",
-        credential_name="anthropic",
-        models=(
-            "claude-sonnet-4-6",
-            "claude-opus-4-8",
-            "claude-haiku-4-5",
-        ),
-        default_model="claude-sonnet-4-6",
-        docs_url="https://docs.anthropic.com",
-        context_windows={
-            "claude-sonnet-4-6": 1_000_000,
-            "claude-opus-4-8": 200_000,
-            "claude-haiku-4-5": 200_000,
-        },
-        thinking_levels=("off", "minimal", "low", "medium", "high", "xhigh"),
-        thinking_models=(
-            "claude-sonnet-4-6",
-            "claude-opus-4-8",
-        ),
-        thinking_default="medium",
-        thinking_parameter="anthropic.thinking",
-    ),
-    ProviderCatalogEntry(
-        name="openrouter",
-        display_name="OpenRouter",
-        kind="openai-compatible",
-        base_url="https://openrouter.ai/api/v1",
-        api_key_env="OPENROUTER_API_KEY",
-        credential_name="openrouter",
-        models=(
-            "openai/gpt-5.5",
-            "openai/gpt-5.4",
-            "openai/gpt-5.3-codex",
-            "anthropic/claude-sonnet-4.6",
-            "anthropic/claude-opus-4.8",
-            "google/gemini-3.5-pro",
-            "moonshotai/kimi-k2.7-code",
-            "moonshotai/kimi-k2-instruct",
-            "deepseek/deepseek-v4-pro",
-            "deepseek/deepseek-v4-flash",
-            "z-ai/glm-5.2",
-            "z-ai/glm-4.5",
-            "minimax/minimax-m3",
-            "qwen/qwen3-coder-plus",
-            "qwen/qwen3-coder",
-            "qwen/qwen3-235b-a22b-thinking-2507",
-            "mistralai/codestral-2508",
-            "meta-llama/llama-4-maverick",
-        ),
-        default_model="openai/gpt-5.5",
-        docs_url="https://openrouter.ai/docs",
-        context_windows={
-            "openai/gpt-5.5": 1_050_000,
-            "openai/gpt-5.4": 1_050_000,
-            "openai/gpt-5.3-codex": 400_000,
-            "anthropic/claude-sonnet-4.6": 1_000_000,
-            "qwen/qwen3-coder-plus": 1_000_000,
-            "mistralai/codestral-2508": 256_000,
-        },
-        thinking_levels=("off", "low", "medium", "high", "xhigh"),
-        thinking_models=(
-            "openai/gpt-5.5",
-            "openai/gpt-5.4",
-            "openai/gpt-5.3-codex",
-            "qwen/qwen3-235b-a22b-thinking-2507",
-        ),
-        thinking_default="medium",
-        thinking_parameter="reasoning_effort",
-    ),
-    ProviderCatalogEntry(
-        name="huggingface",
-        display_name="Hugging Face Inference Providers",
-        kind="openai-compatible",
-        base_url="https://router.huggingface.co/v1",
-        api_key_env="HF_TOKEN",
-        credential_name="huggingface",
-        models=(
-            "openai/gpt-oss-120b",
-            "openai/gpt-oss-20b",
-            "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-            "Qwen/Qwen3-Coder-Next",
-            "Qwen/Qwen3-235B-A22B-Thinking-2507",
-            "Qwen/Qwen2.5-Coder-32B-Instruct",
-            "moonshotai/Kimi-K2.7-Code",
-            "deepseek-ai/DeepSeek-V4-Pro",
-            "deepseek-ai/DeepSeek-V4-Flash",
-            "deepseek-ai/DeepSeek-R1",
-            "moonshotai/Kimi-K2-Instruct",
-            "zai-org/GLM-5.2",
-            "zai-org/GLM-4.5",
-            "MiniMaxAI/MiniMax-M3",
-            "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
-            "mistralai/Codestral-22B-v0.1",
-            "bigcode/starcoder2-15b",
-        ),
-        default_model="openai/gpt-oss-120b",
-        docs_url="https://huggingface.co/inference/get-started",
-        context_windows={
-            "openai/gpt-oss-120b": 131_072,
-            "openai/gpt-oss-20b": 131_072,
-            "Qwen/Qwen3-Coder-480B-A35B-Instruct": 262_144,
-        },
-        thinking_levels=("low", "medium", "high"),
-        thinking_models=(
-            "openai/gpt-oss-120b",
-            "openai/gpt-oss-20b",
-            "Qwen/Qwen3-235B-A22B-Thinking-2507",
-            "deepseek-ai/DeepSeek-R1",
-        ),
-        thinking_default="medium",
-        thinking_parameter="reasoning_effort",
-    ),
-)
+
+def load_provider_catalog(
+    *,
+    user_catalog_path: Path | None = None,
+    project_catalog_path: Path | None = None,
+) -> tuple[ProviderCatalogEntry, ...]:
+    """Load built-in provider catalog entries plus optional user/project overrides.
+
+    Later files override entries with the same provider name while preserving
+    bundled entries that are not mentioned. This keeps Tau's built-in providers
+    config-driven and allows local provider definitions without source changes.
+    """
+    entries = _catalog_entries_from_json(_bundled_catalog_data(), source="bundled provider catalog")
+    for path in (user_catalog_path, project_catalog_path):
+        if path is not None and path.exists():
+            entries = _merge_catalog_entries(
+                entries,
+                _catalog_entries_from_json(
+                    _json_file_data(path),
+                    source=str(path),
+                    existing={entry.name: entry for entry in entries},
+                ),
+            )
+    return entries
 
 
 def builtin_provider_entry(name: str) -> ProviderCatalogEntry | None:
-    """Return a built-in catalog entry by provider name."""
-    for entry in BUILTIN_PROVIDER_CATALOG:
+    """Return a bundled catalog entry by provider name."""
+    return provider_catalog_entry(name, BUILTIN_PROVIDER_CATALOG)
+
+
+def provider_catalog_entry(
+    name: str,
+    catalog: tuple[ProviderCatalogEntry, ...],
+) -> ProviderCatalogEntry | None:
+    """Return a catalog entry by provider name."""
+    for entry in catalog:
         if entry.name == name:
             return entry
     return None
+
+
+def provider_catalog_from_paths(
+    paths_home: Path, cwd: Path | None = None
+) -> tuple[ProviderCatalogEntry, ...]:
+    """Load bundled catalog with user and optional project catalog files."""
+    return load_provider_catalog(
+        user_catalog_path=paths_home / "provider-catalog.json",
+        project_catalog_path=(cwd / ".tau" / "provider-catalog.json") if cwd else None,
+    )
+
+
+def _merge_catalog_entries(
+    existing: tuple[ProviderCatalogEntry, ...],
+    incoming: tuple[ProviderCatalogEntry, ...],
+) -> tuple[ProviderCatalogEntry, ...]:
+    by_name = {entry.name: entry for entry in existing}
+    for entry in incoming:
+        by_name[entry.name] = entry
+    return tuple(by_name[name] for name in sorted(by_name))
+
+
+def _bundled_catalog_data() -> dict[str, Any]:
+    resource = files("tau_coding.data").joinpath("provider_catalog.json")
+    data = loads(resource.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ProviderCatalogError("Bundled provider catalog must be a JSON object")
+    return data
+
+
+def _json_file_data(path: Path) -> dict[str, Any]:
+    data = loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ProviderCatalogError(f"Provider catalog must be a JSON object: {path}")
+    return data
+
+
+def _catalog_entries_from_json(
+    data: dict[str, Any],
+    *,
+    source: str,
+    existing: dict[str, ProviderCatalogEntry] | None = None,
+) -> tuple[ProviderCatalogEntry, ...]:
+    providers_data = data.get("providers")
+    if not isinstance(providers_data, list) or not providers_data:
+        raise ProviderCatalogError(f"Provider catalog must include providers: {source}")
+    entries = tuple(
+        _catalog_entry_from_json(item, source=source, existing=existing) for item in providers_data
+    )
+    names = [entry.name for entry in entries]
+    if len(set(names)) != len(names):
+        raise ProviderCatalogError(f"Provider catalog names must be unique: {source}")
+    return entries
+
+
+def _catalog_entry_from_json(
+    data: object,
+    *,
+    source: str,
+    existing: dict[str, ProviderCatalogEntry] | None,
+) -> ProviderCatalogEntry:
+    if not isinstance(data, dict):
+        raise ProviderCatalogError(f"Provider catalog entries must be objects: {source}")
+    name = _string(data.get("name"), "providers[].name", source=source)
+    base = existing.get(name) if existing else None
+    kind = _kind(data.get("kind", data.get("type", base.kind if base else None)), source=source)
+    display_name = _string(
+        data.get("display_name", base.display_name if base else name),
+        f"providers[{name}].display_name",
+        source=source,
+    )
+    base_url = _string(
+        data.get("base_url", base.base_url if base else None),
+        f"providers[{name}].base_url",
+        source=source,
+    ).rstrip("/")
+    api_key_env = _string(
+        data.get("api_key_env", base.api_key_env if base else None),
+        f"providers[{name}].api_key_env",
+        source=source,
+    )
+    credential_name = _optional_string(
+        data.get("credential_name", base.credential_name if base else None),
+        f"providers[{name}].credential_name",
+        source=source,
+    )
+    docs_url = _string(
+        data.get("docs_url", base.docs_url if base else ""),
+        f"providers[{name}].docs_url",
+        source=source,
+    )
+    models = _string_tuple(
+        data.get("models", base.models if base else None),
+        f"providers[{name}].models",
+        source=source,
+    )
+    default_model = _string(
+        data.get("default_model", base.default_model if base else None),
+        f"providers[{name}].default_model",
+        source=source,
+    )
+    if default_model not in models:
+        models = (*models, default_model)
+    context_windows = _int_dict(
+        data.get("context_windows", base.context_windows if base else {}),
+        f"providers[{name}].context_windows",
+        source=source,
+    )
+    thinking_levels = _optional_thinking_levels(
+        data.get("thinking_levels", base.thinking_levels if base else None),
+        f"providers[{name}].thinking_levels",
+        source=source,
+    )
+    thinking_models = _string_tuple(
+        data.get("thinking_models", base.thinking_models if base else ()),
+        f"providers[{name}].thinking_models",
+        source=source,
+        allow_empty=True,
+    )
+    thinking_default = _optional_thinking_level(
+        data.get("thinking_default", base.thinking_default if base else None),
+        f"providers[{name}].thinking_default",
+        source=source,
+    )
+    thinking_parameter = _optional_thinking_parameter(
+        data.get("thinking_parameter", base.thinking_parameter if base else None),
+        f"providers[{name}].thinking_parameter",
+        source=source,
+    )
+    entry = ProviderCatalogEntry(
+        name=name,
+        display_name=display_name,
+        kind=kind,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        credential_name=credential_name or name,
+        models=models,
+        default_model=default_model,
+        docs_url=docs_url,
+        context_windows=context_windows,
+        thinking_levels=thinking_levels,
+        thinking_models=thinking_models,
+        thinking_default=thinking_default,
+        thinking_parameter=thinking_parameter,
+    )
+    if thinking_levels is None:
+        return replace(
+            entry,
+            thinking_models=(),
+            thinking_default=None,
+            thinking_parameter=None,
+        )
+    if thinking_default is not None and thinking_default not in thinking_levels:
+        raise ProviderCatalogError(f"thinking_default must be in thinking_levels: {source}")
+    return entry
+
+
+def _kind(value: object, *, source: str) -> ProviderKind:
+    if value not in SUPPORTED_PROVIDER_KINDS:
+        raise ProviderCatalogError(f"Unsupported provider kind in catalog: {value!r} ({source})")
+    return value
+
+
+def _string(value: object, field_name: str, *, source: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProviderCatalogError(
+            f"Provider catalog field must be a non-empty string: {field_name} ({source})"
+        )
+    return value.strip()
+
+
+def _optional_string(value: object, field_name: str, *, source: str) -> str | None:
+    if value is None:
+        return None
+    return _string(value, field_name, source=source)
+
+
+def _string_tuple(
+    value: object,
+    field_name: str,
+    *,
+    source: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)) or (not value and not allow_empty):
+        raise ProviderCatalogError(
+            f"Provider catalog field must be a string list: {field_name} ({source})"
+        )
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ProviderCatalogError(
+            f"Provider catalog field must be a string list: {field_name} ({source})"
+        )
+    return tuple(dict.fromkeys(item.strip() for item in value))
+
+
+def _int_dict(value: object, field_name: str, *, source: str) -> dict[str, int]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ProviderCatalogError(
+            f"Provider catalog field must be an integer object: {field_name} ({source})"
+        )
+    parsed: dict[str, int] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip() or not isinstance(item, int) or item <= 0:
+            raise ProviderCatalogError(
+                f"Provider catalog field must be an integer object: {field_name} ({source})"
+            )
+        parsed[key] = item
+    return parsed
+
+
+def _optional_thinking_levels(
+    value: object,
+    field_name: str,
+    *,
+    source: str,
+) -> tuple[ThinkingLevel, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ProviderCatalogError(
+            f"Provider catalog field must be a thinking mode list: {field_name} ({source})"
+        )
+    try:
+        return normalize_thinking_levels(value)
+    except ValueError as exc:
+        raise ProviderCatalogError(f"{field_name}: {exc} ({source})") from exc
+
+
+def _optional_thinking_level(
+    value: object, field_name: str, *, source: str
+) -> ThinkingLevel | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ProviderCatalogError(
+            f"Provider catalog field must be a thinking mode: {field_name} ({source})"
+        )
+    try:
+        return normalize_thinking_level(value)
+    except ValueError as exc:
+        raise ProviderCatalogError(f"{field_name}: {exc} ({source})") from exc
+
+
+def _optional_thinking_parameter(
+    value: object,
+    field_name: str,
+    *,
+    source: str,
+) -> ThinkingParameter | None:
+    if value is None:
+        return None
+    if value == "reasoning_effort":
+        return "reasoning_effort"
+    if value == "reasoning.effort":
+        return "reasoning.effort"
+    if value == "anthropic.thinking":
+        return "anthropic.thinking"
+    raise ProviderCatalogError(
+        f"Provider catalog field must be a thinking parameter: {field_name} ({source})"
+    )
+
+
+BUILTIN_PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = load_provider_catalog()

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -23,7 +23,12 @@ from tau_ai import (
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
 from tau_coding.credentials import FileCredentialStore, credentials_path
 from tau_coding.paths import TauPaths
-from tau_coding.provider_catalog import BUILTIN_PROVIDER_CATALOG, ProviderKind
+from tau_coding.provider_catalog import (
+    BUILTIN_PROVIDER_CATALOG,
+    ProviderCatalogEntry,
+    ProviderKind,
+    provider_catalog_from_paths,
+)
 from tau_coding.thinking import (
     DEFAULT_THINKING_LEVEL,
     ThinkingLevel,
@@ -282,47 +287,30 @@ class ProviderSelection:
 
 
 def builtin_provider_configs() -> tuple[ProviderConfig, ...]:
-    """Return Tau's built-in provider configs."""
-    return tuple(
-        provider_config_from_catalog_entry(entry.name) for entry in BUILTIN_PROVIDER_CATALOG
-    )
+    """Return Tau's bundled provider configs."""
+    return provider_configs_from_catalog(BUILTIN_PROVIDER_CATALOG)
+
+
+def provider_configs_from_catalog(
+    catalog: tuple[ProviderCatalogEntry, ...],
+) -> tuple[ProviderConfig, ...]:
+    """Create durable provider configs from catalog entries."""
+    return tuple(_provider_config_from_catalog_entry(entry) for entry in catalog)
 
 
 def provider_config_from_catalog_entry(name: str) -> ProviderConfig:
-    """Create a durable provider config from a built-in catalog entry."""
+    """Create a durable provider config from a bundled catalog entry."""
     for entry in BUILTIN_PROVIDER_CATALOG:
-        if entry.name != name:
-            continue
-        context_windows = dict(entry.context_windows or {})
-        if entry.kind == "anthropic":
-            return AnthropicProviderConfig(
-                name=entry.name,
-                base_url=entry.base_url,
-                api_key_env=entry.api_key_env,
-                credential_name=entry.credential_name,
-                models=entry.models,
-                default_model=entry.default_model,
-                context_windows=context_windows,
-                thinking_levels=entry.thinking_levels,
-                thinking_models=entry.thinking_models,
-                thinking_default=entry.thinking_default,
-                thinking_parameter=entry.thinking_parameter,
-            )
-        if entry.kind == "openai-codex":
-            return OpenAICodexProviderConfig(
-                name=entry.name,
-                base_url=entry.base_url,
-                api_key_env=entry.api_key_env,
-                credential_name=entry.credential_name,
-                models=entry.models,
-                default_model=entry.default_model,
-                context_windows=context_windows,
-                thinking_levels=entry.thinking_levels,
-                thinking_models=entry.thinking_models,
-                thinking_default=entry.thinking_default,
-                thinking_parameter=entry.thinking_parameter,
-            )
-        return OpenAICompatibleProviderConfig(
+        if entry.name == name:
+            return _provider_config_from_catalog_entry(entry)
+    raise ProviderConfigError(f"Unknown built-in provider: {name}")
+
+
+def _provider_config_from_catalog_entry(entry: ProviderCatalogEntry) -> ProviderConfig:
+    """Create a durable provider config from one catalog entry."""
+    context_windows = dict(entry.context_windows or {})
+    if entry.kind == "anthropic":
+        return AnthropicProviderConfig(
             name=entry.name,
             base_url=entry.base_url,
             api_key_env=entry.api_key_env,
@@ -335,7 +323,33 @@ def provider_config_from_catalog_entry(name: str) -> ProviderConfig:
             thinking_default=entry.thinking_default,
             thinking_parameter=entry.thinking_parameter,
         )
-    raise ProviderConfigError(f"Unknown built-in provider: {name}")
+    if entry.kind == "openai-codex":
+        return OpenAICodexProviderConfig(
+            name=entry.name,
+            base_url=entry.base_url,
+            api_key_env=entry.api_key_env,
+            credential_name=entry.credential_name,
+            models=entry.models,
+            default_model=entry.default_model,
+            context_windows=context_windows,
+            thinking_levels=entry.thinking_levels,
+            thinking_models=entry.thinking_models,
+            thinking_default=entry.thinking_default,
+            thinking_parameter=entry.thinking_parameter,
+        )
+    return OpenAICompatibleProviderConfig(
+        name=entry.name,
+        base_url=entry.base_url,
+        api_key_env=entry.api_key_env,
+        credential_name=entry.credential_name,
+        models=entry.models,
+        default_model=entry.default_model,
+        context_windows=context_windows,
+        thinking_levels=entry.thinking_levels,
+        thinking_models=entry.thinking_models,
+        thinking_default=entry.thinking_default,
+        thinking_parameter=entry.thinking_parameter,
+    )
 
 
 def default_openai_provider_config() -> OpenAICompatibleProviderConfig:
@@ -351,15 +365,23 @@ def provider_settings_path(paths: TauPaths | None = None) -> Path:
     return (paths or TauPaths()).home / "providers.json"
 
 
-def load_provider_settings(paths: TauPaths | None = None) -> ProviderSettings:
-    """Load durable provider settings, falling back to env-compatible defaults."""
+def load_provider_settings(
+    paths: TauPaths | None = None,
+    *,
+    cwd: Path | None = None,
+) -> ProviderSettings:
+    """Load durable provider settings, falling back to config-driven defaults."""
+    paths = paths or TauPaths()
+    catalog = provider_catalog_from_paths(paths.home, cwd=cwd)
     path = provider_settings_path(paths)
     if not path.exists():
-        return ProviderSettings()
+        return ProviderSettings(providers=provider_configs_from_catalog(catalog))
     raw = loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise ProviderConfigError("Provider settings must be a JSON object")
-    return _with_builtin_catalog_models(provider_settings_from_json(raw), paths=paths)
+    return _with_builtin_catalog_models(
+        provider_settings_from_json(raw), paths=paths, catalog=catalog
+    )
 
 
 def save_provider_settings(settings: ProviderSettings, paths: TauPaths | None = None) -> Path:
@@ -495,13 +517,11 @@ def _with_builtin_catalog_models(
     settings: ProviderSettings,
     *,
     paths: TauPaths | None = None,
+    catalog: tuple[ProviderCatalogEntry, ...] = BUILTIN_PROVIDER_CATALOG,
 ) -> ProviderSettings:
-    """Return settings with current built-in model catalogs merged in."""
+    """Return settings with current catalog models merged in."""
     builtin_configs = {
-        provider.name: provider
-        for provider in (
-            provider_config_from_catalog_entry(entry.name) for entry in BUILTIN_PROVIDER_CATALOG
-        )
+        provider.name: provider for provider in provider_configs_from_catalog(catalog)
     }
     providers = tuple(
         _merge_provider_config(provider, builtin_configs[provider.name])
@@ -509,7 +529,12 @@ def _with_builtin_catalog_models(
         else provider
         for provider in settings.providers
     )
-    providers = _append_credentialed_builtin_providers(providers, builtin_configs, paths=paths)
+    providers = _append_credentialed_builtin_providers(
+        providers,
+        builtin_configs,
+        paths=paths,
+        catalog=catalog,
+    )
     default_provider = settings.default_provider
     if default_provider not in {provider.name for provider in providers}:
         default_provider = providers[0].name if providers else DEFAULT_PROVIDER_NAME
@@ -525,12 +550,13 @@ def _append_credentialed_builtin_providers(
     builtin_configs: dict[str, ProviderConfig],
     *,
     paths: TauPaths | None,
+    catalog: tuple[ProviderCatalogEntry, ...],
 ) -> tuple[ProviderConfig, ...]:
-    """Append built-in providers that already have stored Tau credentials."""
+    """Append catalog providers that already have stored Tau credentials."""
     credential_store = FileCredentialStore(credentials_path(paths) if paths else None)
     provider_names = {provider.name for provider in providers}
     appended = list(providers)
-    for entry in BUILTIN_PROVIDER_CATALOG:
+    for entry in catalog:
         provider = builtin_configs[entry.name]
         if provider.name in provider_names:
             continue

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -893,7 +893,13 @@ class CodingSession:
             return
         previous_settings = self._provider_settings
         previous_thinking_level = self._thinking_level
-        self._provider_settings = load_provider_settings(self._resource_paths.paths)
+        try:
+            self._provider_settings = load_provider_settings(
+                self._resource_paths.paths,
+                cwd=self.cwd,
+            )
+        except TypeError:
+            self._provider_settings = load_provider_settings(self._resource_paths.paths)
         try:
             self._sync_thinking_level_to_active_model()
             self._refresh_runtime_provider()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3791,7 +3791,10 @@ async def run_tui_app(
     if new_session and session_id is not None:
         raise RuntimeError("--resume and --new-session cannot be used together")
 
-    provider_settings = load_provider_settings()
+    try:
+        provider_settings = load_provider_settings(cwd=cwd)
+    except TypeError:
+        provider_settings = load_provider_settings()
     shell_settings = load_shell_settings()
     manager = session_manager or SessionManager()
     record = _explicit_resume_record(

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.paths import TauPaths
+from tau_coding.provider_catalog import ProviderCatalogError, load_provider_catalog
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     AnthropicProviderConfig,
@@ -16,6 +17,7 @@ from tau_coding.provider_config import (
     anthropic_config_from_provider,
     load_provider_settings,
     openai_compatible_config_from_provider,
+    provider_configs_from_catalog,
     provider_default_thinking_level,
     provider_has_usable_credentials,
     provider_settings_from_json,
@@ -42,6 +44,151 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"
     assert settings.get_provider("openrouter").api_key_env == "OPENROUTER_API_KEY"
     assert settings.get_provider("huggingface").api_key_env == "HF_TOKEN"
+
+
+def test_provider_catalog_loads_user_defined_provider_without_code_changes(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "provider-catalog.json").write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "local-gateway",
+                        "display_name": "Local Gateway",
+                        "kind": "openai-compatible",
+                        "base_url": "http://localhost:11434/v1",
+                        "api_key_env": "LOCAL_GATEWAY_API_KEY",
+                        "credential_name": "local-gateway",
+                        "models": ["qwen-coder"],
+                        "default_model": "qwen-coder",
+                        "docs_url": "https://example.test/local-gateway",
+                        "context_windows": {"qwen-coder": 64000},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+
+    provider = settings.get_provider("local-gateway")
+    assert isinstance(provider, OpenAICompatibleProviderConfig)
+    assert provider.base_url == "http://localhost:11434/v1"
+    assert provider.api_key_env == "LOCAL_GATEWAY_API_KEY"
+    assert provider.default_model == "qwen-coder"
+    assert provider.context_windows == {"qwen-coder": 64000}
+
+
+def test_project_provider_catalog_overrides_user_catalog(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    project = tmp_path / "project"
+    tau_home.mkdir()
+    (project / ".tau").mkdir(parents=True)
+    (tau_home / "provider-catalog.json").write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "gateway",
+                        "display_name": "Gateway",
+                        "kind": "openai-compatible",
+                        "base_url": "https://user.example/v1",
+                        "api_key_env": "GATEWAY_API_KEY",
+                        "credential_name": "gateway",
+                        "models": ["user-model"],
+                        "default_model": "user-model",
+                        "docs_url": "https://example.test/gateway",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / ".tau" / "provider-catalog.json").write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "gateway",
+                        "base_url": "https://project.example/v1",
+                        "models": ["project-model"],
+                        "default_model": "project-model",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home), cwd=project)
+
+    provider = settings.get_provider("gateway")
+    assert provider.base_url == "https://project.example/v1"
+    assert provider.models == ("project-model",)
+    assert provider.default_model == "project-model"
+    assert provider.api_key_env == "GATEWAY_API_KEY"
+
+
+def test_provider_catalog_rejects_invalid_provider(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "provider-catalog.json"
+    catalog_path.write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "broken",
+                        "display_name": "Broken",
+                        "kind": "openai-compatible",
+                        "base_url": "https://example.test/v1",
+                        "api_key_env": "BROKEN_API_KEY",
+                        "credential_name": "broken",
+                        "models": [],
+                        "default_model": "broken-model",
+                        "docs_url": "https://example.test/broken",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProviderCatalogError, match="string list"):
+        load_provider_catalog(user_catalog_path=catalog_path)
+
+
+def test_provider_configs_from_catalog_converts_config_entries(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "provider-catalog.json"
+    catalog_path.write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "anthropic-alt",
+                        "display_name": "Anthropic Alt",
+                        "kind": "anthropic",
+                        "base_url": "https://anthropic.example/v1",
+                        "api_key_env": "ANTHROPIC_ALT_API_KEY",
+                        "credential_name": "anthropic-alt",
+                        "models": ["claude-alt"],
+                        "default_model": "claude-alt",
+                        "docs_url": "https://example.test/anthropic-alt",
+                        "thinking_levels": ["off", "low"],
+                        "thinking_parameter": "anthropic.thinking",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    providers = provider_configs_from_catalog(load_provider_catalog(user_catalog_path=catalog_path))
+    provider = next(item for item in providers if item.name == "anthropic-alt")
+
+    assert isinstance(provider, AnthropicProviderConfig)
+    assert provider.name == "anthropic-alt"
+    assert provider.thinking_levels == ("off", "low")
 
 
 def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:

--- a/website/src/content/docs/guides/providers-and-models.md
+++ b/website/src/content/docs/guides/providers-and-models.md
@@ -62,7 +62,7 @@ access tokens automatically. It's separate from the API-key `openai` provider.
 ## Adding a custom / local provider
 
 Any OpenAI-compatible endpoint works — including local servers like Ollama or
-llama.cpp. Register one with `tau setup`:
+llama.cpp. For one-off local setup, register one with `tau setup`:
 
 ```bash
 tau --provider local \
@@ -73,7 +73,34 @@ tau --provider local \
 ```
 
 This writes an entry to `~/.tau/providers.json` and (by default) makes it the
-default provider. Run it with:
+default provider.
+
+For reusable provider definitions, add `~/.tau/provider-catalog.json` or a
+project-local `.tau/provider-catalog.json` instead:
+
+```json
+{
+  "providers": [
+    {
+      "name": "local-gateway",
+      "display_name": "Local Gateway",
+      "kind": "openai-compatible",
+      "base_url": "http://localhost:11434/v1",
+      "api_key_env": "LOCAL_GATEWAY_API_KEY",
+      "credential_name": "local-gateway",
+      "models": ["qwen-coder"],
+      "default_model": "qwen-coder",
+      "docs_url": "https://example.test/local-gateway"
+    }
+  ]
+}
+```
+
+Tau loads bundled providers first, then user catalog entries, then project
+catalog entries. A later entry with the same `name` overrides the earlier one,
+so projects can pin endpoints or model lists without a PR.
+
+Run it with:
 
 ```bash
 tau --provider local

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -11,8 +11,9 @@ those locations and file formats.
 
 ```text
 ~/.tau/
-├── providers.json      # configured providers
-├── credentials.json    # saved API keys / OAuth tokens (private permissions)
+├── providers.json          # provider/model preferences
+├── provider-catalog.json   # optional provider definitions / overrides
+├── credentials.json        # saved API keys / OAuth tokens (private permissions)
 ├── settings.json       # general settings (e.g. shell command prefix)
 ├── tui.json            # TUI theme + keybindings
 ├── sessions/           # saved sessions, per project
@@ -31,7 +32,43 @@ Startup update checks cache their latest PyPI result in
 
 ## Providers
 
-Provider metadata lives in `~/.tau/providers.json`:
+Tau loads provider definitions from a bundled catalog plus optional local catalog
+files:
+
+```text
+~/.tau/provider-catalog.json          # user-level provider definitions
+<project>/.tau/provider-catalog.json  # project-level overrides
+```
+
+Project catalog entries override user catalog entries with the same `name`; user
+entries override bundled provider definitions. This lets you add OpenAI-compatible
+providers or override model lists without changing Tau source.
+
+Example catalog entry:
+
+```json
+{
+  "providers": [
+    {
+      "name": "local-gateway",
+      "display_name": "Local Gateway",
+      "kind": "openai-compatible",
+      "base_url": "http://localhost:11434/v1",
+      "api_key_env": "LOCAL_GATEWAY_API_KEY",
+      "credential_name": "local-gateway",
+      "models": ["qwen-coder"],
+      "default_model": "qwen-coder",
+      "docs_url": "https://example.test/local-gateway",
+      "context_windows": { "qwen-coder": 64000 }
+    }
+  ]
+}
+```
+
+Catalog entries support `kind` values of `openai-compatible`, `anthropic`, and
+`openai-codex`. For most custom services, start with `openai-compatible`.
+
+Provider preferences and scoped models live in `~/.tau/providers.json`:
 
 ```json
 {
@@ -63,9 +100,13 @@ Provider metadata lives in `~/.tau/providers.json`:
   `~/.tau/credentials.json`. Resolution order: stored credential, then the env
   var named by `api_key_env`.
 - `scoped_models` are favorites for the **Ctrl+P** quick-cycle.
-- Custom models can declare thinking support with `thinking_levels`,
-  `thinking_default`, `thinking_models`, and `thinking_parameter`
-  (`"reasoning_effort"`, `"reasoning.effort"`, or `"anthropic.thinking"`).
+- Provider definitions can also be placed directly in `providers.json` for local
+  preferences. For reusable additions and overrides, prefer
+  `provider-catalog.json`.
+- Custom models can declare thinking support in either file with
+  `thinking_levels`, `thinking_default`, `thinking_models`, and
+  `thinking_parameter` (`"reasoning_effort"`, `"reasoning.effort"`, or
+  `"anthropic.thinking"`).
 
 Writes after `/login`, `/model`, or scoped-model changes reload the file first,
 apply only the requested change, write atomically, and keep a `.bak` backup.


### PR DESCRIPTION
## Summary
- move bundled provider metadata into a JSON catalog loaded at runtime
- support user and project provider-catalog.json files for provider additions/overrides
- wire catalog-aware provider settings into CLI, TUI, and sessions
- document custom provider catalogs and add architecture notes

Closes #238

## Tests
- uv run pytest
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy