### PR TITLE
Apply role foreground to streaming transcript messages

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -308,6 +308,11 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         self._stream: MarkdownStream | None = None
         super().__init__(item.text, theme=theme)
         self.add_class("transcript-message")
+        # Apply the role foreground so streamed text matches the finalized block
+        # (e.g. dimmed thinking) instead of shifting color on the next redraw.
+        foreground, _ = _split_rich_style_colors(_chat_item_role_style(item, theme).body)
+        if foreground:
+            self.styles.color = foreground
 
     @property
     def stream(self) -> MarkdownStream:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1108,6 +1108,36 @@ async def test_transcript_message_widget_renders_full_height_role_block() -> Non
 
 
 @pytest.mark.anyio
+async def test_streaming_transcript_applies_role_foreground() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+
+        thinking_fg, _ = _split_rich_style_colors(TAU_DARK_THEME.role_styles["thinking"].body)
+        assistant_fg, _ = _split_rich_style_colors(TAU_DARK_THEME.role_styles["assistant"].body)
+
+        # Streamed thinking is dimmed immediately, matching the finalized block
+        # instead of shifting color on the next redraw.
+        await transcript.append_thinking_delta(
+            "reasoning", theme=TAU_DARK_THEME, show_thinking=True
+        )
+        await pilot.pause()
+        thinking = next(
+            w for w in app.query(StreamingTranscriptMessageWidget) if w.item.role == "thinking"
+        )
+        assert thinking.styles.color == Color.parse(thinking_fg)
+
+        await transcript.append_assistant_delta("answer", theme=TAU_DARK_THEME)
+        await pilot.pause()
+        assistant = next(
+            w for w in app.query(StreamingTranscriptMessageWidget) if w.item.role == "assistant"
+        )
+        assert assistant.styles.color == Color.parse(assistant_fg)
+
+
+@pytest.mark.anyio
 async def test_streaming_transcript_deltas_do_not_force_scroll_end_during_scrollback() -> None:
     app = TauTuiApp(
         FakeSession(


### PR DESCRIPTION
Streamed assistant and thinking messages render via `StreamingTranscriptMessageWidget`, which never applied the role foreground color — it used the Markdown default. The finalized `TranscriptMessageWidget` does apply it, so a message's text color shifted the moment a redraw swapped the streaming widget for the finalized one (for example on the next turn or a theme switch). The most visible symptom is that `thinking` text isn't dimmed while streaming and only turns grey after a redraw; assistant text similarly lightens.

This applies the role foreground in `StreamingTranscriptMessageWidget.__init__`, reusing the same `_chat_item_role_style` / `_split_rich_style_colors` helpers the finalized widget uses, so streamed text matches the finalized block immediately and no longer pops on redraw.

Independent of #228 (which removes the border/background for these roles); this addresses the foreground axis and applies cleanly on its own. Added a regression test asserting streamed thinking and assistant widgets carry their role foreground color.

BEFORE:
Thinking message isn't greyed out initially.
<img width="608" height="206" alt="Screenshot 2026-07-03 at 17 13 34" src="https://github.com/user-attachments/assets/5c1ff26a-d13d-484a-9bac-8211b35f71e6" />
After sending the next message it becomes greyed out as desired
<img width="989" height="379" alt="Screenshot 2026-07-03 at 17 13 58" src="https://github.com/user-attachments/assets/e366f365-2ee6-403d-b7a4-fb606184c5e3" />

AFTER:
Thinking appears greyed out immediately as it should.
<img width="716" height="232" alt="Screenshot 2026-07-03 at 17 16 04" src="https://github.com/user-attachments/assets/fd46ffa9-cf90-48b5-ba46-f57a3eaf1b96" />
