### PR TITLE
feat(tui): show session name in header

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -80,6 +80,8 @@ class CommandSession(Protocol):
     @property
     def session_manager(self) -> SessionManager | None: ...
 
+    def ensure_session_indexed(self) -> None: ...
+
     def set_model(self, model: str) -> None: ...
 
     def reload(self) -> CodingReloadSummary: ...
@@ -535,12 +537,11 @@ def _name_command(context: CommandContext) -> CommandResult:
     if manager is None or session_id is None:
         return CommandResult(handled=True, message="Session manager is not available.")
 
-    record = manager.get_session(session_id)
-    if record is None:
-        return CommandResult(handled=True, message=f"Unknown current session: {session_id}")
-
     if not context.args:
-        title = record.title or "Untitled session"
+        record = manager.get_session(session_id)
+        title = (
+            record.title if record is not None else context.session.session_title
+        ) or "Untitled session"
         return CommandResult(
             handled=True,
             message=f"Current session name: {title}\nUsage: /name <new name>",
@@ -550,6 +551,9 @@ def _name_command(context: CommandContext) -> CommandResult:
         name = _validated_session_name(context.args)
     except ValueError as exc:
         return CommandResult(handled=True, message=str(exc))
+
+    if manager.get_session(session_id) is None:
+        context.session.ensure_session_indexed()
 
     updated = manager.touch_session(
         session_id,

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -30,6 +30,7 @@ from tau_agent.session import (
     ThinkingLevelChangeEntry,
 )
 from tau_agent.session.entries import SessionEntry
+from tau_agent.session.jsonl import entry_to_json_line
 from tau_agent.session.tree import SessionTreeError, path_to_entry
 from tau_agent.tools import AgentTool
 from tau_ai import ModelProvider
@@ -1055,6 +1056,20 @@ class CodingSession:
             return CommandResult(handled=False)
         return self._command_registry.execute(self, text)
 
+    def ensure_session_indexed(self) -> None:
+        """Persist pending session metadata and add this session to the resume index."""
+        if self._config.session_id is None or self._config.session_manager is None:
+            return
+        if self._config.session_manager.get_session(self._config.session_id) is None:
+            self._config.session_manager.create_session(
+                cwd=self.cwd,
+                model=self.model,
+                provider_name=self.provider_name,
+                session_id=self._config.session_id,
+            )
+        self._config = replace(self._config, index_on_first_persist=False)
+        self._ensure_session_file_initialized()
+
     def expand_prompt_text(self, text: str) -> str:
         """Expand prompt text using loaded markdown resources."""
         expanded_prompt = expand_prompt_template_command(text, self._prompt_templates)
@@ -1258,11 +1273,21 @@ class CodingSession:
     async def _ensure_session_initialized(self) -> None:
         if not self._pending_initial_entries:
             return
+        await self._write_pending_initial_entries()
+        if self._config.index_on_first_persist:
+            self._index_current_session()
+
+    async def _write_pending_initial_entries(self) -> None:
         for entry in self._pending_initial_entries:
             await self._config.storage.append(entry)
         self._pending_initial_entries = ()
-        if self._config.index_on_first_persist:
-            self._index_current_session()
+
+    def _ensure_session_file_initialized(self) -> None:
+        if not self._pending_initial_entries:
+            return
+        for entry in self._pending_initial_entries:
+            _append_session_entry_sync(self._config.storage, entry)
+        self._pending_initial_entries = ()
 
     def _index_current_session(self) -> None:
         if self._config.session_id is None or self._config.session_manager is None:
@@ -1864,3 +1889,13 @@ def default_session_path(cwd: Path) -> Path:
 def jsonl_session_storage(path: str | Path) -> JsonlSessionStorage:
     """Convenience factory for local JSONL coding-session storage."""
     return JsonlSessionStorage(path)
+
+
+def _append_session_entry_sync(storage: SessionStorage, entry: SessionEntry) -> None:
+    """Append an entry synchronously for slash commands that cannot await storage."""
+    if isinstance(storage, JsonlSessionStorage):
+        storage.path.parent.mkdir(parents=True, exist_ok=True)
+        with storage.path.open("a", encoding="utf-8") as file:
+            file.write(entry_to_json_line(entry))
+        return
+    raise RuntimeError("Session storage does not support synchronous initialization")

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1798,6 +1798,12 @@ class TauTuiApp(App[None]):
         self._activity_timer: Timer | None = None
         self._active_notification_keys: set[tuple[str, str]] = set()
         self._supports_pyperclip: bool | None = None
+        self._sync_header_title()
+
+    def _sync_header_title(self) -> None:
+        """Reflect the active session name in Textual's header state."""
+        self.title = "Tau"
+        self.sub_title = _session_header_sub_title(self.session)
 
     def _sync_text_selection_state(self) -> None:
         """Disable native text selection while the transcript is mutating."""
@@ -2883,6 +2889,7 @@ class TauTuiApp(App[None]):
     def _refresh_chrome(self, *, theme: TuiTheme | None = None) -> None:
         """Refresh non-transcript chrome without remounting transcript blocks."""
         theme = theme or self.tui_settings.resolved_theme
+        self._sync_header_title()
         self._sync_text_selection_state()
         self._sync_queue_state()
         sidebar = self.query_one("#sidebar", SessionSidebar)
@@ -3343,6 +3350,12 @@ def _named_session_title(title: str | None) -> str | None:
     if not stripped or stripped.lower() == "untitled session":
         return None
     return stripped
+
+
+def _session_header_sub_title(session: CodingSession) -> str:
+    """Return the session label shown beside Tau in the TUI header."""
+    title = _named_session_title(getattr(session, "session_title", None))
+    return title or "Untitled session"
 
 
 def _login_provider_label(provider: ProviderCatalogEntry) -> str:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2569,6 +2569,66 @@ async def test_session_new_session_is_indexed_after_first_message(
 
 
 @pytest.mark.anyio
+async def test_session_name_indexes_pending_session_without_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    current_record = manager.create_session(cwd=tmp_path, model="fake", provider_name="fake")
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5",),
+                default_model="gpt-5",
+            ),
+        ),
+    )
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level
+        return FakeProvider([])
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(current_record.path),
+            cwd=current_record.cwd,
+            session_id=current_record.id,
+            session_manager=manager,
+            provider_name="fake",
+            provider_settings=settings,
+        )
+    )
+
+    _message = await session.new_session()
+    pending_id = session.session_id
+
+    assert pending_id is not None
+    assert manager.get_session(pending_id) is None
+
+    result = session.handle_command("/name Customer bugfix")
+
+    indexed = manager.get_session(pending_id)
+    assert result.message == "Session renamed: Customer bugfix"
+    assert indexed is not None
+    assert indexed.title == "Customer bugfix"
+    assert indexed.provider_name == "openai"
+    assert indexed.model == "gpt-5"
+    assert indexed.path.exists()
+    assert await JsonlSessionStorage(indexed.path).read_all()
+
+
+@pytest.mark.anyio
 async def test_session_resume_uses_target_session_provider_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,8 +47,19 @@ class FakeSession:
         self.session_id = "session-1"
         self.session_title: str | None = None
         self.session_manager: SessionManager | None = manager
+        self.ensure_session_indexed_called = False
         self.reload_called = False
         self.provider_reload_called = False
+
+    def ensure_session_indexed(self) -> None:
+        self.ensure_session_indexed_called = True
+        if self.session_manager is not None:
+            self.session_manager.create_session(
+                cwd=self.cwd,
+                model=self.model,
+                provider_name=self.provider_name,
+                session_id=self.session_id,
+            )
 
     def set_model(self, model: str) -> None:
         self.model = model
@@ -419,6 +430,20 @@ def test_name_command_renames_current_session(tmp_path: Path) -> None:
     assert renamed.title == "Customer bugfix"
     assert renamed.model == "fake-model"
     assert renamed.updated_at >= record.updated_at
+
+
+def test_name_command_indexes_pending_session_before_renaming(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    session = FakeSession(tmp_path, manager=manager)
+    session.session_id = "pending-session"
+
+    result = create_default_command_registry().execute(session, "/name Customer bugfix")
+
+    assert result.message == "Session renamed: Customer bugfix"
+    assert session.ensure_session_indexed_called is True
+    record = manager.get_session("pending-session")
+    assert record is not None
+    assert record.title == "Customer bugfix"
 
 
 def test_name_command_reports_missing_session_manager(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -151,6 +151,7 @@ class FakeSession:
         self.resource_diagnostics = ()
         self.system_prompt = "You are Tau."
         self.session_manager = None
+        self._session_title: str | None = None
         self.compact_summaries: list[str] = []
         self.resumed_session_ids: list[str] = []
         self.tree_branch_requests: list[tuple[str, bool, str | None]] = []
@@ -164,6 +165,10 @@ class FakeSession:
         self.terminal_commands: list[tuple[str, bool]] = []
         self.cancel_count = 0
         self.export_calls: list[tuple[Path | None, str | None]] = []
+
+    @property
+    def session_title(self) -> str | None:
+        return self._session_title
 
     def handle_command(self, text: str) -> CommandResult:
         if text == "/session":
@@ -226,9 +231,10 @@ class FakeSession:
         if text.startswith("/theme "):
             return CommandResult(handled=True, theme=text.removeprefix("/theme "))
         if text.startswith("/name "):
+            self._session_title = text.removeprefix("/name ")
             return CommandResult(
                 handled=True,
-                message=f"Session renamed: {text.removeprefix('/name ')}",
+                message=f"Session renamed: {self._session_title}",
             )
         return CommandResult(handled=False)
 
@@ -3108,6 +3114,39 @@ async def test_tui_app_system_appends_command_output_to_transcript() -> None:
 
         assert not isinstance(app.screen, CommandOutputScreen)
         assert app.state.items == [ChatItem(role="status", text="/system\nYou are Tau.")]
+
+
+@pytest.mark.anyio
+async def test_tui_app_uses_session_name_in_header() -> None:
+    session = FakeSession()
+    session._session_title = "Customer bugfix"
+    app = TauTuiApp(session)
+
+    async with app.run_test():
+        assert app.title == "Tau"
+        assert app.sub_title == "Customer bugfix"
+
+
+@pytest.mark.anyio
+async def test_tui_app_uses_default_header_for_unnamed_session() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test():
+        assert app.title == "Tau"
+        assert app.sub_title == "Untitled session"
+
+
+@pytest.mark.anyio
+async def test_tui_app_name_updates_header() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/name Customer bugfix"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.sub_title == "Customer bugfix"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- show the active session name in the Textual header subtitle
- fall back to "Untitled session" when no meaningful session name is set
- refresh header chrome after slash commands so /name updates immediately

Closes #244

## Tests
- uv run pytest tests/test_tui_app.py -q
- uv run pytest -q
- uv run ruff check .
- uv run mypy src

Note: uv run mypy src tests currently fails on pre-existing test typing errors unrelated to this change.