### PR TITLE
feat: show release notes after upgrade

### DIFF
--- a/dev-notes/release-notes-startup.md
+++ b/dev-notes/release-notes-startup.md
@@ -1,0 +1,21 @@
+# Startup release notes
+
+Tau now stores structured release notes in `release-notes/releases.json`.
+
+The same file is used by:
+
+- the TUI startup notice shown after an upgrade
+- the website release-notes page at `/releases/`
+- package metadata tests that ensure the current package version has release notes
+
+Tau records the last installed version seen at startup in `~/.tau/cache/release-notes-state.json`.
+
+On the first run it only writes the current version. On later runs, if the installed version is newer than the recorded version, the TUI prepends a status-style transcript item with release highlights for versions between the old and new versions.
+
+This keeps the reusable agent harness unchanged: release-note detection lives in `tau_coding.update_check`, and the TUI consumes the resulting startup notice as display state.
+
+Test with:
+
+```bash
+uv run pytest tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"
@@ -38,6 +38,7 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tau_ai", "src/tau_agent", "src/tau_coding"]
+artifacts = ["release-notes/releases.json"]
 
 [tool.ruff]
 line-length = 100

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -1,0 +1,47 @@
+[
+  {
+    "version": "0.1.2",
+    "date": "2026-07-03",
+    "sections": {
+      "New": [
+        "Show one-time release highlights in the TUI transcript after Tau is upgraded.",
+        "Show the active session name in the TUI header."
+      ],
+      "Changed": [
+        "Render assistant and thinking messages without role blocks for a cleaner transcript.",
+        "Apply role foreground colors to streaming transcript messages.",
+        "Clarify the PyPI release process in the developer notes."
+      ],
+      "Fixed": [
+        "Fix autocomplete suggestion window shrinking.",
+        "Keep pre-branch context when branching with a summary.",
+        "Keep session state on the active branch when persisting messages."
+      ]
+    }
+  },
+  {
+    "version": "0.1.1",
+    "date": "2026-06-26",
+    "sections": {
+      "New": [
+        "Check PyPI for Tau updates on startup.",
+        "Route OpenAI gpt-5.5, gpt-5.4, and codex models to the /v1/responses API.",
+        "Add the /system command for viewing the active system prompt.",
+        "Add prompt history recall with the Up key."
+      ],
+      "Changed": [
+        "Lower the Python requirement to 3.12.",
+        "Render transcript messages as full-height role blocks."
+      ],
+      "Fixed": [
+        "Restore streaming transcript scrollback.",
+        "Fix TUI code block horizontal scrolling.",
+        "Fix autocomplete suggestion viewport sizing.",
+        "Disable TUI text selection while streaming.",
+        "Guard Markdown selection until blocks are mounted.",
+        "Validate conflicting session flags in the CLI.",
+        "Stabilize CI checks."
+      ]
+    }
+  }
+]

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -149,7 +149,7 @@ from tau_coding.tools import (
     create_write_tool_definition,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "__version__",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -51,7 +51,11 @@ from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.thinking import DEFAULT_THINKING_LEVEL
 from tau_coding.tui import run_tui_app
-from tau_coding.update_check import UpdateNotice, startup_update_notice
+from tau_coding.update_check import (
+    UpdateNotice,
+    startup_release_notes_notice,
+    startup_update_notice,
+)
 
 app = typer.Typer(
     name="tau",
@@ -271,6 +275,15 @@ async def run_openai_tui(
     update_notice: UpdateNotice | None = None,
 ) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
+    release_notes_notice = startup_release_notes_notice(__version__)
+    startup_notices = [
+        notice
+        for notice in (
+            release_notes_notice.message if release_notes_notice is not None else None,
+            update_notice.message if update_notice is not None else None,
+        )
+        if notice is not None
+    ]
     await run_tui_app(
         model=model,
         cwd=cwd,
@@ -279,7 +292,7 @@ async def run_openai_tui(
         provider_name=provider_name,
         auto_compact_token_threshold=auto_compact_token_threshold,
         initial_prompt=initial_prompt,
-        startup_notice=update_notice.message if update_notice is not None else None,
+        startup_notices=tuple(startup_notices),
     )
 
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1774,18 +1774,20 @@ class TauTuiApp(App[None]):
         tui_settings: TuiSettings | None = None,
         startup_message: str | None = None,
         startup_notice: str | None = None,
+        startup_notices: Sequence[str] = (),
         initial_prompt: str | None = None,
     ) -> None:
         self.tui_settings = tui_settings or TuiSettings()
         self.startup_message = startup_message
-        self.startup_notice = startup_notice
+        legacy_notices = (startup_notice,) if startup_notice else ()
+        self.startup_notices = tuple((*startup_notices, *legacy_notices))
         self.initial_prompt = initial_prompt
         super().__init__()
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
         self.state = TuiState(skills=session.skills)
-        if startup_notice:
-            self.state.add_item("status", startup_notice)
+        for notice in self.startup_notices:
+            self.state.add_item("status", notice)
         self._prompt_history: tuple[str, ...] = ()
         self._load_session_messages_from_session()
         self.adapter = TuiEventAdapter(self.state)
@@ -3799,6 +3801,7 @@ async def run_tui_app(
     initial_prompt: str | None = None,
     session_manager: SessionManager | None = None,
     startup_notice: str | None = None,
+    startup_notices: Sequence[str] = (),
 ) -> None:
     """Create the default provider/session and run the Textual app."""
     if new_session and session_id is not None:
@@ -3861,11 +3864,13 @@ async def run_tui_app(
                 shell_command_prefix=shell_settings.shell_command_prefix,
             )
         )
+        legacy_notices = (startup_notice,) if startup_notice else ()
+        all_startup_notices = tuple((*startup_notices, *legacy_notices))
         app = TauTuiApp(
             session,
             tui_settings=load_tui_settings(),
             startup_message=startup_message,
-            startup_notice=startup_notice,
+            startup_notices=all_startup_notices,
             initial_prompt=initial_prompt,
         )
         await app.run_async()

--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -20,6 +20,8 @@ PYPI_JSON_URL = f"https://pypi.org/pypi/{PYPI_PACKAGE_NAME}/json"
 UPDATE_CHECK_INTERVAL = timedelta(days=1)
 UPDATE_CHECK_TIMEOUT_SECONDS = 1.5
 UPDATE_CHECK_ENV_DISABLE = "TAU_NO_UPDATE_CHECK"
+RELEASE_NOTES_STATE_FILENAME = "release-notes-state.json"
+RELEASE_NOTES_PATH = Path(__file__).resolve().parents[2] / "release-notes" / "releases.json"
 
 Fetcher = Callable[[str, float], dict[str, Any]]
 Clock = Callable[[], datetime]
@@ -48,6 +50,59 @@ class UpdateCheckResult:
 
     checked_at: datetime
     latest_version: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseNoteSection:
+    """A named release-note section."""
+
+    title: str
+    items: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseNotesEntry:
+    """Structured release notes for one Tau version."""
+
+    version: str
+    date: str | None
+    sections: tuple[ReleaseNoteSection, ...]
+
+    @property
+    def transcript_items(self) -> tuple[str, ...]:
+        """Return flattened note text for compact in-app display."""
+        return tuple(item for section in self.sections for item in section.items)
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseNotesNotice:
+    """Release notes shown once after the installed Tau version changes."""
+
+    current_version: str
+    previous_version: str
+    entries: tuple[ReleaseNotesEntry, ...]
+
+    @property
+    def notes(self) -> tuple[str, ...]:
+        """Return all release note items included in this notice."""
+        return tuple(item for entry in self.entries for item in entry.transcript_items)
+
+    @property
+    def message(self) -> str:
+        """Return a compact markdown release-notes block for the transcript."""
+        if self.entries:
+            version_blocks = [self._format_entry(entry) for entry in self.entries]
+            body = "\n\n".join(version_blocks)
+        else:
+            body = "- See the changelog for details."
+        return f"Tau updated to {self.current_version}\n\n{body}"
+
+    def _format_entry(self, entry: ReleaseNotesEntry) -> str:
+        section_blocks: list[str] = []
+        for section in entry.sections:
+            bullets = "\n".join(f"- {item}" for item in section.items)
+            section_blocks.append(f"**{section.title}**\n{bullets}")
+        return "\n\n".join(section_blocks)
 
 
 def startup_update_notice(
@@ -90,6 +145,76 @@ def startup_update_notice(
     return UpdateNotice(current_version=current_version, latest_version=latest_version)
 
 
+def startup_release_notes_notice(
+    current_version: str,
+    *,
+    state_path: Path | None = None,
+    release_notes: tuple[ReleaseNotesEntry, ...] | None = None,
+) -> ReleaseNotesNotice | None:
+    """Return release notes once after Tau starts with a newer installed version.
+
+    The first run only records the current version so fresh installs do not see an
+    upgrade banner. Read/write failures are quiet no-ops so startup can continue.
+    """
+    path = state_path or default_release_notes_state_path()
+    try:
+        previous_version = _read_last_seen_version(path)
+    except Exception:  # noqa: BLE001 - release-note state should not block startup
+        previous_version = None
+
+    _write_release_notes_state(path, current_version)
+    if previous_version is None:
+        return None
+
+    try:
+        if Version(current_version) <= Version(previous_version):
+            return None
+    except InvalidVersion:
+        return None
+
+    entries = release_notes_between(
+        previous_version,
+        current_version,
+        release_notes if release_notes is not None else load_release_notes(),
+    )
+    return ReleaseNotesNotice(
+        current_version=current_version,
+        previous_version=previous_version,
+        entries=entries,
+    )
+
+
+def load_release_notes(path: Path | None = None) -> tuple[ReleaseNotesEntry, ...]:
+    """Load structured release notes from the repo-owned JSON file."""
+    data = json.loads((path or RELEASE_NOTES_PATH).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("release notes must be a JSON array")
+    return tuple(_parse_release_notes_entry(item) for item in data)
+
+
+def release_notes_between(
+    previous_version: str,
+    current_version: str,
+    release_notes: tuple[ReleaseNotesEntry, ...],
+) -> tuple[ReleaseNotesEntry, ...]:
+    """Return release-note entries newer than previous_version up to current_version."""
+    try:
+        previous = Version(previous_version)
+        current = Version(current_version)
+    except InvalidVersion:
+        return ()
+
+    selected: list[ReleaseNotesEntry] = []
+    for entry in release_notes:
+        try:
+            parsed = Version(entry.version)
+        except InvalidVersion:
+            continue
+        if previous < parsed <= current:
+            selected.append(entry)
+    return tuple(sorted(selected, key=lambda entry: Version(entry.version)))
+
+
 def fetch_latest_pypi_version(*, fetcher: Fetcher | None = None) -> str | None:
     """Fetch the latest stable Tau version from PyPI."""
     data = (fetcher or _httpx_fetch_json)(PYPI_JSON_URL, UPDATE_CHECK_TIMEOUT_SECONDS)
@@ -112,6 +237,34 @@ def fetch_latest_pypi_version(*, fetcher: Fetcher | None = None) -> str | None:
 def default_update_check_cache_path(paths: TauPaths | None = None) -> Path:
     """Return the on-disk cache path for startup update checks."""
     return (paths or TauPaths()).home / "cache" / "update-check.json"
+
+
+def default_release_notes_state_path(paths: TauPaths | None = None) -> Path:
+    """Return the on-disk state path for one-time release notes."""
+    return (paths or TauPaths()).home / "cache" / RELEASE_NOTES_STATE_FILENAME
+
+
+def _parse_release_notes_entry(data: Any) -> ReleaseNotesEntry:
+    if not isinstance(data, dict):
+        raise ValueError("release note entry must be an object")
+    version = data.get("version")
+    if not isinstance(version, str):
+        raise ValueError("release note entry missing version")
+    date = data.get("date")
+    if date is not None and not isinstance(date, str):
+        raise ValueError("release note date must be a string")
+    raw_sections = data.get("sections")
+    if not isinstance(raw_sections, dict):
+        raise ValueError("release note sections must be an object")
+
+    sections: list[ReleaseNoteSection] = []
+    for title, raw_items in raw_sections.items():
+        if not isinstance(title, str):
+            raise ValueError("release note section title must be a string")
+        if not isinstance(raw_items, list) or not all(isinstance(item, str) for item in raw_items):
+            raise ValueError("release note section items must be strings")
+        sections.append(ReleaseNoteSection(title=title, items=tuple(raw_items)))
+    return ReleaseNotesEntry(version=version, date=date, sections=tuple(sections))
 
 
 def _stable_release_versions(releases: dict[Any, Any]) -> list[Version]:
@@ -184,6 +337,27 @@ def _write_update_check_cache(
                 indent=2,
             )
             + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+
+
+def _read_last_seen_version(path: Path) -> str | None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("release-note state must be a JSON object")
+    version = data.get("last_seen_version")
+    if version is not None and not isinstance(version, str):
+        raise ValueError("release-note last_seen_version must be a string")
+    return version
+
+
+def _write_release_notes_state(path: Path, current_version: str) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"last_seen_version": current_version}, indent=2) + "\n",
             encoding="utf-8",
         )
     except OSError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,8 +232,7 @@ async def test_run_openai_tui_combines_release_notes_and_update_notice(
     assert calls == [
         (
             "Tau updated to 0.1.2\n\n**New**\n- Release note",
-            "Tau 0.1.3 is available (installed: 0.1.2). "
-            "Update with: uv tool upgrade tau-ai",
+            "Tau 0.1.3 is available (installed: 0.1.2). Update with: uv tool upgrade tau-ai",
         )
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,12 @@ from tau_coding.rendering import PrintOutputMode
 from tau_coding.resources import TauResourcePaths
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
-from tau_coding.update_check import UpdateNotice
+from tau_coding.update_check import (
+    ReleaseNoteSection,
+    ReleaseNotesEntry,
+    ReleaseNotesNotice,
+    UpdateNotice,
+)
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
@@ -38,7 +43,7 @@ def test_version_command() -> None:
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.1"
+    assert result.stdout.strip() == "tau 0.1.2"
 
 
 def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,7 +56,7 @@ def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPa
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.1"
+    assert result.stdout.strip() == "tau 0.1.2"
 
 
 def test_print_mode_writes_update_notice_to_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -190,6 +195,47 @@ def test_cli_positional_prompt_invokes_tui_runner(
 
     assert result.exit_code == 0
     assert calls == [(None, tmp_path, None, False, None, None, "explain this repo")]
+
+
+@pytest.mark.anyio
+async def test_run_openai_tui_combines_release_notes_and_update_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_tui_app(**kwargs: object) -> None:
+        calls.append(kwargs["startup_notices"])  # type: ignore[arg-type]
+
+    monkeypatch.setattr(cli, "run_tui_app", fake_run_tui_app)
+    monkeypatch.setattr(
+        cli,
+        "startup_release_notes_notice",
+        lambda version: ReleaseNotesNotice(
+            current_version=version,
+            previous_version="0.1.1",
+            entries=(
+                ReleaseNotesEntry(
+                    version=version,
+                    date=None,
+                    sections=(ReleaseNoteSection(title="New", items=("Release note",)),),
+                ),
+            ),
+        ),
+    )
+
+    await cli.run_openai_tui(
+        model=None,
+        cwd=tmp_path,
+        update_notice=UpdateNotice(current_version="0.1.2", latest_version="0.1.3"),
+    )
+
+    assert calls == [
+        (
+            "Tau updated to 0.1.2\n\n**New**\n- Release note",
+            "Tau 0.1.3 is available (installed: 0.1.2). "
+            "Update with: uv tool upgrade tau-ai",
+        )
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,3 +1,4 @@
+import json
 import tomllib
 from pathlib import Path
 
@@ -11,3 +12,12 @@ def test_python_version_floor_matches_package_metadata() -> None:
     assert pyproject["tool"]["ruff"]["target-version"] == "py312"
     assert pyproject["tool"]["mypy"]["python_version"] == "3.12"
     assert (ROOT / ".python-version").read_text(encoding="utf-8").strip() == "3.12"
+
+
+def test_current_version_has_release_notes() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    release_notes = json.loads((ROOT / "release-notes" / "releases.json").read_text())
+
+    assert any(entry["version"] == pyproject["project"]["version"] for entry in release_notes)
+    artifacts = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["artifacts"]
+    assert "release-notes/releases.json" in artifacts

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4500,7 +4500,7 @@ async def test_tui_resume_refreshes_context_after_session_swap() -> None:
 @pytest.mark.anyio
 async def test_tui_app_shows_startup_update_notice_in_transcript_only() -> None:
     session = FakeSession(messages=[UserMessage(content="Earlier prompt")])
-    app = TauTuiApp(session, startup_notice="Tau 0.2.0 is available")
+    app = TauTuiApp(session, startup_notices=("Tau updated to 0.2.0", "Tau 0.2.0 is available"))
     notifications: list[tuple[str, str | None]] = []
 
     def fake_notify(message: str, **kwargs: object) -> None:
@@ -4513,6 +4513,7 @@ async def test_tui_app_shows_startup_update_notice_in_transcript_only() -> None:
         await pilot.pause()
         transcript = app.query_one("#transcript", TranscriptView)
         assert [line.text for line in transcript.lines] == [
+            "Tau updated to 0.2.0",
             "Tau 0.2.0 is available",
             "Earlier prompt",
         ]
@@ -4988,6 +4989,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
             assert session == "session"
             message = str(kwargs["startup_message"])
             assert "Tau 0.2.0 is available" not in message
+            assert kwargs["startup_notices"] == ("Tau 0.2.0 is available",)
             assert "Login required. Run /login" in message
             assert "/login openai" in message
             assert "OPENAI_API_KEY" not in message

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -3,7 +3,12 @@ from datetime import UTC, datetime, timedelta
 from tau_coding.update_check import (
     PYPI_JSON_URL,
     UPDATE_CHECK_TIMEOUT_SECONDS,
+    ReleaseNoteSection,
+    ReleaseNotesEntry,
     fetch_latest_pypi_version,
+    load_release_notes,
+    release_notes_between,
+    startup_release_notes_notice,
     startup_update_notice,
 )
 
@@ -133,6 +138,126 @@ def test_startup_update_notice_skips_ci(tmp_path) -> None:
     )
 
     assert notice is None
+
+
+def test_load_release_notes_reads_shared_json(tmp_path) -> None:
+    notes_path = tmp_path / "releases.json"
+    notes_path.write_text(
+        """
+        [
+          {
+            "version": "0.1.2",
+            "date": "2026-07-03",
+            "sections": {"New": ["Feature"], "Fixed": ["Fix"]}
+          }
+        ]
+        """,
+        encoding="utf-8",
+    )
+
+    notes = load_release_notes(notes_path)
+
+    assert notes == (
+        ReleaseNotesEntry(
+            version="0.1.2",
+            date="2026-07-03",
+            sections=(
+                ReleaseNoteSection(title="New", items=("Feature",)),
+                ReleaseNoteSection(title="Fixed", items=("Fix",)),
+            ),
+        ),
+    )
+
+
+def test_startup_release_notes_notice_records_first_seen_version(tmp_path) -> None:
+    state_path = tmp_path / "release-notes-state.json"
+
+    notice = startup_release_notes_notice(
+        "0.1.2",
+        state_path=state_path,
+        release_notes=(
+            ReleaseNotesEntry(
+                version="0.1.2",
+                date=None,
+                sections=(ReleaseNoteSection(title="New", items=("New TUI release notes",)),),
+            ),
+        ),
+    )
+
+    assert notice is None
+    assert '"last_seen_version": "0.1.2"' in state_path.read_text(encoding="utf-8")
+
+
+def test_startup_release_notes_notice_reports_upgrade_once(tmp_path) -> None:
+    state_path = tmp_path / "release-notes-state.json"
+    state_path.write_text('{"last_seen_version":"0.1.1"}\n', encoding="utf-8")
+    release_notes = (
+        ReleaseNotesEntry(
+            version="0.1.2",
+            date=None,
+            sections=(ReleaseNoteSection(title="New", items=("New feature", "Bug fix")),),
+        ),
+    )
+
+    notice = startup_release_notes_notice(
+        "0.1.2",
+        state_path=state_path,
+        release_notes=release_notes,
+    )
+
+    assert notice is not None
+    assert notice.previous_version == "0.1.1"
+    assert notice.current_version == "0.1.2"
+    assert notice.notes == ("New feature", "Bug fix")
+    assert notice.message == "Tau updated to 0.1.2\n\n**New**\n- New feature\n- Bug fix"
+
+    second_notice = startup_release_notes_notice(
+        "0.1.2",
+        state_path=state_path,
+        release_notes=release_notes,
+    )
+    assert second_notice is None
+
+
+def test_startup_release_notes_notice_combines_skipped_versions(tmp_path) -> None:
+    state_path = tmp_path / "release-notes-state.json"
+    state_path.write_text('{"last_seen_version":"0.1.0"}\n', encoding="utf-8")
+    release_notes = (
+        ReleaseNotesEntry(
+            version="0.1.2",
+            date=None,
+            sections=(ReleaseNoteSection(title="New", items=("Second change",)),),
+        ),
+        ReleaseNotesEntry(
+            version="0.1.1",
+            date=None,
+            sections=(ReleaseNoteSection(title="Fixed", items=("First change",)),),
+        ),
+        ReleaseNotesEntry(
+            version="0.1.3",
+            date=None,
+            sections=(ReleaseNoteSection(title="New", items=("Future change",)),),
+        ),
+    )
+
+    notice = startup_release_notes_notice(
+        "0.1.2",
+        state_path=state_path,
+        release_notes=release_notes,
+    )
+
+    assert notice is not None
+    assert notice.notes == ("First change", "Second change")
+
+
+def test_release_notes_between_ignores_future_versions() -> None:
+    entries = (
+        ReleaseNotesEntry(version="0.1.1", date=None, sections=()),
+        ReleaseNotesEntry(version="0.1.2", date=None, sections=()),
+        ReleaseNotesEntry(version="0.1.3", date=None, sections=()),
+    )
+
+    assert release_notes_between("0.1.1", "0.1.2", entries) == (entries[1],)
 
 
 def test_fetch_latest_pypi_version_falls_back_to_info_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -122,6 +122,7 @@ export default defineConfig({
             { label: "Build your own frontend", slug: "internals/custom-frontend" },
           ],
         },
+        { label: "Release notes", link: "/releases/" },
         { label: "Contributing", slug: "contributing" },
       ],
     }),

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -17,7 +17,8 @@ tau [OPTIONS] [PROMPT] [COMMAND] [ARGS]
 On TUI and text print-mode startup, Tau may show a non-blocking notice when a
 newer `tau-ai` release is available on PyPI. Disable it with
 `TAU_NO_UPDATE_CHECK=1`; utility commands such as `tau --version`, `tau sessions`,
-and `tau export` do not run the check.
+and `tau export` do not run the check. After an upgrade, the TUI also adds a
+one-time release-notes message to the transcript with the new features and fixes.
 
 ## Commands
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,7 +19,7 @@ const base = import.meta.env.BASE_URL;
           <a href={`${base}why-tau/`}>Why &#964;?</a>
           <a href={`${base}quickstart/`}>Docs</a>
           <a href={`${base}internals/architecture/`}>Lessons</a>
-          <a href="https://github.com/alejandro-ao/tau/issues/1">Roadmap</a>
+          <a href={`${base}releases/`}>Releases</a>
           <a class="gh" href="https://github.com/alejandro-ao/tau">GitHub &#8599;</a>
         </div>
       </nav>
@@ -215,8 +215,8 @@ const base = import.meta.env.BASE_URL;
         <div class="l">
           <a href={`${base}quickstart/`}>Docs</a>
           <a href={`${base}internals/architecture/`}>Architecture</a>
+          <a href={`${base}releases/`}>Releases</a>
           <a href="https://github.com/alejandro-ao/tau">GitHub</a>
-          <a href="https://github.com/alejandro-ao/tau/issues/1">Roadmap</a>
         </div>
         <span>An educational project &middot; inspired by Pi</span>
       </footer>

--- a/website/src/pages/releases.astro
+++ b/website/src/pages/releases.astro
@@ -1,0 +1,311 @@
+---
+import Landing from "../layouts/Landing.astro";
+import releases from "../../../release-notes/releases.json";
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Landing
+  title="Tau release notes"
+  description="New features, fixes, and changes in each Tau release."
+>
+  <div class="tau-landing">
+    <div class="wrap">
+      <nav>
+        <a class="brand" href={base} aria-label="Tau home">
+          <span class="glyph">&#964;</span>
+          <span class="name">tau</span>
+          <span class="ver">v0.1</span>
+        </a>
+        <div class="navlinks">
+          <a href={`${base}why-tau/`}>Why &#964;?</a>
+          <a href={`${base}quickstart/`}>Docs</a>
+          <a href={`${base}internals/architecture/`}>Lessons</a>
+          <a href={`${base}releases/`}>Releases</a>
+          <a class="gh" href="https://github.com/alejandro-ao/tau">GitHub &#8599;</a>
+        </div>
+      </nav>
+
+      <header class="release-header">
+        <div class="release-hero">
+          <p class="eyebrow">Changelog</p>
+          <h1>Release notes.</h1>
+          <p class="lede">
+            Every release is structured data in the repo &mdash; the same notes
+            Tau shows in the TUI after an upgrade and publishes here.
+          </p>
+        </div>
+
+        <div class="release-meta-row">
+          <div class="meta-cell">
+            <span class="meta-num">v{releases[0]?.version}</span>
+            <span class="meta-cap">latest release</span>
+          </div>
+          <div class="meta-cell">
+            <span class="meta-num">{releases.length}</span>
+            <span class="meta-cap">releases published</span>
+          </div>
+          <div class="meta-cell">
+            <span class="meta-num">{releases[0]?.date}</span>
+            <span class="meta-cap">shipped</span>
+          </div>
+        </div>
+      </header>
+    </div>
+
+    <div class="wrap">
+      <section>
+        <div class="sec-head">
+          <span class="mark">01</span>
+          <h2>All releases</h2>
+        </div>
+
+        <div class="release-list">
+          {releases.map((release, i) => (
+            <details class="release-card" id={`v${release.version}`} open={i === 0}>
+              <summary class="release-card-head">
+                <span class="release-version">
+                  <span class="chevron" aria-hidden="true">&rsaquo;</span>
+                  v{release.version}
+                </span>
+                <span class="release-head-right">
+                  {i === 0 && <span class="badge">Latest</span>}
+                  {release.date && <time datetime={release.date}>{release.date}</time>}
+                </span>
+              </summary>
+
+              <div class="release-sections">
+                {Object.entries(release.sections).map(([section, items]) => (
+                  <section class="release-section">
+                    <h4>{section}</h4>
+                    <ul>
+                      {items.map((item) => <li>{item}</li>)}
+                    </ul>
+                  </section>
+                ))}
+              </div>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      <footer>
+        <div class="brand">
+          <span class="glyph" style="font-size:20px;">&#964;</span>
+          <span class="name">tau</span>
+        </div>
+        <div class="l">
+          <a href={`${base}quickstart/`}>Docs</a>
+          <a href={`${base}internals/architecture/`}>Architecture</a>
+          <a href={`${base}releases/`}>Releases</a>
+          <a href="https://github.com/alejandro-ao/tau">GitHub</a>
+        </div>
+        <span>An educational project &middot; inspired by Pi</span>
+      </footer>
+    </div>
+  </div>
+</Landing>
+
+<style>
+  .release-header {
+    padding-top: 8px;
+  }
+
+  .release-hero {
+    max-width: 640px;
+  }
+
+  .release-hero h1 {
+    margin: 8px 0 0;
+    font-family: var(--serif);
+    font-size: clamp(40px, 6vw, 60px);
+    font-weight: 400;
+    letter-spacing: -0.01em;
+  }
+
+  .release-hero .lede {
+    margin-top: 16px;
+  }
+
+  .release-meta-row {
+    display: flex;
+    gap: 0;
+    margin-top: 40px;
+    border-top: 1px solid var(--grid-strong);
+    border-bottom: 1px solid var(--grid-strong);
+  }
+
+  .meta-cell {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 20px 24px;
+    border-right: 1px solid var(--grid-strong);
+  }
+
+  .meta-cell:last-child {
+    border-right: none;
+  }
+
+  .meta-num {
+    font-family: var(--mono);
+    font-size: 22px;
+    color: var(--accent);
+  }
+
+  .meta-cap {
+    font-family: var(--grotesk);
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+
+  @media (max-width: 640px) {
+    .release-meta-row {
+      flex-direction: column;
+    }
+
+    .meta-cell {
+      border-right: none;
+      border-bottom: 1px solid var(--grid-strong);
+    }
+
+    .meta-cell:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .release-list {
+    display: grid;
+    gap: 1px;
+    border: 1px solid var(--grid-strong);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--grid-strong);
+  }
+
+  .release-card {
+    background: rgba(255, 255, 255, 0.86);
+  }
+
+  .release-card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 22px 32px;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+    transition: background-color 0.15s;
+  }
+
+  .release-card-head::-webkit-details-marker {
+    display: none;
+  }
+
+  .release-card-head:hover {
+    background: rgba(27, 63, 160, 0.045);
+  }
+
+  .release-version {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--serif);
+    font-size: clamp(22px, 3vw, 28px);
+    font-weight: 400;
+    color: var(--accent);
+    letter-spacing: -0.01em;
+  }
+
+  .chevron {
+    display: inline-block;
+    font-family: var(--serif);
+    font-size: 22px;
+    color: var(--ink-soft);
+    transition: transform 0.2s ease;
+  }
+
+  .release-card[open] .chevron {
+    transform: rotate(90deg);
+  }
+
+  .release-head-right {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .badge {
+    font-family: var(--grotesk);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #fff;
+    background: var(--red);
+    padding: 3px 9px;
+    border-radius: 999px;
+  }
+
+  .release-card time {
+    font-family: var(--mono);
+    color: var(--ink-soft);
+    font-size: 13px;
+  }
+
+  .release-sections {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 28px;
+    padding: 4px 32px 32px;
+    border-top: 1px solid var(--grid-strong);
+    padding-top: 24px;
+  }
+
+  .release-section {
+    padding: 0;
+  }
+
+  .release-section h4 {
+    margin: 0 0 10px;
+    font-family: var(--grotesk);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--red);
+  }
+
+  .release-section ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--ink-soft);
+    font-size: 16.5px;
+    line-height: 1.6;
+  }
+
+  .release-section li + li {
+    margin-top: 8px;
+  }
+
+  @media (max-width: 860px) {
+    .release-sections {
+      grid-template-columns: 1fr;
+      gap: 22px;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .release-card-head {
+      padding: 18px 20px;
+    }
+
+    .release-sections {
+      padding: 4px 20px 24px;
+    }
+  }
+</style>

--- a/website/src/pages/why-tau.astro
+++ b/website/src/pages/why-tau.astro
@@ -15,7 +15,7 @@ const body = `
         <a href="${base}why-tau/">Why &#964;?</a>
         <a href="${base}quickstart/">Docs</a>
         <a href="${base}internals/architecture/">Lessons</a>
-        <a href="https://github.com/alejandro-ao/tau/issues/1">Roadmap</a>
+        <a href="${base}releases/">Releases</a>
         <a class="gh" href="https://github.com/alejandro-ao/tau">GitHub &#8599;</a>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add shared structured release notes in `release-notes/releases.json`
- show one-time release highlights in the TUI transcript after Tau is upgraded
- add a website release notes page and navbar links
- bump package version to `0.1.2`

## Tests
- `uv run ruff check src/tau_coding/update_check.py src/tau_coding/cli.py src/tau_coding/tui/app.py tests/test_update_check.py tests/test_cli.py tests/test_package_metadata.py tests/test_tui_app.py`
- `cd website && bun run build`
- `uv run pytest`