### PR TITLE
Optimize Ctrl+T thinking-token toggle via targeted DOM updates

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2467,7 +2467,17 @@ class TauTuiApp(App[None]):
     def action_toggle_thinking(self) -> None:
         """Toggle thinking-token display in the transcript."""
         self.state.toggle_thinking()
-        self._refresh()
+        if not self.screen_stack:
+            return
+        try:
+            transcript = self.query_one("#transcript", TranscriptView)
+        except NoMatches:
+            self._refresh()
+            return
+        transcript.update_thinking_visibility(
+            self.state,
+            theme=self.tui_settings.resolved_theme,
+        )
 
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -225,8 +225,12 @@ class TranscriptMessageWidget(Horizontal):
         *,
         theme: TuiTheme,
         show_tool_results: bool,
+        item_index: int = -1,
+        placeholder_item_range: tuple[int, int] | None = None,
     ) -> None:
         self.item = item
+        self._item_index = item_index
+        self._placeholder_item_range = placeholder_item_range
         self.selection_text = transcript_item_selection_text(
             item,
             show_tool_results=show_tool_results,
@@ -412,6 +416,97 @@ class TranscriptView(VerticalScroll):
         self._render_theme = theme
         self._redraw(scroll_end=self._should_follow_output)
 
+    def update_thinking_visibility(
+        self,
+        state: TuiState,
+        *,
+        theme: TuiTheme = TAU_DARK_THEME,
+    ) -> None:
+        """Toggle thinking-token visibility without rebuilding the whole transcript."""
+        self._render_state = state
+        self._render_theme = theme
+        was_at_end = self.is_vertical_scroll_end
+        saved_scroll_y = self.scroll_y
+
+        if not state.show_thinking:
+            self._collapse_thinking_widgets(state, theme=theme)
+        else:
+            self._expand_thinking_placeholders(state, theme=theme)
+
+        self.refresh(layout=True)
+        if was_at_end:
+            self._request_follow_scroll(force=True)
+        else:
+            self.scroll_to(y=saved_scroll_y, animate=False, immediate=True)
+
+    def _collapse_thinking_widgets(self, state: TuiState, *, theme: TuiTheme) -> None:
+        """DOM surgery: replace thinking widgets with placeholders."""
+        thinking_widgets = [
+            c for c in self.children
+            if isinstance(c, TranscriptMessageWidget)
+            and c.item.role == "thinking"
+            and c._placeholder_item_range is None
+        ]
+        if not thinking_widgets:
+            return
+
+        groups: list[list[TranscriptMessageWidget]] = []
+        current_group = [thinking_widgets[0]]
+        for w in thinking_widgets[1:]:
+            if w._item_index == current_group[-1]._item_index + 1:
+                current_group.append(w)
+            else:
+                groups.append(current_group)
+                current_group = [w]
+        groups.append(current_group)
+
+        for group in reversed(groups):
+            first = group[0]
+            last = group[-1]
+            start_idx = first._item_index
+            end_idx = last._item_index + 1
+
+            placeholder = TranscriptMessageWidget(
+                ChatItem(
+                    role="thinking",
+                    text="Thinking… Press Ctrl+T to show thinking tokens.",
+                ),
+                theme=theme,
+                show_tool_results=state.show_tool_results,
+                item_index=start_idx,
+                placeholder_item_range=(start_idx, end_idx),
+            )
+            self.mount(placeholder, before=first)
+            for widget in group:
+                widget.remove()
+
+    def _expand_thinking_placeholders(self, state: TuiState, *, theme: TuiTheme) -> None:
+        """DOM surgery: replace placeholders with actual thinking widgets."""
+        placeholders = [
+            c for c in self.children
+            if isinstance(c, TranscriptMessageWidget)
+            and c._placeholder_item_range is not None
+        ]
+        if not placeholders:
+            return
+
+        for placeholder in reversed(placeholders):
+            start_idx, end_idx = placeholder._placeholder_item_range
+            thinking_items = [
+                (i, state.items[i])
+                for i in range(start_idx, end_idx)
+                if state.items[i].role == "thinking"
+            ]
+            for i, item in reversed(thinking_items):
+                new_widget = TranscriptMessageWidget(
+                    item,
+                    theme=theme,
+                    show_tool_results=state.show_tool_results or item.always_show_tool_result,
+                    item_index=i,
+                )
+                self.mount(new_widget, before=placeholder)
+            placeholder.remove()
+
     def on_resize(self, event: Resize) -> None:
         """Re-render transcript entries when the terminal width changes."""
         del event
@@ -441,27 +536,46 @@ class TranscriptView(VerticalScroll):
         self._active_thinking_widget = None
         self._hidden_thinking_placeholder_visible = False
         hidden_thinking_placeholder = False
-        for item in state.items:
+        group_start = -1
+        for i, item in enumerate(state.items):
             if item.role == "thinking" and not state.show_thinking:
                 if not hidden_thinking_placeholder:
-                    self.mount(
-                        TranscriptMessageWidget(
-                            ChatItem(
-                                role="thinking",
-                                text="Thinking… Press Ctrl+T to show thinking tokens.",
-                            ),
-                            theme=theme,
-                            show_tool_results=state.show_tool_results,
-                        )
-                    )
+                    group_start = i
                     hidden_thinking_placeholder = True
                 continue
-            hidden_thinking_placeholder = False
+            if hidden_thinking_placeholder:
+                self.mount(
+                    TranscriptMessageWidget(
+                        ChatItem(
+                            role="thinking",
+                            text="Thinking… Press Ctrl+T to show thinking tokens.",
+                        ),
+                        theme=theme,
+                        show_tool_results=state.show_tool_results,
+                        item_index=group_start,
+                        placeholder_item_range=(group_start, i),
+                    )
+                )
+                hidden_thinking_placeholder = False
             self.mount(
                 TranscriptMessageWidget(
                     item,
                     theme=theme,
                     show_tool_results=state.show_tool_results or item.always_show_tool_result,
+                    item_index=i,
+                )
+            )
+        if hidden_thinking_placeholder:
+            self.mount(
+                TranscriptMessageWidget(
+                    ChatItem(
+                        role="thinking",
+                        text="Thinking… Press Ctrl+T to show thinking tokens.",
+                    ),
+                    theme=theme,
+                    show_tool_results=state.show_tool_results,
+                    item_index=group_start,
+                    placeholder_item_range=(group_start, len(state.items)),
                 )
             )
         if state.assistant_buffer:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -422,7 +422,18 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Toggle thinking-token visibility without rebuilding the whole transcript."""
+        """Toggle thinking-token visibility without rebuilding the whole transcript.
+
+        Falls back to a full redraw when streaming state is active, because
+        the DOM surgery helpers only target finalized TranscriptMessageWidget
+        instances.  StreamingTranscriptMessageWidget instances produced during
+        live thinking or hidden-placeholder streaming are invisible to those
+        helpers and must be handled by the full redraw path.
+        """
+        if self._active_thinking_widget is not None or self._hidden_thinking_placeholder_visible:
+            self.update_from_state(state, theme=theme)
+            return
+
         self._render_state = state
         self._render_theme = theme
         was_at_end = self.is_vertical_scroll_end

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4262,6 +4262,121 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
     assert notifications == []
 
 
+
+@pytest.mark.anyio
+async def test_tui_app_toggles_thinking_targeted_hide_show_hide_multiple_blocks() -> None:
+    app = TauTuiApp(FakeSession())
+
+    def transcript_text() -> str:
+        transcript = app.query_one("#transcript", TranscriptView)
+        return "\n".join(line.text for line in transcript.lines)
+
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#transcript", TranscriptView)
+        app.state.add_item("user", "Hello")
+        app.state.add_item("thinking", "First thoughts 1")
+        app.state.add_item("thinking", "First thoughts 2")
+        app.state.add_item("assistant", "Final response 1")
+        app.state.add_item("thinking", "Second thoughts 1")
+        app.state.add_item("thinking", "Second thoughts 2")
+        app.state.add_item("assistant", "Final response 2")
+
+        app._refresh()
+        await pilot.pause()
+
+        assert "First thoughts" not in transcript_text()
+        assert "Second thoughts" not in transcript_text()
+        assert "Thinking… Press Ctrl+T to show thinking tokens." in transcript_text()
+
+        original_user_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "user"
+        ]
+        original_assistant_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "assistant"
+        ]
+        assert len(original_user_widgets) == 1
+        assert len(original_assistant_widgets) == 2
+
+        # 1. Toggle show thinking
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert app.state.show_thinking is True
+        assert "First thoughts 1" in transcript_text()
+        assert "First thoughts 2" in transcript_text()
+        assert "Second thoughts 1" in transcript_text()
+        assert "Second thoughts 2" in transcript_text()
+        assert "Thinking… Press Ctrl+T to show thinking tokens." not in transcript_text()
+
+        current_user_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "user"
+        ]
+        current_assistant_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "assistant"
+        ]
+        assert current_user_widgets == original_user_widgets
+        assert current_assistant_widgets == original_assistant_widgets
+
+        # 2. Toggle hide thinking again
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert app.state.show_thinking is False
+        assert "First thoughts" not in transcript_text()
+        assert "Second thoughts" not in transcript_text()
+        assert "Thinking… Press Ctrl+T to show thinking tokens." in transcript_text()
+
+        current_user_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "user"
+        ]
+        current_assistant_widgets = [
+            (id(w), w.item.text)
+            for w in transcript.children
+            if isinstance(w, TranscriptMessageWidget) and w.item.role == "assistant"
+        ]
+        assert current_user_widgets == original_user_widgets
+        assert current_assistant_widgets == original_assistant_widgets
+
+
+@pytest.mark.anyio
+async def test_tui_thinking_toggle_preserves_scrollback_position() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#transcript", TranscriptView)
+        for i in range(100):
+            app.state.add_item("user", f"Message {i}")
+        app.state.add_item("thinking", "Deep thoughts")
+        app._refresh()
+        await pilot.pause()
+
+        transcript.scroll_y = 10.0
+        transcript._follow_output = False
+        await pilot.pause()
+
+        # Toggle show thinking
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert transcript.scroll_y == 10.0
+
+        # Toggle hide thinking
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert transcript.scroll_y == 10.0
+
+
 @pytest.mark.anyio
 async def test_tui_prompt_ctrl_c_clears_text() -> None:
     app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4377,6 +4377,57 @@ async def test_tui_thinking_toggle_preserves_scrollback_position() -> None:
         assert transcript.scroll_y == 10.0
 
 
+
+@pytest.mark.anyio
+async def test_tui_thinking_toggle_mid_stream_falls_back_to_full_redraw() -> None:
+    """Toggling thinking visibility while streaming must not leave a stale widget."""
+    app = TauTuiApp(FakeSession())
+
+    def transcript_text() -> str:
+        transcript = app.query_one("#transcript", TranscriptView)
+        return "\n".join(line.text for line in transcript.lines)
+
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#transcript", TranscriptView)
+        theme = app.tui_settings.resolved_theme
+
+        # Simulate streaming a thinking token (real usage updates state first, then widget)
+        app.state.show_thinking = True
+        app.state.add_thinking_delta("live thoughts")
+        await transcript.append_thinking_delta("live thoughts", show_thinking=True, theme=theme)
+        await pilot.pause()
+
+        assert transcript._active_thinking_widget is not None
+        assert "live thoughts" in transcript_text()
+
+        # Press Ctrl+T while thinking is actively streaming.
+        # The guard must detect the active streaming widget and fall back to a full
+        # redraw, which removes the streaming widget and shows the placeholder.
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert app.state.show_thinking is False
+        assert "live thoughts" not in transcript_text()
+        assert "Thinking… Press Ctrl+T to show thinking tokens." in transcript_text()
+        assert transcript._active_thinking_widget is None
+
+        # Simulate the hidden-placeholder path: delta arrives while show_thinking=False
+        app.state.add_thinking_delta("more thoughts")
+        await transcript.append_thinking_delta("more thoughts", show_thinking=False, theme=theme)
+        await pilot.pause()
+
+        assert transcript._hidden_thinking_placeholder_visible is True
+
+        # Press Ctrl+T again — guard detects _hidden_thinking_placeholder_visible
+        # and falls back to full redraw, which shows all thinking items from state.
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert app.state.show_thinking is True
+        assert "live thoughts" in transcript_text()
+        assert "more thoughts" in transcript_text()
+        assert "Thinking… Press Ctrl+T to show thinking tokens." not in transcript_text()
+        assert transcript._hidden_thinking_placeholder_visible is False
 @pytest.mark.anyio
 async def test_tui_prompt_ctrl_c_clears_text() -> None:
     app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))


### PR DESCRIPTION
## Summary

Closes #248.

`Ctrl+T` thinking-token visibility toggles previously routed through `_refresh()`, which performed an unconditional full transcript rebuild: `remove_children()` on every mounted widget followed by a fresh `mount()` for each `state.items` entry. Cost scaled with total transcript length, not with the number of thinking blocks.

## Root cause

```
action_toggle_thinking()
  → state.toggle_thinking()        # O(1) — fine
  → _refresh()
      → _refresh_chrome()          # sidebar/footer — not affected by show_thinking
      → transcript.update_from_state()
          → _redraw()              # demolish + rebuild ALL N widgets
```

Only thinking-role widgets change visibility on toggle. All other widgets (user, assistant, tool, status, …) were torn down and identically remounted.

## Changes

### `src/tau_coding/tui/widgets.py`

- **`TranscriptMessageWidget`** — added `_item_index: int` (position in `state.items`) and `_placeholder_item_range: tuple[int, int] | None` (non-None only on thinking placeholders, stores the collapsed item range).
- **`TranscriptView._redraw()`** — passes `item_index` when mounting each widget; thinking placeholders carry their collapsed range so they can be expanded later without a full redraw.
- **`TranscriptView.update_thinking_visibility()`** — new targeted method: saves scroll position, performs DOM surgery (collapse or expand only thinking-related widgets), restores scroll position.
  - **Hide path** (`_collapse_thinking_widgets`): finds contiguous groups of real thinking widgets in the DOM, replaces each group with one placeholder in-place. Non-thinking widgets are untouched.
  - **Show path** (`_expand_thinking_placeholders`): finds placeholder widgets, looks up their stored item range in `state.items`, mounts the actual thinking widgets before each placeholder, then removes the placeholder.
  - **Streaming fallback**: when `_active_thinking_widget is not None` or `_hidden_thinking_placeholder_visible` is `True`, falls back to a full `update_from_state()` redraw. `StreamingTranscriptMessageWidget` instances produced during live streaming are not covered by the DOM surgery helpers, so the full redraw path is needed for correctness in that (brief, uncommon) window.

### `src/tau_coding/tui/app.py`

- **`action_toggle_thinking()`** — routes to `transcript.update_thinking_visibility()` instead of `_refresh()`, skipping the unnecessary `_refresh_chrome()` call entirely.

## Tests

Three new tests in `tests/test_tui_app.py`:

| Test | What it covers |
|---|---|
| `test_tui_app_toggles_thinking_targeted_hide_show_hide_multiple_blocks` | Full hide→show→hide cycle with two separate thinking groups; asserts non-thinking widget identity is preserved across both toggles |
| `test_tui_thinking_toggle_preserves_scrollback_position` | `scroll_y` is unchanged when the user is in scrollback mode |
| `test_tui_thinking_toggle_mid_stream_falls_back_to_full_redraw` | Toggling while a `StreamingTranscriptMessageWidget` is active (both live-thinking and hidden-placeholder paths) falls back correctly and leaves no stale widget |

All 626 tests pass.