### PR TITLE
Hide code block scrollbars while streaming

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -301,7 +301,13 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         margin: 0 0 1 0;
     }
 
-    StreamingTranscriptMessageWidget MarkdownFence {
+    StreamingTranscriptMessageWidget.-streaming MarkdownFence {
+        overflow-x: hidden;
+        scrollbar-size-horizontal: 0;
+    }
+
+    StreamingTranscriptMessageWidget.-finalized MarkdownFence {
+        overflow-x: auto;
         scrollbar-size-horizontal: 1;
     }
     """
@@ -312,8 +318,10 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         self.item = item
         self.selection_text = item.text
         self._stream: MarkdownStream | None = None
+        self._is_streaming = True
         super().__init__(item.text, theme=theme)
         self.add_class("transcript-message")
+        self.add_class("-streaming")
         # Apply the role foreground so streamed text matches the finalized block
         # (e.g. dimmed thinking) instead of shifting color on the next redraw.
         foreground, _ = _split_rich_style_colors(_chat_item_role_style(item, theme).body)
@@ -341,6 +349,16 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         self.selection_text = text
         self._stream = None
         await self.update(text)
+
+    async def finalize(self, text: str | None = None) -> None:
+        """Mark the streamed message complete and restore finalized Markdown chrome."""
+        if text is not None:
+            await self.replace_text(text)
+        elif self._is_streaming:
+            await self.update(self.item.text)
+        self._is_streaming = False
+        self.remove_class("-streaming")
+        self.add_class("-finalized")
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected text from this streamed message block."""
@@ -584,8 +602,7 @@ class TranscriptView(VerticalScroll):
                     theme=self._render_theme,
                 )
             return
-        if text is not None:
-            await widget.replace_text(text)
+        await widget.finalize(text)
         self._active_assistant_widget = None
 
     @property

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1837,6 +1837,32 @@ async def test_tui_transcript_code_block_scrollbar_matches_overflow(
         assert fence.show_horizontal_scrollbar is has_horizontal_overflow
 
 
+@pytest.mark.anyio
+async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized() -> None:
+    app = TauTuiApp(FakeSession())
+    long_code_line = "value = '" + ("x" * 140) + "'"
+
+    async with app.run_test(size=(64, 30)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+
+        await transcript.append_assistant_delta("```python\n" + long_code_line)
+        await pilot.pause()
+
+        streaming_fence = app.query_one("MarkdownFence")
+        assert streaming_fence.max_scroll_x > 0
+        assert streaming_fence.styles.scrollbar_size_horizontal == 0
+        assert streaming_fence.show_horizontal_scrollbar is False
+
+        await transcript.finish_assistant_message("```python\n" + long_code_line + "\n```")
+        await pilot.pause()
+
+        finalized_fence = app.query_one("MarkdownFence")
+        assert finalized_fence.max_scroll_x > 0
+        assert finalized_fence.styles.scrollbar_size_horizontal == 1
+        assert finalized_fence.show_horizontal_scrollbar is True
+
+
 def test_tui_app_uses_configured_theme_css_variables() -> None:
     app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme="high-contrast"))
 


### PR DESCRIPTION
## Summary
- hide horizontal scrollbars on streamed Markdown code fences while a message is still in progress
- restore normal horizontal overflow/scrollbar behavior when the assistant message is finalized
- add a TUI regression test for a long streamed code line

Fixes #254.

## Tests
- `uv run pytest tests/test_tui_app.py`
- `uv run ruff check .`
- `uv run mypy .` *(fails on existing test typing errors unrelated to this change; first errors are in `tests/test_agent_loop.py`, `tests/test_agent_harness.py`, etc.)*
