### PR TITLE
Optimize TUI transcript thinking toggle and markdown streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@ Do not let Textual become a dependency of the reusable agent harness.
 - Prefer simple, explicit abstractions over framework-heavy designs.
 - Keep commits atomic: one coherent feature, fix, docs update, refactor, or cleanup per commit.
 
+## GitHub Issue and PR Formatting
+
+- When creating or editing GitHub issues and pull requests from the CLI, write multiline Markdown bodies through a temporary file or heredoc and pass them with `--body-file`.
+- Do not pass escaped newlines like `\n` inside quoted `--body` strings; GitHub will render them literally instead of as line breaks.
+- Use Markdown headings, blank lines, bullets, and backticks for commands/paths so issue and PR descriptions are readable.
+- After creating or editing a GitHub issue or PR body, verify the rendered source with `gh issue view ... --json body` or `gh pr view ... --json body` when practical.
+
 ## Python Guidelines
 
 - Target the Python version declared in `pyproject.toml`.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2467,7 +2467,11 @@ class TauTuiApp(App[None]):
     def action_toggle_thinking(self) -> None:
         """Toggle thinking-token display in the transcript."""
         self.state.toggle_thinking()
-        self._refresh()
+        transcript = self.query_one("#transcript", TranscriptView)
+        transcript.update_thinking_visibility(
+            self.state,
+            theme=self.tui_settings.resolved_theme,
+        )
 
     def _handle_session_picker_result(self, session_id: str | None) -> None:
         if session_id is None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -484,9 +484,7 @@ class TranscriptView(VerticalScroll):
             for child in self.children
             if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
         ]
-        thinking_children = [
-            child for child in message_children if child.item.role == "thinking"
-        ]
+        thinking_children = [child for child in message_children if child.item.role == "thinking"]
         if thinking_children:
             self.remove_children(thinking_children)
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -535,7 +535,12 @@ class TranscriptView(VerticalScroll):
             if target is not None:
                 flush_pending(before=target)
 
-        flush_pending(before=None)
+        tail_child = (
+            non_thinking_children[non_thinking_index]
+            if non_thinking_index < len(non_thinking_children)
+            else None
+        )
+        flush_pending(before=tail_child)
         self._active_thinking_widget = None
         self._hidden_thinking_placeholder_visible = (
             _last_transcript_child_is_hidden_thinking_placeholder(self.children)
@@ -672,7 +677,6 @@ class TranscriptView(VerticalScroll):
         scroll_end: bool = False,
     ) -> None:
         """Append streamed assistant text to the active message widget."""
-        self._hidden_thinking_placeholder_visible = False
         should_follow = self._should_follow_output if not scroll_end else True
         widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
         await widget.append_fragment(delta)
@@ -692,15 +696,21 @@ class TranscriptView(VerticalScroll):
         if not show_thinking:
             if self._hidden_thinking_placeholder_visible:
                 return
-            await self.append_item(
+            widget = TranscriptMessageWidget(
                 ChatItem(
                     role="thinking",
                     text=_HIDDEN_THINKING_PLACEHOLDER,
                 ),
                 theme=theme,
-                scroll_end=should_follow,
+                show_tool_results=False,
             )
+            await self.mount(widget, before=self._active_assistant_widget)
+            self._active_thinking_widget = None
             self._hidden_thinking_placeholder_visible = True
+            self._last_render_width = self.scrollable_content_region.width
+            self.refresh(layout=True)
+            if should_follow:
+                self._request_follow_scroll(force=scroll_end)
             return
         self._hidden_thinking_placeholder_visible = False
         if self._active_thinking_widget is None:
@@ -708,7 +718,10 @@ class TranscriptView(VerticalScroll):
                 ChatItem(role="thinking", text=""),
                 theme=theme,
             )
-            await self.mount(self._active_thinking_widget)
+            await self.mount(
+                self._active_thinking_widget,
+                before=self._active_assistant_widget,
+            )
         await self._active_thinking_widget.append_fragment(delta)
         if should_follow:
             self._request_follow_scroll(force=scroll_end)
@@ -725,6 +738,7 @@ class TranscriptView(VerticalScroll):
             return
         await widget.finalize(text)
         self._active_assistant_widget = None
+        self._hidden_thinking_placeholder_visible = False
 
     @property
     def lines(self) -> tuple[TranscriptLine, ...]:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -337,30 +337,44 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
         return self._stream
 
     async def append_fragment(self, fragment: str) -> None:
-        """Append streamed markdown using the same renderer as finalized messages."""
+        """Append streamed markdown without reparsing the full accumulated message."""
         if not fragment:
             return
         self.item.text += fragment
         self.selection_text += fragment
+        await self.stream.write(fragment)
+
+    async def _stop_stream(self) -> None:
+        """Stop the Textual markdown stream, flushing pending fragments first."""
+        stream = self._stream
+        if stream is None:
+            return
         self._stream = None
-        await self.update(self.item.text)
+        await stream.stop()
 
     async def replace_text(self, text: str) -> None:
-        """Replace the current markdown text, usually with the final provider message."""
+        """Replace the current markdown text, usually with corrected final content."""
+        await self._stop_stream()
         self.item.text = text
         self.selection_text = text
-        self._stream = None
         await self.update(text)
 
     async def finalize(self, text: str | None = None) -> None:
         """Mark the streamed message complete and restore finalized Markdown chrome."""
-        if text is not None:
+        if text is not None and text != self.selection_text:
             await self.replace_text(text)
-        elif self._is_streaming:
-            await self.update(self.item.text)
+        else:
+            if text is not None:
+                self.item.text = text
+                self.selection_text = text
+            await self._stop_stream()
         self._is_streaming = False
         self.remove_class("-streaming")
         self.add_class("-finalized")
+
+    async def on_unmount(self) -> None:
+        """Cancel the markdown stream task if the widget is removed mid-stream."""
+        await self._stop_stream()
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected text from this streamed message block."""
@@ -388,6 +402,7 @@ class TranscriptView(VerticalScroll):
         self._active_thinking_widget: StreamingTranscriptMessageWidget | None = None
         self._hidden_thinking_placeholder_visible = False
         self._follow_output = True
+        self._follow_scroll_pending = False
 
     def on_mount(self) -> None:
         """Follow new transcript content until the user scrolls away."""
@@ -396,13 +411,17 @@ class TranscriptView(VerticalScroll):
     def follow_output(self) -> None:
         """Return to follow mode for a user-driven turn or explicit jump to bottom."""
         self._follow_output = True
-        self.anchor(False)
+        self.anchor(True)
         self._request_follow_scroll(force=True)
 
     def _request_follow_scroll(self, *, force: bool = False) -> None:
         """Scroll to the bottom after layout if follow mode is still active."""
+        if self._follow_scroll_pending and not force:
+            return
+        self._follow_scroll_pending = True
 
         def scroll_if_still_following() -> None:
+            self._follow_scroll_pending = False
             if force or self._follow_output or self.is_vertical_scroll_end:
                 self.scroll_end(animate=False, immediate=True)
 
@@ -420,6 +439,22 @@ class TranscriptView(VerticalScroll):
             self._follow_output = False
         elif new_value >= self.max_scroll_y:
             self._follow_output = True
+
+    async def _finalize_active_thinking_message(self) -> None:
+        """Stop streaming for a completed thinking block before another block starts."""
+        widget = self._active_thinking_widget
+        if widget is None:
+            return
+        await widget.finalize()
+        self._active_thinking_widget = None
+
+    async def _finalize_active_assistant_message(self) -> None:
+        """Stop streaming for a completed assistant block before another block starts."""
+        widget = self._active_assistant_widget
+        if widget is None:
+            return
+        await widget.finalize()
+        self._active_assistant_widget = None
 
     def update_from_state(
         self,
@@ -590,6 +625,8 @@ class TranscriptView(VerticalScroll):
     ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
         """Append one transcript item without rebuilding previous blocks."""
         should_follow = self._should_follow_output if not scroll_end else True
+        await self._finalize_active_assistant_message()
+        await self._finalize_active_thinking_message()
         self._render_theme = theme
         widget = _transcript_widget(
             item,
@@ -615,6 +652,7 @@ class TranscriptView(VerticalScroll):
         """Create the active assistant message widget if needed."""
         if self._active_assistant_widget is not None:
             return self._active_assistant_widget
+        await self._finalize_active_thinking_message()
         should_follow = self._should_follow_output if not scroll_end else True
         widget = StreamingTranscriptMessageWidget(
             ChatItem(role="assistant", text=""),
@@ -636,7 +674,6 @@ class TranscriptView(VerticalScroll):
         scroll_end: bool = False,
     ) -> None:
         """Append streamed assistant text to the active message widget."""
-        self._active_thinking_widget = None
         self._hidden_thinking_placeholder_visible = False
         should_follow = self._should_follow_output if not scroll_end else True
         widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -25,6 +25,7 @@ from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.events import Resize
 from textual.geometry import Offset
 from textual.selection import Selection
+from textual.widget import Widget
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets import Static
 from textual.widgets.markdown import MarkdownBlock, MarkdownStream
@@ -195,6 +196,7 @@ class ThemedMarkdownWidget(TextualMarkdown):
 # Roles rendered as free-flowing text with no left accent or role background,
 # matching how they appear while streaming.
 _BORDERLESS_TRANSCRIPT_ROLES = frozenset({"assistant", "thinking"})
+_HIDDEN_THINKING_PLACEHOLDER = "Thinking… Press Ctrl+T to show thinking tokens."
 
 
 class TranscriptMessageWidget(Horizontal):
@@ -430,6 +432,90 @@ class TranscriptView(VerticalScroll):
         self._render_theme = theme
         self._redraw(scroll_end=self._should_follow_output)
 
+    def update_thinking_visibility(
+        self,
+        state: TuiState,
+        *,
+        theme: TuiTheme = TAU_DARK_THEME,
+    ) -> None:
+        """Update only thinking-token widgets after visibility changes."""
+        self._render_state = state
+        self._render_theme = theme
+        should_follow = self._should_follow_output
+        previous_scroll_y = self.scroll_y
+
+        message_children = [
+            child
+            for child in self.children
+            if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+        ]
+        thinking_children = [
+            child for child in message_children if child.item.role == "thinking"
+        ]
+        if thinking_children:
+            self.remove_children(thinking_children)
+
+        non_thinking_children = [
+            child for child in message_children if child.item.role != "thinking"
+        ]
+        non_thinking_index = 0
+        pending_thinking: list[TranscriptMessageWidget] = []
+        hidden_thinking_placeholder = False
+
+        def flush_pending(
+            *, before: TranscriptMessageWidget | StreamingTranscriptMessageWidget | None
+        ) -> None:
+            nonlocal pending_thinking
+            for widget in pending_thinking:
+                self.mount(widget, before=before)
+            pending_thinking = []
+
+        for item in state.items:
+            if item.role == "thinking":
+                if state.show_thinking:
+                    pending_thinking.append(
+                        TranscriptMessageWidget(
+                            item,
+                            theme=theme,
+                            show_tool_results=state.show_tool_results,
+                        )
+                    )
+                elif not hidden_thinking_placeholder:
+                    pending_thinking.append(
+                        TranscriptMessageWidget(
+                            ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                            theme=theme,
+                            show_tool_results=state.show_tool_results,
+                        )
+                    )
+                    hidden_thinking_placeholder = True
+                continue
+
+            hidden_thinking_placeholder = False
+            target = None
+            while non_thinking_index < len(non_thinking_children):
+                candidate = non_thinking_children[non_thinking_index]
+                non_thinking_index += 1
+                if candidate.item is item:
+                    target = candidate
+                    break
+            if target is not None:
+                flush_pending(before=target)
+
+        flush_pending(before=None)
+        self._active_thinking_widget = None
+        self._hidden_thinking_placeholder_visible = (
+            _last_transcript_child_is_hidden_thinking_placeholder(self.children)
+        )
+        self._last_render_width = self.scrollable_content_region.width
+        self.refresh(layout=True)
+        if should_follow:
+            self._request_follow_scroll()
+        else:
+            self.call_after_refresh(
+                lambda: self.scroll_to(y=previous_scroll_y, animate=False, immediate=True)
+            )
+
     def on_resize(self, event: Resize) -> None:
         """Re-render transcript entries when the terminal width changes."""
         del event
@@ -466,7 +552,7 @@ class TranscriptView(VerticalScroll):
                         TranscriptMessageWidget(
                             ChatItem(
                                 role="thinking",
-                                text="Thinking… Press Ctrl+T to show thinking tokens.",
+                                text=_HIDDEN_THINKING_PLACEHOLDER,
                             ),
                             theme=theme,
                             show_tool_results=state.show_tool_results,
@@ -574,7 +660,7 @@ class TranscriptView(VerticalScroll):
             await self.append_item(
                 ChatItem(
                     role="thinking",
-                    text="Thinking… Press Ctrl+T to show thinking tokens.",
+                    text=_HIDDEN_THINKING_PLACEHOLDER,
                 ),
                 theme=theme,
                 scroll_end=should_follow,
@@ -618,6 +704,16 @@ class TranscriptView(VerticalScroll):
             for message in messages
             for line in message.selection_text.splitlines()
         )
+
+
+def _last_transcript_child_is_hidden_thinking_placeholder(children: Sequence[Widget]) -> bool:
+    for child in reversed(children):
+        if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget):
+            return (
+                child.item.role == "thinking"
+                and child.selection_text == _HIDDEN_THINKING_PLACEHOLDER
+            )
+    return False
 
 
 def _transcript_widget(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -13,6 +13,7 @@ from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
 from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
 from textual.widgets import Markdown as TextualMarkdown
+from textual.widgets.markdown import MarkdownStream
 
 from tau_agent import (
     AgentEndEvent,
@@ -1478,7 +1479,23 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
     )
     app = TauTuiApp(session)
     stream_replacements: list[str] = []
+    stream_writes: list[str] = []
+    full_stream_updates: list[str] = []
     original_replace_text = StreamingTranscriptMessageWidget.replace_text
+    original_stream_update = StreamingTranscriptMessageWidget.update
+    original_stream_write = MarkdownStream.write
+
+    def tracking_stream_update(
+        self: StreamingTranscriptMessageWidget,
+        markdown: str,
+    ) -> object:
+        if markdown:
+            full_stream_updates.append(markdown)
+        return original_stream_update(self, markdown)
+
+    async def tracking_stream_write(self: MarkdownStream, fragment: str) -> None:
+        stream_writes.append(fragment)
+        await original_stream_write(self, fragment)
 
     async def tracking_replace_text(
         self: StreamingTranscriptMessageWidget,
@@ -1488,6 +1505,8 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
         await original_replace_text(self, text)
 
     StreamingTranscriptMessageWidget.replace_text = tracking_replace_text  # type: ignore[method-assign]
+    StreamingTranscriptMessageWidget.update = tracking_stream_update  # type: ignore[method-assign]
+    MarkdownStream.write = tracking_stream_write  # type: ignore[method-assign]
     full_refreshes = 0
 
     original_refresh = app._refresh
@@ -1509,9 +1528,13 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
             transcript_text = "\n".join(line.text for line in transcript.lines)
     finally:
         StreamingTranscriptMessageWidget.replace_text = original_replace_text  # type: ignore[method-assign]
+        StreamingTranscriptMessageWidget.update = original_stream_update  # type: ignore[method-assign]
+        MarkdownStream.write = original_stream_write  # type: ignore[method-assign]
 
     assert full_refreshes == 1
-    assert stream_replacements == ["alpha beta"]
+    assert stream_writes == ["alpha ", "beta"]
+    assert stream_replacements == []
+    assert full_stream_updates == []
     assert streamed.selection_text == "alpha beta"
     assert "alpha beta" in transcript_text
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4333,12 +4333,15 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
             and widget.item.role != "thinking"
         ]
         assert len(stable_widgets) == 4
-        assert sum(
-            1
-            for widget in transcript.children
-            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-            and widget.item.role == "thinking"
-        ) == 2
+        assert (
+            sum(
+                1
+                for widget in transcript.children
+                if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+                and widget.item.role == "thinking"
+            )
+            == 2
+        )
 
         await pilot.press("ctrl+t")
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4289,6 +4289,70 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
 
 
 @pytest.mark.anyio
+async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        app.state.add_item("user", "first prompt")
+        app.state.add_thinking_delta("plan one")
+        app.state.add_item("assistant", "first answer")
+        app.state.add_item("user", "second prompt")
+        app.state.add_thinking_delta("plan two")
+        app.state.add_item("assistant", "second answer")
+        app._refresh()
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        stable_widgets = [
+            widget
+            for widget in transcript.children
+            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+            and widget.item.role != "thinking"
+        ]
+        assert len(stable_widgets) == 4
+        assert sum(
+            1
+            for widget in transcript.children
+            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+            and widget.item.role == "thinking"
+        ) == 2
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+        assert [
+            widget
+            for widget in transcript.children
+            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+            and widget.item.role != "thinking"
+        ] == stable_widgets
+        assert [line.text for line in transcript.lines] == [
+            "first prompt",
+            "plan one",
+            "first answer",
+            "second prompt",
+            "plan two",
+            "second answer",
+        ]
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+        assert [
+            widget
+            for widget in transcript.children
+            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+            and widget.item.role != "thinking"
+        ] == stable_widgets
+        assert [line.text for line in transcript.lines] == [
+            "first prompt",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "first answer",
+            "second prompt",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "second answer",
+        ]
+
+
+@pytest.mark.anyio
 async def test_tui_prompt_ctrl_c_clears_text() -> None:
     app = TauTuiApp(FakeSession(messages=(UserMessage(content="User prompt"),)))
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -26,6 +26,7 @@ from tau_agent import (
     MessageEndEvent,
     MessageStartEvent,
     QueueUpdateEvent,
+    ThinkingDeltaEvent,
     ToolCall,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
@@ -4312,6 +4313,31 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
 
 
 @pytest.mark.anyio
+async def test_tui_app_hidden_thinking_placeholder_stays_before_streamed_answer() -> None:
+    session = FakeSession(
+        events=[
+            AgentStartEvent(),
+            ThinkingDeltaEvent(delta="private plan"),
+            MessageStartEvent(message_role="assistant"),
+            MessageDeltaEvent(delta="public answer"),
+            MessageEndEvent(message=AssistantMessage(content="public answer")),
+            AgentEndEvent(),
+        ]
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        await app._run_prompt("stream")
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "public answer",
+        ]
+
+
+@pytest.mark.anyio
 async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
     app = TauTuiApp(FakeSession())
 
@@ -4360,6 +4386,18 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
             "second answer",
         ]
 
+        app.state.add_item("status", "late status")
+        await transcript.append_item(app.state.items[-1])
+        await pilot.pause()
+        stable_widgets.append(
+            next(
+                widget
+                for widget in reversed(transcript.children)
+                if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+                and widget.item.role == "status"
+            )
+        )
+
         await pilot.press("ctrl+t")
         await pilot.pause()
         assert [
@@ -4375,6 +4413,7 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
             "second prompt",
             "Thinking… Press Ctrl+T to show thinking tokens.",
             "second answer",
+            "late status",
         ]
 
 


### PR DESCRIPTION
## Summary

- Add an incremental `TranscriptView` thinking visibility update path so `Ctrl+T` avoids a full transcript rebuild.
- Preserve unrelated transcript widgets while hiding/showing multiple thinking blocks.
- Restore Textual `MarkdownStream`-based assistant/thinking streaming so long responses do not reparse the full accumulated Markdown on every delta.
- Avoid unnecessary final full Markdown replacement when streamed text already matches the final assistant message.

Fixes #248

## Tests

- `uv run ruff check src/tau_coding/tui/app.py src/tau_coding/tui/widgets.py tests/test_tui_app.py`
- `uv run mypy src/tau_coding/tui/app.py src/tau_coding/tui/widgets.py`
- `uv run pytest tests/test_tui_app.py`

Note: `pyright` is not installed in the project environment; used `mypy` instead.
