### PR TITLE
Fix provider/model selection safety

### DIFF
--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -44,6 +44,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Phase 17.5: TUI Transcript Wrapping](./phase-17-5-transcript-wrapping.md)
 - [Phase 18: Provider Configuration Foundation](./phase-18-provider-config-foundation.md)
 - [Provider Retry Events](./provider-retries.md)
+- [Provider/model safety and HTTP error details](./provider-model-safety.md)
 - [Phase 19: Project Context Discovery and Reload](./phase-19-context-discovery.md)
 - [Phase 20: Installation and Configuration Docs](./phase-20-installation-docs.md)
 - [Phase 20.1: Context Accounting Refresh](./phase-20-1-context-accounting.md)

--- a/dev-notes/architecture/provider-model-safety.md
+++ b/dev-notes/architecture/provider-model-safety.md
@@ -1,0 +1,48 @@
+# Provider/model safety and HTTP error details
+
+Issue #226 overlaps with the provider/model mismatch fixed by PR #249: `/tree`
+navigation now preserves the active runtime model instead of replaying only the
+historical model from the selected branch. This note documents the additional
+hardening added afterward.
+
+## What changed
+
+- Provider/model selection now validates that the selected model is declared by
+  the chosen provider before print mode, TUI startup, model switching, provider
+  refresh, or runtime provider construction proceeds.
+- Sessions with older persisted `model_change` entries that no longer match the
+  active provider fall back to the current provider's configured default instead
+  of creating a mismatched runtime provider.
+- TUI resume heuristics only infer a provider from a saved model when that
+  provider is currently usable, so an unavailable provider with the same model
+  name cannot win accidentally.
+- OpenAI-compatible, OpenAI Codex, and Anthropic HTTP errors now share a helper
+  that extracts useful provider error details from JSON bodies and includes the
+  HTTP status and selected model in the user-visible provider error message.
+
+## Why it exists
+
+Tau's provider catalog is intentionally provider-specific: the `openai` API key
+provider and the `openai-codex` subscription provider are separate transports and
+may not support the same models. Validating the model against the active provider
+turns invalid combinations into immediate, actionable configuration errors.
+
+The shared HTTP error formatter keeps production failures debuggable when a
+provider rejects a request for account, model availability, request shape, or
+other validation reasons. The coding-session diagnostic log already records the
+provider name, model, status, and safe response body for non-recoverable provider
+errors.
+
+## How to test
+
+```bash
+uv run pytest tests/test_provider_config.py tests/test_provider_runtime.py \
+  tests/test_tau_ai.py tests/test_coding_session.py tests/test_tui_app.py
+```
+
+Run the full suite before merging:
+
+```bash
+uv run ruff check
+uv run pytest
+```

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -21,6 +21,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -84,6 +85,7 @@ class AnthropicProvider:
                     ) as response:
                         if response.status_code >= 400:
                             body = await response.aread()
+                            body_text = body.decode(errors="replace")
                             if self._should_retry(attempt, status_code=response.status_code):
                                 delay = retry_delay_seconds(
                                     attempt,
@@ -96,7 +98,7 @@ class AnthropicProvider:
                                     reason=f"HTTP {response.status_code}",
                                     data={
                                         "status_code": response.status_code,
-                                        "body": body.decode(errors="replace"),
+                                        "body": body_text,
                                     },
                                 )
                                 attempt += 1
@@ -104,11 +106,15 @@ class AnthropicProvider:
                                     return
                                 continue
                             yield ProviderErrorEvent(
-                                message=(
-                                    f"Provider request failed with status {response.status_code}"
+                                message=provider_http_error_message(
+                                    provider_name=self._config.provider_name,
+                                    status_code=response.status_code,
+                                    body=body_text,
+                                    model=model,
                                 ),
                                 data={
-                                    "body": body.decode(errors="replace"),
+                                    "status_code": response.status_code,
+                                    "body": body_text,
                                     "attempts": attempt + 1,
                                 },
                             )

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -25,6 +25,7 @@ class OpenAICompatibleConfig:
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
     reasoning_effort: str | None = None
     reasoning_effort_parameter: str = "reasoning_effort"
+    provider_name: str = "OpenAI-compatible provider"
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +39,7 @@ class AnthropicConfig:
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
     thinking_budget_tokens: int | None = None
+    provider_name: str = "Anthropic"
 
 
 def openai_compatible_config_from_env(

--- a/src/tau_ai/http_errors.py
+++ b/src/tau_ai/http_errors.py
@@ -1,0 +1,65 @@
+"""Helpers for surfacing safe provider HTTP error details."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from json import JSONDecodeError, loads
+from typing import Any
+
+_MAX_ERROR_DETAIL_LENGTH = 1000
+
+
+def provider_http_error_message(
+    *,
+    provider_name: str,
+    status_code: int,
+    body: str,
+    model: str | None = None,
+) -> str:
+    """Return an actionable, secret-free HTTP error message for a provider response."""
+    prefix = f"{provider_name} request failed with status {status_code}"
+    if model:
+        prefix = f"{prefix} for model {model}"
+    detail = provider_http_error_detail(body)
+    if detail:
+        return f"{prefix}: {detail}"
+    return prefix
+
+
+def provider_http_error_detail(body: str) -> str:
+    """Extract a concise provider-supplied error detail from an HTTP body."""
+    parsed = _loads_object(body)
+    if parsed is not None:
+        detail = provider_error_detail_from_mapping(parsed)
+        if detail:
+            return detail
+    return body.strip()[:_MAX_ERROR_DETAIL_LENGTH]
+
+
+def provider_error_detail_from_mapping(value: Mapping[str, Any]) -> str:
+    """Return the most useful message/code from a provider error object."""
+    error = value.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+        code = error.get("code")
+        if isinstance(code, str) and code:
+            return code
+    for key in ("message", "detail", "error"):
+        detail = value.get(key)
+        if isinstance(detail, str) and detail:
+            return detail
+        if isinstance(detail, Mapping):
+            nested = provider_error_detail_from_mapping(detail)
+            if nested:
+                return nested
+    return ""
+
+
+def _loads_object(value: str) -> Mapping[str, Any] | None:
+    try:
+        parsed = loads(value)
+    except JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, Mapping) else None

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -27,6 +27,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -57,6 +58,7 @@ class OpenAICodexConfig:
     originator: str = "tau"
     reasoning_effort: str | None = None
     reasoning_summary: str = "auto"
+    provider_name: str = "OpenAI Codex"
 
 
 class OpenAICodexProvider:
@@ -145,9 +147,11 @@ class OpenAICodexProvider:
                                     return
                                 continue
                             yield ProviderErrorEvent(
-                                message=_codex_http_error_message(
+                                message=provider_http_error_message(
+                                    provider_name=self._config.provider_name,
                                     status_code=response.status_code,
                                     body=body_text,
+                                    model=model,
                                 ),
                                 data={
                                     "status_code": response.status_code,
@@ -645,43 +649,6 @@ def _finish_reason_from_response(event: Mapping[str, Any]) -> str | None:
     if isinstance(status, str):
         return status
     return None
-
-
-def _codex_http_error_message(*, status_code: int, body: str) -> str:
-    prefix = f"OpenAI Codex request failed with status {status_code}"
-    detail = _http_error_detail(body)
-    if detail:
-        return f"{prefix}: {detail}"
-    return prefix
-
-
-def _http_error_detail(body: str) -> str:
-    parsed = _loads_object(body)
-    if parsed is not None:
-        detail = _error_detail_from_mapping(parsed)
-        if detail:
-            return detail
-    return body.strip()[:1000]
-
-
-def _error_detail_from_mapping(value: Mapping[str, Any]) -> str:
-    error = value.get("error")
-    if isinstance(error, Mapping):
-        message = error.get("message")
-        if isinstance(message, str) and message:
-            return message
-        code = error.get("code")
-        if isinstance(code, str) and code:
-            return code
-    for key in ("message", "detail", "error"):
-        detail = value.get(key)
-        if isinstance(detail, str) and detail:
-            return detail
-        if isinstance(detail, Mapping):
-            nested = _error_detail_from_mapping(detail)
-            if nested:
-                return nested
-    return ""
 
 
 def _response_error_message(event: Mapping[str, Any]) -> str:

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -29,6 +29,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 
@@ -177,6 +178,7 @@ class OpenAICompatibleProvider:
                     ) as response:
                         if response.status_code >= 400:
                             body = await response.aread()
+                            body_text = body.decode(errors="replace")
                             if self._should_retry(attempt, status_code=response.status_code):
                                 delay = retry_delay_seconds(
                                     attempt,
@@ -189,7 +191,7 @@ class OpenAICompatibleProvider:
                                     reason=f"HTTP {response.status_code}",
                                     data={
                                         "status_code": response.status_code,
-                                        "body": body.decode(errors="replace"),
+                                        "body": body_text,
                                     },
                                 )
                                 attempt += 1
@@ -197,11 +199,15 @@ class OpenAICompatibleProvider:
                                     return
                                 continue
                             yield ProviderErrorEvent(
-                                message=(
-                                    f"Provider request failed with status {response.status_code}"
+                                message=provider_http_error_message(
+                                    provider_name=self._config.provider_name,
+                                    status_code=response.status_code,
+                                    body=body_text,
+                                    model=model,
                                 ),
                                 data={
-                                    "body": body.decode(errors="replace"),
+                                    "status_code": response.status_code,
+                                    "body": body_text,
                                     "attempts": attempt + 1,
                                 },
                             )

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -75,6 +75,7 @@ from tau_coding.provider_config import (
     upsert_openai_compatible_provider,
     upsert_provider,
     upsert_saved_provider,
+    validate_provider_model,
 )
 from tau_coding.rendering import (
     EventRenderer,
@@ -272,4 +273,5 @@ __all__ = [
     "upsert_provider",
     "upsert_openai_compatible_provider",
     "upsert_saved_provider",
+    "validate_provider_model",
 ]

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -446,8 +446,8 @@ def set_default_provider_model(
 ) -> ProviderSettings:
     """Return settings with the default provider/model preference updated."""
     provider = settings.get_provider(provider_name)
-    models = provider.models if model in provider.models else (*provider.models, model)
-    updated_provider = replace(provider, models=models, default_model=model)
+    validate_provider_model(provider, model)
+    updated_provider = replace(provider, default_model=model)
     providers = tuple(
         updated_provider if item.name == provider_name else item for item in settings.providers
     )
@@ -544,7 +544,10 @@ def _merge_provider_config(existing: ProviderConfig, incoming: ProviderConfig) -
     """Merge a replacement provider config without losing local customizations."""
     if type(existing) is not type(incoming):
         return incoming
-    models = _unique_strings((*incoming.models, *existing.models))
+    if isinstance(incoming, OpenAICodexProviderConfig):
+        models = incoming.models
+    else:
+        models = _unique_strings((*incoming.models, *existing.models))
     default_model = (
         existing.default_model if existing.default_model in models else incoming.default_model
     )
@@ -659,7 +662,19 @@ def resolve_provider_selection(
     selected_model = model or provider.default_model
     if not selected_model:
         raise ProviderConfigError(f"Provider {provider.name} does not define a default model")
+    validate_provider_model(provider, selected_model)
     return ProviderSelection(provider=provider, model=selected_model)
+
+
+def validate_provider_model(provider: ProviderConfig, model: str) -> None:
+    """Raise when ``model`` is not declared by ``provider``."""
+    if model in provider.models:
+        return
+    available = ", ".join(sorted(provider.models)) or "none"
+    raise ProviderConfigError(
+        f"Model is not configured for provider {provider.name}: {model}. "
+        f"Available models: {available}"
+    )
 
 
 def provider_thinking_levels(
@@ -731,6 +746,7 @@ def openai_compatible_config_from_provider(
     )
     return OpenAICompatibleConfig(
         api_key=api_key,
+        provider_name=provider.name,
         base_url=base_url.rstrip("/"),
         headers=provider.headers,
         timeout_seconds=provider.timeout_seconds,
@@ -755,6 +771,7 @@ def anthropic_config_from_provider(
     )
     return AnthropicConfig(
         api_key=api_key,
+        provider_name=provider.name,
         base_url=provider.base_url.rstrip("/"),
         headers=provider.headers,
         timeout_seconds=provider.timeout_seconds,

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -27,6 +27,7 @@ from tau_coding.provider_config import (
     anthropic_config_from_provider,
     openai_compatible_config_from_provider,
     provider_thinking_levels,
+    validate_provider_model,
 )
 from tau_coding.thinking import ThinkingLevel, normalize_thinking_level, reasoning_effort_for_level
 
@@ -47,6 +48,8 @@ def create_model_provider(
     thinking_level: ThinkingLevel | None = None,
 ) -> ClosableModelProvider:
     """Create a runtime model provider from durable provider settings."""
+    if model is not None:
+        validate_provider_model(provider, model)
     credentials = credential_store or FileCredentialStore()
     if isinstance(provider, AnthropicProviderConfig):
         return AnthropicProvider(
@@ -64,6 +67,7 @@ def create_model_provider(
                     credential_store=credentials,
                 ),
                 base_url=provider.base_url,
+                provider_name=provider.name,
                 headers=provider.headers,
                 timeout_seconds=provider.timeout_seconds,
                 max_retries=provider.max_retries,

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -73,6 +73,7 @@ from tau_coding.provider_config import (
     resolve_provider_selection,
     save_default_provider_model,
     toggle_saved_scoped_model,
+    validate_provider_model,
 )
 from tau_coding.provider_runtime import ClosableModelProvider, create_model_provider
 from tau_coding.reload import CodingReloadSummary, ReloadCategorySummary
@@ -249,7 +250,10 @@ class CodingSession:
         pending_initial_entries: tuple[SessionEntry, ...] = ()
         if not entries:
             info = SessionInfoEntry(cwd=str(config.cwd))
-            model = ModelChangeEntry(parent_id=info.id, model=config.model)
+            model = ModelChangeEntry(
+                parent_id=info.id,
+                model=_initial_model_for_config(config),
+            )
             thinking = ThinkingLevelChangeEntry(
                 parent_id=model.id,
                 thinking_level=config.thinking_level,
@@ -293,7 +297,7 @@ class CodingSession:
         harness = AgentHarness(
             AgentHarnessConfig(
                 provider=config.provider,
-                model=state.model or config.model,
+                model=_runtime_model_for_state(config, state),
                 system=system,
                 tools=tools,
             ),
@@ -647,6 +651,9 @@ class CodingSession:
 
     def set_model(self, model: str) -> None:
         """Switch the active model for future turns and make it the default."""
+        provider = self._active_provider_config()
+        if provider is not None:
+            validate_provider_model(provider, model)
         self._harness.config.model = model
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
@@ -800,13 +807,6 @@ class CodingSession:
             current=self._thinking_level,
         )
 
-    def _validate_provider_model(self, provider_name: str, model: str) -> None:
-        if self._provider_settings is None:
-            return
-        provider = self._provider_settings.get_provider(provider_name)
-        if model not in provider.models:
-            raise ProviderConfigError(f"Model is not configured: {provider_name}:{model}")
-
     def _persist_default_model_choice(self) -> None:
         if self._provider_settings is None:
             return
@@ -822,6 +822,7 @@ class CodingSession:
         if self._runtime_provider_config is None:
             return
         provider_config = self._active_provider_config() or self._runtime_provider_config
+        validate_provider_model(provider_config, self.model)
         try:
             provider = create_model_provider(
                 provider_config,
@@ -936,7 +937,7 @@ class CodingSession:
             provider_name = runtime_provider_config.name
             model = record.model
             restore_record_model = True
-            self._validate_provider_model(provider_name, model)
+            validate_provider_model(runtime_provider_config, model)
 
         replacement = await type(self).load(
             CodingSessionConfig(
@@ -962,7 +963,9 @@ class CodingSession:
             )
         )
         if restore_record_model:
-            self._validate_provider_model(provider_name, replacement.model)
+            if runtime_provider_config is None:
+                raise ProviderConfigError(f"Session provider is not configured: {provider_name}")
+            validate_provider_model(runtime_provider_config, replacement.model)
         else:
             replacement._harness.config.model = self.model
             replacement._sync_thinking_level_to_active_model()
@@ -1749,6 +1752,47 @@ def _session_export_title(session: CodingSession) -> str:
         if record is not None and record.title:
             return record.title
     return f"Tau session {session_id}" if session_id is not None else "Tau Session Export"
+
+
+def _initial_model_for_config(config: CodingSessionConfig) -> str:
+    if config.provider_settings is None or config.runtime_provider_config is None:
+        return config.model
+    provider = _provider_config_for_name(config, config.provider_name)
+    if provider is None:
+        return config.model
+    try:
+        validate_provider_model(provider, config.model)
+    except ProviderConfigError:
+        return provider.default_model
+    return config.model
+
+
+def _runtime_model_for_state(config: CodingSessionConfig, state: SessionState) -> str:
+    state_model = state.model or config.model
+    if config.provider_settings is None or config.runtime_provider_config is None:
+        return state_model
+    provider = _provider_config_for_name(config, config.provider_name)
+    if provider is None:
+        return state_model
+    try:
+        validate_provider_model(provider, state_model)
+    except ProviderConfigError:
+        return config.model if config.model in provider.models else provider.default_model
+    return state_model
+
+
+def _provider_config_for_name(
+    config: CodingSessionConfig,
+    provider_name: str,
+) -> ProviderConfig | None:
+    if config.provider_settings is not None:
+        try:
+            return config.provider_settings.get_provider(provider_name)
+        except ProviderConfigError:
+            pass
+    if config.runtime_provider_config is not None:
+        return config.runtime_provider_config
+    return None
 
 
 def _state_thinking_level(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3772,9 +3772,13 @@ def _selection_from_session_record(settings: Any, record: Any | None) -> Provide
                 model=choice.model,
             )
 
+    credential_store = FileCredentialStore()
     for provider in settings.providers:
-        if record_model in provider.models:
-            return ProviderSelection(provider=provider, model=record_model)
+        if record_model not in provider.models:
+            continue
+        if not provider_has_usable_credentials(provider, credential_reader=credential_store):
+            continue
+        return ProviderSelection(provider=provider, model=record_model)
     return None
 
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2375,6 +2375,82 @@ async def test_session_toggle_scoped_model_preserves_newer_provider_file_changes
 
 
 @pytest.mark.anyio
+async def test_session_set_model_rejects_model_not_declared_for_provider(tmp_path: Path) -> None:
+    provider_config = OpenAICompatibleProviderConfig(
+        name="openai",
+        models=("gpt-5",),
+        default_model="gpt-5",
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="gpt-5",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+        )
+    )
+
+    with pytest.raises(
+        coding_session_module.ProviderConfigError,
+        match="Model is not configured for provider openai: gpt-5.5",
+    ):
+        session.set_model("gpt-5.5")
+
+    assert session.model == "gpt-5"
+
+
+@pytest.mark.anyio
+async def test_session_load_falls_back_when_persisted_model_does_not_match_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created: list[tuple[str, str | None]] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+    ) -> SwitchableFakeProvider:
+        del credential_store, thinking_level
+        created.append((provider_config.name, model))  # type: ignore[attr-defined]
+        return SwitchableFakeProvider(provider_config)
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(SessionInfoEntry(cwd=str(tmp_path)))
+    await storage.append(ModelChangeEntry(model="gpt-5"))
+    provider_config = OpenAICodexProviderConfig(
+        models=("gpt-5.5",),
+        default_model="gpt-5.5",
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="gpt-5.5",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=ProviderSettings(
+                default_provider="openai-codex",
+                providers=(provider_config,),
+            ),
+            runtime_provider_config=provider_config,
+        )
+    )
+
+    assert session.state.model == "gpt-5"
+    assert session.model == "gpt-5.5"
+    assert created == [("openai-codex", "gpt-5.5")]
+
+
+@pytest.mark.anyio
 async def test_session_set_model_persists_default_provider_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2855,7 +2931,7 @@ async def test_session_resume_missing_provider_preserves_active_provider_model(
 
     assert session.provider_name == "openai"
     assert session.model == "gpt-5"
-    assert created == [("openai", "qwen"), ("openai", "gpt-5")]
+    assert created == [("openai", "gpt-5"), ("openai", "gpt-5")]
 
 
 @pytest.mark.anyio
@@ -2921,7 +2997,10 @@ async def test_session_resume_rejects_incompatible_provider_model(
         )
     )
 
-    with pytest.raises(ProviderConfigError, match="Model is not configured: local:gpt-5.5"):
+    with pytest.raises(
+        ProviderConfigError,
+        match="Model is not configured for provider local: gpt-5.5",
+    ):
         await session.resume(second_record.id)
 
     assert session.provider_name == "openai"

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -23,6 +23,7 @@ from tau_coding.provider_config import (
     provider_thinking_unavailable_reason,
     resolve_provider_selection,
     save_provider_settings,
+    set_default_provider_model,
     upsert_openai_compatible_provider,
 )
 
@@ -269,6 +270,48 @@ def test_resolve_provider_selection_rejects_unknown_provider() -> None:
         resolve_provider_selection(ProviderSettings(), provider_name="missing")
 
 
+def test_resolve_provider_selection_rejects_model_not_declared_for_provider() -> None:
+    settings = ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("qwen",),
+                default_model="qwen",
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        ProviderConfigError,
+        match="Model is not configured for provider local: llama",
+    ):
+        resolve_provider_selection(settings, model="llama")
+
+
+def test_set_default_provider_model_rejects_model_not_declared_for_provider() -> None:
+    settings = ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("qwen",),
+                default_model="qwen",
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        ProviderConfigError,
+        match="Model is not configured for provider local: llama",
+    ):
+        set_default_provider_model(settings, provider_name="local", model="llama")
+
+
 def test_openai_compatible_config_from_provider_uses_configured_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -284,6 +327,7 @@ def test_openai_compatible_config_from_provider_uses_configured_env_var(
     config = openai_compatible_config_from_provider(provider)
 
     assert config.api_key == "test-key"
+    assert config.provider_name == "local"
     assert config.base_url == "http://localhost:11434/v1"
     assert config.headers == {}
     assert config.timeout_seconds == 60.0
@@ -651,6 +695,45 @@ def test_provider_settings_from_json_loads_anthropic_thinking_provider() -> None
         "high",
     )
     assert provider.thinking_parameter == "anthropic.thinking"
+
+
+def test_load_provider_settings_does_not_restore_stale_codex_builtin_models(
+    tmp_path: Path,
+) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        """
+{
+  "default_provider": "openai-codex",
+  "providers": [
+    {
+      "type": "openai-codex",
+      "name": "openai-codex",
+      "base_url": "https://chatgpt.com/backend-api",
+      "api_key_env": "OPENAI_CODEX_ACCESS_TOKEN",
+      "credential_name": "openai-codex",
+      "models": ["gpt-5", "gpt-5.5"],
+      "default_model": "gpt-5"
+    }
+  ]
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+    provider = settings.get_provider("openai-codex")
+
+    assert provider.models == (
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+    )
+    assert provider.default_model == "gpt-5.5"
 
 
 def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> None:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -3,7 +3,11 @@ import pytest
 from tau_ai import OpenAICodexProvider
 from tau_coding import provider_runtime
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
-from tau_coding.provider_config import OpenAICodexProviderConfig
+from tau_coding.provider_config import (
+    OpenAICodexProviderConfig,
+    OpenAICompatibleProviderConfig,
+    ProviderConfigError,
+)
 from tau_coding.provider_runtime import OpenAICodexCredentialResolver, create_model_provider
 
 
@@ -16,6 +20,21 @@ def test_create_model_provider_returns_openai_codex_provider(tmp_path) -> None:
     )
 
     assert isinstance(provider, OpenAICodexProvider)
+
+
+def test_create_model_provider_rejects_model_not_declared_for_provider(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    provider_config = OpenAICompatibleProviderConfig(
+        name="local",
+        models=("qwen",),
+        default_model="qwen",
+    )
+
+    with pytest.raises(
+        ProviderConfigError,
+        match="Model is not configured for provider local: llama",
+    ):
+        create_model_provider(provider_config, credential_store=store, model="llama")
 
 
 def test_create_model_provider_maps_codex_reasoning_effort_like_pi(tmp_path) -> None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -458,12 +458,16 @@ async def test_openai_compatible_provider_does_not_retry_non_transient_status() 
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
-        return httpx.Response(400, text="bad request")
+        return httpx.Response(
+            400,
+            json={"error": {"message": "The selected model is unavailable."}},
+        )
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
             OpenAICompatibleConfig(
                 api_key="test-key",
+                provider_name="test-openai",
                 base_url="https://example.test/v1",
                 max_retries=3,
                 max_retry_delay_seconds=0,
@@ -482,7 +486,51 @@ async def test_openai_compatible_provider_does_not_retry_non_transient_status() 
 
     assert len(requests) == 1
     assert isinstance(events[-1], ProviderErrorEvent)
-    assert events[-1].data == {"body": "bad request", "attempts": 1}
+    assert events[-1].message == (
+        "test-openai request failed with status 400 for model test-model: "
+        "The selected model is unavailable."
+    )
+    assert events[-1].data == {
+        "status_code": 400,
+        "body": '{"error":{"message":"The selected model is unavailable."}}',
+        "attempts": 1,
+    }
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_includes_plain_http_error_body_in_message() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="bad request details")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                provider_name="test-openai",
+                base_url="https://example.test/v1",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].message == (
+        "test-openai request failed with status 400 for model test-model: bad request details"
+    )
+    assert events[-1].data == {
+        "status_code": 400,
+        "body": "bad request details",
+        "attempts": 1,
+    }
 
 
 @pytest.mark.anyio
@@ -501,6 +549,7 @@ async def test_openai_codex_provider_includes_http_error_detail_in_message() -> 
             OpenAICodexConfig(
                 credential_resolver=credentials,
                 base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
                 max_retries=0,
             ),
             client=client,
@@ -517,7 +566,8 @@ async def test_openai_codex_provider_includes_http_error_detail_in_message() -> 
 
     assert isinstance(events[-1], ProviderErrorEvent)
     assert events[-1].message == (
-        "OpenAI Codex request failed with status 400: The requested model does not exist."
+        "openai-codex request failed with status 400 for model gpt-5.5: "
+        "The requested model does not exist."
     )
     assert events[-1].data == {
         "status_code": 400,
@@ -539,6 +589,7 @@ async def test_openai_codex_provider_includes_plain_http_error_body_in_message()
             OpenAICodexConfig(
                 credential_resolver=credentials,
                 base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
                 max_retries=0,
             ),
             client=client,
@@ -555,7 +606,7 @@ async def test_openai_codex_provider_includes_plain_http_error_body_in_message()
 
     assert isinstance(events[-1], ProviderErrorEvent)
     assert events[-1].message == (
-        "OpenAI Codex request failed with status 400: bad request details"
+        "openai-codex request failed with status 400 for model gpt-5.5: bad request details"
     )
     assert events[-1].data == {
         "status_code": 400,
@@ -1096,6 +1147,46 @@ async def test_anthropic_provider_retries_transient_status_with_event() -> None:
         "text_delta",
         "response_end",
     ]
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_includes_http_error_detail_in_message() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"error": {"message": "model: invalid-model is not supported"}},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                provider_name="anthropic",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], ProviderErrorEvent)
+    assert events[-1].message == (
+        "anthropic request failed with status 400 for model claude-test: "
+        "model: invalid-model is not supported"
+    )
+    assert events[-1].data == {
+        "status_code": 400,
+        "body": '{"error":{"message":"model: invalid-model is not supported"}}',
+        "attempts": 1,
+    }
 
 
 def _weather_tool() -> AgentTool:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -5187,6 +5187,7 @@ async def test_run_tui_app_resumes_explicit_session(
         title=None,
         created_at=1.0,
         updated_at=1.0,
+        provider_name="local",
     )
 
     class FakeProvider:
@@ -5210,6 +5211,8 @@ async def test_run_tui_app_resumes_explicit_session(
     class FakeCodingSession:
         @classmethod
         async def load(cls, config: object) -> str:
+            assert config.provider_name == "local"  # type: ignore[attr-defined]
+            assert config.model == "fake-model"  # type: ignore[attr-defined]
             calls.append("load")
             return "session"
 
@@ -5221,25 +5224,143 @@ async def test_run_tui_app_resumes_explicit_session(
         async def run_async(self) -> None:
             calls.append("run")
 
-    settings = ProviderSettings()
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5.5",),
+                default_model="gpt-5.5",
+            ),
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("fake-model",),
+                default_model="fake-model",
+            ),
+        ),
+    )
     monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
     monkeypatch.setattr(
         tui_app,
         "create_model_provider",
-        lambda provider, **kwargs: FakeProvider(),
+        lambda provider, **kwargs: (
+            calls.append(f"provider:{provider.name}:{kwargs['model']}") or FakeProvider()
+        ),
     )
     monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
     monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
     monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
 
     await tui_app.run_tui_app(
-        model="fake-model",
+        model=None,
         cwd=tmp_path,
         session_id="session-1",
         session_manager=FakeManager(),
     )
 
-    assert calls == ["get:session-1", "load", "run", "provider_closed"]
+    assert calls == [
+        "get:session-1",
+        "provider:local:fake-model",
+        "load",
+        "run",
+        "provider_closed",
+    ]
+
+
+@pytest.mark.anyio
+async def test_run_tui_app_ignores_uncredentialed_provider_when_matching_resume_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    record = CodingSessionRecord(
+        id="session-1",
+        path=tmp_path / "session-1.jsonl",
+        cwd=tmp_path,
+        model="shared-model",
+        title=None,
+        created_at=1.0,
+        updated_at=1.0,
+    )
+
+    class FakeCredentialStore:
+        def get(self, name: str) -> str | None:
+            return "stored-key" if name == "openai" else None
+
+        def get_oauth(self, name: str) -> object | None:
+            return None
+
+    class FakeProvider:
+        async def aclose(self) -> None:
+            calls.append("provider_closed")
+
+    class FakeManager:
+        def get_session(self, session_id: str) -> CodingSessionRecord | None:
+            calls.append(f"get:{session_id}")
+            return record
+
+    class FakeCodingSession:
+        @classmethod
+        async def load(cls, config: object) -> str:
+            assert config.provider_name == "openai"  # type: ignore[attr-defined]
+            calls.append("load")
+            return "session"
+
+    class FakeApp:
+        def __init__(self, session: str, **kwargs: object) -> None:
+            assert session == "session"
+
+        async def run_async(self) -> None:
+            calls.append("run")
+
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                credential_name=None,
+                models=("shared-model",),
+                default_model="shared-model",
+            ),
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                credential_name="openai",
+                models=("shared-model",),
+                default_model="shared-model",
+            ),
+        ),
+    )
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+    monkeypatch.setattr(tui_app, "FileCredentialStore", lambda: FakeCredentialStore())
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
+    monkeypatch.setattr(
+        tui_app,
+        "create_model_provider",
+        lambda provider, **kwargs: (
+            calls.append(f"provider:{provider.name}:{kwargs['model']}") or FakeProvider()
+        ),
+    )
+    monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
+    monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+
+    await tui_app.run_tui_app(
+        model=None,
+        cwd=tmp_path,
+        session_id="session-1",
+        session_manager=FakeManager(),
+    )
+
+    assert calls == [
+        "get:session-1",
+        "provider:openai:shared-model",
+        "load",
+        "run",
+        "provider_closed",
+    ]
 
 
 class _FakeSessionManager:

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -59,6 +59,11 @@ access tokens automatically. It's separate from the API-key `openai` provider.
   Build the list with `/scoped-models`, or press `Space` on a model in the
   `/model` picker.
 
+Tau validates the selected model against the active provider's configured model
+list before creating or refreshing a runtime provider. This prevents accidental
+provider/model mismatches, such as trying to send an API-only OpenAI model to the
+separate `openai-codex` subscription provider.
+
 ## Adding a custom / local provider
 
 Any OpenAI-compatible endpoint works — including local servers like Ollama or

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -62,6 +62,9 @@ Provider metadata lives in `~/.tau/providers.json`:
 - API keys and OAuth credentials are **not** stored here — they live in
   `~/.tau/credentials.json`. Resolution order: stored credential, then the env
   var named by `api_key_env`.
+- The selected model must be present in that provider's `models` list. Add
+  custom or local model names to `models` before using them as defaults,
+  CLI/TUI selections, or scoped models.
 - `scoped_models` are favorites for the **Ctrl+P** quick-cycle.
 - Custom models can declare thinking support with `thinking_levels`,
   `thinking_default`, `thinking_models`, and `thinking_parameter`


### PR DESCRIPTION
## Summary

- Verified the branching provider/model mismatch was addressed by PR #249 / issue #247, then added broader provider/model validation gates for startup, model switching, provider refresh, and runtime provider creation.
- Prevent stale OpenAI Codex catalog models from being preserved, and fall back safely when older persisted session model entries do not match the active provider.
- Standardize HTTP error detail formatting for OpenAI-compatible, OpenAI Codex, and Anthropic providers, including status, provider name, selected model, and safe provider response detail.

Fixes #226

## Tests

- `uv run ruff check`
- `uv run mypy`
- `uv run pytest`