### PR TITLE
Optimize scoped provider model switching

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -660,9 +660,10 @@ class CodingSession:
 
     def set_model_choice(self, choice: ModelChoice) -> None:
         """Switch provider/model as one operation."""
-        if choice.provider_name != self.provider_name:
-            self.set_provider(choice.provider_name)
-        self.set_model(choice.model)
+        if choice.provider_name == self.provider_name:
+            self.set_model(choice.model)
+            return
+        self._set_provider_model(choice.provider_name, choice.model)
 
     def is_scoped_model(self, choice: ModelChoice) -> bool:
         """Return whether a provider/model pair is in the scoped model list."""
@@ -706,9 +707,27 @@ class CodingSession:
         """Switch the active provider and reset to that provider's default model."""
         if self._provider_settings is None:
             raise ProviderConfigError("Provider settings are not available for this session")
+        provider_config = self._provider_settings.get_provider(provider_name)
+        self._set_provider_model(
+            provider_name,
+            provider_config.default_model,
+            persist_default=persist_default,
+        )
+
+    def _set_provider_model(
+        self,
+        provider_name: str,
+        model: str,
+        *,
+        persist_default: bool = True,
+    ) -> None:
+        """Switch active provider/model without constructing an intermediate provider."""
+        if self._provider_settings is None:
+            raise ProviderConfigError("Provider settings are not available for this session")
 
         provider_config = self._provider_settings.get_provider(provider_name)
-        model = provider_config.default_model
+        if model not in provider_config.models:
+            raise ProviderConfigError(f"Model is not configured: {provider_name}:{model}")
         thinking_level = _coerced_thinking_level(
             provider_config,
             model=model,

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2461,7 +2461,72 @@ async def test_session_set_model_choice_persists_default_provider_model(
     saved = coding_session_module.load_provider_settings(tau_paths)
     assert saved.default_provider == "local"
     assert saved.get_provider("local").default_model == "llama"
-    assert created == [("local", "qwen"), ("local", "llama")]
+    assert created == [("local", "llama")]
+
+
+@pytest.mark.anyio
+async def test_session_set_model_choice_switches_provider_model_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_API_KEY", "local-key")
+    tau_paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5",),
+                default_model="gpt-5",
+            ),
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("qwen", "llama"),
+                default_model="qwen",
+            ),
+        ),
+        scoped_models=(
+            ScopedModelConfig(provider="openai", model="gpt-5"),
+            ScopedModelConfig(provider="local", model="llama"),
+        ),
+    )
+    created: list[tuple[str, str | None]] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+    ) -> SwitchableFakeProvider:
+        del credential_store, thinking_level
+        created.append((provider_config.name, model))  # type: ignore[attr-defined]
+        return SwitchableFakeProvider(provider_config)
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="gpt-5",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai",
+            provider_settings=settings,
+            runtime_provider_config=settings.get_provider("openai"),
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+    created.clear()
+
+    choice = session.cycle_scoped_model()
+
+    assert choice == ModelChoice(provider_name="local", model="llama")
+    assert session.provider_name == "local"
+    assert session.model == "llama"
+    assert created == [("local", "llama")]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- switch provider/model choices directly instead of constructing the provider default first
- keep scoped Ctrl+P model cycling to a single runtime provider refresh for cross-provider switches
- add regression coverage for direct scoped provider/model cycling

Fixes #263

## Tests
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy
- uv run pytest