### PR TITLE
fix(cli): surface bad `--model` as a clean error in TUI and print mode

### DIFF
--- a/dev-notes/architecture/cli-bad-model-error.md
+++ b/dev-notes/architecture/cli-bad-model-error.md
@@ -1,0 +1,86 @@
+# CLI: surface bad `--model` as a clean error (issue #265)
+
+## What changed
+
+`tau --model <bad-model>` no longer crashes with an `anyio`/`asyncio` traceback
+when the model is not declared by the selected provider. Two `except` handlers in
+`src/tau_coding/cli.py` were broadened from `RuntimeError` to
+`(RuntimeError, ValueError)`:
+
+- the **TUI** startup branch (`main()` → `anyio.run(run_openai_tui, …)`), and
+- the **print-mode** branch (`main()` → `anyio.run(run_openai_print_mode, …)`).
+
+`ProviderConfigError(ValueError)` is raised by `validate_provider_model()` deep
+inside the event loop (via `resolve_provider_selection()` →
+`_resolve_tui_startup_selection()` / `run_openai_print_mode`). Because the
+handlers only caught `RuntimeError`, the `ValueError` subclass escaped as an
+unhandled exception and printed a multi-frame traceback. Catching `ValueError`
+lets `typer.BadParameter` surface the existing, friendly message verbatim:
+
+> Invalid value: Model is not configured for provider local: llama. Available
+> models: qwen
+
+The `export` command in the same file already used the correct pattern
+(`except (RuntimeError, ValueError)`) and served as the reference.
+
+## Why it exists
+
+Reported in https://github.com/alejandro-ao/tau/issues/265. The provider catalog
+is intentionally provider-specific, so an unknown/typo'd model name is a common
+user error. The actionable message (which lists the valid models for the
+provider) already existed in `provider_config.validate_provider_model`; it just
+wasn't being surfaced cleanly through the CLI entry points.
+
+This keeps the validation logic in `provider_config.py` as the single source of
+truth for the message and restores parity across all `--model` entry points
+(TUI, print mode, and export).
+
+## How it maps to the design
+
+This is a pure CLI-layer fix. It does not touch:
+
+- the portable agent harness (`tau_agent`),
+- the provider/model streaming layer (`tau_ai`), or
+- the Textual TUI rendering.
+
+The validation itself already lives in `tau_coding.provider_config`; only the
+CLI's error boundary was wrong. This is consistent with the architecture
+principle that CLI error handling should consume errors from the lower layers
+rather than letting them leak as raw tracebacks.
+
+## How to test
+
+Regression tests (verified to fail before the fix and pass after):
+
+```bash
+uv run pytest tests/test_cli.py -k "bad_model" -v
+```
+
+- `test_tui_surfaces_bad_model_as_clean_error`
+- `test_print_mode_surfaces_bad_model_as_clean_error`
+
+Both monkeypatch `load_provider_settings` (in both the `cli` and `tui.app`
+namespaces, since each imports it) to return a provider whose only model is
+`qwen`, then invoke the CLI runner with `--model llama --provider local` (TUI)
+and with `-p hello` added (print mode). They assert `exit_code == 2` (Typer's
+`BadParameter` convention) and that the output panel contains
+`"Model is not configured for provider local: llama. Available models: qwen"`.
+
+Full suite:
+
+```bash
+uv run pytest -q
+uv run ruff check src/tau_coding/cli.py tests/test_cli.py
+uv run ruff format --check src/tau_coding/cli.py tests/test_cli.py
+```
+
+## Notes / follow-ups
+
+- The original issue draft incorrectly claimed the print-mode path already
+  handled `ValueError`; that `except (RuntimeError, ValueError)` snippet was
+  actually from the `export` command. Empirical reproduction confirmed
+  print-mode was *also* broken, so both paths were fixed together.
+- A larger follow-up (not in scope here): audit remaining `anyio.run(...)` call
+  sites and extract a shared error-handling helper so all entry points use one
+  handler and cannot drift apart again. Pre-loop validation (resolving the
+  provider/model before entering the event loop) is another optional polish.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -244,7 +244,7 @@ def main(
                 initial_prompt,
                 notice,
             )
-        except RuntimeError as exc:
+        except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
         raise typer.Exit()
 
@@ -258,7 +258,7 @@ def main(
 
     try:
         ok = anyio.run(run_openai_print_mode, prompt, model, cwd or Path.cwd(), output, provider)
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
     if not ok:
         raise typer.Exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,11 +48,14 @@ def _panel_text(value: str) -> str:
     """Strip ANSI escapes and Rich/Click panel borders, then collapse whitespace.
 
     Typer renders ``BadParameter`` errors inside a bordered panel whose box-drawing
-    characters and line-wrapping can split a single message across lines, so
-    contiguous-substring assertions need the borders and extra whitespace removed.
+    characters and line-wrapping can split a single message across lines. On CI
+    (no real TTY) Rich/Click also emit ANSI color codes around the wrapped border,
+    so the ANSI escapes must be removed *before* the border characters, otherwise
+    leftover escapes keep "Available" and "models: qwen" from being contiguous.
     """
+    no_ansi = _strip_ansi(value)
     borders = str.maketrans({ch: " " for ch in "│╭╮╰╯─"})
-    return _collapse_ws(value.translate(borders))
+    return _collapse_ws(no_ansi.translate(borders))
 
 
 def test_version_command() -> None:
@@ -640,6 +643,28 @@ def _constrained_provider_settings() -> ProviderSettings:
             ),
         ),
     )
+
+
+def test_panel_text_strips_ansi_and_borders() -> None:
+    """``_panel_text`` must strip ANSI escapes *and* panel borders before matching.
+
+    On CI (no real TTY) Rich/Click emit ANSI color codes around the wrapped panel
+    border, so ``Available`` and ``models: qwen`` get split by escape sequences.
+    This guards the helper used by the bad-model regression tests regardless of
+    the local CliRunner's rendering mode. See issue #265.
+    """
+    ci_style = (
+        "\x1b[33mUsage: \x1b[0mtau [OPTIONS] ...\n"
+        "\x1b[31m╭─\x1b[0m\x1b[31m Error \x1b[0m\x1b[31m─╮\x1b[0m\n"
+        "\x1b[31m│\x1b[0m Invalid value: Model is not configured for provider local: "
+        "llama. Available \x1b[31m│\x1b[0m\n"
+        "\x1b[31m│\x1b[0m models: qwen \x1b[31m│\x1b[0m\n"
+        "\x1b[31m╰╯\x1b[0m"
+    )
+    out = _panel_text(ci_style)
+    assert "Model is not configured for provider local: llama" in out
+    assert "Available models: qwen" in out
+    assert "\x1b" not in out
 
 
 def test_tui_surfaces_bad_model_as_clean_error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,22 @@ def _strip_ansi(value: str) -> str:
     return _ANSI_ESCAPE_RE.sub("", value)
 
 
+def _collapse_ws(value: str) -> str:
+    """Collapse all runs of whitespace to single spaces (Rich panel wrapping)."""
+    return re.sub(r"\s+", " ", value)
+
+
+def _panel_text(value: str) -> str:
+    """Strip ANSI escapes and Rich/Click panel borders, then collapse whitespace.
+
+    Typer renders ``BadParameter`` errors inside a bordered panel whose box-drawing
+    characters and line-wrapping can split a single message across lines, so
+    contiguous-substring assertions need the borders and extra whitespace removed.
+    """
+    borders = str.maketrans({ch: " " for ch in "│╭╮╰╯─"})
+    return _collapse_ws(value.translate(borders))
+
+
 def test_version_command() -> None:
     result = CliRunner().invoke(app, ["--version"])
 
@@ -608,6 +624,79 @@ def test_default_tui_rejects_resume_with_new_session(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "--resume and --new-session cannot be used together" in _strip_ansi(result.output)
+
+
+def _constrained_provider_settings() -> ProviderSettings:
+    """Settings with a single provider that only declares ``qwen``."""
+    return ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("qwen",),
+                default_model="qwen",
+            ),
+        ),
+    )
+
+
+def test_tui_surfaces_bad_model_as_clean_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: ``tau --model <bad>`` must exit with a clean error, not a traceback.
+
+    See https://github.com/alejandro-ao/tau/issues/265. The TUI startup path
+    previously only caught ``RuntimeError``, so a ``ProviderConfigError`` (a
+    ``ValueError`` subclass) raised while resolving the provider/model selection
+    escaped the ``anyio`` event loop as an unhandled traceback.
+    """
+    import tau_coding.tui.app as tui_app
+
+    settings = _constrained_provider_settings()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "load_provider_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda *args, **kwargs: settings)
+
+    result = CliRunner().invoke(app, ["--model", "llama", "--provider", "local"])
+
+    # A clean BadParameter exits 2 (Typer's convention) and includes the
+    # actionable message listing valid models for the provider.
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    out = _panel_text(result.output)
+    assert "Model is not configured for provider local: llama" in out
+    assert "Available models: qwen" in out
+
+
+def test_print_mode_surfaces_bad_model_as_clean_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The print-mode ``--model <bad>`` path must also surface a clean error.
+
+    Companion regression to the TUI path (issue #265): the print-mode handler
+    likewise only caught ``RuntimeError``, so it also dumped a
+    ``ProviderConfigError`` traceback instead of a friendly message.
+    """
+    import tau_coding.tui.app as tui_app
+
+    settings = _constrained_provider_settings()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "load_provider_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda *args, **kwargs: settings)
+
+    result = CliRunner().invoke(app, ["--model", "llama", "--provider", "local", "-p", "hello"])
+
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    out = _panel_text(result.output)
+    assert "Model is not configured for provider local: llama" in out
+    assert "Available models: qwen" in out
 
 
 def test_sessions_command_lists_indexed_sessions(


### PR DESCRIPTION
## Summary

`tau --model <bad-model>` crashed with a full `anyio`/`asyncio` traceback
instead of a clean, actionable error when the model is not declared by the
selected provider. This closes #265.

**Root cause:** `ProviderConfigError(ValueError)` is raised inside the event
loop by `validate_provider_model()`, but the `except RuntimeError` handlers in
two branches of `main()` (`src/tau_coding/cli.py`) only caught `RuntimeError`,
so the `ValueError` subclass escaped as an unhandled exception and dumped the
whole stack on the user.

The friendly message (*"Model is not configured for provider {name}: {model}.
Available models: {available}"*) already existed in
`provider_config.validate_provider_model` — it just wasn't being surfaced
cleanly through the CLI entry points.

## Scope (wider than the issue title implied)

Empirical reproduction while writing the fix revealed that **both** the TUI and
the print-mode entry points were broken, not just the TUI path reported in #265.
The issue's original draft incorrectly claimed print-mode already handled
`ValueError`; that snippet was actually from the `export` command. The issue
body has been updated with a correction note (see #265).

The `export` command in the same file already used the correct pattern and
serves as the reference.

## Changes

Broaden two `except RuntimeError` handlers in `src/tau_coding/cli.py` to
`except (RuntimeError, ValueError)`, matching the existing `export` handler:

- the **TUI** startup branch (`main()` → `anyio.run(run_openai_tui, …)`), and
- the **print-mode** branch (`main()` → `anyio.run(run_openai_print_mode, …)`).

Now both paths surface the existing message via `typer.BadParameter` (exit
code 2) instead of a traceback:

> Invalid value: Model is not configured for provider local: llama. Available
> models: qwen

This is a pure CLI-layer fix. It does not touch the portable agent harness
(`tau_agent`), the provider/model streaming layer (`tau_ai`), or the Textual
TUI rendering. The validation logic in `provider_config.py` remains the single
source of truth for the message.

## How to reproduce (before vs. after)

With a provider whose only model is `qwen`:

| Command | Before | After |
| --- | --- | --- |
| `tau --model llama --provider local` (TUI) | exit 1, unhandled `ProviderConfigError` traceback | exit 2, clean panel listing `Available models: qwen` |
| `tau --model llama --provider local -p hello` (print) | exit 1, unhandled `ProviderConfigError` traceback | exit 2, clean panel listing `Available models: qwen` |

## Tests

Added two regression tests in `tests/test_cli.py`, both verified to **fail
before** the fix (unhandled `ProviderConfigError`, exit 1) and **pass after**
(clean `BadParameter` panel, exit 2):

- `test_tui_surfaces_bad_model_as_clean_error`
- `test_print_mode_surfaces_bad_model_as_clean_error`

Both monkeypatch `load_provider_settings` in the `cli` and `tui.app`
namespaces to a constrained provider (`models=("qwen",)`) and assert
`exit_code == 2` plus the
`"Model is not configured for provider local: llama. Available models: qwen"`
panel text (ANSI + Rich border stripped for robust substring matching).

A small test helper `_panel_text` was added to strip ANSI escapes and Rich
panel box-drawing characters and collapse whitespace, since Typer renders
`BadParameter` errors inside a wrapped, bordered panel.

## Verification

```bash
uv run pytest -q                              # 641 passed
uv run pytest tests/test_cli.py -k bad_model  # 2 passed
uv run ruff check src/tau_coding/cli.py tests/test_cli.py   # All checks passed!
uv run ruff format --check src/tau_coding/cli.py tests/test_cli.py  # clean
```

## Tradeoff

Catching `ValueError` is slightly broader than `RuntimeError`. It is safe here
because `ProviderConfigError` is the only `ValueError` raised on these paths.
If a future change raises an unrelated `ValueError` deep in startup, it would
now be converted to `typer.BadParameter` rather than propagating. Mitigation:
the two regression tests cover both paths, and we could alternatively catch
`ProviderConfigError` directly (imported from `tau_coding.provider_config`)
for maximal conservatism. This PR uses `ValueError` to stay consistent with
the existing `export` handler.

## Notes / follow-ups (out of scope for this PR)

- Audit remaining `anyio.run(...)` call sites in `cli.py` for the same
  `RuntimeError`-only pattern so all entry points use consistent, friendly
  error handling.
- Extract a shared error-handling helper so all `--model` branches use one
  handler and cannot drift apart again.
- Optional: validate the `--model`/`--provider` combination *before* entering
  the event loop, so the error is reported synchronously with no `anyio`
  frames on the stack.
- Optional: suggest the closest valid model (fuzzy match, "Did you mean ...?")
  when `--model` doesn't match any configured model.

## Docs

Added `dev-notes/architecture/cli-bad-model-error.md` documenting what changed,
why, how it maps to the architecture, and how to test.

Closes #265.