### PR TITLE
fix: persist interrupted tool repairs on resume

### DIFF
--- a/dev-notes/architecture/phase-14-session-manager-resume.md
+++ b/dev-notes/architecture/phase-14-session-manager-resume.md
@@ -138,6 +138,31 @@ The first implementation prints tab-separated rows:
 The richer modal session picker now uses the same project-scoped session records
 as `/resume`.
 
+## Interrupted tool-call repair on resume
+
+Tau repairs cancelled tool calls by adding a synthetic tool result:
+
+```text
+Tool call interrupted by user
+```
+
+This keeps OpenAI-compatible transcripts valid, because those providers reject
+any history where an assistant tool call has no matching tool output. A subtle
+resume bug existed in older builds: the repair could be added to the in-memory
+`AgentHarness`, letting the live session continue, but not written back to the
+append-only JSONL file. After `/resume`, Tau rebuilt the branch from disk without
+that synthetic tool result, so the next provider request failed with errors like:
+
+```text
+No tool output found for function call call_...
+```
+
+`CodingSession.load()` now checks the active branch for unmatched assistant tool
+calls before returning a resumed session. If it finds one, it appends durable
+repair entries and advances the leaf to the repaired branch. This also covers
+historical corrupted sessions where a user message was already appended after the
+dangling tool call.
+
 ## Tests
 
 The phase is covered by:

--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -250,50 +250,43 @@ class AgentHarness:
             return messages
         return (queue.popleft(),)
 
+    def append_interrupted_tool_results(self) -> int:
+        """Repair a transcript left mid-tool-call by an interrupted run.
+
+        Returns the number of synthetic tool results that were appended.
+        """
+        before_count = len(self._messages)
+        self._append_interrupted_tool_results()
+        return len(self._messages) - before_count
+
     def _append_interrupted_tool_results(self) -> None:
         """Repair a transcript left mid-tool-call by an interrupted run.
 
         OpenAI-compatible providers reject a transcript where an assistant tool
-        call is not followed by a matching tool result. If the UI cancels the
-        worker while a tool is still running, the normal loop may not get a
-        chance to append the cancellation result, so repair that gap before the
-        next model request.
+        call has no matching tool result anywhere in the submitted history. If
+        the UI cancels the worker while a tool is still running, the normal loop
+        may not get a chance to append the cancellation result, so repair that
+        gap before the next model request.
         """
-        assistant_index = _latest_open_tool_call_assistant_index(self._messages)
-        if assistant_index is None:
-            return
-
-        assistant = self._messages[assistant_index]
-        if not isinstance(assistant, AssistantMessage):
-            return
-
         returned_ids = {
             message.tool_call_id
-            for message in self._messages[assistant_index + 1 :]
+            for message in self._messages
             if isinstance(message, ToolResultMessage)
         }
-        for tool_call in assistant.tool_calls:
-            if tool_call.id in returned_ids:
+        for message in tuple(self._messages):
+            if not isinstance(message, AssistantMessage):
                 continue
-            message = "Tool call interrupted by user"
-            self._messages.append(
-                ToolResultMessage(
-                    tool_call_id=tool_call.id,
-                    name=tool_call.name,
-                    content=message,
-                    ok=False,
-                    error=message,
+            for tool_call in message.tool_calls:
+                if tool_call.id in returned_ids:
+                    continue
+                returned_ids.add(tool_call.id)
+                content = "Tool call interrupted by user"
+                self._messages.append(
+                    ToolResultMessage(
+                        tool_call_id=tool_call.id,
+                        name=tool_call.name,
+                        content=content,
+                        ok=False,
+                        error=content,
+                    )
                 )
-            )
-
-
-def _latest_open_tool_call_assistant_index(messages: Sequence[AgentMessage]) -> int | None:
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if isinstance(message, UserMessage):
-            return None
-        if isinstance(message, AssistantMessage):
-            if message.tool_calls:
-                return index
-            return None
-    return None

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -17,7 +17,7 @@ from tau_agent import (
     QueueUpdateEvent,
     ToolExecutionEndEvent,
 )
-from tau_agent.messages import AgentMessage, AssistantMessage, UserMessage
+from tau_agent.messages import AgentMessage, AssistantMessage, ToolResultMessage, UserMessage
 from tau_agent.session import (
     BranchSummaryEntry,
     CompactionEntry,
@@ -317,6 +317,7 @@ class CodingSession:
             command_registry=config.command_registry,
             pending_initial_entries=pending_initial_entries,
         )
+        await session._persist_loaded_interrupted_tool_repairs()
         session._sync_thinking_level_to_active_model()
         session._refresh_runtime_provider()
         return session
@@ -1290,6 +1291,43 @@ class CodingSession:
             run_id=new_agent_call_run_id(),
         )
 
+    async def _persist_loaded_interrupted_tool_repairs(self) -> None:
+        """Persist repairs for loaded sessions with dangling tool calls.
+
+        Older Tau builds repaired interrupted tool-call transcripts only in the
+        in-memory harness. If the app was later resumed from JSONL, the synthetic
+        tool result was absent and providers rejected the whole transcript. Repair
+        the active branch on load so resume/tree branches are durable and
+        provider-safe.
+        """
+        repair = _interrupted_tool_repair_plan(
+            self._state.messages,
+            context_entry_ids=self._state.context_entry_ids,
+        )
+        if repair is None:
+            return
+
+        parent_id, suffix = repair
+        for message in suffix:
+            entry = MessageEntry(parent_id=parent_id, message=message)
+            await self._append_session_entry(entry)
+            parent_id = entry.id
+        leaf = LeafEntry(parent_id=parent_id, entry_id=parent_id)
+        await self._append_session_entry(leaf)
+        self._last_parent_id = parent_id
+        await self._refresh_persisted_state(leaf_id=parent_id)
+        self._harness = AgentHarness(
+            AgentHarnessConfig(
+                provider=self._harness.config.provider,
+                model=self._harness.config.model,
+                system=self._harness.config.system,
+                tools=self._harness.config.tools,
+                max_turns=self._harness.config.max_turns,
+                queue_mode=self._harness.config.queue_mode,
+            ),
+            messages=self._state.messages,
+        )
+
     async def _persist_messages_since(self, persisted_count: int) -> int:
         """Persist completed harness messages after ``persisted_count``.
 
@@ -1986,6 +2024,47 @@ def _merge_context_files(
         seen.add(context_file.path)
         merged.append(context_file)
     return tuple(merged)
+
+
+def _interrupted_tool_repair_plan(
+    messages: tuple[AgentMessage, ...],
+    *,
+    context_entry_ids: tuple[str, ...],
+) -> tuple[str, tuple[AgentMessage, ...]] | None:
+    repaired: list[AgentMessage] = []
+    returned_ids = {
+        message.tool_call_id for message in messages if isinstance(message, ToolResultMessage)
+    }
+    for message in messages:
+        repaired.append(message)
+        if not isinstance(message, AssistantMessage):
+            continue
+        for tool_call in message.tool_calls:
+            if tool_call.id in returned_ids:
+                continue
+            returned_ids.add(tool_call.id)
+            content = "Tool call interrupted by user"
+            repaired.append(
+                ToolResultMessage(
+                    tool_call_id=tool_call.id,
+                    name=tool_call.name,
+                    content=content,
+                    ok=False,
+                    error=content,
+                )
+            )
+
+    if tuple(repaired) == messages:
+        return None
+
+    common_prefix_length = 0
+    for old_message, repaired_message in zip(messages, repaired, strict=False):
+        if old_message != repaired_message:
+            break
+        common_prefix_length += 1
+    if common_prefix_length == 0:
+        return None
+    return context_entry_ids[common_prefix_length - 1], tuple(repaired[common_prefix_length:])
 
 
 def default_session_path(cwd: Path) -> Path:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -281,7 +281,7 @@ async def test_prompt_logs_error_event_diagnostic_data(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_prompt_repairs_loaded_session_with_interrupted_tool_call(
+async def test_load_persists_repair_for_session_with_interrupted_tail_tool_call(
     tmp_path: Path,
 ) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
@@ -313,7 +313,59 @@ async def test_prompt_repairs_loaded_session_with_interrupted_tool_call(
         )
     )
 
-    await _collect_session_events(session.prompt("What happened?"))
+    expected_repair = ToolResultMessage(
+        tool_call_id="call-1",
+        name="read",
+        content="Tool call interrupted by user",
+        ok=False,
+        error="Tool call interrupted by user",
+    )
+    assert provider.calls == []
+    assert session.messages == (
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        expected_repair,
+    )
+
+    entries = await storage.read_all()
+    message_entries = [entry for entry in entries if entry.type == "message"]
+    assert [entry.message for entry in message_entries] == [
+        UserMessage(content="Read README.md"),
+        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+        expected_repair,
+    ]
+
+
+@pytest.mark.anyio
+async def test_load_persists_repair_for_historical_interrupted_tool_call(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user_entry = MessageEntry(message=UserMessage(content="Read README.md"))
+    await storage.append(user_entry)
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    assistant_entry = MessageEntry(
+        parent_id=user_entry.id,
+        message=AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+    )
+    await storage.append(assistant_entry)
+    continued_entry = MessageEntry(
+        parent_id=assistant_entry.id,
+        message=UserMessage(content="continue"),
+    )
+    await storage.append(continued_entry)
+    await storage.append(LeafEntry(parent_id=continued_entry.id, entry_id=continued_entry.id))
+
+    provider = FakeProvider([])
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
 
     expected_repair = ToolResultMessage(
         tool_call_id="call-1",
@@ -322,22 +374,31 @@ async def test_prompt_repairs_loaded_session_with_interrupted_tool_call(
         ok=False,
         error="Tool call interrupted by user",
     )
-    assert provider.calls[0][2] == [
+    assert provider.calls == []
+    assert session.messages == (
         UserMessage(content="Read README.md"),
         AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
         expected_repair,
-        UserMessage(content="What happened?"),
-    ]
+        UserMessage(content="continue"),
+    )
 
     entries = await storage.read_all()
     message_entries = [entry for entry in entries if entry.type == "message"]
-    assert [entry.message for entry in message_entries] == [
-        UserMessage(content="Read README.md"),
-        AssistantMessage(content="I'll read it.", tool_calls=[tool_call]),
+    assert [entry.message for entry in message_entries[-2:]] == [
         expected_repair,
-        UserMessage(content="What happened?"),
-        AssistantMessage(content="Recovered."),
+        UserMessage(content="continue"),
     ]
+
+    restored = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+    assert restored.messages == session.messages
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes resumed sessions that contain an assistant tool call without a matching tool result.

Older cancellation repair could add `Tool call interrupted by user` to the in-memory harness, allowing the live session to continue, but the synthetic tool result was not always persisted to the JSONL session file. After `/resume`, Tau rebuilt the active branch from disk without that repair, and OpenAI-compatible providers rejected the next request with:

```text
No tool output found for function call call_...
```

## Changes

- Repair unmatched tool calls during `CodingSession.load()` before a resumed session is used.
- Persist the repaired branch and advance the leaf so future resumes stay valid.
- Handle both tail corruption and historical corruption where a user message was already appended after the dangling tool call.
- Update session architecture notes with the root cause and durable repair behavior.

## Tests

```bash
uv run pytest
```

Result: `641 passed`.
