### PR TITLE
Copy selected text in /session modal

### DIFF
--- a/dev-notes/tui-session-modal-selection-copy.md
+++ b/dev-notes/tui-session-modal-selection-copy.md
@@ -1,0 +1,35 @@
+# TUI /session modal selection copy
+
+## What changed
+
+The `/session` command output modal now opts into automatic copy-on-select behavior. Users can select text in the session details modal and Tau copies the selected text to the clipboard, even when the global transcript `auto_copy_selection` setting is disabled.
+
+## Why it exists
+
+The session modal contains IDs, paths, provider/model details, resource diagnostics, and context accounting that are often useful when documenting production work or starting a follow-up PR. Copy-on-select makes that information easy to reuse without adding another command or exporting the whole session.
+
+## Architecture notes
+
+The change stays in the Textual TUI layer:
+
+- `CommandOutputScreen` exposes a modal-local `auto_copy_selection` flag.
+- `TauTuiApp._show_command_message()` enables that flag only for `/session` output.
+- `TauTuiApp.on_text_selected()` now checks either the global TUI setting or the active screen's modal-local flag before copying.
+
+No clipboard or Textual dependencies were added to `tau_agent`.
+
+## How to test
+
+Automated checks:
+
+```bash
+uv run pytest tests/test_tui_app.py -k "session_modal_auto_copies_selected_text or non_session_modal_uses_global_auto_copy_setting or command_modal"
+uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py
+```
+
+Manual check:
+
+1. Run `uv run tau`.
+2. Open `/session`.
+3. Select text inside the modal.
+4. Paste into another application or terminal prompt and confirm the selected text was copied.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -716,6 +716,8 @@ class CommandOutputScroll(VerticalScroll):
 class CommandOutputScreen(ModalScreen[None]):
     """Dismissible modal for slash-command output."""
 
+    auto_copy_selection: bool = False
+
     BINDINGS: ClassVar[list[BindingEntry]] = [
         Binding("escape", "close", "Close"),
         Binding("enter", "close", "Close"),
@@ -723,11 +725,19 @@ class CommandOutputScreen(ModalScreen[None]):
         Binding("down", "scroll_down", "Scroll down", show=False, priority=True),
     ]
 
-    def __init__(self, title: str, message: str, *, theme: TuiTheme) -> None:
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        *,
+        theme: TuiTheme,
+        auto_copy_selection: bool = False,
+    ) -> None:
         super().__init__()
         self.title_text = title
         self.message = message
         self.theme = theme
+        self.auto_copy_selection = auto_copy_selection
 
     def compose(self) -> ComposeResult:
         """Compose command output."""
@@ -735,7 +745,7 @@ class CommandOutputScreen(ModalScreen[None]):
             yield Static(self.title_text, id="command-output-title")
             with CommandOutputScroll(id="command-output-scroll"):
                 yield Static(self.message, id="command-output-body", markup=False)
-            yield Static("Enter or Escape closes", id="command-output-help")
+            yield Static(self._help_text(), id="command-output-help")
 
     def on_mount(self) -> None:
         """Focus the scroll area so arrow keys navigate long output."""
@@ -753,6 +763,11 @@ class CommandOutputScreen(ModalScreen[None]):
     def action_close(self) -> None:
         """Close the command output modal."""
         self.dismiss(None)
+
+    def _help_text(self) -> str:
+        if self.auto_copy_selection:
+            return "Select text to copy - Enter or Escape closes"
+        return "Enter or Escape closes"
 
     def action_scroll_up(self) -> None:
         """Scroll command output up."""
@@ -1895,10 +1910,14 @@ class TauTuiApp(App[None]):
 
     @on(events.TextSelected)
     async def on_text_selected(self) -> None:
-        """Optionally copy selected transcript text automatically."""
-        if not self.tui_settings.auto_copy_selection:
+        """Optionally copy selected text automatically."""
+        active_screen = self.screen
+        if not (
+            self.tui_settings.auto_copy_selection
+            or getattr(active_screen, "auto_copy_selection", False)
+        ):
             return
-        selection = self.screen.get_selected_text()
+        selection = active_screen.get_selected_text()
         if selection:
             self.copy_to_clipboard(selection)
             self._notify("Copied selection to clipboard.")
@@ -2590,6 +2609,7 @@ class TauTuiApp(App[None]):
                 _command_output_title(command_text),
                 message,
                 theme=self.tui_settings.resolved_theme,
+                auto_copy_selection=_is_session_command(command_text),
             )
         )
 
@@ -3448,6 +3468,11 @@ def _command_message_uses_notification(command_text: str, message: str) -> bool:
 def _command_output_title(command_text: str) -> str:
     command_name = command_text.split(maxsplit=1)[0].removeprefix("/")
     return f"/{command_name or 'help'}"
+
+
+def _is_session_command(command_text: str) -> bool:
+    """Return whether command output is the /session details modal."""
+    return command_text.split(maxsplit=1)[0].casefold() == "/session"
 
 
 def _is_thinking_cycle_key(key: str, configured_key: str) -> bool:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3326,6 +3326,48 @@ async def test_tui_app_command_modal_uses_centered_picker_style() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_session_modal_auto_copies_selected_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(auto_copy_selection=False))
+    copied: list[str] = []
+    monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+    async with app.run_test() as pilot:
+        app._show_command_message("/session", "Session info")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CommandOutputScreen)
+        body = app.screen.query_one("#command-output-body")
+        app.screen.selections = {body: SELECT_ALL}
+
+        await app.on_text_selected()
+
+    assert copied == ["Session info"]
+
+
+@pytest.mark.anyio
+async def test_tui_app_non_session_modal_uses_global_auto_copy_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(auto_copy_selection=False))
+    copied: list[str] = []
+    monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+    async with app.run_test() as pilot:
+        app._show_command_message("/hotkeys", "Shortcut info")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CommandOutputScreen)
+        body = app.screen.query_one("#command-output-body")
+        app.screen.selections = {body: SELECT_ALL}
+
+        await app.on_text_selected()
+
+    assert copied == []
+
+
+@pytest.mark.anyio
 async def test_tui_app_escape_cancels_running_session_from_prompt() -> None:
     class RunningSession(FakeSession):
         @property

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -34,7 +34,7 @@ While the agent is working you don't have to wait:
 In-session commands start with `/`. Open the **command palette** with **Ctrl+K**
 to search and run them. Common ones:
 
-- `/session` — show model, tools, skills, and context usage for the session
+- `/session` — show model, tools, skills, and context usage for the session. Text selected in this modal is copied to the clipboard automatically.
 - `/model` — pick the active model
 - `/compact` — summarize and shrink the context
 - `/resume`, `/tree` — open previous sessions or branch from history


### PR DESCRIPTION
## Summary

- Enables copy-on-select for the `/session` command modal, even when global transcript auto-copy is disabled.
- Keeps the behavior scoped to the TUI command output modal for `/session`.
- Adds tests, a dev note, and user-facing TUI guide documentation.

Fixes #268.

## Testing

- `uv run pytest tests/test_tui_app.py -k "session_modal_auto_copies_selected_text or non_session_modal_uses_global_auto_copy_setting or command_modal"`
- `uv run pytest tests/test_tui_app.py`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
