### PR TITLE
Add Pi API provider catalog

### DIFF
--- a/dev-notes/architecture/provider-catalog-live-validation.md
+++ b/dev-notes/architecture/provider-catalog-live-validation.md
@@ -1,36 +1,276 @@
-# Provider catalog live validation
+# Provider catalog live-validation runbook
 
-This note records the live validation pass for the Pi-derived API provider catalog.
+This runbook explains how we validated the Pi-derived API provider catalog and how to
+repeat the process when adding or changing providers/models.
 
-## What was validated
+The goal is not to benchmark answer quality. The goal is to prove that every model and
+every thinking/reasoning level shown by Tau can be accepted by the provider API with the
+payload Tau sends.
 
-A temporary local script under `~/.tau/provider-validation/` enumerated the effective
-provider/model/thinking-level matrix, made one minimal request for each entry, and wrote
-resumable JSONL results. The script was later switched to `--builtins-only` mode so the
-packaged PR catalog could be verified independently from `~/.tau/catalog.toml` overlays.
+## When to use this runbook
 
-The validation prompt was intentionally tiny:
+Run live validation when:
+
+- importing or regenerating provider catalog metadata
+- adding a provider runtime adapter
+- changing reasoning/thinking payloads
+- changing model lists or default models
+- seeing provider errors such as deprecated model IDs or unsupported reasoning levels
+
+Do **not** run it casually against large catalogs. Even tiny prompts can consume credits
+when repeated across hundreds of models and reasoning levels.
+
+## What counts as validated
+
+For this pass we used a tiny prompt:
 
 ```text
 Reply with exactly: OK
 ```
 
-A request counted as accepted once the provider returned `response_start`; this keeps the
-validation cheap while still exercising model IDs and reasoning/thinking payloads.
+A request counted as valid once Tau received a provider `response_start` event. That means:
 
-## Fixes from validation
+1. Tau built the runtime provider successfully.
+2. Credentials were accepted well enough to make the request.
+3. The provider accepted the model ID.
+4. The provider accepted the reasoning/thinking payload for that level.
+5. The endpoint started a streaming response.
 
-- Google Generative AI rejected Tau's first payload because `systemInstruction` was inside
-  `generationConfig`. It now lives at the top level of the request payload.
-- OpenRouter needed catalog-driven provider routing for one model. Tau now passes
-  `compat.openrouterProvider` through as OpenRouter's `provider` request option.
-- The built-in catalog was pruned for stale/deprecated/unroutable model IDs discovered
-  during live validation.
-- Per-model `unsupported_thinking_levels` were added where providers accepted a model but
-  rejected one or more displayed reasoning levels.
-- Anthropic adaptive-thinking metadata was tightened for current adaptive models.
+This intentionally stops early. Waiting for full text output validates more of the stream,
+but costs more tokens. Use full-response validation only for a small sample or when testing
+stream parsing behavior.
 
-## Final packaged-catalog result
+## Validation matrix
+
+The matrix is:
+
+```text
+credentialed providers
+  × provider.models
+  × provider_thinking_levels(provider, model)
+```
+
+For non-reasoning models, validate one request with no thinking level.
+
+Tau has two useful catalog scopes:
+
+- **Effective catalog**: built-in catalog plus `~/.tau/catalog.toml` user overlays. This
+  matches what the UI shows on a specific machine.
+- **Packaged catalog**: built-in catalog only. Use this for PR verification so local user
+  overlays do not mask or reintroduce stale models.
+
+In this pass, we first validated the effective catalog to catch what the UI showed locally,
+then reran summaries and retries with `--builtins-only` to verify the PR catalog itself.
+
+## Local validation helper
+
+We used a temporary helper script at:
+
+```text
+~/.tau/provider-validation/validate_provider_catalog.py
+```
+
+The script is intentionally resumable. Each attempt appends one JSON object to:
+
+```text
+~/.tau/provider-validation/pi-api-provider-catalog/results.jsonl
+```
+
+The key fields are:
+
+| Field | Meaning |
+|---|---|
+| `provider` | Tau provider name |
+| `model` | Model ID sent to the provider |
+| `thinking_level` | Tau thinking level, or `null` for non-reasoning validation |
+| `status` | `ok` or `error` |
+| `message` | Provider/runtime error message for failed attempts |
+| `data.status_code` | HTTP status when available |
+| `data.body` | Truncated provider error body when available |
+
+The script supports three operations:
+
+```bash
+# Show credentialed providers, missing credentials, and total attempt counts.
+uv run python ~/.tau/provider-validation/validate_provider_catalog.py plan
+
+# Run live validation.
+uv run python ~/.tau/provider-validation/validate_provider_catalog.py run \
+  --builtins-only \
+  --concurrency 4 \
+  --provider-concurrency 2 \
+  --timeout-seconds 30 \
+  --max-retries 0
+
+# Summarize recorded results.
+uv run python ~/.tau/provider-validation/validate_provider_catalog.py summarize \
+  --builtins-only \
+  --top-errors 12
+```
+
+Important flags:
+
+| Flag | Use |
+|---|---|
+| `--builtins-only` | Ignore `~/.tau/catalog.toml`; validate the packaged PR catalog only. |
+| `--provider NAME` | Limit the run to one provider; repeatable. |
+| `--limit N` | Run only the next N pending attempts. Useful for sampling. |
+| `--retry-errors` | Retry attempts that already have error rows. Use after fixes. |
+| `--concurrency N` | Global maximum concurrent calls. |
+| `--provider-concurrency N` | Maximum concurrent calls per provider. |
+| `--wait-for response_start` | Cheapest success condition; validates request acceptance. |
+| `--wait-for text` | More expensive; validates that text actually streams. |
+
+The script skips attempts that already have a result unless `--retry-errors` is set.
+
+## Safe concurrency defaults
+
+Start conservative:
+
+```bash
+--concurrency 4 --provider-concurrency 2 --max-retries 0
+```
+
+For expensive providers or accounts with low limits, use:
+
+```bash
+--concurrency 1 --provider-concurrency 1
+```
+
+For OpenRouter, we used low per-provider concurrency because the catalog is large and many
+routes are free/shared upstreams:
+
+```bash
+uv run python ~/.tau/provider-validation/validate_provider_catalog.py run \
+  --builtins-only \
+  --provider openrouter \
+  --concurrency 2 \
+  --provider-concurrency 1 \
+  --timeout-seconds 35 \
+  --max-retries 0
+```
+
+Avoid automatic retries during the first pass. Retries can hide deterministic payload/model
+failures and consume extra credits. Retry only after classifying errors.
+
+## Failure classification
+
+Classify errors before fixing anything.
+
+### Fix immediately if recurring provider-wide
+
+If every model for a provider fails with the same payload/schema error, pause validation,
+fix the adapter, then rerun that provider with `--retry-errors`.
+
+Example from this pass:
+
+- Google rejected every model because `systemInstruction` was nested under
+  `generationConfig`.
+- Fix: move `systemInstruction` to the top-level Google request payload.
+- Rerun: Google models then passed except for real model/level issues.
+
+### Fix in catalog/runtime
+
+These are real Tau catalog/runtime issues:
+
+| Error pattern | Typical fix |
+|---|---|
+| `model ... does not exist`, `No endpoints found`, `deprecated` | Remove the model from the packaged catalog. |
+| `not a chat model`, requires audio/tools/search/file/MCP | Remove from coding-chat API catalog for now. |
+| `Unsupported value: 'minimal'`, expected `low/medium/high` | Add per-model `unsupported_thinking_levels`. |
+| Provider expects a different reasoning value | Add `thinking_level_map`. |
+| Provider needs special routing/header/compat option | Add provider/model `compat` metadata and runtime support. |
+| Provider-wide invalid JSON/payload | Fix the adapter and add a regression test. |
+
+### Document, do not globally fix
+
+These are account/runtime conditions, not necessarily catalog truth:
+
+| Error pattern | Treatment |
+|---|---|
+| `401`, `403`, missing credential | Report as not validated or account-specific. |
+| `402 Insufficient Balance` | Report as credentialed but not validated due balance. |
+| Account entitlement errors | Report separately; do not remove globally unless provider docs confirm. |
+| `429` rate limit | Retry later or report as rate-limited. Do not remove by default. |
+| `500`, `502`, `503` transient/high demand | Retry once; if persistent, report as transient/upstream. |
+
+Example from this pass:
+
+- DeepSeek returned `402 Insufficient Balance`; we did not remove DeepSeek models.
+- OpenAI Codex rejected some models for the logged-in ChatGPT account; we did not remove
+  them globally because entitlement can vary.
+- OpenRouter free/shared routes returned `429`; we left them in the catalog and reported
+  them as upstream rate limits.
+
+## Fix/rerun loop
+
+Use this loop until all fixable errors are gone:
+
+1. Run a plan or dry run.
+2. Run a small batch for new providers.
+3. If failures are provider-wide, fix the adapter first.
+4. Run the full provider/catalog pass.
+5. Summarize errors.
+6. Apply catalog/runtime fixes.
+7. Rerun only failures:
+
+   ```bash
+   uv run python ~/.tau/provider-validation/validate_provider_catalog.py run \
+     --builtins-only \
+     --provider PROVIDER_NAME \
+     --retry-errors \
+     --concurrency 2 \
+     --provider-concurrency 1
+   ```
+
+8. Summarize again.
+9. Repeat until remaining errors are only documented account/balance/rate-limit cases.
+
+## Updating Tau after validation
+
+Common code/catalog changes:
+
+- Remove stale model IDs from `src/tau_coding/data/catalog.toml`.
+- Set validated defaults for providers whose previous default was removed.
+- Add `unsupported_thinking_levels` under `providers.model_metadata.<model>`.
+- Add `thinking_level_map` for provider-specific value mapping.
+- Add model `compat` fields for adapter-specific behavior.
+- Add adapter regression tests for any provider-wide payload fixes.
+- Update stale tests that hardcoded old defaults or provider lists.
+
+For this validation pass, notable fixes were:
+
+- Google Generative AI: `systemInstruction` now lives at request top level.
+- OpenRouter: Tau passes `compat.openrouterProvider` as OpenRouter's `provider` routing
+  option.
+- Catalog: stale/deprecated/unroutable model IDs were pruned.
+- Catalog: unsupported reasoning levels were hidden per model.
+- Anthropic: adaptive-thinking metadata was tightened for current adaptive models.
+
+## Final report format
+
+End every validation pass with a concise report containing:
+
+1. Catalog scope: effective or packaged/built-in.
+2. Prompt and success condition.
+3. Total expected attempts, recorded attempts, pending attempts.
+4. Per-provider OK/error counts.
+5. Remaining failures grouped by reason.
+6. Providers not validated because credentials were missing.
+7. Code/catalog fixes made.
+8. Final project validation commands and results.
+
+Store detailed local artifacts outside the repo:
+
+```text
+~/.tau/provider-validation/<validation-name>/results.jsonl
+~/.tau/provider-validation/<validation-name>/validation-summary.md
+```
+
+Do not commit raw JSONL logs. They should not contain secrets, but they can include account
+IDs, provider-specific metadata, rate-limit details, and paid-account availability clues.
+
+## Result from the Pi API provider pass
 
 After fixes, the packaged catalog had 1,193 expected validation attempts for credentialed
 providers. All fixable model/reasoning mismatches were cleared.
@@ -45,15 +285,13 @@ Remaining failures were not global catalog/runtime bugs:
 Providers without credentials were not live-validated in this pass: Cerebras, Fireworks,
 Mistral, Moonshot, Together, Vercel AI Gateway, xAI, Xiaomi, Z.ai, and regional variants.
 
-## Verification
+Final local project validation:
 
 ```bash
 uv run pytest -q
 uv run ruff check .
 uv run mypy
 ```
-
-Final local result:
 
 ```text
 677 passed

--- a/dev-notes/architecture/provider-catalog-live-validation.md
+++ b/dev-notes/architecture/provider-catalog-live-validation.md
@@ -1,0 +1,62 @@
+# Provider catalog live validation
+
+This note records the live validation pass for the Pi-derived API provider catalog.
+
+## What was validated
+
+A temporary local script under `~/.tau/provider-validation/` enumerated the effective
+provider/model/thinking-level matrix, made one minimal request for each entry, and wrote
+resumable JSONL results. The script was later switched to `--builtins-only` mode so the
+packaged PR catalog could be verified independently from `~/.tau/catalog.toml` overlays.
+
+The validation prompt was intentionally tiny:
+
+```text
+Reply with exactly: OK
+```
+
+A request counted as accepted once the provider returned `response_start`; this keeps the
+validation cheap while still exercising model IDs and reasoning/thinking payloads.
+
+## Fixes from validation
+
+- Google Generative AI rejected Tau's first payload because `systemInstruction` was inside
+  `generationConfig`. It now lives at the top level of the request payload.
+- OpenRouter needed catalog-driven provider routing for one model. Tau now passes
+  `compat.openrouterProvider` through as OpenRouter's `provider` request option.
+- The built-in catalog was pruned for stale/deprecated/unroutable model IDs discovered
+  during live validation.
+- Per-model `unsupported_thinking_levels` were added where providers accepted a model but
+  rejected one or more displayed reasoning levels.
+- Anthropic adaptive-thinking metadata was tightened for current adaptive models.
+
+## Final packaged-catalog result
+
+After fixes, the packaged catalog had 1,193 expected validation attempts for credentialed
+providers. All fixable model/reasoning mismatches were cleared.
+
+Remaining failures were not global catalog/runtime bugs:
+
+- DeepSeek returned `402 Insufficient Balance` for the available API key.
+- OpenAI Codex returned account-entitlement errors for `gpt-5.3-codex` and `gpt-5.2` with
+  the logged-in ChatGPT account, while other Codex models worked.
+- Several OpenRouter free/shared upstream routes returned `429` rate limits.
+
+Providers without credentials were not live-validated in this pass: Cerebras, Fireworks,
+Mistral, Moonshot, Together, Vercel AI Gateway, xAI, Xiaomi, Z.ai, and regional variants.
+
+## Verification
+
+```bash
+uv run pytest -q
+uv run ruff check .
+uv run mypy
+```
+
+Final local result:
+
+```text
+677 passed
+All checks passed!
+Success: no issues found in 64 source files
+```

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -23,6 +23,8 @@ from tau_ai.events import (
     ProviderToolCallEvent,
 )
 from tau_ai.fake import FakeProvider
+from tau_ai.google import GoogleGenerativeAIProvider
+from tau_ai.mistral import MistralConversationsProvider
 from tau_ai.openai_codex import (
     DEFAULT_OPENAI_CODEX_BASE_URL,
     OpenAICodexConfig,
@@ -42,6 +44,8 @@ __all__ = [
     "DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS",
     "DEFAULT_OPENAI_CODEX_BASE_URL",
     "FakeProvider",
+    "GoogleGenerativeAIProvider",
+    "MistralConversationsProvider",
     "ModelProvider",
     "OpenAICodexConfig",
     "OpenAICodexCredentials",

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -66,7 +66,10 @@ class AnthropicProvider:
                 system=system,
                 messages=messages,
                 tools=tools,
+                max_tokens=self._config.max_tokens,
                 thinking_budget_tokens=self._config.thinking_budget_tokens,
+                thinking_effort=self._config.thinking_effort,
+                thinking_mode=self._config.thinking_mode,
             )
             headers = {
                 **(dict(self._config.headers or {})),
@@ -266,19 +269,25 @@ def _build_messages_payload(
     system: str,
     messages: list[AgentMessage],
     tools: list[AgentTool],
+    max_tokens: int | None = None,
     thinking_budget_tokens: int | None = None,
+    thinking_effort: str | None = None,
+    thinking_mode: str = "budget",
 ) -> dict[str, JSONValue]:
-    max_tokens = DEFAULT_MAX_TOKENS
+    resolved_max_tokens = max_tokens or DEFAULT_MAX_TOKENS
     if thinking_budget_tokens is not None:
-        max_tokens = max(max_tokens, thinking_budget_tokens + 1024)
+        resolved_max_tokens = max(resolved_max_tokens, thinking_budget_tokens + 1024)
     payload: dict[str, JSONValue] = {
         "model": model,
-        "max_tokens": max_tokens,
+        "max_tokens": resolved_max_tokens,
         "stream": True,
         "system": system,
         "messages": [_anthropic_message(message) for message in messages],
     }
-    if thinking_budget_tokens is not None:
+    if thinking_mode == "adaptive" and thinking_effort is not None:
+        payload["thinking"] = {"type": "adaptive", "display": "summarized"}
+        payload["output_config"] = {"effort": thinking_effort}
+    elif thinking_budget_tokens is not None:
         payload["thinking"] = {
             "type": "enabled",
             "budget_tokens": thinking_budget_tokens,

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from os import environ
+
+from tau_agent.types import JSONValue
 
 DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
@@ -23,8 +25,13 @@ class OpenAICompatibleConfig:
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
+    api: str = "openai-completions"
+    max_tokens: int | None = None
     reasoning_effort: str | None = None
     reasoning_effort_parameter: str = "reasoning_effort"
+    thinking_format: str = "openai"
+    compat: Mapping[str, JSONValue] = field(default_factory=dict)
+    include_reasoning_effort_none: bool = False
     provider_name: str = "OpenAI-compatible provider"
 
 
@@ -38,7 +45,10 @@ class AnthropicConfig:
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
+    max_tokens: int | None = None
     thinking_budget_tokens: int | None = None
+    thinking_effort: str | None = None
+    thinking_mode: str = "budget"
     provider_name: str = "Anthropic"
 
 

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -1,0 +1,378 @@
+"""Google Generative AI provider."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from json import JSONDecodeError, loads
+
+import httpx
+
+from tau_agent.messages import AgentMessage, AssistantMessage, UserMessage
+from tau_agent.tools import AgentTool, ToolCall
+from tau_agent.types import JSONValue
+from tau_ai.env import OpenAICompatibleConfig
+from tau_ai.events import (
+    ProviderErrorEvent,
+    ProviderEvent,
+    ProviderResponseEndEvent,
+    ProviderResponseStartEvent,
+    ProviderTextDeltaEvent,
+    ProviderThinkingDeltaEvent,
+    ProviderToolCallEvent,
+)
+from tau_ai.http_errors import provider_http_error_message
+from tau_ai.provider import CancellationToken
+from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
+
+
+class GoogleGenerativeAIProvider:
+    """Provider adapter for Google's Generative Language streaming API."""
+
+    def __init__(
+        self,
+        config: OpenAICompatibleConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this provider created it."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Stream one Gemini response as provider-neutral events."""
+
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            client = self._get_client()
+            payload = _build_google_payload(
+                model=model,
+                system=system,
+                messages=messages,
+                tools=tools,
+                reasoning_effort=self._config.reasoning_effort,
+                max_tokens=self._config.max_tokens,
+            )
+            url = (
+                f"{self._config.base_url.rstrip('/')}/models/"
+                f"{model}:streamGenerateContent?alt=sse&key={self._config.api_key}"
+            )
+            headers = {
+                **dict(self._config.headers or {}),
+                "content-type": "application/json",
+            }
+
+            attempt = 0
+            parser = _GoogleStreamParser()
+            while True:
+                parser = _GoogleStreamParser()
+                try:
+                    async with client.stream(
+                        "POST", url, json=payload, headers=headers
+                    ) as response:
+                        if response.status_code >= 400:
+                            body = await response.aread()
+                            body_text = body.decode(errors="replace")
+                            if self._should_retry(attempt, status_code=response.status_code):
+                                delay = retry_delay_seconds(
+                                    attempt,
+                                    max_delay_seconds=self._config.max_retry_delay_seconds,
+                                )
+                                yield provider_retry_event(
+                                    attempt=attempt,
+                                    max_retries=self._config.max_retries,
+                                    delay_seconds=delay,
+                                    reason=f"HTTP {response.status_code}",
+                                    data={"status_code": response.status_code, "body": body_text},
+                                )
+                                attempt += 1
+                                if not await wait_for_retry(delay, signal=signal):
+                                    return
+                                continue
+                            yield ProviderErrorEvent(
+                                message=provider_http_error_message(
+                                    provider_name=self._config.provider_name,
+                                    status_code=response.status_code,
+                                    body=body_text,
+                                    model=model,
+                                ),
+                                data={"status_code": response.status_code, "body": body_text},
+                            )
+                            return
+
+                        yield ProviderResponseStartEvent(model=model)
+                        async for line in response.aiter_lines():
+                            if signal is not None and signal.is_cancelled():
+                                return
+                            event = _parse_sse_line(line)
+                            if event is None:
+                                continue
+                            for parser_event in parser.feed(event):
+                                yield parser_event
+                        for parser_event in parser.finalize():
+                            yield parser_event
+                        return
+                except httpx.HTTPError as exc:
+                    if not parser.emitted_content and self._should_retry(attempt):
+                        delay = retry_delay_seconds(
+                            attempt,
+                            max_delay_seconds=self._config.max_retry_delay_seconds,
+                        )
+                        yield provider_retry_event(
+                            attempt=attempt,
+                            max_retries=self._config.max_retries,
+                            delay_seconds=delay,
+                            reason="network error",
+                            data={"error": str(exc), "error_type": type(exc).__name__},
+                        )
+                        attempt += 1
+                        if not await wait_for_retry(delay, signal=signal):
+                            return
+                        continue
+                    yield ProviderErrorEvent(message=str(exc), data={"attempts": attempt + 1})
+                    return
+
+        return iterator()
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+        return self._client
+
+    def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:
+        if attempt >= self._config.max_retries:
+            return False
+        return status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
+
+
+class _GoogleStreamParser:
+    def __init__(self) -> None:
+        self.emitted_content = False
+        self._content_parts: list[str] = []
+        self._thinking_parts: list[str] = []
+        self._tool_calls: list[ToolCall] = []
+        self._finish_reason: str | None = None
+
+    def feed(self, event: str) -> list[ProviderEvent]:
+        chunk = _loads_object(event)
+        if chunk is None:
+            return []
+        events: list[ProviderEvent] = []
+        candidates = chunk.get("candidates")
+        if not isinstance(candidates, list) or not candidates:
+            return []
+        candidate = candidates[0]
+        if not isinstance(candidate, Mapping):
+            return []
+        finish_reason = candidate.get("finishReason")
+        if isinstance(finish_reason, str):
+            self._finish_reason = finish_reason
+        content = candidate.get("content")
+        if not isinstance(content, Mapping):
+            return events
+        parts = content.get("parts")
+        if not isinstance(parts, list):
+            return events
+        for part in parts:
+            if not isinstance(part, Mapping):
+                continue
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                self.emitted_content = True
+                if part.get("thought") is True:
+                    self._thinking_parts.append(text)
+                    events.append(ProviderThinkingDeltaEvent(delta=text))
+                else:
+                    self._content_parts.append(text)
+                    events.append(ProviderTextDeltaEvent(delta=text))
+            function_call = part.get("functionCall")
+            if isinstance(function_call, Mapping):
+                self.emitted_content = True
+                default_id = f"tool-call-{len(self._tool_calls)}"
+                tool_call = ToolCall(
+                    id=_string_or_default(function_call.get("id"), default_id),
+                    name=_string_or_default(function_call.get("name"), ""),
+                    arguments=_object_or_empty(function_call.get("args")),
+                )
+                self._tool_calls.append(tool_call)
+                events.append(ProviderToolCallEvent(tool_call=tool_call))
+        return events
+
+    def finalize(self) -> list[ProviderEvent]:
+        return [
+            ProviderResponseEndEvent(
+                message=AssistantMessage(
+                    content="".join(self._content_parts), tool_calls=self._tool_calls
+                ),
+                finish_reason=_normalize_finish_reason(
+                    self._finish_reason, has_tool_calls=bool(self._tool_calls)
+                ),
+            )
+        ]
+
+
+def _build_google_payload(
+    *,
+    model: str,
+    system: str,
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+    reasoning_effort: str | None,
+    max_tokens: int | None,
+) -> dict[str, JSONValue]:
+    config: dict[str, JSONValue] = {}
+    if system:
+        config["systemInstruction"] = {"parts": [{"text": system}]}
+    if max_tokens is not None:
+        config["maxOutputTokens"] = max_tokens
+    thinking_config = _google_thinking_config(model, reasoning_effort)
+    if thinking_config is not None:
+        config["thinkingConfig"] = thinking_config
+    if tools:
+        config["tools"] = [{"functionDeclarations": [_tool_to_google(tool) for tool in tools]}]
+    return {
+        "contents": [_message_to_google(message) for message in messages],
+        "generationConfig": config,
+    }
+
+
+def _google_thinking_config(
+    model: str, reasoning_effort: str | None
+) -> dict[str, JSONValue] | None:
+    if reasoning_effort is None:
+        return None
+    if reasoning_effort == "none":
+        if _is_gemini3_pro_model(model):
+            return {"thinkingLevel": "LOW"}
+        if _is_gemini3_flash_model(model) or _is_gemma4_model(model):
+            return {"thinkingLevel": "MINIMAL"}
+        return {"thinkingBudget": 0}
+    if reasoning_effort in {"MINIMAL", "LOW", "MEDIUM", "HIGH"}:
+        return {"includeThoughts": True, "thinkingLevel": reasoning_effort}
+    budget = _google_budget(model, reasoning_effort)
+    if budget is None:
+        return {"includeThoughts": True, "thinkingLevel": _google_level(model, reasoning_effort)}
+    return {"includeThoughts": True, "thinkingBudget": budget}
+
+
+def _google_budget(model: str, effort: str) -> int | None:
+    normalized = effort.lower()
+    if normalized == "xhigh":
+        normalized = "high"
+    if normalized not in {"minimal", "low", "medium", "high"}:
+        return None
+    if _is_gemini3_pro_model(model) or _is_gemini3_flash_model(model) or _is_gemma4_model(model):
+        return None
+    if "2.5-pro" in model:
+        return {"minimal": 128, "low": 2048, "medium": 8192, "high": 32768}[normalized]
+    if "2.5-flash-lite" in model:
+        return {"minimal": 512, "low": 2048, "medium": 8192, "high": 24576}[normalized]
+    if "2.5-flash" in model:
+        return {"minimal": 128, "low": 2048, "medium": 8192, "high": 24576}[normalized]
+    return -1
+
+
+def _google_level(model: str, effort: str) -> str:
+    normalized = effort.lower()
+    if normalized == "xhigh":
+        normalized = "high"
+    if _is_gemini3_pro_model(model):
+        return "LOW" if normalized in {"minimal", "low"} else "HIGH"
+    if _is_gemma4_model(model):
+        return "MINIMAL" if normalized in {"minimal", "low"} else "HIGH"
+    return {
+        "minimal": "MINIMAL",
+        "low": "LOW",
+        "medium": "MEDIUM",
+        "high": "HIGH",
+    }.get(normalized, "HIGH")
+
+
+def _is_gemini3_pro_model(model: str) -> bool:
+    return "gemini-3" in model.lower() and "pro" in model.lower()
+
+
+def _is_gemini3_flash_model(model: str) -> bool:
+    return "gemini-3" in model.lower() and "flash" in model.lower()
+
+
+def _is_gemma4_model(model: str) -> bool:
+    return "gemma-4" in model.lower() or "gemma4" in model.lower()
+
+
+def _message_to_google(message: AgentMessage) -> dict[str, JSONValue]:
+    if isinstance(message, UserMessage):
+        return {"role": "user", "parts": [{"text": message.content}]}
+    if isinstance(message, AssistantMessage):
+        parts: list[JSONValue] = []
+        if message.content:
+            parts.append({"text": message.content})
+        for tool_call in message.tool_calls:
+            parts.append(
+                {
+                    "functionCall": {
+                        "id": tool_call.id,
+                        "name": tool_call.name,
+                        "args": dict(tool_call.arguments),
+                    }
+                }
+            )
+        return {"role": "model", "parts": parts or [{"text": ""}]}
+    response: dict[str, JSONValue] = {
+        "name": message.name,
+        "response": {"output" if message.ok else "error": message.content},
+    }
+    if message.tool_call_id:
+        response["id"] = message.tool_call_id
+    return {"role": "user", "parts": [{"functionResponse": response}]}
+
+
+def _tool_to_google(tool: AgentTool) -> dict[str, JSONValue]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": dict(tool.input_schema),
+    }
+
+
+def _parse_sse_line(line: str) -> str | None:
+    line = line.strip()
+    if not line or not line.startswith("data:"):
+        return None
+    return line.removeprefix("data:").strip()
+
+
+def _loads_object(value: str) -> dict[str, JSONValue] | None:
+    try:
+        loaded = loads(value)
+    except JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _string_or_default(value: object, default: str) -> str:
+    return value if isinstance(value, str) and value else default
+
+
+def _object_or_empty(value: object) -> dict[str, JSONValue]:
+    return value if isinstance(value, dict) else {}
+
+
+def _normalize_finish_reason(reason: str | None, *, has_tool_calls: bool) -> str:
+    if has_tool_calls:
+        return "tool_calls"
+    if reason in {"MAX_TOKENS", "MODEL_ARMOR", "RECITATION"}:
+        return "length"
+    return "stop"

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -233,19 +233,21 @@ def _build_google_payload(
     max_tokens: int | None,
 ) -> dict[str, JSONValue]:
     config: dict[str, JSONValue] = {}
+    payload: dict[str, JSONValue] = {
+        "contents": [_message_to_google(message) for message in messages],
+    }
     if system:
-        config["systemInstruction"] = {"parts": [{"text": system}]}
+        payload["systemInstruction"] = {"parts": [{"text": system}]}
     if max_tokens is not None:
         config["maxOutputTokens"] = max_tokens
     thinking_config = _google_thinking_config(model, reasoning_effort)
     if thinking_config is not None:
         config["thinkingConfig"] = thinking_config
+    if config:
+        payload["generationConfig"] = config
     if tools:
-        config["tools"] = [{"functionDeclarations": [_tool_to_google(tool) for tool in tools]}]
-    return {
-        "contents": [_message_to_google(message) for message in messages],
-        "generationConfig": config,
-    }
+        payload["tools"] = [{"functionDeclarations": [_tool_to_google(tool) for tool in tools]}]
+    return payload
 
 
 def _google_thinking_config(

--- a/src/tau_ai/mistral.py
+++ b/src/tau_ai/mistral.py
@@ -1,0 +1,415 @@
+"""Mistral Conversations provider."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from json import JSONDecodeError, dumps, loads
+from typing import Any, Protocol
+
+import httpx
+
+from tau_agent.messages import AgentMessage, AssistantMessage, UserMessage
+from tau_agent.tools import AgentTool, ToolCall
+from tau_agent.types import JSONValue
+from tau_ai.env import OpenAICompatibleConfig
+from tau_ai.events import (
+    ProviderErrorEvent,
+    ProviderEvent,
+    ProviderResponseEndEvent,
+    ProviderResponseStartEvent,
+    ProviderTextDeltaEvent,
+    ProviderThinkingDeltaEvent,
+    ProviderToolCallEvent,
+)
+from tau_ai.http_errors import provider_http_error_message
+from tau_ai.provider import CancellationToken
+from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
+
+
+class MistralConversationsProvider:
+    """Provider adapter for Mistral's streaming chat API."""
+
+    def __init__(
+        self,
+        config: OpenAICompatibleConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this provider created it."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+    ) -> AsyncIterator[ProviderEvent]:
+        """Stream one Mistral response as provider-neutral events."""
+        payload = _build_mistral_payload(
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            reasoning_effort=self._config.reasoning_effort,
+            max_tokens=self._config.max_tokens,
+        )
+        return self._stream(
+            model=model,
+            url=f"{_mistral_base_url(self._config.base_url)}/chat/completions",
+            payload=payload,
+            signal=signal,
+        )
+
+    def _stream(
+        self,
+        *,
+        model: str,
+        url: str,
+        payload: Mapping[str, JSONValue],
+        signal: CancellationToken | None,
+    ) -> AsyncIterator[ProviderEvent]:
+        async def iterator() -> AsyncIterator[ProviderEvent]:
+            client = self._get_client()
+            headers = {
+                **dict(self._config.headers or {}),
+                "Authorization": f"Bearer {self._config.api_key}",
+            }
+            attempt = 0
+            while True:
+                parser = _MistralStreamParser()
+                try:
+                    async with client.stream(
+                        "POST", url, json=payload, headers=headers
+                    ) as response:
+                        if response.status_code >= 400:
+                            body = await response.aread()
+                            body_text = body.decode(errors="replace")
+                            if self._should_retry(attempt, status_code=response.status_code):
+                                delay = retry_delay_seconds(
+                                    attempt,
+                                    max_delay_seconds=self._config.max_retry_delay_seconds,
+                                )
+                                yield provider_retry_event(
+                                    attempt=attempt,
+                                    max_retries=self._config.max_retries,
+                                    delay_seconds=delay,
+                                    reason=f"HTTP {response.status_code}",
+                                    data={"status_code": response.status_code, "body": body_text},
+                                )
+                                attempt += 1
+                                if not await wait_for_retry(delay, signal=signal):
+                                    return
+                                continue
+                            yield ProviderErrorEvent(
+                                message=provider_http_error_message(
+                                    provider_name=self._config.provider_name,
+                                    status_code=response.status_code,
+                                    body=body_text,
+                                    model=model,
+                                ),
+                                data={"status_code": response.status_code, "body": body_text},
+                            )
+                            return
+
+                        yield ProviderResponseStartEvent(model=model)
+                        async for line in response.aiter_lines():
+                            if signal is not None and signal.is_cancelled():
+                                return
+                            event = _parse_sse_line(line)
+                            if event is None:
+                                continue
+                            events, stop = parser.feed(event)
+                            for parser_event in events:
+                                yield parser_event
+                            if stop:
+                                break
+                        for parser_event in parser.finalize():
+                            yield parser_event
+                        return
+                except httpx.HTTPError as exc:
+                    if not parser.emitted_content and self._should_retry(attempt):
+                        delay = retry_delay_seconds(
+                            attempt,
+                            max_delay_seconds=self._config.max_retry_delay_seconds,
+                        )
+                        yield provider_retry_event(
+                            attempt=attempt,
+                            max_retries=self._config.max_retries,
+                            delay_seconds=delay,
+                            reason="network error",
+                            data={"error": str(exc), "error_type": type(exc).__name__},
+                        )
+                        attempt += 1
+                        if not await wait_for_retry(delay, signal=signal):
+                            return
+                        continue
+                    yield ProviderErrorEvent(message=str(exc), data={"attempts": attempt + 1})
+                    return
+
+        return iterator()
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+        return self._client
+
+    def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:
+        if attempt >= self._config.max_retries:
+            return False
+        return status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
+
+
+class _StreamParser(Protocol):
+    emitted_content: bool
+
+    def feed(self, event: str) -> tuple[list[ProviderEvent], bool]: ...
+
+    def finalize(self) -> list[ProviderEvent]: ...
+
+
+class _MistralStreamParser:
+    def __init__(self) -> None:
+        self.emitted_content = False
+        self._content_parts: list[str] = []
+        self._tool_call_builders: dict[int, _ToolCallBuilder] = {}
+        self._finish_reason: str | None = None
+
+    def feed(self, event: str) -> tuple[list[ProviderEvent], bool]:
+        if event == "[DONE]":
+            return [], True
+        chunk = _loads_object(event)
+        if chunk is None:
+            return [], False
+        choice = _first_choice(chunk)
+        if choice is None:
+            return [], False
+        self._finish_reason = (
+            choice.get("finish_reason") or choice.get("finishReason") or self._finish_reason
+        )
+        delta = choice.get("delta")
+        if not isinstance(delta, Mapping):
+            return [], False
+        events: list[ProviderEvent] = []
+        for content in _content_deltas(delta):
+            self.emitted_content = True
+            self._content_parts.append(content)
+            events.append(ProviderTextDeltaEvent(delta=content))
+        for thinking in _thinking_deltas(delta):
+            self.emitted_content = True
+            events.append(ProviderThinkingDeltaEvent(delta=thinking))
+        for tool_call_delta in _tool_call_deltas(delta):
+            self.emitted_content = True
+            index = int(tool_call_delta.get("index", 0))
+            builder = self._tool_call_builders.setdefault(index, _ToolCallBuilder())
+            builder.add_delta(tool_call_delta)
+        return events, False
+
+    def finalize(self) -> list[ProviderEvent]:
+        tool_calls = [
+            builder.build(index) for index, builder in sorted(self._tool_call_builders.items())
+        ]
+        events: list[ProviderEvent] = [
+            ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
+        ]
+        events.append(
+            ProviderResponseEndEvent(
+                message=AssistantMessage(
+                    content="".join(self._content_parts), tool_calls=tool_calls
+                ),
+                finish_reason=self._finish_reason or ("tool_calls" if tool_calls else "stop"),
+            )
+        )
+        return events
+
+
+class _ToolCallBuilder:
+    def __init__(self) -> None:
+        self.id = ""
+        self.name = ""
+        self.arguments_parts: list[str] = []
+
+    def add_delta(self, delta: Mapping[str, Any]) -> None:
+        call_id = delta.get("id")
+        if isinstance(call_id, str) and call_id != "null":
+            self.id = call_id
+        function = delta.get("function")
+        if not isinstance(function, Mapping):
+            return
+        name = function.get("name")
+        if isinstance(name, str):
+            self.name = name
+        arguments = function.get("arguments")
+        if isinstance(arguments, str):
+            self.arguments_parts.append(arguments)
+        elif isinstance(arguments, Mapping):
+            self.arguments_parts.append(dumps(arguments))
+
+    def build(self, index: int) -> ToolCall:
+        arguments_text = "".join(self.arguments_parts)
+        arguments = _loads_object(arguments_text) if arguments_text else {}
+        if arguments is None:
+            arguments = {"_raw_arguments": arguments_text}
+        return ToolCall(
+            id=self.id or f"tool-call-{index}",
+            name=self.name,
+            arguments=arguments,
+        )
+
+
+def _build_mistral_payload(
+    *,
+    model: str,
+    system: str,
+    messages: list[AgentMessage],
+    tools: list[AgentTool],
+    reasoning_effort: str | None,
+    max_tokens: int | None,
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "model": model,
+        "stream": True,
+        "messages": [
+            *_system_messages(system),
+            *[_message_to_mistral(message) for message in messages],
+        ],
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if tools:
+        payload["tools"] = [_tool_to_mistral(tool) for tool in tools]
+    if reasoning_effort is not None and reasoning_effort != "none":
+        if _uses_reasoning_effort(model):
+            payload["reasoning_effort"] = "high"
+        else:
+            payload["prompt_mode"] = "reasoning"
+    return payload
+
+
+def _system_messages(system: str) -> list[dict[str, JSONValue]]:
+    return [{"role": "system", "content": system}] if system else []
+
+
+def _message_to_mistral(message: AgentMessage) -> dict[str, JSONValue]:
+    if isinstance(message, UserMessage):
+        return {"role": "user", "content": message.content}
+    if isinstance(message, AssistantMessage):
+        item: dict[str, JSONValue] = {"role": "assistant", "content": message.content}
+        if message.tool_calls:
+            item["tool_calls"] = [
+                _tool_call_to_mistral(tool_call) for tool_call in message.tool_calls
+            ]
+        return item
+    return {
+        "role": "tool",
+        "tool_call_id": message.tool_call_id,
+        "name": message.name,
+        "content": message.content,
+    }
+
+
+def _tool_to_mistral(tool: AgentTool) -> dict[str, JSONValue]:
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": dict(tool.input_schema),
+            "strict": False,
+        },
+    }
+
+
+def _tool_call_to_mistral(tool_call: ToolCall) -> dict[str, JSONValue]:
+    return {
+        "id": tool_call.id,
+        "type": "function",
+        "function": {"name": tool_call.name, "arguments": dumps(tool_call.arguments)},
+    }
+
+
+def _mistral_base_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
+
+
+def _uses_reasoning_effort(model: str) -> bool:
+    return model in {"mistral-small-2603", "mistral-small-latest", "mistral-medium-3.5"}
+
+
+def _parse_sse_line(line: str) -> str | None:
+    line = line.strip()
+    if not line or not line.startswith("data:"):
+        return None
+    return line.removeprefix("data:").strip()
+
+
+def _loads_object(value: str) -> dict[str, JSONValue] | None:
+    try:
+        loaded = loads(value)
+    except JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _first_choice(chunk: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    choices = chunk.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+    choice = choices[0]
+    return choice if isinstance(choice, Mapping) else None
+
+
+def _content_deltas(delta: Mapping[str, Any]) -> list[str]:
+    content = delta.get("content")
+    if isinstance(content, str) and content:
+        return [content]
+    if not isinstance(content, list):
+        return []
+    output: list[str] = []
+    for item in content:
+        if isinstance(item, str) and item:
+            output.append(item)
+        elif isinstance(item, Mapping) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                output.append(text)
+    return output
+
+
+def _thinking_deltas(delta: Mapping[str, Any]) -> list[str]:
+    content = delta.get("content")
+    if not isinstance(content, list):
+        return []
+    output: list[str] = []
+    for item in content:
+        if not isinstance(item, Mapping) or item.get("type") != "thinking":
+            continue
+        thinking = item.get("thinking")
+        if isinstance(thinking, str) and thinking:
+            output.append(thinking)
+        elif isinstance(thinking, list):
+            for part in thinking:
+                if isinstance(part, Mapping):
+                    text = part.get("text")
+                    if isinstance(text, str) and text:
+                        output.append(text)
+    return output
+
+
+def _tool_call_deltas(delta: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    tool_calls = delta.get("tool_calls") or delta.get("toolCalls")
+    if not isinstance(tool_calls, list):
+        return []
+    return [tool_call for tool_call in tool_calls if isinstance(tool_call, Mapping)]

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -589,9 +589,9 @@ def _build_chat_payload(
     if supports_store:
         payload["store"] = False
     if max_tokens is not None:
-        payload[
-            "max_tokens" if max_tokens_field == "max_tokens" else "max_completion_tokens"
-        ] = max_tokens
+        payload["max_tokens" if max_tokens_field == "max_tokens" else "max_completion_tokens"] = (
+            max_tokens
+        )
     openrouter_provider = resolved_compat.get("openrouterProvider")
     if isinstance(openrouter_provider, dict):
         payload["provider"] = openrouter_provider

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -78,7 +78,7 @@ class OpenAICompatibleProvider:
         signal: CancellationToken | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one model response as provider-neutral events."""
-        if _use_responses_api(model):
+        if self._config.api == "openai-responses" or _use_responses_api(model):
             return self._stream_responses(
                 model=model,
                 system=system,
@@ -111,6 +111,10 @@ class OpenAICompatibleProvider:
             tools=tools,
             reasoning_effort=self._config.reasoning_effort,
             reasoning_effort_parameter=self._config.reasoning_effort_parameter,
+            thinking_format=self._config.thinking_format,
+            compat=self._config.compat,
+            max_tokens=self._config.max_tokens,
+            include_reasoning_effort_none=self._config.include_reasoning_effort_none,
         )
         return self._stream(
             model=model,
@@ -136,6 +140,7 @@ class OpenAICompatibleProvider:
             messages=messages,
             tools=tools,
             reasoning_effort=self._config.reasoning_effort,
+            max_tokens=self._config.max_tokens,
         )
         return self._stream(
             model=model,
@@ -559,7 +564,18 @@ def _build_chat_payload(
     tools: list[AgentTool],
     reasoning_effort: str | None = None,
     reasoning_effort_parameter: str = "reasoning_effort",
+    thinking_format: str = "openai",
+    compat: Mapping[str, JSONValue] | None = None,
+    max_tokens: int | None = None,
+    include_reasoning_effort_none: bool = False,
 ) -> dict[str, JSONValue]:
+    resolved_compat = dict(compat or {})
+    supports_store = bool(resolved_compat.get("supportsStore", True))
+    supports_usage = bool(resolved_compat.get("supportsUsageInStreaming", True))
+    supports_reasoning_effort = bool(resolved_compat.get("supportsReasoningEffort", True))
+    max_tokens_field = _string_compat(
+        resolved_compat.get("maxTokensField"), default="max_completion_tokens"
+    )
     payload: dict[str, JSONValue] = {
         "model": model,
         "stream": True,
@@ -568,14 +584,68 @@ def _build_chat_payload(
             *[_message_to_openai(message) for message in messages],
         ],
     }
-    if reasoning_effort is not None:
-        if reasoning_effort_parameter == "reasoning.effort":
-            payload["reasoning"] = {"effort": reasoning_effort}
-        else:
-            payload["reasoning_effort"] = reasoning_effort
+    if supports_usage:
+        payload["stream_options"] = {"include_usage": True}
+    if supports_store:
+        payload["store"] = False
+    if max_tokens is not None:
+        payload[
+            "max_tokens" if max_tokens_field == "max_tokens" else "max_completion_tokens"
+        ] = max_tokens
+    _apply_chat_reasoning(
+        payload,
+        reasoning_effort=reasoning_effort if supports_reasoning_effort else None,
+        reasoning_effort_parameter=reasoning_effort_parameter,
+        thinking_format=thinking_format,
+        include_reasoning_effort_none=include_reasoning_effort_none,
+    )
     if tools:
         payload["tools"] = [_tool_to_openai(tool) for tool in tools]
+        if resolved_compat.get("zaiToolStream") is True:
+            payload["tool_stream"] = True
     return payload
+
+
+def _apply_chat_reasoning(
+    payload: dict[str, JSONValue],
+    *,
+    reasoning_effort: str | None,
+    reasoning_effort_parameter: str,
+    thinking_format: str,
+    include_reasoning_effort_none: bool,
+) -> None:
+    reasoning_enabled = reasoning_effort is not None and reasoning_effort != "none"
+    if thinking_format in {"zai", "qwen"}:
+        payload["enable_thinking"] = reasoning_enabled
+        return
+    if thinking_format == "qwen-chat-template":
+        payload["chat_template_kwargs"] = {
+            "enable_thinking": reasoning_enabled,
+            "preserve_thinking": True,
+        }
+        return
+    if thinking_format == "deepseek":
+        payload["thinking"] = {"type": "enabled" if reasoning_enabled else "disabled"}
+        if reasoning_enabled:
+            payload["reasoning_effort"] = reasoning_effort
+        return
+    if thinking_format == "openrouter" or reasoning_effort_parameter == "reasoning.effort":
+        if reasoning_enabled:
+            payload["reasoning"] = {"effort": reasoning_effort}
+        elif include_reasoning_effort_none:
+            payload["reasoning"] = {"effort": "none"}
+        return
+    if thinking_format == "together":
+        payload["reasoning"] = {"enabled": reasoning_enabled}
+        if reasoning_enabled:
+            payload["reasoning_effort"] = reasoning_effort
+        return
+    if reasoning_enabled or include_reasoning_effort_none:
+        payload["reasoning_effort"] = reasoning_effort or "none"
+
+
+def _string_compat(value: object, *, default: str) -> str:
+    return value if isinstance(value, str) and value else default
 
 
 def _build_responses_payload(
@@ -585,6 +655,7 @@ def _build_responses_payload(
     messages: list[AgentMessage],
     tools: list[AgentTool],
     reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> dict[str, JSONValue]:
     payload: dict[str, JSONValue] = {
         "model": model,
@@ -596,6 +667,8 @@ def _build_responses_payload(
         "instructions": system,
         "input": _messages_to_responses_input(messages),
     }
+    if max_tokens is not None:
+        payload["max_output_tokens"] = max_tokens
     effort = _normalize_responses_effort(reasoning_effort)
     if effort is not None:
         # ``summary: auto`` streams ``response.reasoning_summary_text.delta``

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -592,6 +592,9 @@ def _build_chat_payload(
         payload[
             "max_tokens" if max_tokens_field == "max_tokens" else "max_completion_tokens"
         ] = max_tokens
+    openrouter_provider = resolved_compat.get("openrouterProvider")
+    if isinstance(openrouter_provider, dict):
+        payload["provider"] = openrouter_provider
     _apply_chat_reasoning(
         payload,
         reasoning_effort=reasoning_effort if supports_reasoning_effort else None,

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import tomllib
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from contextlib import suppress
 from functools import cache
 from importlib.resources import files
@@ -12,10 +12,25 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StringConstraints, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    ValidationError,
+)
 
+from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
-from tau_coding.provider_catalog import ProviderCatalogEntry, ProviderKind
+from tau_coding.provider_catalog import (
+    ModelCatalogMetadata,
+    ModelInput,
+    ProviderApi,
+    ProviderCatalogEntry,
+    ProviderKind,
+)
 from tau_coding.thinking import ThinkingLevel, ThinkingParameter
 
 CATALOG_SCHEMA_VERSION = 1
@@ -31,10 +46,28 @@ _NonEmptyString = Annotated[
 ]
 _NonEmptyStringTuple = Annotated[tuple[_NonEmptyString, ...], Field(min_length=1)]
 _PositiveInt = Annotated[StrictInt, Field(gt=0)]
+_NonNegativeFloat = Annotated[float, Field(ge=0)]
 
 
 class CatalogError(ValueError):
     """Raised when a Tau catalog file is invalid."""
+
+
+class _CatalogModelMetadata(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: _NonEmptyString | None = None
+    api: ProviderApi | None = None
+    base_url: _NonEmptyString | None = None
+    reasoning: StrictBool | None = None
+    input: tuple[ModelInput, ...] = ()
+    cost: dict[_NonEmptyString, _NonNegativeFloat] | None = None
+    context_window: _PositiveInt | None = None
+    max_tokens: _PositiveInt | None = None
+    headers: dict[_NonEmptyString, _NonEmptyString] = {}
+    compat: dict[_NonEmptyString, Any] = {}
+    thinking_level_map: dict[ThinkingLevel, _NonEmptyString] = {}
+    unsupported_thinking_levels: tuple[ThinkingLevel, ...] = ()
 
 
 class _CatalogProvider(BaseModel):
@@ -49,7 +82,11 @@ class _CatalogProvider(BaseModel):
     models: _NonEmptyStringTuple
     default_model: _NonEmptyString
     docs_url: _NonEmptyString
+    api: ProviderApi | None = None
     context_windows: dict[_NonEmptyString, _PositiveInt] | None = None
+    headers: dict[_NonEmptyString, _NonEmptyString] = {}
+    compat: dict[_NonEmptyString, Any] = {}
+    model_metadata: dict[_NonEmptyString, _CatalogModelMetadata] = {}
     thinking_levels: tuple[ThinkingLevel, ...] | None = None
     thinking_models: tuple[_NonEmptyString, ...] = ()
     thinking_default: ThinkingLevel | None = None
@@ -176,16 +213,40 @@ def _merge_raw_provider(base: dict[str, Any], overlay: dict[str, Any]) -> dict[s
     overlay_models = overlay.get("models", [])
     if isinstance(base_models, list) and isinstance(overlay_models, list):
         merged["models"] = list(dict.fromkeys([*overlay_models, *base_models]))
-    base_windows = base.get("context_windows")
-    overlay_windows = overlay.get("context_windows")
-    if isinstance(base_windows, dict) and isinstance(overlay_windows, dict):
-        merged["context_windows"] = {**base_windows, **overlay_windows}
+    for key in ("context_windows", "headers", "compat"):
+        base_mapping = base.get(key)
+        overlay_mapping = overlay.get(key)
+        if isinstance(base_mapping, dict) and isinstance(overlay_mapping, dict):
+            merged[key] = {**base_mapping, **overlay_mapping}
+    base_metadata = base.get("model_metadata")
+    overlay_metadata = overlay.get("model_metadata")
+    if isinstance(base_metadata, dict) and isinstance(overlay_metadata, dict):
+        merged["model_metadata"] = _merge_model_metadata(base_metadata, overlay_metadata)
     if "thinking_levels" in overlay:
         for field in _THINKING_FIELDS:
             if field in overlay:
                 merged[field] = overlay[field]
             else:
                 merged.pop(field, None)
+    return merged
+
+
+def _merge_model_metadata(
+    base: dict[str, Any], overlay: dict[str, Any]
+) -> dict[str, Any]:
+    merged: dict[str, Any] = {**base}
+    for model, overlay_metadata in overlay.items():
+        base_metadata = merged.get(model)
+        if isinstance(base_metadata, dict) and isinstance(overlay_metadata, dict):
+            next_metadata = {**base_metadata, **overlay_metadata}
+            for key in ("headers", "compat", "thinking_level_map"):
+                base_mapping = base_metadata.get(key)
+                overlay_mapping = overlay_metadata.get(key)
+                if isinstance(base_mapping, dict) and isinstance(overlay_mapping, dict):
+                    next_metadata[key] = {**base_mapping, **overlay_mapping}
+            merged[model] = next_metadata
+        else:
+            merged[model] = overlay_metadata
     return merged
 
 
@@ -226,6 +287,9 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
     for model in provider.context_windows or {}:
         if model not in provider.models:
             raise CatalogError(f"{prefix}.context_windows: {model!r} is not in models")
+    for model in provider.model_metadata:
+        if model not in provider.models:
+            raise CatalogError(f"{prefix}.model_metadata: {model!r} is not in models")
     if provider.thinking_default is not None and (
         provider.thinking_levels is None
         or provider.thinking_default not in provider.thinking_levels
@@ -233,6 +297,16 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
         raise CatalogError(
             f"{prefix}.thinking_default: {provider.thinking_default!r} is not in thinking_levels"
         )
+
+    model_metadata = {
+        model: _model_metadata_from_provider(metadata)
+        for model, metadata in provider.model_metadata.items()
+    }
+    context_windows = dict(provider.context_windows or {})
+    for model, metadata in model_metadata.items():
+        if metadata.context_window is not None and model not in context_windows:
+            context_windows[model] = metadata.context_window
+
     return ProviderCatalogEntry(
         name=provider.name,
         display_name=provider.display_name,
@@ -243,12 +317,54 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
         models=provider.models,
         default_model=provider.default_model,
         docs_url=provider.docs_url,
-        context_windows=dict(provider.context_windows) if provider.context_windows else None,
+        api=provider.api,
+        context_windows=context_windows or None,
+        headers=dict(provider.headers),
+        compat=_json_object(provider.compat, f"{prefix}.compat"),
+        model_metadata=model_metadata,
         thinking_levels=provider.thinking_levels,
         thinking_models=provider.thinking_models,
         thinking_default=provider.thinking_default,
         thinking_parameter=provider.thinking_parameter,
     )
+
+
+def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatalogMetadata:
+    thinking_level_map: dict[ThinkingLevel, str | None] = dict(metadata.thinking_level_map)
+    for level in metadata.unsupported_thinking_levels:
+        thinking_level_map[level] = None
+    return ModelCatalogMetadata(
+        name=metadata.name,
+        api=metadata.api,
+        base_url=metadata.base_url,
+        reasoning=metadata.reasoning,
+        input=metadata.input,
+        cost=dict(metadata.cost) if metadata.cost else None,
+        context_window=metadata.context_window,
+        max_tokens=metadata.max_tokens,
+        headers=dict(metadata.headers),
+        compat=_json_object(metadata.compat, "model_metadata.compat"),
+        thinking_level_map=thinking_level_map,
+    )
+
+
+def _json_object(value: Mapping[str, Any], field_name: str) -> dict[str, JSONValue]:
+    return {key: _json_value(item, f"{field_name}.{key}") for key, item in value.items()}
+
+
+def _json_value(value: Any, field_name: str) -> JSONValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, list):
+        return [_json_value(item, field_name) for item in value]
+    if isinstance(value, dict):
+        output: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CatalogError(f"{field_name}: object keys must be strings")
+            output[key] = _json_value(item, f"{field_name}.{key}")
+        return output
+    raise CatalogError(f"{field_name}: unsupported value {value!r}")
 
 
 def _format_validation_error(raw: dict[str, Any], error: ValidationError) -> str:
@@ -286,10 +402,21 @@ def _raw_provider_from_entry(entry: ProviderCatalogEntry) -> dict[str, Any]:
         "default_model": entry.default_model,
         "docs_url": entry.docs_url,
     }
+    if entry.api is not None:
+        raw["api"] = entry.api
     if entry.credential_name is not None:
         raw["credential_name"] = entry.credential_name
     if entry.context_windows:
         raw["context_windows"] = dict(entry.context_windows)
+    if entry.headers:
+        raw["headers"] = dict(entry.headers)
+    if entry.compat:
+        raw["compat"] = dict(entry.compat)
+    if entry.model_metadata:
+        raw["model_metadata"] = {
+            model: _raw_model_metadata_from_entry(metadata)
+            for model, metadata in entry.model_metadata.items()
+        }
     if entry.thinking_levels is not None:
         raw["thinking_levels"] = list(entry.thinking_levels)
     if entry.thinking_models:
@@ -298,6 +425,39 @@ def _raw_provider_from_entry(entry: ProviderCatalogEntry) -> dict[str, Any]:
         raw["thinking_default"] = entry.thinking_default
     if entry.thinking_parameter is not None:
         raw["thinking_parameter"] = entry.thinking_parameter
+    return raw
+
+
+def _raw_model_metadata_from_entry(metadata: ModelCatalogMetadata) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    if metadata.name is not None:
+        raw["name"] = metadata.name
+    if metadata.api is not None:
+        raw["api"] = metadata.api
+    if metadata.base_url is not None:
+        raw["base_url"] = metadata.base_url
+    if metadata.reasoning is not None:
+        raw["reasoning"] = metadata.reasoning
+    if metadata.input:
+        raw["input"] = list(metadata.input)
+    if metadata.cost:
+        raw["cost"] = dict(metadata.cost)
+    if metadata.context_window is not None:
+        raw["context_window"] = metadata.context_window
+    if metadata.max_tokens is not None:
+        raw["max_tokens"] = metadata.max_tokens
+    if metadata.headers:
+        raw["headers"] = dict(metadata.headers)
+    if metadata.compat:
+        raw["compat"] = dict(metadata.compat)
+    thinking_level_map = {
+        level: value for level, value in metadata.thinking_level_map.items() if value is not None
+    }
+    unsupported = [level for level, value in metadata.thinking_level_map.items() if value is None]
+    if thinking_level_map:
+        raw["thinking_level_map"] = thinking_level_map
+    if unsupported:
+        raw["unsupported_thinking_levels"] = unsupported
     return raw
 
 
@@ -315,6 +475,9 @@ def _catalog_to_toml(raw: dict[str, Any]) -> str:
             "models",
             "default_model",
             "docs_url",
+            "api",
+            "headers",
+            "compat",
             "thinking_levels",
             "thinking_models",
             "thinking_default",
@@ -328,6 +491,15 @@ def _catalog_to_toml(raw: dict[str, Any]) -> str:
             lines.append("[providers.context_windows]")
             for model, context_window in context_windows.items():
                 lines.append(f"{_toml_key(model)} = {_toml_value(context_window)}")
+        model_metadata = provider.get("model_metadata")
+        if isinstance(model_metadata, dict) and model_metadata:
+            for model, metadata in model_metadata.items():
+                if not isinstance(metadata, dict):
+                    continue
+                lines.append("")
+                lines.append(f"[providers.model_metadata.{_toml_key(model)}]")
+                for key, value in metadata.items():
+                    lines.append(f"{key} = {_toml_value(value)}")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
@@ -347,6 +519,10 @@ def _toml_value(value: object) -> str:
         return str(value)
     if isinstance(value, list | tuple):
         return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return "{ " + ", ".join(
+            f"{_toml_key(str(key))} = {_toml_value(item)}" for key, item in value.items()
+        ) + " }"
     raise TypeError(f"Unsupported TOML value: {value!r}")
 
 

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -231,9 +231,7 @@ def _merge_raw_provider(base: dict[str, Any], overlay: dict[str, Any]) -> dict[s
     return merged
 
 
-def _merge_model_metadata(
-    base: dict[str, Any], overlay: dict[str, Any]
-) -> dict[str, Any]:
+def _merge_model_metadata(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
     merged: dict[str, Any] = {**base}
     for model, overlay_metadata in overlay.items():
         base_metadata = merged.get(model)
@@ -520,9 +518,13 @@ def _toml_value(value: object) -> str:
     if isinstance(value, list | tuple):
         return "[" + ", ".join(_toml_value(item) for item in value) + "]"
     if isinstance(value, dict):
-        return "{ " + ", ".join(
-            f"{_toml_key(str(key))} = {_toml_value(item)}" for key, item in value.items()
-        ) + " }"
+        return (
+            "{ "
+            + ", ".join(
+                f"{_toml_key(str(key))} = {_toml_value(item)}" for key, item in value.items()
+            )
+            + " }"
+        )
     raise TypeError(f"Unsupported TOML value: {value!r}")
 
 

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -1,8 +1,5 @@
-# Tau's built-in provider catalog.
-#
-# To add a provider or model, edit this file — no Python changes needed.
-# For personal or unreleased providers, create ~/.tau/catalog.toml with the
-# same schema; it is overlaid on top of this file (your values win).
+# Tau built-in provider catalog, generated from Pi API-provider metadata.
+# User overrides live in ~/.tau/catalog.toml.
 
 schema_version = 1
 
@@ -11,50 +8,419 @@ name = "openai"
 display_name = "OpenAI"
 kind = "openai-compatible"
 base_url = "https://api.openai.com/v1"
+api = "openai-responses"
 api_key_env = "OPENAI_API_KEY"
 credential_name = "openai"
-models = [
-  "gpt-5.5",
-  "gpt-5.5-pro",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.3-codex",
-  "gpt-5.2",
-  "gpt-5.1",
-  "gpt-5",
-  "gpt-5-mini",
-  "gpt-4.1",
-  "gpt-4.1-mini",
-]
-default_model = "gpt-5.5"
+models = ["gpt-4", "gpt-4-turbo", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20", "gpt-4o-mini", "gpt-5", "gpt-5-chat-latest", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.1", "gpt-5.1-chat-latest", "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-chat-latest", "gpt-5.2-codex", "gpt-5.2-pro", "gpt-5.3-chat-latest", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "o1", "o1-pro", "o3", "o3-deep-research", "o3-mini", "o3-pro", "o4-mini", "o4-mini-deep-research"]
+default_model = "gpt-5.4"
 docs_url = "https://platform.openai.com/docs"
-thinking_levels = ["off", "low", "medium", "high", "xhigh"]
-thinking_models = [
-  "gpt-5.5",
-  "gpt-5.5-pro",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.3-codex",
-  "gpt-5.2",
-  "gpt-5.1",
-  "gpt-5",
-  "gpt-5-mini",
-]
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-"gpt-5.5" = 272000
-"gpt-5.5-pro" = 1050000
-"gpt-5.4" = 272000
-"gpt-5.4-mini" = 400000
-"gpt-5.3-codex" = 400000
-"gpt-5.2" = 400000
-"gpt-5.1" = 400000
-"gpt-5" = 400000
-"gpt-5-mini" = 400000
+gpt-4 = 8192
+gpt-4-turbo = 128000
 "gpt-4.1" = 1047576
 "gpt-4.1-mini" = 1047576
+"gpt-4.1-nano" = 1047576
+gpt-4o = 128000
+gpt-4o-2024-05-13 = 128000
+gpt-4o-2024-08-06 = 128000
+gpt-4o-2024-11-20 = 128000
+gpt-4o-mini = 128000
+gpt-5 = 400000
+gpt-5-chat-latest = 128000
+gpt-5-codex = 400000
+gpt-5-mini = 400000
+gpt-5-nano = 400000
+gpt-5-pro = 400000
+"gpt-5.1" = 400000
+"gpt-5.1-chat-latest" = 128000
+"gpt-5.1-codex" = 400000
+"gpt-5.1-codex-max" = 400000
+"gpt-5.1-codex-mini" = 400000
+"gpt-5.2" = 400000
+"gpt-5.2-chat-latest" = 128000
+"gpt-5.2-codex" = 400000
+"gpt-5.2-pro" = 400000
+"gpt-5.3-chat-latest" = 128000
+"gpt-5.3-codex" = 400000
+"gpt-5.3-codex-spark" = 128000
+"gpt-5.4" = 272000
+"gpt-5.4-mini" = 400000
+"gpt-5.4-nano" = 400000
+"gpt-5.4-pro" = 1050000
+"gpt-5.5" = 272000
+"gpt-5.5-pro" = 1050000
+o1 = 200000
+o1-pro = 200000
+o3 = 200000
+o3-deep-research = 200000
+o3-mini = 200000
+o3-pro = 200000
+o4-mini = 200000
+o4-mini-deep-research = 200000
+
+[providers.model_metadata.gpt-4]
+name = "GPT-4"
+reasoning = false
+input = ["text"]
+context_window = 8192
+max_tokens = 8192
+cost = { input = 30, output = 60, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4-turbo]
+name = "GPT-4 Turbo"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."gpt-4.1"]
+name = "GPT-4.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."gpt-4.1-mini"]
+name = "GPT-4.1 mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.4, output = 1.6, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."gpt-4.1-nano"]
+name = "GPT-4.1 nano"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.1, output = 0.4, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4o]
+name = "GPT-4o"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4o-2024-05-13]
+name = "GPT-4o (2024-05-13)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 5, output = 15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4o-2024-08-06]
+name = "GPT-4o (2024-08-06)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4o-2024-11-20]
+name = "GPT-4o (2024-11-20)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-4o-mini]
+name = "GPT-4o mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata.gpt-5]
+name = "GPT-5"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gpt-5-chat-latest]
+name = "GPT-5 Chat Latest"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gpt-5-codex]
+name = "GPT-5-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gpt-5-mini]
+name = "GPT-5 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.025, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gpt-5-nano]
+name = "GPT-5 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.05, output = 0.4, cacheRead = 0.005, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gpt-5-pro]
+name = "GPT-5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 272000
+cost = { input = 15, output = 120, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.1"]
+name = "GPT-5.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.13, cacheWrite = 0 }
+thinking_level_map = { off = "none" }
+
+[providers.model_metadata."gpt-5.1-chat-latest"]
+name = "GPT-5.1 Chat"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.1-codex"]
+name = "GPT-5.1 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.1-codex-max"]
+name = "GPT-5.1 Codex Max"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.1-codex-mini"]
+name = "GPT-5.1 Codex mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.025, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.2"]
+name = "GPT-5.2"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.2-chat-latest"]
+name = "GPT-5.2 Chat"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.2-codex"]
+name = "GPT-5.2 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.2-pro"]
+name = "GPT-5.2 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 21, output = 168, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.3-chat-latest"]
+name = "GPT-5.3 Chat (latest)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.3-codex"]
+name = "GPT-5.3 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.3-codex-spark"]
+name = "GPT-5.3 Codex Spark"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 32000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.4"]
+name = "GPT-5.4"
+reasoning = true
+input = ["text", "image"]
+context_window = 272000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.4-mini"]
+name = "GPT-5.4 mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.4-nano"]
+name = "GPT-5.4 nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.2, output = 1.25, cacheRead = 0.02, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.4-pro"]
+name = "GPT-5.4 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gpt-5.5"]
+name = "GPT-5.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 272000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+
+[providers.model_metadata."gpt-5.5-pro"]
+name = "GPT-5.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.o1]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 15, output = 60, cacheRead = 7.5, cacheWrite = 0 }
+
+[providers.model_metadata.o1-pro]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 150, output = 600, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.o3]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata.o3-deep-research]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 10, output = 40, cacheRead = 2.5, cacheWrite = 0 }
+
+[providers.model_metadata.o3-mini]
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+
+[providers.model_metadata.o3-pro]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 20, output = 80, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.o4-mini]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.28, cacheWrite = 0 }
+
+[providers.model_metadata.o4-mini-deep-research]
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
 
 [[providers]]
 name = "openai-codex"
@@ -63,25 +429,11 @@ kind = "openai-codex"
 base_url = "https://chatgpt.com/backend-api"
 api_key_env = "OPENAI_CODEX_ACCESS_TOKEN"
 credential_name = "openai-codex"
-models = [
-  "gpt-5.5",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.3-codex",
-  "gpt-5.3-codex-spark",
-  "gpt-5.2",
-]
+models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 default_model = "gpt-5.5"
 docs_url = "https://chatgpt.com/codex"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
-thinking_models = [
-  "gpt-5.5",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.3-codex",
-  "gpt-5.3-codex-spark",
-  "gpt-5.2",
-]
+thinking_models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 thinking_default = "medium"
 thinking_parameter = "reasoning.effort"
 
@@ -97,115 +449,6080 @@ thinking_parameter = "reasoning.effort"
 name = "anthropic"
 display_name = "Anthropic"
 kind = "anthropic"
-base_url = "https://api.anthropic.com/v1"
+base_url = "https://api.anthropic.com"
+api = "anthropic-messages"
 api_key_env = "ANTHROPIC_API_KEY"
 credential_name = "anthropic"
-models = [
-  "claude-sonnet-4-6",
-  "claude-opus-4-8",
-  "claude-haiku-4-5",
-]
-default_model = "claude-sonnet-4-6"
+models = ["claude-3-5-haiku-20241022", "claude-3-5-haiku-latest", "claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022", "claude-3-7-sonnet-20250219", "claude-3-haiku-20240307", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-0", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-20250514", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-0", "claude-sonnet-4-20250514", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6"]
+default_model = "claude-opus-4-7"
 docs_url = "https://docs.anthropic.com"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
-thinking_models = [
-  "claude-sonnet-4-6",
-  "claude-opus-4-8",
-]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
 
 [providers.context_windows]
-"claude-sonnet-4-6" = 1000000
-"claude-opus-4-8" = 200000
-"claude-haiku-4-5" = 200000
+claude-3-5-haiku-20241022 = 200000
+claude-3-5-haiku-latest = 200000
+claude-3-5-sonnet-20240620 = 200000
+claude-3-5-sonnet-20241022 = 200000
+claude-3-7-sonnet-20250219 = 200000
+claude-3-haiku-20240307 = 200000
+claude-3-opus-20240229 = 200000
+claude-3-sonnet-20240229 = 200000
+claude-haiku-4-5 = 200000
+claude-haiku-4-5-20251001 = 200000
+claude-opus-4-0 = 200000
+claude-opus-4-1 = 200000
+claude-opus-4-1-20250805 = 200000
+claude-opus-4-20250514 = 200000
+claude-opus-4-5 = 200000
+claude-opus-4-5-20251101 = 200000
+claude-opus-4-6 = 1000000
+claude-opus-4-7 = 1000000
+claude-sonnet-4-0 = 200000
+claude-sonnet-4-20250514 = 200000
+claude-sonnet-4-5 = 200000
+claude-sonnet-4-5-20250929 = 200000
+claude-sonnet-4-6 = 1000000
+
+[providers.model_metadata.claude-3-5-haiku-20241022]
+name = "Claude Haiku 3.5"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 0.8, output = 4, cacheRead = 0.08, cacheWrite = 1 }
+
+[providers.model_metadata.claude-3-5-haiku-latest]
+name = "Claude Haiku 3.5 (latest)"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 0.8, output = 4, cacheRead = 0.08, cacheWrite = 1 }
+
+[providers.model_metadata.claude-3-5-sonnet-20240620]
+name = "Claude Sonnet 3.5"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-3-5-sonnet-20241022]
+name = "Claude Sonnet 3.5 v2"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-3-7-sonnet-20250219]
+name = "Claude Sonnet 3.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-3-haiku-20240307]
+name = "Claude Haiku 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 0.25, output = 1.25, cacheRead = 0.03, cacheWrite = 0.3 }
+
+[providers.model_metadata.claude-3-opus-20240229]
+name = "Claude Opus 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata.claude-3-sonnet-20240229]
+name = "Claude Sonnet 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 0.3 }
+
+[providers.model_metadata.claude-haiku-4-5]
+name = "Claude Haiku 4.5 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+
+[providers.model_metadata.claude-haiku-4-5-20251001]
+name = "Claude Haiku 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+
+[providers.model_metadata.claude-opus-4-0]
+name = "Claude Opus 4 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata.claude-opus-4-1]
+name = "Claude Opus 4.1 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata.claude-opus-4-1-20250805]
+name = "Claude Opus 4.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata.claude-opus-4-20250514]
+name = "Claude Opus 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata.claude-opus-4-5]
+name = "Claude Opus 4.5 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata.claude-opus-4-5-20251101]
+name = "Claude Opus 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata.claude-opus-4-6]
+name = "Claude Opus 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "max" }
+
+[providers.model_metadata.claude-opus-4-7]
+name = "Claude Opus 4.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata.claude-sonnet-4-0]
+name = "Claude Sonnet 4 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-sonnet-4-20250514]
+name = "Claude Sonnet 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-sonnet-4-5]
+name = "Claude Sonnet 4.5 (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-sonnet-4-5-20250929]
+name = "Claude Sonnet 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.claude-sonnet-4-6]
+name = "Claude Sonnet 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[[providers]]
+name = "google"
+display_name = "Google Gemini"
+kind = "google-generative-ai"
+base_url = "https://generativelanguage.googleapis.com/v1beta"
+api = "google-generative-ai"
+api_key_env = "GEMINI_API_KEY"
+credential_name = "google"
+models = ["gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3-pro-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools", "gemini-3.5-flash", "gemini-flash-latest", "gemini-flash-lite-latest", "gemma-4-26b-a4b-it", "gemma-4-31b-it"]
+default_model = "gemini-3.1-pro-preview"
+docs_url = "https://ai.google.dev/gemini-api/docs"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"gemini-2.0-flash" = 1048576
+"gemini-2.0-flash-lite" = 1048576
+"gemini-2.5-flash" = 1048576
+"gemini-2.5-flash-lite" = 1048576
+"gemini-2.5-pro" = 1048576
+gemini-3-flash-preview = 1048576
+gemini-3-pro-preview = 1048576
+"gemini-3.1-flash-lite" = 1048576
+"gemini-3.1-flash-lite-preview" = 1048576
+"gemini-3.1-pro-preview" = 1048576
+"gemini-3.1-pro-preview-customtools" = 1048576
+"gemini-3.5-flash" = 1048576
+gemini-flash-latest = 1048576
+gemini-flash-lite-latest = 1048576
+gemma-4-26b-a4b-it = 262144
+gemma-4-31b-it = 262144
+
+[providers.model_metadata."gemini-2.0-flash"]
+name = "Gemini 2.0 Flash"
+reasoning = false
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 8192
+cost = { input = 0.1, output = 0.4, cacheRead = 0.025, cacheWrite = 0 }
+
+[providers.model_metadata."gemini-2.0-flash-lite"]
+name = "Gemini 2.0 Flash-Lite"
+reasoning = false
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 8192
+cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."gemini-2.5-flash"]
+name = "Gemini 2.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."gemini-2.5-flash-lite"]
+name = "Gemini 2.5 Flash-Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.1, output = 0.4, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."gemini-2.5-pro"]
+name = "Gemini 2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata.gemini-3-flash-preview]
+name = "Gemini 3 Flash Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.5, output = 3, cacheRead = 0.05, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gemini-3-pro-preview]
+name = "Gemini 3 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.2, cacheWrite = 0 }
+thinking_level_map = { low = "LOW", high = "HIGH" }
+unsupported_thinking_levels = ["off", "minimal", "medium"]
+
+[providers.model_metadata."gemini-3.1-flash-lite"]
+name = "Gemini 3.1 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0.025, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gemini-3.1-flash-lite-preview"]
+name = "Gemini 3.1 Flash Lite Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0.025, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gemini-3.1-pro-preview"]
+name = "Gemini 3.1 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.2, cacheWrite = 0 }
+thinking_level_map = { low = "LOW", high = "HIGH" }
+unsupported_thinking_levels = ["off", "minimal", "medium"]
+
+[providers.model_metadata."gemini-3.1-pro-preview-customtools"]
+name = "Gemini 3.1 Pro Preview Custom Tools"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.2, cacheWrite = 0 }
+thinking_level_map = { low = "LOW", high = "HIGH" }
+unsupported_thinking_levels = ["off", "minimal", "medium"]
+
+[providers.model_metadata."gemini-3.5-flash"]
+name = "Gemini 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata.gemini-flash-latest]
+name = "Gemini Flash Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata.gemini-flash-lite-latest]
+name = "Gemini Flash-Lite Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.1, output = 0.4, cacheRead = 0.025, cacheWrite = 0 }
+
+[providers.model_metadata.gemma-4-26b-a4b-it]
+name = "Gemma 4 26B A4B IT"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { minimal = "MINIMAL", high = "HIGH" }
+unsupported_thinking_levels = ["off", "low", "medium"]
+
+[providers.model_metadata.gemma-4-31b-it]
+name = "Gemma 4 31B IT"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { minimal = "MINIMAL", high = "HIGH" }
+unsupported_thinking_levels = ["off", "low", "medium"]
+
+[[providers]]
+name = "deepseek"
+display_name = "DeepSeek"
+kind = "openai-compatible"
+base_url = "https://api.deepseek.com"
+api = "openai-completions"
+api_key_env = "DEEPSEEK_API_KEY"
+credential_name = "deepseek"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default_model = "deepseek-v4-pro"
+docs_url = "https://api-docs.deepseek.com"
+thinking_levels = ["off", "high", "xhigh"]
+thinking_default = "off"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+deepseek-v4-flash = 1000000
+deepseek-v4-pro = 1000000
+
+[providers.model_metadata.deepseek-v4-flash]
+name = "DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.14, output = 0.28, cacheRead = 0.0028, cacheWrite = 0 }
+thinking_level_map = { high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata.deepseek-v4-pro]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.435, output = 0.87, cacheRead = 0.003625, cacheWrite = 0 }
+thinking_level_map = { high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[[providers]]
+name = "xai"
+display_name = "xAI"
+kind = "openai-compatible"
+base_url = "https://api.x.ai/v1"
+api = "openai-completions"
+api_key_env = "XAI_API_KEY"
+credential_name = "xai"
+models = ["grok-3", "grok-3-fast", "grok-4.20-0309-non-reasoning", "grok-4.20-0309-reasoning", "grok-4.3", "grok-build-0.1", "grok-code-fast-1"]
+default_model = "grok-4.20-0309-reasoning"
+docs_url = "https://docs.x.ai"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+grok-3 = 131072
+grok-3-fast = 131072
+"grok-4.20-0309-non-reasoning" = 2000000
+"grok-4.20-0309-reasoning" = 2000000
+"grok-4.3" = 1000000
+"grok-build-0.1" = 256000
+grok-code-fast-1 = 32768
+
+[providers.model_metadata.grok-3]
+name = "Grok 3"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 3, output = 15, cacheRead = 0.75, cacheWrite = 0 }
+
+[providers.model_metadata.grok-3-fast]
+name = "Grok 3 Fast"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 5, output = 25, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata."grok-4.20-0309-non-reasoning"]
+name = "Grok 4.20 (Non-Reasoning)"
+reasoning = false
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 30000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."grok-4.20-0309-reasoning"]
+name = "Grok 4.20 (Reasoning)"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 30000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."grok-4.3"]
+name = "Grok 4.3"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 30000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."grok-build-0.1"]
+name = "Grok Build 0.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 1, output = 2, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata.grok-code-fast-1]
+name = "Grok Code Fast 1"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 8192
+cost = { input = 0.2, output = 1.5, cacheRead = 0.02, cacheWrite = 0 }
+
+[[providers]]
+name = "groq"
+display_name = "Groq"
+kind = "openai-compatible"
+base_url = "https://api.groq.com/openai/v1"
+api = "openai-completions"
+api_key_env = "GROQ_API_KEY"
+credential_name = "groq"
+models = ["deepseek-r1-distill-llama-70b", "gemma2-9b-it", "groq/compound", "groq/compound-mini", "llama-3.1-8b-instant", "llama-3.3-70b-versatile", "llama3-70b-8192", "llama3-8b-8192", "meta-llama/llama-4-maverick-17b-128e-instruct", "meta-llama/llama-4-scout-17b-16e-instruct", "mistral-saba-24b", "moonshotai/kimi-k2-instruct", "moonshotai/kimi-k2-instruct-0905", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "qwen-qwq-32b", "qwen/qwen3-32b"]
+default_model = "openai/gpt-oss-120b"
+docs_url = "https://console.groq.com/docs"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+deepseek-r1-distill-llama-70b = 131072
+gemma2-9b-it = 8192
+"groq/compound" = 131072
+"groq/compound-mini" = 131072
+"llama-3.1-8b-instant" = 131072
+"llama-3.3-70b-versatile" = 131072
+llama3-70b-8192 = 8192
+llama3-8b-8192 = 8192
+"meta-llama/llama-4-maverick-17b-128e-instruct" = 131072
+"meta-llama/llama-4-scout-17b-16e-instruct" = 131072
+mistral-saba-24b = 32768
+"moonshotai/kimi-k2-instruct" = 131072
+"moonshotai/kimi-k2-instruct-0905" = 262144
+"openai/gpt-oss-120b" = 131072
+"openai/gpt-oss-20b" = 131072
+"openai/gpt-oss-safeguard-20b" = 131072
+qwen-qwq-32b = 131072
+"qwen/qwen3-32b" = 131072
+
+[providers.model_metadata.deepseek-r1-distill-llama-70b]
+name = "DeepSeek R1 Distill Llama 70B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.75, output = 0.99, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.gemma2-9b-it]
+name = "Gemma 2 9B"
+reasoning = false
+input = ["text"]
+context_window = 8192
+max_tokens = 8192
+cost = { input = 0.2, output = 0.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."groq/compound"]
+name = "Compound"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."groq/compound-mini"]
+name = "Compound Mini"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."llama-3.1-8b-instant"]
+name = "Llama 3.1 8B Instant"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.05, output = 0.08, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."llama-3.3-70b-versatile"]
+name = "Llama 3.3 70B Versatile"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.llama3-70b-8192]
+name = "Llama 3 70B"
+reasoning = false
+input = ["text"]
+context_window = 8192
+max_tokens = 8192
+cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.llama3-8b-8192]
+name = "Llama 3 8B"
+reasoning = false
+input = ["text"]
+context_window = 8192
+max_tokens = 8192
+cost = { input = 0.05, output = 0.08, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-4-maverick-17b-128e-instruct"]
+name = "Llama 4 Maverick 17B"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.2, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-4-scout-17b-16e-instruct"]
+name = "Llama 4 Scout 17B"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.11, output = 0.34, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-saba-24b]
+name = "Mistral Saba 24B"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 32768
+cost = { input = 0.79, output = 0.79, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-instruct"]
+name = "Kimi K2 Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-instruct-0905"]
+name = "Kimi K2 Instruct 0905"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-120b"]
+name = "GPT OSS 120B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-20b"]
+name = "GPT OSS 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-safeguard-20b"]
+name = "Safety GPT OSS 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.075, output = 0.3, cacheRead = 0.037, cacheWrite = 0 }
+
+[providers.model_metadata.qwen-qwq-32b]
+name = "Qwen QwQ 32B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.29, output = 0.39, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-32b"]
+name = "Qwen3 32B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 40960
+cost = { input = 0.29, output = 0.59, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { high = "default" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[[providers]]
+name = "cerebras"
+display_name = "Cerebras"
+kind = "openai-compatible"
+base_url = "https://api.cerebras.ai/v1"
+api = "openai-completions"
+api_key_env = "CEREBRAS_API_KEY"
+credential_name = "cerebras"
+models = ["gpt-oss-120b", "llama3.1-8b", "qwen-3-235b-a22b-instruct-2507", "zai-glm-4.7"]
+default_model = "zai-glm-4.7"
+docs_url = "https://inference-docs.cerebras.ai"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+gpt-oss-120b = 131072
+"llama3.1-8b" = 32000
+qwen-3-235b-a22b-instruct-2507 = 131000
+"zai-glm-4.7" = 131072
+
+[providers.model_metadata.gpt-oss-120b]
+name = "GPT OSS 120B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.25, output = 0.69, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."llama3.1-8b"]
+name = "Llama 3.1 8B"
+reasoning = false
+input = ["text"]
+context_window = 32000
+max_tokens = 8000
+cost = { input = 0.1, output = 0.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.qwen-3-235b-a22b-instruct-2507]
+name = "Qwen 3 235B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131000
+max_tokens = 32000
+cost = { input = 0.6, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-glm-4.7"]
+name = "Z.AI GLM-4.7"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 40000
+cost = { input = 2.25, output = 2.75, cacheRead = 0, cacheWrite = 0 }
 
 [[providers]]
 name = "openrouter"
 display_name = "OpenRouter"
 kind = "openai-compatible"
 base_url = "https://openrouter.ai/api/v1"
+api = "openai-completions"
 api_key_env = "OPENROUTER_API_KEY"
 credential_name = "openrouter"
-models = [
-  "openai/gpt-5.5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.3-codex",
-  "anthropic/claude-sonnet-4.6",
-  "anthropic/claude-opus-4.8",
-  "google/gemini-3.5-pro",
-  "moonshotai/kimi-k2.7-code",
-  "moonshotai/kimi-k2-instruct",
-  "deepseek/deepseek-v4-pro",
-  "deepseek/deepseek-v4-flash",
-  "z-ai/glm-5.2",
-  "z-ai/glm-4.5",
-  "minimax/minimax-m3",
-  "qwen/qwen3-coder-plus",
-  "qwen/qwen3-coder",
-  "qwen/qwen3-235b-a22b-thinking-2507",
-  "mistralai/codestral-2508",
-  "meta-llama/llama-4-maverick",
-]
-default_model = "openai/gpt-5.5"
+models = ["ai21/jamba-large-1.7", "alibaba/tongyi-deepresearch-30b-a3b", "amazon/nova-2-lite-v1", "amazon/nova-lite-v1", "amazon/nova-micro-v1", "amazon/nova-premier-v1", "amazon/nova-pro-v1", "anthropic/claude-3-haiku", "anthropic/claude-3.5-haiku", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4", "anthropic/claude-opus-4.1", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.6-fast", "anthropic/claude-opus-4.7", "anthropic/claude-opus-4.7-fast", "anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.6", "arcee-ai/trinity-large-thinking", "arcee-ai/trinity-large-thinking:free", "arcee-ai/trinity-mini", "arcee-ai/virtuoso-large", "auto", "baidu/cobuddy:free", "baidu/ernie-4.5-21b-a3b", "baidu/ernie-4.5-vl-28b-a3b", "bytedance-seed/seed-1.6", "bytedance-seed/seed-1.6-flash", "bytedance-seed/seed-2.0-lite", "bytedance-seed/seed-2.0-mini", "cohere/command-r-08-2024", "cohere/command-r-plus-08-2024", "deepseek/deepseek-chat", "deepseek/deepseek-chat-v3-0324", "deepseek/deepseek-chat-v3.1", "deepseek/deepseek-r1", "deepseek/deepseek-r1-0528", "deepseek/deepseek-v3.1-terminus", "deepseek/deepseek-v3.2", "deepseek/deepseek-v3.2-exp", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash:free", "deepseek/deepseek-v4-pro", "essentialai/rnj-1-instruct", "google/gemini-2.0-flash-001", "google/gemini-2.0-flash-lite-001", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash-lite-preview-09-2025", "google/gemini-2.5-pro", "google/gemini-2.5-pro-preview", "google/gemini-2.5-pro-preview-05-06", "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.1-pro-preview-customtools", "google/gemini-3.5-flash", "google/gemma-3-12b-it", "google/gemma-3-27b-it", "google/gemma-4-26b-a4b-it", "google/gemma-4-26b-a4b-it:free", "google/gemma-4-31b-it", "google/gemma-4-31b-it:free", "ibm-granite/granite-4.1-8b", "inception/mercury-2", "inclusionai/ling-2.6-1t", "inclusionai/ling-2.6-flash", "inclusionai/ring-2.6-1t", "kwaipilot/kat-coder-pro-v2", "meta-llama/llama-3.1-70b-instruct", "meta-llama/llama-3.1-8b-instruct", "meta-llama/llama-3.3-70b-instruct", "meta-llama/llama-3.3-70b-instruct:free", "meta-llama/llama-4-scout", "minimax/minimax-m1", "minimax/minimax-m2", "minimax/minimax-m2.1", "minimax/minimax-m2.5", "minimax/minimax-m2.5:free", "minimax/minimax-m2.7", "mistralai/codestral-2508", "mistralai/devstral-2512", "mistralai/devstral-medium", "mistralai/devstral-small", "mistralai/ministral-14b-2512", "mistralai/ministral-3b-2512", "mistralai/ministral-8b-2512", "mistralai/mistral-large", "mistralai/mistral-large-2407", "mistralai/mistral-large-2411", "mistralai/mistral-large-2512", "mistralai/mistral-medium-3", "mistralai/mistral-medium-3-5", "mistralai/mistral-medium-3.1", "mistralai/mistral-nemo", "mistralai/mistral-saba", "mistralai/mistral-small-2603", "mistralai/mistral-small-3.2-24b-instruct", "mistralai/mixtral-8x22b-instruct", "mistralai/pixtral-large-2411", "mistralai/voxtral-small-24b-2507", "moonshotai/kimi-k2", "moonshotai/kimi-k2-0905", "moonshotai/kimi-k2-thinking", "moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "nex-agi/deepseek-v3.1-nex-n1", "nvidia/llama-3.3-nemotron-super-49b-v1.5", "nvidia/nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-nano-30b-a3b:free", "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free", "nvidia/nemotron-3-super-120b-a12b", "nvidia/nemotron-3-super-120b-a12b:free", "nvidia/nemotron-nano-12b-v2-vl:free", "nvidia/nemotron-nano-9b-v2", "nvidia/nemotron-nano-9b-v2:free", "openai/gpt-3.5-turbo", "openai/gpt-3.5-turbo-0613", "openai/gpt-3.5-turbo-16k", "openai/gpt-4", "openai/gpt-4-0314", "openai/gpt-4-1106-preview", "openai/gpt-4-turbo", "openai/gpt-4-turbo-preview", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4.1-nano", "openai/gpt-4o", "openai/gpt-4o-2024-05-13", "openai/gpt-4o-2024-08-06", "openai/gpt-4o-2024-11-20", "openai/gpt-4o-audio-preview", "openai/gpt-4o-mini", "openai/gpt-4o-mini-2024-07-18", "openai/gpt-5", "openai/gpt-5-codex", "openai/gpt-5-mini", "openai/gpt-5-nano", "openai/gpt-5-pro", "openai/gpt-5.1", "openai/gpt-5.1-chat", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-max", "openai/gpt-5.1-codex-mini", "openai/gpt-5.2", "openai/gpt-5.2-chat", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.3-chat", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-audio", "openai/gpt-audio-mini", "openai/gpt-chat-latest", "openai/gpt-oss-120b", "openai/gpt-oss-120b:free", "openai/gpt-oss-20b", "openai/gpt-oss-20b:free", "openai/gpt-oss-safeguard-20b", "openai/o1", "openai/o3", "openai/o3-deep-research", "openai/o3-mini", "openai/o3-mini-high", "openai/o3-pro", "openai/o4-mini", "openai/o4-mini-deep-research", "openai/o4-mini-high", "openrouter/auto", "openrouter/free", "openrouter/owl-alpha", "poolside/laguna-m.1:free", "poolside/laguna-xs.2:free", "prime-intellect/intellect-3", "qwen/qwen-2.5-72b-instruct", "qwen/qwen-2.5-7b-instruct", "qwen/qwen-plus", "qwen/qwen-plus-2025-07-28", "qwen/qwen-plus-2025-07-28:thinking", "qwen/qwen3-14b", "qwen/qwen3-235b-a22b", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-235b-a22b-thinking-2507", "qwen/qwen3-30b-a3b", "qwen/qwen3-30b-a3b-instruct-2507", "qwen/qwen3-30b-a3b-thinking-2507", "qwen/qwen3-32b", "qwen/qwen3-8b", "qwen/qwen3-coder", "qwen/qwen3-coder-30b-a3b-instruct", "qwen/qwen3-coder-flash", "qwen/qwen3-coder-next", "qwen/qwen3-coder-plus", "qwen/qwen3-coder:free", "qwen/qwen3-max", "qwen/qwen3-max-thinking", "qwen/qwen3-next-80b-a3b-instruct", "qwen/qwen3-next-80b-a3b-instruct:free", "qwen/qwen3-next-80b-a3b-thinking", "qwen/qwen3-vl-235b-a22b-instruct", "qwen/qwen3-vl-235b-a22b-thinking", "qwen/qwen3-vl-30b-a3b-instruct", "qwen/qwen3-vl-30b-a3b-thinking", "qwen/qwen3-vl-32b-instruct", "qwen/qwen3-vl-8b-instruct", "qwen/qwen3-vl-8b-thinking", "qwen/qwen3.5-122b-a10b", "qwen/qwen3.5-27b", "qwen/qwen3.5-35b-a3b", "qwen/qwen3.5-397b-a17b", "qwen/qwen3.5-9b", "qwen/qwen3.5-flash-02-23", "qwen/qwen3.5-plus-02-15", "qwen/qwen3.5-plus-20260420", "qwen/qwen3.6-27b", "qwen/qwen3.6-35b-a3b", "qwen/qwen3.6-flash", "qwen/qwen3.6-max-preview", "qwen/qwen3.6-plus", "qwen/qwen3.7-max", "rekaai/reka-edge", "relace/relace-search", "sao10k/l3-euryale-70b", "sao10k/l3.1-euryale-70b", "stepfun/step-3.5-flash", "tencent/hy3-preview", "thedrummer/rocinante-12b", "thedrummer/unslopnemo-12b", "upstage/solar-pro-3", "x-ai/grok-4.20", "x-ai/grok-4.3", "x-ai/grok-build-0.1", "xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-omni", "xiaomi/mimo-v2-pro", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro", "z-ai/glm-4-32b", "z-ai/glm-4.5", "z-ai/glm-4.5-air", "z-ai/glm-4.5-air:free", "z-ai/glm-4.5v", "z-ai/glm-4.6", "z-ai/glm-4.6v", "z-ai/glm-4.7", "z-ai/glm-4.7-flash", "z-ai/glm-5", "z-ai/glm-5-turbo", "z-ai/glm-5.1", "z-ai/glm-5v-turbo", "~anthropic/claude-haiku-latest", "~anthropic/claude-opus-latest", "~anthropic/claude-sonnet-latest", "~google/gemini-flash-latest", "~google/gemini-pro-latest", "~moonshotai/kimi-latest", "~openai/gpt-latest", "~openai/gpt-mini-latest"]
+default_model = "moonshotai/kimi-k2.6"
 docs_url = "https://openrouter.ai/docs"
-thinking_levels = ["off", "low", "medium", "high", "xhigh"]
-thinking_models = [
-  "openai/gpt-5.5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.3-codex",
-  "qwen/qwen3-235b-a22b-thinking-2507",
-]
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-"openai/gpt-5.5" = 1050000
-"openai/gpt-5.4" = 1050000
-"openai/gpt-5.3-codex" = 400000
+"ai21/jamba-large-1.7" = 256000
+"alibaba/tongyi-deepresearch-30b-a3b" = 131072
+"amazon/nova-2-lite-v1" = 1000000
+"amazon/nova-lite-v1" = 300000
+"amazon/nova-micro-v1" = 128000
+"amazon/nova-premier-v1" = 1000000
+"amazon/nova-pro-v1" = 300000
+"anthropic/claude-3-haiku" = 200000
+"anthropic/claude-3.5-haiku" = 200000
+"anthropic/claude-haiku-4.5" = 200000
+"anthropic/claude-opus-4" = 200000
+"anthropic/claude-opus-4.1" = 200000
+"anthropic/claude-opus-4.5" = 200000
+"anthropic/claude-opus-4.6" = 1000000
+"anthropic/claude-opus-4.6-fast" = 1000000
+"anthropic/claude-opus-4.7" = 1000000
+"anthropic/claude-opus-4.7-fast" = 1000000
+"anthropic/claude-sonnet-4" = 1000000
+"anthropic/claude-sonnet-4.5" = 1000000
 "anthropic/claude-sonnet-4.6" = 1000000
-"qwen/qwen3-coder-plus" = 1000000
+"arcee-ai/trinity-large-thinking" = 262144
+"arcee-ai/trinity-large-thinking:free" = 262144
+"arcee-ai/trinity-mini" = 131072
+"arcee-ai/virtuoso-large" = 131072
+auto = 2000000
+"baidu/cobuddy:free" = 131072
+"baidu/ernie-4.5-21b-a3b" = 131072
+"baidu/ernie-4.5-vl-28b-a3b" = 131072
+"bytedance-seed/seed-1.6" = 262144
+"bytedance-seed/seed-1.6-flash" = 262144
+"bytedance-seed/seed-2.0-lite" = 262144
+"bytedance-seed/seed-2.0-mini" = 262144
+"cohere/command-r-08-2024" = 128000
+"cohere/command-r-plus-08-2024" = 128000
+"deepseek/deepseek-chat" = 163840
+"deepseek/deepseek-chat-v3-0324" = 163840
+"deepseek/deepseek-chat-v3.1" = 163840
+"deepseek/deepseek-r1" = 163840
+"deepseek/deepseek-r1-0528" = 163840
+"deepseek/deepseek-v3.1-terminus" = 163840
+"deepseek/deepseek-v3.2" = 131072
+"deepseek/deepseek-v3.2-exp" = 163840
+"deepseek/deepseek-v4-flash" = 1048576
+"deepseek/deepseek-v4-flash:free" = 1048576
+"deepseek/deepseek-v4-pro" = 1048576
+"essentialai/rnj-1-instruct" = 32768
+"google/gemini-2.0-flash-001" = 1000000
+"google/gemini-2.0-flash-lite-001" = 1048576
+"google/gemini-2.5-flash" = 1048576
+"google/gemini-2.5-flash-lite" = 1048576
+"google/gemini-2.5-flash-lite-preview-09-2025" = 1048576
+"google/gemini-2.5-pro" = 1048576
+"google/gemini-2.5-pro-preview" = 1048576
+"google/gemini-2.5-pro-preview-05-06" = 1048576
+"google/gemini-3-flash-preview" = 1048576
+"google/gemini-3.1-flash-lite" = 1048576
+"google/gemini-3.1-flash-lite-preview" = 1048576
+"google/gemini-3.1-pro-preview" = 1048576
+"google/gemini-3.1-pro-preview-customtools" = 1048756
+"google/gemini-3.5-flash" = 1048576
+"google/gemma-3-12b-it" = 131072
+"google/gemma-3-27b-it" = 131072
+"google/gemma-4-26b-a4b-it" = 262144
+"google/gemma-4-26b-a4b-it:free" = 262144
+"google/gemma-4-31b-it" = 262144
+"google/gemma-4-31b-it:free" = 262144
+"ibm-granite/granite-4.1-8b" = 131072
+"inception/mercury-2" = 128000
+"inclusionai/ling-2.6-1t" = 262144
+"inclusionai/ling-2.6-flash" = 262144
+"inclusionai/ring-2.6-1t" = 262144
+"kwaipilot/kat-coder-pro-v2" = 256000
+"meta-llama/llama-3.1-70b-instruct" = 131072
+"meta-llama/llama-3.1-8b-instruct" = 131072
+"meta-llama/llama-3.3-70b-instruct" = 131072
+"meta-llama/llama-3.3-70b-instruct:free" = 131072
+"meta-llama/llama-4-scout" = 10000000
+"minimax/minimax-m1" = 1000000
+"minimax/minimax-m2" = 204800
+"minimax/minimax-m2.1" = 204800
+"minimax/minimax-m2.5" = 204800
+"minimax/minimax-m2.5:free" = 204800
+"minimax/minimax-m2.7" = 204800
 "mistralai/codestral-2508" = 256000
+"mistralai/devstral-2512" = 262144
+"mistralai/devstral-medium" = 131072
+"mistralai/devstral-small" = 131072
+"mistralai/ministral-14b-2512" = 262144
+"mistralai/ministral-3b-2512" = 131072
+"mistralai/ministral-8b-2512" = 262144
+"mistralai/mistral-large" = 128000
+"mistralai/mistral-large-2407" = 131072
+"mistralai/mistral-large-2411" = 131072
+"mistralai/mistral-large-2512" = 262144
+"mistralai/mistral-medium-3" = 131072
+"mistralai/mistral-medium-3-5" = 262144
+"mistralai/mistral-medium-3.1" = 131072
+"mistralai/mistral-nemo" = 131072
+"mistralai/mistral-saba" = 32768
+"mistralai/mistral-small-2603" = 262144
+"mistralai/mistral-small-3.2-24b-instruct" = 128000
+"mistralai/mixtral-8x22b-instruct" = 65536
+"mistralai/pixtral-large-2411" = 131072
+"mistralai/voxtral-small-24b-2507" = 32000
+"moonshotai/kimi-k2" = 131072
+"moonshotai/kimi-k2-0905" = 262144
+"moonshotai/kimi-k2-thinking" = 262144
+"moonshotai/kimi-k2.5" = 262144
+"moonshotai/kimi-k2.6" = 262144
+"nex-agi/deepseek-v3.1-nex-n1" = 131072
+"nvidia/llama-3.3-nemotron-super-49b-v1.5" = 131072
+"nvidia/nemotron-3-nano-30b-a3b" = 262144
+"nvidia/nemotron-3-nano-30b-a3b:free" = 256000
+"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free" = 256000
+"nvidia/nemotron-3-super-120b-a12b" = 1000000
+"nvidia/nemotron-3-super-120b-a12b:free" = 1000000
+"nvidia/nemotron-nano-12b-v2-vl:free" = 128000
+"nvidia/nemotron-nano-9b-v2" = 131072
+"nvidia/nemotron-nano-9b-v2:free" = 128000
+"openai/gpt-3.5-turbo" = 16385
+"openai/gpt-3.5-turbo-0613" = 4095
+"openai/gpt-3.5-turbo-16k" = 16385
+"openai/gpt-4" = 8191
+"openai/gpt-4-0314" = 8191
+"openai/gpt-4-1106-preview" = 128000
+"openai/gpt-4-turbo" = 128000
+"openai/gpt-4-turbo-preview" = 128000
+"openai/gpt-4.1" = 1047576
+"openai/gpt-4.1-mini" = 1047576
+"openai/gpt-4.1-nano" = 1047576
+"openai/gpt-4o" = 128000
+"openai/gpt-4o-2024-05-13" = 128000
+"openai/gpt-4o-2024-08-06" = 128000
+"openai/gpt-4o-2024-11-20" = 128000
+"openai/gpt-4o-audio-preview" = 128000
+"openai/gpt-4o-mini" = 128000
+"openai/gpt-4o-mini-2024-07-18" = 128000
+"openai/gpt-5" = 400000
+"openai/gpt-5-codex" = 400000
+"openai/gpt-5-mini" = 400000
+"openai/gpt-5-nano" = 400000
+"openai/gpt-5-pro" = 400000
+"openai/gpt-5.1" = 400000
+"openai/gpt-5.1-chat" = 128000
+"openai/gpt-5.1-codex" = 400000
+"openai/gpt-5.1-codex-max" = 400000
+"openai/gpt-5.1-codex-mini" = 400000
+"openai/gpt-5.2" = 400000
+"openai/gpt-5.2-chat" = 128000
+"openai/gpt-5.2-codex" = 400000
+"openai/gpt-5.2-pro" = 400000
+"openai/gpt-5.3-chat" = 128000
+"openai/gpt-5.3-codex" = 400000
+"openai/gpt-5.4" = 1050000
+"openai/gpt-5.4-mini" = 400000
+"openai/gpt-5.4-nano" = 400000
+"openai/gpt-5.4-pro" = 1050000
+"openai/gpt-5.5" = 1050000
+"openai/gpt-5.5-pro" = 1050000
+"openai/gpt-audio" = 128000
+"openai/gpt-audio-mini" = 128000
+"openai/gpt-chat-latest" = 400000
+"openai/gpt-oss-120b" = 131072
+"openai/gpt-oss-120b:free" = 131072
+"openai/gpt-oss-20b" = 131072
+"openai/gpt-oss-20b:free" = 131072
+"openai/gpt-oss-safeguard-20b" = 131072
+"openai/o1" = 200000
+"openai/o3" = 200000
+"openai/o3-deep-research" = 200000
+"openai/o3-mini" = 200000
+"openai/o3-mini-high" = 200000
+"openai/o3-pro" = 200000
+"openai/o4-mini" = 200000
+"openai/o4-mini-deep-research" = 200000
+"openai/o4-mini-high" = 200000
+"openrouter/auto" = 2000000
+"openrouter/free" = 200000
+"openrouter/owl-alpha" = 1048756
+"poolside/laguna-m.1:free" = 131072
+"poolside/laguna-xs.2:free" = 131072
+"prime-intellect/intellect-3" = 131072
+"qwen/qwen-2.5-72b-instruct" = 131072
+"qwen/qwen-2.5-7b-instruct" = 131072
+"qwen/qwen-plus" = 1000000
+"qwen/qwen-plus-2025-07-28" = 1000000
+"qwen/qwen-plus-2025-07-28:thinking" = 1000000
+"qwen/qwen3-14b" = 131702
+"qwen/qwen3-235b-a22b" = 131072
+"qwen/qwen3-235b-a22b-2507" = 262144
+"qwen/qwen3-235b-a22b-thinking-2507" = 262144
+"qwen/qwen3-30b-a3b" = 131072
+"qwen/qwen3-30b-a3b-instruct-2507" = 262144
+"qwen/qwen3-30b-a3b-thinking-2507" = 131072
+"qwen/qwen3-32b" = 131072
+"qwen/qwen3-8b" = 131072
+"qwen/qwen3-coder" = 1048576
+"qwen/qwen3-coder-30b-a3b-instruct" = 160000
+"qwen/qwen3-coder-flash" = 1000000
+"qwen/qwen3-coder-next" = 262144
+"qwen/qwen3-coder-plus" = 1000000
+"qwen/qwen3-coder:free" = 1048576
+"qwen/qwen3-max" = 262144
+"qwen/qwen3-max-thinking" = 262144
+"qwen/qwen3-next-80b-a3b-instruct" = 262144
+"qwen/qwen3-next-80b-a3b-instruct:free" = 262144
+"qwen/qwen3-next-80b-a3b-thinking" = 262144
+"qwen/qwen3-vl-235b-a22b-instruct" = 262144
+"qwen/qwen3-vl-235b-a22b-thinking" = 131072
+"qwen/qwen3-vl-30b-a3b-instruct" = 262144
+"qwen/qwen3-vl-30b-a3b-thinking" = 131072
+"qwen/qwen3-vl-32b-instruct" = 262144
+"qwen/qwen3-vl-8b-instruct" = 256000
+"qwen/qwen3-vl-8b-thinking" = 256000
+"qwen/qwen3.5-122b-a10b" = 262144
+"qwen/qwen3.5-27b" = 262144
+"qwen/qwen3.5-35b-a3b" = 262144
+"qwen/qwen3.5-397b-a17b" = 262144
+"qwen/qwen3.5-9b" = 262144
+"qwen/qwen3.5-flash-02-23" = 1000000
+"qwen/qwen3.5-plus-02-15" = 1000000
+"qwen/qwen3.5-plus-20260420" = 1000000
+"qwen/qwen3.6-27b" = 262144
+"qwen/qwen3.6-35b-a3b" = 262144
+"qwen/qwen3.6-flash" = 1000000
+"qwen/qwen3.6-max-preview" = 262144
+"qwen/qwen3.6-plus" = 1000000
+"qwen/qwen3.7-max" = 1000000
+"rekaai/reka-edge" = 16384
+"relace/relace-search" = 256000
+"sao10k/l3-euryale-70b" = 8192
+"sao10k/l3.1-euryale-70b" = 131072
+"stepfun/step-3.5-flash" = 262144
+"tencent/hy3-preview" = 262144
+"thedrummer/rocinante-12b" = 32768
+"thedrummer/unslopnemo-12b" = 32768
+"upstage/solar-pro-3" = 128000
+"x-ai/grok-4.20" = 2000000
+"x-ai/grok-4.3" = 1000000
+"x-ai/grok-build-0.1" = 256000
+"xiaomi/mimo-v2-flash" = 262144
+"xiaomi/mimo-v2-omni" = 262144
+"xiaomi/mimo-v2-pro" = 1048576
+"xiaomi/mimo-v2.5" = 1048576
+"xiaomi/mimo-v2.5-pro" = 1048576
+"z-ai/glm-4-32b" = 128000
+"z-ai/glm-4.5" = 131072
+"z-ai/glm-4.5-air" = 131072
+"z-ai/glm-4.5-air:free" = 131072
+"z-ai/glm-4.5v" = 65536
+"z-ai/glm-4.6" = 202752
+"z-ai/glm-4.6v" = 131072
+"z-ai/glm-4.7" = 202752
+"z-ai/glm-4.7-flash" = 202752
+"z-ai/glm-5" = 202752
+"z-ai/glm-5-turbo" = 202752
+"z-ai/glm-5.1" = 202752
+"z-ai/glm-5v-turbo" = 202752
+"~anthropic/claude-haiku-latest" = 200000
+"~anthropic/claude-opus-latest" = 1000000
+"~anthropic/claude-sonnet-latest" = 1000000
+"~google/gemini-flash-latest" = 1048576
+"~google/gemini-pro-latest" = 1048576
+"~moonshotai/kimi-latest" = 262144
+"~openai/gpt-latest" = 1050000
+"~openai/gpt-mini-latest" = 400000
+
+[providers.model_metadata."ai21/jamba-large-1.7"]
+name = "AI21: Jamba Large 1.7"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 4096
+cost = { input = 2, output = 8, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/tongyi-deepresearch-30b-a3b"]
+name = "Tongyi DeepResearch 30B A3B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.09, output = 0.44999999999999996, cacheRead = 0.09, cacheWrite = 0 }
+
+[providers.model_metadata."amazon/nova-2-lite-v1"]
+name = "Amazon: Nova 2 Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65535
+cost = { input = 0.3, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."amazon/nova-lite-v1"]
+name = "Amazon: Nova Lite 1.0"
+reasoning = false
+input = ["text", "image"]
+context_window = 300000
+max_tokens = 5120
+cost = { input = 0.06, output = 0.24, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."amazon/nova-micro-v1"]
+name = "Amazon: Nova Micro 1.0"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 5120
+cost = { input = 0.035, output = 0.14, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."amazon/nova-premier-v1"]
+name = "Amazon: Nova Premier 1.0"
+reasoning = false
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 32000
+cost = { input = 2.5, output = 12.5, cacheRead = 0.625, cacheWrite = 0 }
+
+[providers.model_metadata."amazon/nova-pro-v1"]
+name = "Amazon: Nova Pro 1.0"
+reasoning = false
+input = ["text", "image"]
+context_window = 300000
+max_tokens = 5120
+cost = { input = 0.7999999999999999, output = 3.1999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-3-haiku"]
+name = "Anthropic: Claude 3 Haiku"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 0.25, output = 1.25, cacheRead = 0.03, cacheWrite = 0.3 }
+
+[providers.model_metadata."anthropic/claude-3.5-haiku"]
+name = "Anthropic: Claude 3.5 Haiku"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 0.7999999999999999, output = 4, cacheRead = 0.08, cacheWrite = 1 }
+
+[providers.model_metadata."anthropic/claude-haiku-4.5"]
+name = "Anthropic: Claude Haiku 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.09999999999999999, cacheWrite = 1.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4"]
+name = "Anthropic: Claude Opus 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata."anthropic/claude-opus-4.1"]
+name = "Anthropic: Claude Opus 4.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata."anthropic/claude-opus-4.5"]
+name = "Anthropic: Claude Opus 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4.6"]
+name = "Anthropic: Claude Opus 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "max" }
+
+[providers.model_metadata."anthropic/claude-opus-4.6-fast"]
+name = "Anthropic: Claude Opus 4.6 (Fast)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 30, output = 150, cacheRead = 3, cacheWrite = 37.5 }
+thinking_level_map = { xhigh = "max" }
+
+[providers.model_metadata."anthropic/claude-opus-4.7"]
+name = "Anthropic: Claude Opus 4.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."anthropic/claude-opus-4.7-fast"]
+name = "Anthropic: Claude Opus 4.7 (Fast)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 30, output = 150, cacheRead = 3, cacheWrite = 37.5 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."anthropic/claude-sonnet-4"]
+name = "Anthropic: Claude Sonnet 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.5"]
+name = "Anthropic: Claude Sonnet 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.6"]
+name = "Anthropic: Claude Sonnet 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."arcee-ai/trinity-large-thinking"]
+name = "Arcee AI: Trinity Large Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.22, output = 0.85, cacheRead = 0.06, cacheWrite = 0 }
+
+[providers.model_metadata."arcee-ai/trinity-large-thinking:free"]
+name = "Arcee AI: Trinity Large Thinking (free)"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 80000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."arcee-ai/trinity-mini"]
+name = "Arcee AI: Trinity Mini"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.045, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."arcee-ai/virtuoso-large"]
+name = "Arcee AI: Virtuoso Large"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 64000
+cost = { input = 0.75, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.auto]
+name = "Auto"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 30000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."baidu/cobuddy:free"]
+name = "Baidu Qianfan: CoBuddy (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."baidu/ernie-4.5-21b-a3b"]
+name = "Baidu: ERNIE 4.5 21B A3B"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 8000
+cost = { input = 0.07, output = 0.28, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."baidu/ernie-4.5-vl-28b-a3b"]
+name = "Baidu: ERNIE 4.5 VL 28B A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 8000
+cost = { input = 0.14, output = 0.56, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."bytedance-seed/seed-1.6"]
+name = "ByteDance Seed: Seed 1.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.25, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."bytedance-seed/seed-1.6-flash"]
+name = "ByteDance Seed: Seed 1.6 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."bytedance-seed/seed-2.0-lite"]
+name = "ByteDance Seed: Seed-2.0-Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+cost = { input = 0.25, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."bytedance-seed/seed-2.0-mini"]
+name = "ByteDance Seed: Seed-2.0-Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."cohere/command-r-08-2024"]
+name = "Cohere: Command R (08-2024)"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."cohere/command-r-plus-08-2024"]
+name = "Cohere: Command R+ (08-2024)"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-chat"]
+name = "DeepSeek: DeepSeek V3"
+reasoning = false
+input = ["text"]
+context_window = 163840
+max_tokens = 16384
+cost = { input = 0.32, output = 0.8899999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-chat-v3-0324"]
+name = "DeepSeek: DeepSeek V3 0324"
+reasoning = false
+input = ["text"]
+context_window = 163840
+max_tokens = 16384
+cost = { input = 0.19999999999999998, output = 0.77, cacheRead = 0.135, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-chat-v3.1"]
+name = "DeepSeek: DeepSeek V3.1"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 32768
+cost = { input = 0.21, output = 0.7899999999999999, cacheRead = 0.13, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-r1"]
+name = "DeepSeek: R1"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 16000
+cost = { input = 0.7, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-r1-0528"]
+name = "DeepSeek: R1 0528"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 32768
+cost = { input = 0.5, output = 2.1500000000000004, cacheRead = 0.35, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.1-terminus"]
+name = "DeepSeek: DeepSeek V3.1 Terminus"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 32768
+cost = { input = 0.27, output = 0.95, cacheRead = 0.13, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.2"]
+name = "DeepSeek: DeepSeek V3.2"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.252, output = 0.378, cacheRead = 0.0252, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.2-exp"]
+name = "DeepSeek: DeepSeek V3.2 Exp"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 65536
+cost = { input = 0.27, output = 0.41, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-flash"]
+name = "DeepSeek: DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 16384
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.09999999999999999, output = 0.19999999999999998, cacheRead = 0.02, cacheWrite = 0 }
+thinking_level_map = { high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek/deepseek-v4-flash:free"]
+name = "DeepSeek: DeepSeek V4 Flash (free)"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek/deepseek-v4-pro"]
+name = "DeepSeek: DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.435, output = 0.87, cacheRead = 0.003625, cacheWrite = 0 }
+thinking_level_map = { high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."essentialai/rnj-1-instruct"]
+name = "EssentialAI: Rnj 1 Instruct"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 4096
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.0-flash-001"]
+name = "Google: Gemini 2.0 Flash"
+reasoning = false
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 8192
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.024999999999999998, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-2.0-flash-lite-001"]
+name = "Google: Gemini 2.0 Flash Lite"
+reasoning = false
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 8192
+cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash"]
+name = "Google: Gemini 2.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 0.3, output = 2.5, cacheRead = 0.03, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-2.5-flash-lite"]
+name = "Google: Gemini 2.5 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-2.5-flash-lite-preview-09-2025"]
+name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-2.5-pro"]
+name = "Google: Gemini 2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0.375 }
+
+[providers.model_metadata."google/gemini-2.5-pro-preview"]
+name = "Google: Gemini 2.5 Pro Preview 06-05"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0.375 }
+
+[providers.model_metadata."google/gemini-2.5-pro-preview-05-06"]
+name = "Google: Gemini 2.5 Pro Preview 05-06"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0.375 }
+
+[providers.model_metadata."google/gemini-3-flash-preview"]
+name = "Google: Gemini 3 Flash Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.5, output = 3, cacheRead = 0.049999999999999996, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-3.1-flash-lite"]
+name = "Google: Gemini 3.1 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0.024999999999999998, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-3.1-flash-lite-preview"]
+name = "Google: Gemini 3.1 Flash Lite Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0.024999999999999998, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemini-3.1-pro-preview"]
+name = "Google: Gemini 3.1 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.19999999999999998, cacheWrite = 0.375 }
+
+[providers.model_metadata."google/gemini-3.1-pro-preview-customtools"]
+name = "Google: Gemini 3.1 Pro Preview Custom Tools"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048756
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.19999999999999998, cacheWrite = 0.375 }
+
+[providers.model_metadata."google/gemini-3.5-flash"]
+name = "Google: Gemini 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."google/gemma-3-12b-it"]
+name = "Google: Gemma 3 12B"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.04, output = 0.13, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-3-27b-it"]
+name = "Google: Gemma 3 27B"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.08, output = 0.16, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-26b-a4b-it"]
+name = "Google: Gemma 4 26B A4B "
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.06, output = 0.33, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-26b-a4b-it:free"]
+name = "Google: Gemma 4 26B A4B  (free)"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-31b-it"]
+name = "Google: Gemma 4 31B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 0.12, output = 0.37, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-31b-it:free"]
+name = "Google: Gemma 4 31B (free)"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."ibm-granite/granite-4.1-8b"]
+name = "IBM: Granite 4.1 8B"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.049999999999999996, output = 0.09999999999999999, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."inception/mercury-2"]
+name = "Inception: Mercury 2"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 50000
+cost = { input = 0.25, output = 0.75, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."inclusionai/ling-2.6-1t"]
+name = "inclusionAI: Ling-2.6-1T"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.075, output = 0.625, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."inclusionai/ling-2.6-flash"]
+name = "inclusionAI: Ling-2.6-flash"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.01, output = 0.03, cacheRead = 0.002, cacheWrite = 0 }
+
+[providers.model_metadata."inclusionai/ring-2.6-1t"]
+name = "inclusionAI: Ring-2.6-1T"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.075, output = 0.625, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."kwaipilot/kat-coder-pro-v2"]
+name = "Kwaipilot: KAT-Coder-Pro V2"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 80000
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-3.1-70b-instruct"]
+name = "Meta: Llama 3.1 70B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.39999999999999997, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-3.1-8b-instruct"]
+name = "Meta: Llama 3.1 8B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.02, output = 0.049999999999999996, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-3.3-70b-instruct"]
+name = "Meta: Llama 3.3 70B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.09999999999999999, output = 0.32, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-3.3-70b-instruct:free"]
+name = "Meta: Llama 3.3 70B Instruct (free)"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/llama-4-scout"]
+name = "Meta: Llama 4 Scout"
+reasoning = false
+input = ["text", "image"]
+context_window = 10000000
+max_tokens = 16384
+cost = { input = 0.08, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m1"]
+name = "MiniMax: MiniMax M1"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 40000
+cost = { input = 0.39999999999999997, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2"]
+name = "MiniMax: MiniMax M2"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 196608
+cost = { input = 0.255, output = 1, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.1"]
+name = "MiniMax: MiniMax M2.1"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 196608
+cost = { input = 0.29, output = 0.95, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.5"]
+name = "MiniMax: MiniMax M2.5"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 196608
+cost = { input = 0.15, output = 1.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.5:free"]
+name = "MiniMax: MiniMax M2.5 (free)"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.7"]
+name = "MiniMax: MiniMax M2.7"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.27899999999999997, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/codestral-2508"]
+name = "Mistral: Codestral 2508"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 4096
+cost = { input = 0.3, output = 0.8999999999999999, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/devstral-2512"]
+name = "Mistral: Devstral 2 2512"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/devstral-medium"]
+name = "Mistral: Devstral Medium"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/devstral-small"]
+name = "Mistral: Devstral Small 1.1"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/ministral-14b-2512"]
+name = "Mistral: Ministral 3 14B 2512"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.19999999999999998, output = 0.19999999999999998, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/ministral-3b-2512"]
+name = "Mistral: Ministral 3 3B 2512"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.09999999999999999, output = 0.09999999999999999, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/ministral-8b-2512"]
+name = "Mistral: Ministral 3 8B 2512"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.15, output = 0.15, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-large"]
+name = "Mistral Large"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-large-2407"]
+name = "Mistral Large 2407"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-large-2411"]
+name = "Mistral Large 2411"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-large-2512"]
+name = "Mistral: Mistral Large 3 2512"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.5, output = 1.5, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-medium-3"]
+name = "Mistral: Mistral Medium 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-medium-3-5"]
+name = "Mistral: Mistral Medium 3.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-medium-3.1"]
+name = "Mistral: Mistral Medium 3.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-nemo"]
+name = "Mistral: Mistral Nemo"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.02, output = 0.03, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-saba"]
+name = "Mistral: Saba"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 4096
+cost = { input = 0.19999999999999998, output = 0.6, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-small-2603"]
+name = "Mistral: Mistral Small 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.15, output = 0.6, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mistral-small-3.2-24b-instruct"]
+name = "Mistral: Mistral Small 3.2 24B"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.075, output = 0.19999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/mixtral-8x22b-instruct"]
+name = "Mistral: Mixtral 8x22B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 65536
+max_tokens = 4096
+cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/pixtral-large-2411"]
+name = "Mistral: Pixtral Large 2411"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."mistralai/voxtral-small-24b-2507"]
+name = "Mistral: Voxtral Small 24B 2507"
+reasoning = false
+input = ["text"]
+context_window = 32000
+max_tokens = 4096
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2"]
+name = "MoonshotAI: Kimi K2 0711"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.5700000000000001, output = 2.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-0905"]
+name = "MoonshotAI: Kimi K2 0905"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.6, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-thinking"]
+name = "MoonshotAI: Kimi K2 Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.6, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2.5"]
+name = "MoonshotAI: Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.41, output = 2.06, cacheRead = 0.07, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2.6"]
+name = "MoonshotAI: Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262142
+cost = { input = 0.73, output = 3.49, cacheRead = 0.25, cacheWrite = 0 }
+
+[providers.model_metadata."nex-agi/deepseek-v3.1-nex-n1"]
+name = "Nex AGI: DeepSeek V3.1 Nex N1"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 163840
+cost = { input = 0.135, output = 0.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/llama-3.3-nemotron-super-49b-v1.5"]
+name = "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-3-nano-30b-a3b"]
+name = "NVIDIA: Nemotron 3 Nano 30B A3B"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 228000
+cost = { input = 0.049999999999999996, output = 0.19999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-3-nano-30b-a3b:free"]
+name = "NVIDIA: Nemotron 3 Nano 30B A3B (free)"
+reasoning = true
+input = ["text"]
+context_window = 256000
+max_tokens = 4096
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"]
+name = "NVIDIA: Nemotron 3 Nano Omni (free)"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 65536
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-3-super-120b-a12b"]
+name = "NVIDIA: Nemotron 3 Super"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 4096
+cost = { input = 0.09, output = 0.44999999999999996, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-3-super-120b-a12b:free"]
+name = "NVIDIA: Nemotron 3 Super (free)"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-nano-12b-v2-vl:free"]
+name = "NVIDIA: Nemotron Nano 12B 2 VL (free)"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-nano-9b-v2"]
+name = "NVIDIA: Nemotron Nano 9B V2"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.04, output = 0.16, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-nano-9b-v2:free"]
+name = "NVIDIA: Nemotron Nano 9B V2 (free)"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-3.5-turbo"]
+name = "OpenAI: GPT-3.5 Turbo"
+reasoning = false
+input = ["text"]
+context_window = 16385
+max_tokens = 4096
+cost = { input = 0.5, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-3.5-turbo-0613"]
+name = "OpenAI: GPT-3.5 Turbo (older v0613)"
+reasoning = false
+input = ["text"]
+context_window = 4095
+max_tokens = 4096
+cost = { input = 1, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-3.5-turbo-16k"]
+name = "OpenAI: GPT-3.5 Turbo 16k"
+reasoning = false
+input = ["text"]
+context_window = 16385
+max_tokens = 4096
+cost = { input = 3, output = 4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4"]
+name = "OpenAI: GPT-4"
+reasoning = false
+input = ["text"]
+context_window = 8191
+max_tokens = 4096
+cost = { input = 30, output = 60, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-0314"]
+name = "OpenAI: GPT-4 (older v0314)"
+reasoning = false
+input = ["text"]
+context_window = 8191
+max_tokens = 4096
+cost = { input = 30, output = 60, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-1106-preview"]
+name = "OpenAI: GPT-4 Turbo (older v1106)"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-turbo"]
+name = "OpenAI: GPT-4 Turbo"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-turbo-preview"]
+name = "OpenAI: GPT-4 Turbo Preview"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1"]
+name = "OpenAI: GPT-4.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 4096
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-mini"]
+name = "OpenAI: GPT-4.1 Mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.39999999999999997, output = 1.5999999999999999, cacheRead = 0.09999999999999999, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-nano"]
+name = "OpenAI: GPT-4.1 Nano"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o"]
+name = "OpenAI: GPT-4o"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-05-13"]
+name = "OpenAI: GPT-4o (2024-05-13)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 5, output = 15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-08-06"]
+name = "OpenAI: GPT-4o (2024-08-06)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-11-20"]
+name = "OpenAI: GPT-4o (2024-11-20)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-audio-preview"]
+name = "OpenAI: GPT-4o Audio"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini"]
+name = "OpenAI: GPT-4o-mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini-2024-07-18"]
+name = "OpenAI: GPT-4o-mini (2024-07-18)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5"]
+name = "OpenAI: GPT-5"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-codex"]
+name = "OpenAI: GPT-5 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-mini"]
+name = "OpenAI: GPT-5 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-nano"]
+name = "OpenAI: GPT-5 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 4096
+cost = { input = 0.049999999999999996, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-pro"]
+name = "OpenAI: GPT-5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 15, output = 120, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1"]
+name = "OpenAI: GPT-5.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.13, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-chat"]
+name = "OpenAI: GPT-5.1 Chat"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex"]
+name = "OpenAI: GPT-5.1-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex-max"]
+name = "OpenAI: GPT-5.1-Codex-Max"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex-mini"]
+name = "OpenAI: GPT-5.1-Codex-Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2"]
+name = "OpenAI: GPT-5.2"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-chat"]
+name = "OpenAI: GPT-5.2 Chat"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 32000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-codex"]
+name = "OpenAI: GPT-5.2-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-pro"]
+name = "OpenAI: GPT-5.2 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 21, output = 168, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.3-chat"]
+name = "OpenAI: GPT-5.3 Chat"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.3-codex"]
+name = "OpenAI: GPT-5.3-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4"]
+name = "OpenAI: GPT-5.4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-mini"]
+name = "OpenAI: GPT-5.4 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-nano"]
+name = "OpenAI: GPT-5.4 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.19999999999999998, output = 1.25, cacheRead = 0.02, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-pro"]
+name = "OpenAI: GPT-5.4 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.5"]
+name = "OpenAI: GPT-5.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.5-pro"]
+name = "OpenAI: GPT-5.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-audio"]
+name = "OpenAI: GPT Audio"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-audio-mini"]
+name = "OpenAI: GPT Audio Mini"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.6, output = 2.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-chat-latest"]
+name = "OpenAI: GPT Chat Latest"
+reasoning = false
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-120b"]
+name = "OpenAI: gpt-oss-120b"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+cost = { input = 0.039, output = 0.18, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-120b:free"]
+name = "OpenAI: gpt-oss-120b (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-20b"]
+name = "OpenAI: gpt-oss-20b"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.03, output = 0.14, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-20b:free"]
+name = "OpenAI: gpt-oss-20b (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-safeguard-20b"]
+name = "OpenAI: gpt-oss-safeguard-20b"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.075, output = 0.3, cacheRead = 0.037, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o1"]
+name = "OpenAI: o1"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 15, output = 60, cacheRead = 7.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3"]
+name = "OpenAI: o3"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-deep-research"]
+name = "OpenAI: o3 Deep Research"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 10, output = 40, cacheRead = 2.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-mini"]
+name = "OpenAI: o3 Mini"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-mini-high"]
+name = "OpenAI: o3 Mini High"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-pro"]
+name = "OpenAI: o3 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 20, output = 80, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o4-mini"]
+name = "OpenAI: o4 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.275, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o4-mini-deep-research"]
+name = "OpenAI: o4 Mini Deep Research"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o4-mini-high"]
+name = "OpenAI: o4 Mini High"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.275, cacheWrite = 0 }
+
+[providers.model_metadata."openrouter/auto"]
+name = "Auto Router"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 4096
+
+[providers.model_metadata."openrouter/free"]
+name = "Free Models Router"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openrouter/owl-alpha"]
+name = "Owl Alpha"
+reasoning = false
+input = ["text"]
+context_window = 1048756
+max_tokens = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."poolside/laguna-m.1:free"]
+name = "Poolside: Laguna M.1 (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."poolside/laguna-xs.2:free"]
+name = "Poolside: Laguna XS.2 (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."prime-intellect/intellect-3"]
+name = "Prime Intellect: INTELLECT-3"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.19999999999999998, output = 1.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen-2.5-72b-instruct"]
+name = "Qwen2.5 72B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.36, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen-2.5-7b-instruct"]
+name = "Qwen: Qwen2.5 7B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.04, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen-plus"]
+name = "Qwen: Qwen-Plus"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 32768
+cost = { input = 0.26, output = 0.78, cacheRead = 0.052000000000000005, cacheWrite = 0.325 }
+
+[providers.model_metadata."qwen/qwen-plus-2025-07-28"]
+name = "Qwen: Qwen Plus 0728"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 32768
+cost = { input = 0.26, output = 0.78, cacheRead = 0, cacheWrite = 0.325 }
+
+[providers.model_metadata."qwen/qwen-plus-2025-07-28:thinking"]
+name = "Qwen: Qwen Plus 0728 (thinking)"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 32768
+cost = { input = 0.26, output = 0.78, cacheRead = 0, cacheWrite = 0.325 }
+
+[providers.model_metadata."qwen/qwen3-14b"]
+name = "Qwen: Qwen3 14B"
+reasoning = true
+input = ["text"]
+context_window = 131702
+max_tokens = 40960
+cost = { input = 0.09999999999999999, output = 0.24, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-235b-a22b"]
+name = "Qwen: Qwen3 235B A22B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.45499999999999996, output = 1.8199999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-235b-a22b-2507"]
+name = "Qwen: Qwen3 235B A22B Instruct 2507"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 0.071, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-235b-a22b-thinking-2507"]
+name = "Qwen: Qwen3 235B A22B Thinking 2507"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.14950000000000002, output = 1.495, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-30b-a3b"]
+name = "Qwen: Qwen3 30B A3B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 20000
+cost = { input = 0.09, output = 0.44999999999999996, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-30b-a3b-instruct-2507"]
+name = "Qwen: Qwen3 30B A3B Instruct 2507"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.09, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-30b-a3b-thinking-2507"]
+name = "Qwen: Qwen3 30B A3B Thinking 2507"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.08, output = 0.39999999999999997, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-32b"]
+name = "Qwen: Qwen3 32B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.08, output = 0.28, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-8b"]
+name = "Qwen: Qwen3 8B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.049999999999999996, output = 0.39999999999999997, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-coder"]
+name = "Qwen: Qwen3 Coder 480B A35B"
+reasoning = false
+input = ["text"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.22, output = 1.7999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-coder-30b-a3b-instruct"]
+name = "Qwen: Qwen3 Coder 30B A3B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 160000
+max_tokens = 32768
+cost = { input = 0.07, output = 0.27, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-coder-flash"]
+name = "Qwen: Qwen3 Coder Flash"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.195, output = 0.975, cacheRead = 0.039, cacheWrite = 0.24375 }
+
+[providers.model_metadata."qwen/qwen3-coder-next"]
+name = "Qwen: Qwen3 Coder Next"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.11, output = 0.7999999999999999, cacheRead = 0.07, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-coder-plus"]
+name = "Qwen: Qwen3 Coder Plus"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.65, output = 3.25, cacheRead = 0.13, cacheWrite = 0.8125 }
+
+[providers.model_metadata."qwen/qwen3-coder:free"]
+name = "Qwen: Qwen3 Coder 480B A35B (free)"
+reasoning = false
+input = ["text"]
+context_window = 1048576
+max_tokens = 262000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-max"]
+name = "Qwen: Qwen3 Max"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.78, output = 3.9, cacheRead = 0.156, cacheWrite = 0.975 }
+
+[providers.model_metadata."qwen/qwen3-max-thinking"]
+name = "Qwen: Qwen3 Max Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.78, output = 3.9, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-next-80b-a3b-instruct"]
+name = "Qwen: Qwen3 Next 80B A3B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 0.09, output = 1.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-next-80b-a3b-instruct:free"]
+name = "Qwen: Qwen3 Next 80B A3B Instruct (free)"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-next-80b-a3b-thinking"]
+name = "Qwen: Qwen3 Next 80B A3B Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.0975, output = 0.78, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-235b-a22b-instruct"]
+name = "Qwen: Qwen3 VL 235B A22B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 0.19999999999999998, output = 0.88, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-235b-a22b-thinking"]
+name = "Qwen: Qwen3 VL 235B A22B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.26, output = 2.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-30b-a3b-instruct"]
+name = "Qwen: Qwen3 VL 30B A3B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.13, output = 0.52, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-30b-a3b-thinking"]
+name = "Qwen: Qwen3 VL 30B A3B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.13, output = 1.56, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-32b-instruct"]
+name = "Qwen: Qwen3 VL 32B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.10400000000000001, output = 0.41600000000000004, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-8b-instruct"]
+name = "Qwen: Qwen3 VL 8B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 32768
+cost = { input = 0.08, output = 0.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-8b-thinking"]
+name = "Qwen: Qwen3 VL 8B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 32768
+cost = { input = 0.117, output = 1.365, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-122b-a10b"]
+name = "Qwen: Qwen3.5-122B-A10B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.26, output = 2.08, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-27b"]
+name = "Qwen: Qwen3.5-27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.195, output = 1.56, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-35b-a3b"]
+name = "Qwen: Qwen3.5-35B-A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 4096
+cost = { input = 0.13899999999999998, output = 1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-397b-a17b"]
+name = "Qwen: Qwen3.5 397B A17B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.39, output = 2.34, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-9b"]
+name = "Qwen: Qwen3.5-9B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 81920
+cost = { input = 0.04, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-flash-02-23"]
+name = "Qwen: Qwen3.5-Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.065, output = 0.26, cacheRead = 0, cacheWrite = 0.08125 }
+
+[providers.model_metadata."qwen/qwen3.5-plus-02-15"]
+name = "Qwen: Qwen3.5 Plus 2026-02-15"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.26, output = 1.56, cacheRead = 0, cacheWrite = 0.325 }
+
+[providers.model_metadata."qwen/qwen3.5-plus-20260420"]
+name = "Qwen: Qwen3.5 Plus 2026-04-20"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.3, output = 1.7999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-27b"]
+name = "Qwen: Qwen3.6 27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.3, output = 3.1999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-35b-a3b"]
+name = "Qwen: Qwen3.6 35B A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262140
+cost = { input = 0.15, output = 1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-flash"]
+name = "Qwen: Qwen3.6 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.1875, output = 1.125, cacheRead = 0, cacheWrite = 0.234375 }
+
+[providers.model_metadata."qwen/qwen3.6-max-preview"]
+name = "Qwen: Qwen3.6 Max Preview"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 1.04, output = 6.24, cacheRead = 0, cacheWrite = 1.3 }
+
+[providers.model_metadata."qwen/qwen3.6-plus"]
+name = "Qwen: Qwen3.6 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.325, output = 1.95, cacheRead = 0, cacheWrite = 0.40625 }
+
+[providers.model_metadata."qwen/qwen3.7-max"]
+name = "Qwen: Qwen3.7 Max"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 2.5, output = 7.5, cacheRead = 0, cacheWrite = 3.125 }
+
+[providers.model_metadata."rekaai/reka-edge"]
+name = "Reka Edge"
+reasoning = false
+input = ["text", "image"]
+context_window = 16384
+max_tokens = 16384
+cost = { input = 0.09999999999999999, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."relace/relace-search"]
+name = "Relace: Relace Search"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 128000
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."sao10k/l3-euryale-70b"]
+name = "Sao10k: Llama 3 Euryale 70B v2.1"
+reasoning = false
+input = ["text"]
+context_window = 8192
+max_tokens = 8192
+cost = { input = 1.48, output = 1.48, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."sao10k/l3.1-euryale-70b"]
+name = "Sao10K: Llama 3.1 Euryale 70B v2.2"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 0.85, output = 0.85, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."stepfun/step-3.5-flash"]
+name = "StepFun: Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 16384
+cost = { input = 0.09, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."tencent/hy3-preview"]
+name = "Tencent: Hy3 preview"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.06599999999999999, output = 0.26, cacheRead = 0.029, cacheWrite = 0 }
+
+[providers.model_metadata."thedrummer/rocinante-12b"]
+name = "TheDrummer: Rocinante 12B"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 32768
+cost = { input = 0.16999999999999998, output = 0.43, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."thedrummer/unslopnemo-12b"]
+name = "TheDrummer: UnslopNemo 12B"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 32768
+cost = { input = 0.39999999999999997, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."upstage/solar-pro-3"]
+name = "Upstage: Solar Pro 3"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 0.15, output = 0.6, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."x-ai/grok-4.20"]
+name = "xAI: Grok 4.20"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 4096
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."x-ai/grok-4.3"]
+name = "xAI: Grok 4.3"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 4096
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."x-ai/grok-build-0.1"]
+name = "xAI: Grok Build 0.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 4096
+cost = { input = 1, output = 2, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2-flash"]
+name = "Xiaomi: MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2-omni"]
+name = "Xiaomi: MiMo-V2-Omni"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2-pro"]
+name = "Xiaomi: MiMo-V2-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2.5"]
+name = "Xiaomi: MiMo-V2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 131072
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2.5-pro"]
+name = "Xiaomi: MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 16384
+cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4-32b"]
+name = "Z.ai: GLM 4 32B "
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 0.09999999999999999, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5"]
+name = "Z.ai: GLM 4.5"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 98304
+cost = { input = 0.6, output = 2.2, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5-air"]
+name = "Z.ai: GLM 4.5 Air"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 98304
+cost = { input = 0.13, output = 0.85, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5-air:free"]
+name = "Z.ai: GLM 4.5 Air (free)"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 96000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5v"]
+name = "Z.ai: GLM 4.5V"
+reasoning = true
+input = ["text", "image"]
+context_window = 65536
+max_tokens = 16384
+cost = { input = 0.6, output = 1.7999999999999998, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.6"]
+name = "Z.ai: GLM 4.6"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+cost = { input = 0.43, output = 1.74, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.6v"]
+name = "Z.ai: GLM 4.6V"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 24000
+cost = { input = 0.3, output = 0.8999999999999999, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.7"]
+name = "Z.ai: GLM 4.7"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+cost = { input = 0.39999999999999997, output = 1.75, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.7-flash"]
+name = "Z.ai: GLM 4.7 Flash"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 16384
+cost = { input = 0.06, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5"]
+name = "Z.ai: GLM 5"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 4096
+cost = { input = 0.6, output = 1.9, cacheRead = 0.119, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5-turbo"]
+name = "Z.ai: GLM 5 Turbo"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+cost = { input = 1.2, output = 4, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5.1"]
+name = "Z.ai: GLM 5.1"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 4096
+cost = { input = 0.98, output = 3.08, cacheRead = 0.182, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5v-turbo"]
+name = "Z.ai: GLM 5V Turbo"
+reasoning = true
+input = ["text", "image"]
+context_window = 202752
+max_tokens = 131072
+cost = { input = 1.2, output = 4, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."~anthropic/claude-haiku-latest"]
+name = "Anthropic Claude Haiku Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.09999999999999999, cacheWrite = 1.25 }
+
+[providers.model_metadata."~anthropic/claude-opus-latest"]
+name = "Anthropic: Claude Opus Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata."~anthropic/claude-sonnet-latest"]
+name = "Anthropic Claude Sonnet Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."~google/gemini-flash-latest"]
+name = "Google Gemini Flash Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 0.08333333333333334 }
+
+[providers.model_metadata."~google/gemini-pro-latest"]
+name = "Google Gemini Pro Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2, output = 12, cacheRead = 0.19999999999999998, cacheWrite = 0.375 }
+
+[providers.model_metadata."~moonshotai/kimi-latest"]
+name = "MoonshotAI Kimi Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262142
+cost = { input = 0.73, output = 3.49, cacheRead = 0.25, cacheWrite = 0 }
+
+[providers.model_metadata."~openai/gpt-latest"]
+name = "OpenAI GPT Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."~openai/gpt-mini-latest"]
+name = "OpenAI GPT Mini Latest"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+
+[[providers]]
+name = "zai"
+display_name = "ZAI"
+kind = "openai-compatible"
+base_url = "https://api.z.ai/api/coding/paas/v4"
+api = "openai-completions"
+api_key_env = "ZAI_API_KEY"
+credential_name = "zai"
+models = ["glm-4.5-air", "glm-4.7", "glm-5-turbo", "glm-5.1", "glm-5v-turbo"]
+default_model = "glm-5.1"
+docs_url = "https://docs.z.ai"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"glm-4.5-air" = 131072
+"glm-4.7" = 204800
+glm-5-turbo = 200000
+"glm-5.1" = 200000
+glm-5v-turbo = 200000
+
+[providers.model_metadata."glm-4.5-air"]
+name = "GLM-4.5-Air"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 98304
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai" }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."glm-4.7"]
+name = "GLM-4.7"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.glm-5-turbo]
+name = "GLM-5-Turbo"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 131072
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."glm-5.1"]
+name = "GLM-5.1"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 131072
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.glm-5v-turbo]
+name = "GLM-5V-Turbo"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 131072
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[[providers]]
+name = "mistral"
+display_name = "Mistral"
+kind = "mistral-conversations"
+base_url = "https://api.mistral.ai"
+api = "mistral-conversations"
+api_key_env = "MISTRAL_API_KEY"
+credential_name = "mistral"
+models = ["codestral-latest", "devstral-2512", "devstral-medium-2507", "devstral-medium-latest", "devstral-small-2505", "devstral-small-2507", "labs-devstral-small-2512", "magistral-medium-latest", "magistral-small", "ministral-3b-latest", "ministral-8b-latest", "mistral-large-2411", "mistral-large-2512", "mistral-large-latest", "mistral-medium-2505", "mistral-medium-2508", "mistral-medium-2604", "mistral-medium-3.5", "mistral-medium-latest", "mistral-nemo", "mistral-small-2506", "mistral-small-2603", "mistral-small-latest", "open-mistral-7b", "open-mixtral-8x22b", "open-mixtral-8x7b", "pixtral-12b", "pixtral-large-latest"]
+default_model = "devstral-medium-latest"
+docs_url = "https://docs.mistral.ai"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+codestral-latest = 256000
+devstral-2512 = 262144
+devstral-medium-2507 = 128000
+devstral-medium-latest = 262144
+devstral-small-2505 = 128000
+devstral-small-2507 = 128000
+labs-devstral-small-2512 = 256000
+magistral-medium-latest = 128000
+magistral-small = 128000
+ministral-3b-latest = 128000
+ministral-8b-latest = 128000
+mistral-large-2411 = 131072
+mistral-large-2512 = 262144
+mistral-large-latest = 262144
+mistral-medium-2505 = 131072
+mistral-medium-2508 = 262144
+mistral-medium-2604 = 262144
+"mistral-medium-3.5" = 262144
+mistral-medium-latest = 262144
+mistral-nemo = 128000
+mistral-small-2506 = 128000
+mistral-small-2603 = 256000
+mistral-small-latest = 256000
+open-mistral-7b = 8000
+open-mixtral-8x22b = 64000
+open-mixtral-8x7b = 32000
+pixtral-12b = 128000
+pixtral-large-latest = 128000
+
+[providers.model_metadata.codestral-latest]
+name = "Codestral (latest)"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 4096
+cost = { input = 0.3, output = 0.9, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.devstral-2512]
+name = "Devstral 2"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.4, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.devstral-medium-2507]
+name = "Devstral Medium"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.4, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.devstral-medium-latest]
+name = "Devstral 2 (latest)"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.4, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.devstral-small-2505]
+name = "Devstral Small 2505"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.devstral-small-2507]
+name = "Devstral Small"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.labs-devstral-small-2512]
+name = "Devstral Small 2"
+reasoning = false
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.magistral-medium-latest]
+name = "Magistral Medium (latest)"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2, output = 5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.magistral-small]
+name = "Magistral Small"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.5, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.ministral-3b-latest]
+name = "Ministral 3B (latest)"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.04, output = 0.04, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.ministral-8b-latest]
+name = "Ministral 8B (latest)"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.1, output = 0.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-large-2411]
+name = "Mistral Large 2.1"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+cost = { input = 2, output = 6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-large-2512]
+name = "Mistral Large 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.5, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-large-latest]
+name = "Mistral Large (latest)"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.5, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-medium-2505]
+name = "Mistral Medium 3"
+reasoning = false
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.4, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-medium-2508]
+name = "Mistral Medium 3.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.4, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-medium-2604]
+name = "Mistral Medium 3.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral-medium-3.5"]
+name = "Mistral Medium 3.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-medium-latest]
+name = "Mistral Medium (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-nemo]
+name = "Mistral Nemo"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-small-2506]
+name = "Mistral Small 3.2"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-small-2603]
+name = "Mistral Small 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.mistral-small-latest]
+name = "Mistral Small (latest)"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.open-mistral-7b]
+name = "Mistral 7B"
+reasoning = false
+input = ["text"]
+context_window = 8000
+max_tokens = 8000
+cost = { input = 0.25, output = 0.25, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.open-mixtral-8x22b]
+name = "Mixtral 8x22B"
+reasoning = false
+input = ["text"]
+context_window = 64000
+max_tokens = 64000
+cost = { input = 2, output = 6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.open-mixtral-8x7b]
+name = "Mixtral 8x7B"
+reasoning = false
+input = ["text"]
+context_window = 32000
+max_tokens = 32000
+cost = { input = 0.7, output = 0.7, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.pixtral-12b]
+name = "Pixtral 12B"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata.pixtral-large-latest]
+name = "Pixtral Large (latest)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 2, output = 6, cacheRead = 0, cacheWrite = 0 }
+
+[[providers]]
+name = "minimax"
+display_name = "MiniMax"
+kind = "anthropic"
+base_url = "https://api.minimax.io/anthropic"
+api = "anthropic-messages"
+api_key_env = "MINIMAX_API_KEY"
+credential_name = "minimax"
+models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+default_model = "MiniMax-M2.7"
+docs_url = "https://www.minimax.io/platform/document"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "anthropic.thinking"
+
+[providers.context_windows]
+"MiniMax-M2.7" = 204800
+"MiniMax-M2.7-highspeed" = 204800
+
+[providers.model_metadata."MiniMax-M2.7"]
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[providers.model_metadata."MiniMax-M2.7-highspeed"]
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.6, output = 2.4, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[[providers]]
+name = "minimax-cn"
+display_name = "MiniMax (China)"
+kind = "anthropic"
+base_url = "https://api.minimaxi.com/anthropic"
+api = "anthropic-messages"
+api_key_env = "MINIMAX_CN_API_KEY"
+credential_name = "minimax-cn"
+models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+default_model = "MiniMax-M2.7"
+docs_url = "https://www.minimaxi.com/document"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "anthropic.thinking"
+
+[providers.context_windows]
+"MiniMax-M2.7" = 204800
+"MiniMax-M2.7-highspeed" = 204800
+
+[providers.model_metadata."MiniMax-M2.7"]
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[providers.model_metadata."MiniMax-M2.7-highspeed"]
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.6, output = 2.4, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[[providers]]
+name = "moonshotai"
+display_name = "Moonshot AI"
+kind = "openai-compatible"
+base_url = "https://api.moonshot.ai/v1"
+api = "openai-completions"
+api_key_env = "MOONSHOT_API_KEY"
+credential_name = "moonshotai"
+models = ["kimi-k2-0711-preview", "kimi-k2-0905-preview", "kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo-preview", "kimi-k2.5", "kimi-k2.6"]
+default_model = "kimi-k2.6"
+docs_url = "https://platform.moonshot.ai/docs"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+kimi-k2-0711-preview = 131072
+kimi-k2-0905-preview = 262144
+kimi-k2-thinking = 262144
+kimi-k2-thinking-turbo = 262144
+kimi-k2-turbo-preview = 262144
+"kimi-k2.5" = 262144
+"kimi-k2.6" = 262144
+
+[providers.model_metadata.kimi-k2-0711-preview]
+name = "Kimi K2 0711"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-0905-preview]
+name = "Kimi K2 0905"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-thinking]
+name = "Kimi K2 Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-thinking-turbo]
+name = "Kimi K2 Thinking Turbo"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 1.15, output = 8, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-turbo-preview]
+name = "Kimi K2 Turbo"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 2.4, output = 10, cacheRead = 0.6, cacheWrite = 0 }
+
+[providers.model_metadata."kimi-k2.5"]
+name = "Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 3, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."kimi-k2.6"]
+name = "Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.95, output = 4, cacheRead = 0.16, cacheWrite = 0 }
+
+[[providers]]
+name = "moonshotai-cn"
+display_name = "Moonshot AI (China)"
+kind = "openai-compatible"
+base_url = "https://api.moonshot.cn/v1"
+api = "openai-completions"
+api_key_env = "MOONSHOT_API_KEY"
+credential_name = "moonshotai-cn"
+models = ["kimi-k2-0711-preview", "kimi-k2-0905-preview", "kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo-preview", "kimi-k2.5", "kimi-k2.6"]
+default_model = "kimi-k2.6"
+docs_url = "https://platform.moonshot.cn/docs"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+kimi-k2-0711-preview = 131072
+kimi-k2-0905-preview = 262144
+kimi-k2-thinking = 262144
+kimi-k2-thinking-turbo = 262144
+kimi-k2-turbo-preview = 262144
+"kimi-k2.5" = 262144
+"kimi-k2.6" = 262144
+
+[providers.model_metadata.kimi-k2-0711-preview]
+name = "Kimi K2 0711"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-0905-preview]
+name = "Kimi K2 0905"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-thinking]
+name = "Kimi K2 Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-thinking-turbo]
+name = "Kimi K2 Thinking Turbo"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 1.15, output = 8, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k2-turbo-preview]
+name = "Kimi K2 Turbo"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 2.4, output = 10, cacheRead = 0.6, cacheWrite = 0 }
+
+[providers.model_metadata."kimi-k2.5"]
+name = "Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.6, output = 3, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."kimi-k2.6"]
+name = "Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0.95, output = 4, cacheRead = 0.16, cacheWrite = 0 }
 
 [[providers]]
 name = "huggingface"
-display_name = "Hugging Face Inference Providers"
+display_name = "Hugging Face"
 kind = "openai-compatible"
 base_url = "https://router.huggingface.co/v1"
+api = "openai-completions"
 api_key_env = "HF_TOKEN"
 credential_name = "huggingface"
-models = [
-  "openai/gpt-oss-120b",
-  "openai/gpt-oss-20b",
-  "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-  "Qwen/Qwen3-Coder-Next",
-  "Qwen/Qwen3-235B-A22B-Thinking-2507",
-  "Qwen/Qwen2.5-Coder-32B-Instruct",
-  "moonshotai/Kimi-K2.7-Code",
-  "deepseek-ai/DeepSeek-V4-Pro",
-  "deepseek-ai/DeepSeek-V4-Flash",
-  "deepseek-ai/DeepSeek-R1",
-  "moonshotai/Kimi-K2-Instruct",
-  "zai-org/GLM-5.2",
-  "zai-org/GLM-4.5",
-  "MiniMaxAI/MiniMax-M3",
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
-  "mistralai/Codestral-22B-v0.1",
-  "bigcode/starcoder2-15b",
-]
-default_model = "openai/gpt-oss-120b"
-docs_url = "https://huggingface.co/inference/get-started"
-thinking_levels = ["low", "medium", "high"]
-thinking_models = [
-  "openai/gpt-oss-120b",
-  "openai/gpt-oss-20b",
-  "Qwen/Qwen3-235B-A22B-Thinking-2507",
-  "deepseek-ai/DeepSeek-R1",
-]
+models = ["MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3-Next-80B-A3B-Thinking", "Qwen/Qwen3.5-397B-A17B", "XiaomiMiMo/MiMo-V2-Flash", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Pro", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2-Thinking", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1"]
+default_model = "moonshotai/Kimi-K2.6"
+docs_url = "https://huggingface.co/docs/inference-providers"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-"openai/gpt-oss-120b" = 131072
-"openai/gpt-oss-20b" = 131072
+"MiniMaxAI/MiniMax-M2.1" = 204800
+"MiniMaxAI/MiniMax-M2.5" = 204800
+"MiniMaxAI/MiniMax-M2.7" = 204800
+"Qwen/Qwen3-235B-A22B-Thinking-2507" = 262144
 "Qwen/Qwen3-Coder-480B-A35B-Instruct" = 262144
+"Qwen/Qwen3-Coder-Next" = 262144
+"Qwen/Qwen3-Next-80B-A3B-Instruct" = 262144
+"Qwen/Qwen3-Next-80B-A3B-Thinking" = 262144
+"Qwen/Qwen3.5-397B-A17B" = 262144
+"XiaomiMiMo/MiMo-V2-Flash" = 262144
+"deepseek-ai/DeepSeek-R1-0528" = 163840
+"deepseek-ai/DeepSeek-V3.2" = 163840
+"deepseek-ai/DeepSeek-V4-Pro" = 1048576
+"moonshotai/Kimi-K2-Instruct" = 131072
+"moonshotai/Kimi-K2-Instruct-0905" = 262144
+"moonshotai/Kimi-K2-Thinking" = 262144
+"moonshotai/Kimi-K2.5" = 262144
+"moonshotai/Kimi-K2.6" = 262144
+"zai-org/GLM-4.7" = 204800
+"zai-org/GLM-4.7-Flash" = 200000
+"zai-org/GLM-5" = 202752
+"zai-org/GLM-5.1" = 202752
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2.1"]
+name = "MiniMax-M2.1"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2.5"]
+name = "MiniMax-M2.5"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2.7"]
+name = "MiniMax-M2.7"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-235B-A22B-Thinking-2507"]
+name = "Qwen3-235B-A22B-Thinking-2507"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Coder-480B-A35B-Instruct"]
+name = "Qwen3-Coder-480B-A35B-Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 66536
+compat = { supportsDeveloperRole = false }
+cost = { input = 2, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Coder-Next"]
+name = "Qwen3-Coder-Next"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.2, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Next-80B-A3B-Instruct"]
+name = "Qwen3-Next-80B-A3B-Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 66536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.25, output = 1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Next-80B-A3B-Thinking"]
+name = "Qwen3-Next-80B-A3B-Thinking"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.5-397B-A17B"]
+name = "Qwen3.5-397B-A17B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 3.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."XiaomiMiMo/MiMo-V2-Flash"]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 4096
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-R1-0528"]
+name = "DeepSeek-R1-0528"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 163840
+compat = { supportsDeveloperRole = false }
+cost = { input = 3, output = 5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V3.2"]
+name = "DeepSeek-V3.2"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.28, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 393216
+compat = { supportsDeveloperRole = false }
+cost = { input = 1.74, output = 3.48, cacheRead = 0.145, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2-Instruct"]
+name = "Kimi-K2-Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+compat = { supportsDeveloperRole = false }
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2-Instruct-0905"]
+name = "Kimi-K2-Instruct-0905"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 16384
+compat = { supportsDeveloperRole = false }
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2-Thinking"]
+name = "Kimi-K2-Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2.5"]
+name = "Kimi-K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 3, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2.6"]
+name = "Kimi-K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.95, output = 4, cacheRead = 0.16, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.7"]
+name = "GLM-4.7"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 2.2, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.7-Flash"]
+name = "GLM-4.7-Flash"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-5"]
+name = "GLM-5"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 1, output = 3.2, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-5.1"]
+name = "GLM-5.1"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 1, output = 3.2, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "fireworks"
+display_name = "Fireworks"
+kind = "anthropic"
+base_url = "https://api.fireworks.ai/inference"
+api = "anthropic-messages"
+api_key_env = "FIREWORKS_API_KEY"
+credential_name = "fireworks"
+models = ["accounts/fireworks/models/deepseek-v4-flash", "accounts/fireworks/models/deepseek-v4-pro", "accounts/fireworks/models/glm-5p1", "accounts/fireworks/models/gpt-oss-120b", "accounts/fireworks/models/gpt-oss-20b", "accounts/fireworks/models/kimi-k2p5", "accounts/fireworks/models/kimi-k2p6", "accounts/fireworks/models/minimax-m2p5", "accounts/fireworks/models/minimax-m2p7", "accounts/fireworks/models/qwen3p6-plus", "accounts/fireworks/routers/glm-5p1-fast", "accounts/fireworks/routers/kimi-k2p6-turbo"]
+default_model = "accounts/fireworks/models/kimi-k2p6"
+docs_url = "https://docs.fireworks.ai"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "anthropic.thinking"
+
+[providers.context_windows]
+"accounts/fireworks/models/deepseek-v4-flash" = 1000000
+"accounts/fireworks/models/deepseek-v4-pro" = 1000000
+"accounts/fireworks/models/glm-5p1" = 202800
+"accounts/fireworks/models/gpt-oss-120b" = 131072
+"accounts/fireworks/models/gpt-oss-20b" = 131072
+"accounts/fireworks/models/kimi-k2p5" = 256000
+"accounts/fireworks/models/kimi-k2p6" = 262000
+"accounts/fireworks/models/minimax-m2p5" = 196608
+"accounts/fireworks/models/minimax-m2p7" = 196608
+"accounts/fireworks/models/qwen3p6-plus" = 128000
+"accounts/fireworks/routers/glm-5p1-fast" = 202800
+"accounts/fireworks/routers/kimi-k2p6-turbo" = 262000
+
+[providers.model_metadata."accounts/fireworks/models/deepseek-v4-flash"]
+name = "DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.14, output = 0.28, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/deepseek-v4-pro"]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 1.74, output = 3.48, cacheRead = 0.145, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/glm-5p1"]
+name = "GLM 5.1"
+reasoning = true
+input = ["text"]
+context_window = 202800
+max_tokens = 131072
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 1.4, output = 4.4, cacheRead = 0.26, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/gpt-oss-120b"]
+name = "GPT OSS 120B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.15, output = 0.6, cacheRead = 0.015, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/gpt-oss-20b"]
+name = "GPT OSS 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.07, output = 0.3, cacheRead = 0.035, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/kimi-k2p5"]
+name = "Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.6, output = 3, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/kimi-k2p6"]
+name = "Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262000
+max_tokens = 262000
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.95, output = 4, cacheRead = 0.16, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/minimax-m2p5"]
+name = "MiniMax-M2.5"
+reasoning = true
+input = ["text"]
+context_window = 196608
+max_tokens = 196608
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/minimax-m2p7"]
+name = "MiniMax-M2.7"
+reasoning = true
+input = ["text"]
+context_window = 196608
+max_tokens = 196608
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/models/qwen3p6-plus"]
+name = "Qwen 3.6 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 8192
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 0.5, output = 3, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/routers/glm-5p1-fast"]
+name = "GLM 5.1 Fast"
+reasoning = true
+input = ["text"]
+context_window = 202800
+max_tokens = 131072
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 2.8, output = 8.8, cacheRead = 0.52, cacheWrite = 0 }
+
+[providers.model_metadata."accounts/fireworks/routers/kimi-k2p6-turbo"]
+name = "Kimi K2.6 Turbo"
+reasoning = true
+input = ["text", "image"]
+context_window = 262000
+max_tokens = 262000
+compat = { sendSessionAffinityHeaders = true, supportsEagerToolInputStreaming = false, supportsCacheControlOnTools = false, supportsLongCacheRetention = false }
+cost = { input = 2, output = 8, cacheRead = 0.3, cacheWrite = 0 }
+
+[[providers]]
+name = "together"
+display_name = "Together AI"
+kind = "openai-compatible"
+base_url = "https://api.together.ai/v1"
+api = "openai-completions"
+api_key_env = "TOGETHER_API_KEY"
+credential_name = "together"
+models = ["MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Instruct-2507-tput", "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8", "Qwen/Qwen3-Coder-Next-FP8", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.6-Plus", "Qwen/Qwen3.7-Max", "deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-V3-1", "deepseek-ai/DeepSeek-V4-Pro", "essentialai/Rnj-1-Instruct", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct-Turbo", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "openai/gpt-oss-120b", "zai-org/GLM-5.1"]
+default_model = "moonshotai/Kimi-K2.6"
+docs_url = "https://docs.together.ai"
+thinking_levels = ["off", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"MiniMaxAI/MiniMax-M2.5" = 204800
+"MiniMaxAI/MiniMax-M2.7" = 202752
+"Qwen/Qwen3-235B-A22B-Instruct-2507-tput" = 262144
+"Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8" = 262144
+"Qwen/Qwen3-Coder-Next-FP8" = 262144
+"Qwen/Qwen3.5-397B-A17B" = 262144
+"Qwen/Qwen3.6-Plus" = 1000000
+"Qwen/Qwen3.7-Max" = 1000000
+"deepseek-ai/DeepSeek-V3" = 131072
+"deepseek-ai/DeepSeek-V3-1" = 131072
+"deepseek-ai/DeepSeek-V4-Pro" = 512000
+"essentialai/Rnj-1-Instruct" = 32768
+"google/gemma-4-31B-it" = 262144
+"meta-llama/Llama-3.3-70B-Instruct-Turbo" = 131072
+"moonshotai/Kimi-K2.5" = 262144
+"moonshotai/Kimi-K2.6" = 262144
+"openai/gpt-oss-120b" = 131072
+"zai-org/GLM-5.1" = 202752
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2.5"]
+name = "MiniMax-M2.5"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2.7"]
+name = "MiniMax-M2.7"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
+
+[providers.model_metadata."Qwen/Qwen3-235B-A22B-Instruct-2507-tput"]
+name = "Qwen3 235B A22B Instruct 2507 FP8"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.2, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"]
+name = "Qwen3 Coder 480B A35B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false }
+cost = { input = 2, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Coder-Next-FP8"]
+name = "Qwen3 Coder Next FP8"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.5, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."Qwen/Qwen3.5-397B-A17B"]
+name = "Qwen3.5 397B A17B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 130000
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.6, output = 3.6, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."Qwen/Qwen3.6-Plus"]
+name = "Qwen3.6 Plus"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 500000
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.5, output = 3, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."Qwen/Qwen3.7-Max"]
+name = "Qwen3.7 Max"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 500000
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 2.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V3"]
+name = "DeepSeek V3"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 1.25, output = 1.25, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V3-1"]
+name = "DeepSeek V3.1"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.6, output = 1.7, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 512000
+max_tokens = 384000
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = true, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 2.1, output = 4.4, cacheRead = 0.2, cacheWrite = 0 }
+thinking_level_map = { high = "high" }
+unsupported_thinking_levels = ["minimal", "low", "medium", "xhigh"]
+
+[providers.model_metadata."essentialai/Rnj-1-Instruct"]
+name = "Rnj-1 Instruct"
+reasoning = false
+input = ["text"]
+context_window = 32768
+max_tokens = 32768
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false }
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-31B-it"]
+name = "Gemma 4 31B Instruct"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.2, output = 0.5, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."meta-llama/Llama-3.3-70B-Instruct-Turbo"]
+name = "Llama 3.3 70B"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false }
+cost = { input = 0.88, output = 0.88, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2.5"]
+name = "Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 0.5, output = 2.8, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."moonshotai/Kimi-K2.6"]
+name = "Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131000
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 1.2, output = 4.5, cacheRead = 0.2, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."openai/gpt-oss-120b"]
+name = "GPT OSS 120B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = true, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "openai" }
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal"]
+
+[providers.model_metadata."zai-org/GLM-5.1"]
+name = "GLM-5.1"
+reasoning = true
+input = ["text"]
+context_window = 202752
+max_tokens = 131072
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false, supportsLongCacheRetention = false, thinkingFormat = "together" }
+cost = { input = 1.4, output = 4.4, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[[providers]]
+name = "vercel-ai-gateway"
+display_name = "Vercel AI Gateway"
+kind = "anthropic"
+base_url = "https://ai-gateway.vercel.sh"
+api = "anthropic-messages"
+api_key_env = "AI_GATEWAY_API_KEY"
+credential_name = "vercel-ai-gateway"
+models = ["alibaba/qwen-3-14b", "alibaba/qwen-3-235b", "alibaba/qwen-3-30b", "alibaba/qwen-3-32b", "alibaba/qwen-3.6-max-preview", "alibaba/qwen3-235b-a22b-thinking", "alibaba/qwen3-coder", "alibaba/qwen3-coder-30b-a3b", "alibaba/qwen3-coder-next", "alibaba/qwen3-coder-plus", "alibaba/qwen3-max", "alibaba/qwen3-max-preview", "alibaba/qwen3-max-thinking", "alibaba/qwen3-vl-thinking", "alibaba/qwen3.5-flash", "alibaba/qwen3.5-plus", "alibaba/qwen3.6-27b", "alibaba/qwen3.6-plus", "alibaba/qwen3.7-max", "anthropic/claude-3-haiku", "anthropic/claude-3.5-haiku", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4", "anthropic/claude-opus-4.1", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.7", "anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.6", "arcee-ai/trinity-large-preview", "arcee-ai/trinity-large-thinking", "bytedance/seed-1.6", "cohere/command-a", "deepseek/deepseek-r1", "deepseek/deepseek-v3", "deepseek/deepseek-v3.1", "deepseek/deepseek-v3.1-terminus", "deepseek/deepseek-v3.2", "deepseek/deepseek-v3.2-thinking", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro", "google/gemini-2.0-flash", "google/gemini-2.0-flash-lite", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-pro", "google/gemini-3-flash", "google/gemini-3-pro-preview", "google/gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.5-flash", "google/gemma-4-26b-a4b-it", "google/gemma-4-31b-it", "inception/mercury-2", "inception/mercury-coder-small", "kwaipilot/kat-coder-pro-v2", "meituan/longcat-flash-chat", "meta/llama-3.1-70b", "meta/llama-3.1-8b", "meta/llama-3.2-11b", "meta/llama-3.2-90b", "meta/llama-3.3-70b", "meta/llama-4-maverick", "meta/llama-4-scout", "minimax/minimax-m2", "minimax/minimax-m2.1", "minimax/minimax-m2.1-lightning", "minimax/minimax-m2.5", "minimax/minimax-m2.5-highspeed", "minimax/minimax-m2.7", "minimax/minimax-m2.7-highspeed", "mistral/codestral", "mistral/devstral-2", "mistral/devstral-small", "mistral/devstral-small-2", "mistral/ministral-3b", "mistral/ministral-8b", "mistral/mistral-medium", "mistral/mistral-medium-3.5", "mistral/mistral-small", "mistral/pixtral-12b", "mistral/pixtral-large", "moonshotai/kimi-k2", "moonshotai/kimi-k2-thinking", "moonshotai/kimi-k2-thinking-turbo", "moonshotai/kimi-k2-turbo", "moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "nvidia/nemotron-nano-12b-v2-vl", "nvidia/nemotron-nano-9b-v2", "openai/gpt-4-turbo", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4.1-nano", "openai/gpt-4o", "openai/gpt-4o-mini", "openai/gpt-5", "openai/gpt-5-chat", "openai/gpt-5-codex", "openai/gpt-5-mini", "openai/gpt-5-nano", "openai/gpt-5-pro", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-max", "openai/gpt-5.1-codex-mini", "openai/gpt-5.1-instant", "openai/gpt-5.1-thinking", "openai/gpt-5.2", "openai/gpt-5.2-chat", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.3-chat", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "openai/o1", "openai/o3", "openai/o3-deep-research", "openai/o3-mini", "openai/o3-pro", "openai/o4-mini", "perplexity/sonar", "perplexity/sonar-pro", "xai/grok-4.1-fast-non-reasoning", "xai/grok-4.1-fast-reasoning", "xai/grok-4.20-multi-agent", "xai/grok-4.20-multi-agent-beta", "xai/grok-4.20-non-reasoning", "xai/grok-4.20-non-reasoning-beta", "xai/grok-4.20-reasoning", "xai/grok-4.20-reasoning-beta", "xai/grok-4.3", "xai/grok-build-0.1", "xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-pro", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro", "zai/glm-4.5", "zai/glm-4.5-air", "zai/glm-4.5v", "zai/glm-4.6", "zai/glm-4.6v", "zai/glm-4.6v-flash", "zai/glm-4.7", "zai/glm-4.7-flash", "zai/glm-4.7-flashx", "zai/glm-5", "zai/glm-5-turbo", "zai/glm-5.1", "zai/glm-5v-turbo"]
+default_model = "zai/glm-5.1"
+docs_url = "https://vercel.com/docs/ai-gateway"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "anthropic.thinking"
+
+[providers.context_windows]
+"alibaba/qwen-3-14b" = 40960
+"alibaba/qwen-3-235b" = 131000
+"alibaba/qwen-3-30b" = 40960
+"alibaba/qwen-3-32b" = 128000
+"alibaba/qwen-3.6-max-preview" = 240000
+"alibaba/qwen3-235b-a22b-thinking" = 131072
+"alibaba/qwen3-coder" = 262144
+"alibaba/qwen3-coder-30b-a3b" = 262144
+"alibaba/qwen3-coder-next" = 256000
+"alibaba/qwen3-coder-plus" = 1000000
+"alibaba/qwen3-max" = 262144
+"alibaba/qwen3-max-preview" = 262144
+"alibaba/qwen3-max-thinking" = 256000
+"alibaba/qwen3-vl-thinking" = 131072
+"alibaba/qwen3.5-flash" = 1000000
+"alibaba/qwen3.5-plus" = 1000000
+"alibaba/qwen3.6-27b" = 256000
+"alibaba/qwen3.6-plus" = 1000000
+"alibaba/qwen3.7-max" = 991000
+"anthropic/claude-3-haiku" = 200000
+"anthropic/claude-3.5-haiku" = 200000
+"anthropic/claude-haiku-4.5" = 200000
+"anthropic/claude-opus-4" = 200000
+"anthropic/claude-opus-4.1" = 200000
+"anthropic/claude-opus-4.5" = 200000
+"anthropic/claude-opus-4.6" = 1000000
+"anthropic/claude-opus-4.7" = 1000000
+"anthropic/claude-sonnet-4" = 1000000
+"anthropic/claude-sonnet-4.5" = 1000000
+"anthropic/claude-sonnet-4.6" = 1000000
+"arcee-ai/trinity-large-preview" = 131000
+"arcee-ai/trinity-large-thinking" = 262100
+"bytedance/seed-1.6" = 256000
+"cohere/command-a" = 256000
+"deepseek/deepseek-r1" = 128000
+"deepseek/deepseek-v3" = 163840
+"deepseek/deepseek-v3.1" = 163840
+"deepseek/deepseek-v3.1-terminus" = 131072
+"deepseek/deepseek-v3.2" = 128000
+"deepseek/deepseek-v3.2-thinking" = 128000
+"deepseek/deepseek-v4-flash" = 1000000
+"deepseek/deepseek-v4-pro" = 1000000
+"google/gemini-2.0-flash" = 1048576
+"google/gemini-2.0-flash-lite" = 1048576
+"google/gemini-2.5-flash" = 1000000
+"google/gemini-2.5-flash-lite" = 1048576
+"google/gemini-2.5-pro" = 1048576
+"google/gemini-3-flash" = 1000000
+"google/gemini-3-pro-preview" = 1000000
+"google/gemini-3.1-flash-lite" = 1000000
+"google/gemini-3.1-flash-lite-preview" = 1000000
+"google/gemini-3.1-pro-preview" = 1000000
+"google/gemini-3.5-flash" = 1000000
+"google/gemma-4-26b-a4b-it" = 262144
+"google/gemma-4-31b-it" = 262144
+"inception/mercury-2" = 128000
+"inception/mercury-coder-small" = 32000
+"kwaipilot/kat-coder-pro-v2" = 256000
+"meituan/longcat-flash-chat" = 128000
+"meta/llama-3.1-70b" = 128000
+"meta/llama-3.1-8b" = 128000
+"meta/llama-3.2-11b" = 128000
+"meta/llama-3.2-90b" = 128000
+"meta/llama-3.3-70b" = 128000
+"meta/llama-4-maverick" = 128000
+"meta/llama-4-scout" = 128000
+"minimax/minimax-m2" = 205000
+"minimax/minimax-m2.1" = 204800
+"minimax/minimax-m2.1-lightning" = 204800
+"minimax/minimax-m2.5" = 204800
+"minimax/minimax-m2.5-highspeed" = 204800
+"minimax/minimax-m2.7" = 204800
+"minimax/minimax-m2.7-highspeed" = 204800
+"mistral/codestral" = 128000
+"mistral/devstral-2" = 256000
+"mistral/devstral-small" = 128000
+"mistral/devstral-small-2" = 256000
+"mistral/ministral-3b" = 128000
+"mistral/ministral-8b" = 128000
+"mistral/mistral-medium" = 128000
+"mistral/mistral-medium-3.5" = 256000
+"mistral/mistral-small" = 32000
+"mistral/pixtral-12b" = 128000
+"mistral/pixtral-large" = 128000
+"moonshotai/kimi-k2" = 131072
+"moonshotai/kimi-k2-thinking" = 262114
+"moonshotai/kimi-k2-thinking-turbo" = 262114
+"moonshotai/kimi-k2-turbo" = 256000
+"moonshotai/kimi-k2.5" = 262114
+"moonshotai/kimi-k2.6" = 262000
+"nvidia/nemotron-nano-12b-v2-vl" = 131072
+"nvidia/nemotron-nano-9b-v2" = 131072
+"openai/gpt-4-turbo" = 128000
+"openai/gpt-4.1" = 1047576
+"openai/gpt-4.1-mini" = 1047576
+"openai/gpt-4.1-nano" = 1047576
+"openai/gpt-4o" = 128000
+"openai/gpt-4o-mini" = 128000
+"openai/gpt-5" = 400000
+"openai/gpt-5-chat" = 128000
+"openai/gpt-5-codex" = 400000
+"openai/gpt-5-mini" = 400000
+"openai/gpt-5-nano" = 400000
+"openai/gpt-5-pro" = 400000
+"openai/gpt-5.1-codex" = 400000
+"openai/gpt-5.1-codex-max" = 400000
+"openai/gpt-5.1-codex-mini" = 400000
+"openai/gpt-5.1-instant" = 128000
+"openai/gpt-5.1-thinking" = 400000
+"openai/gpt-5.2" = 400000
+"openai/gpt-5.2-chat" = 128000
+"openai/gpt-5.2-codex" = 400000
+"openai/gpt-5.2-pro" = 400000
+"openai/gpt-5.3-chat" = 128000
+"openai/gpt-5.3-codex" = 400000
+"openai/gpt-5.4" = 1050000
+"openai/gpt-5.4-mini" = 400000
+"openai/gpt-5.4-nano" = 400000
+"openai/gpt-5.4-pro" = 1050000
+"openai/gpt-5.5" = 1000000
+"openai/gpt-5.5-pro" = 1000000
+"openai/gpt-oss-20b" = 131072
+"openai/gpt-oss-safeguard-20b" = 131072
+"openai/o1" = 200000
+"openai/o3" = 200000
+"openai/o3-deep-research" = 200000
+"openai/o3-mini" = 200000
+"openai/o3-pro" = 200000
+"openai/o4-mini" = 200000
+"perplexity/sonar" = 127000
+"perplexity/sonar-pro" = 200000
+"xai/grok-4.1-fast-non-reasoning" = 1000000
+"xai/grok-4.1-fast-reasoning" = 1000000
+"xai/grok-4.20-multi-agent" = 2000000
+"xai/grok-4.20-multi-agent-beta" = 2000000
+"xai/grok-4.20-non-reasoning" = 2000000
+"xai/grok-4.20-non-reasoning-beta" = 2000000
+"xai/grok-4.20-reasoning" = 2000000
+"xai/grok-4.20-reasoning-beta" = 2000000
+"xai/grok-4.3" = 1000000
+"xai/grok-build-0.1" = 256000
+"xiaomi/mimo-v2-flash" = 262144
+"xiaomi/mimo-v2-pro" = 1000000
+"xiaomi/mimo-v2.5" = 1050000
+"xiaomi/mimo-v2.5-pro" = 1050000
+"zai/glm-4.5" = 128000
+"zai/glm-4.5-air" = 128000
+"zai/glm-4.5v" = 66000
+"zai/glm-4.6" = 200000
+"zai/glm-4.6v" = 128000
+"zai/glm-4.6v-flash" = 128000
+"zai/glm-4.7" = 131000
+"zai/glm-4.7-flash" = 200000
+"zai/glm-4.7-flashx" = 200000
+"zai/glm-5" = 202800
+"zai/glm-5-turbo" = 202800
+"zai/glm-5.1" = 202800
+"zai/glm-5v-turbo" = 200000
+
+[providers.model_metadata."alibaba/qwen-3-14b"]
+name = "Qwen3-14B"
+reasoning = true
+input = ["text"]
+context_window = 40960
+max_tokens = 16384
+cost = { input = 0.12, output = 0.24, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen-3-235b"]
+name = "Qwen3 235B A22b Instruct 2507"
+reasoning = false
+input = ["text"]
+context_window = 131000
+max_tokens = 40000
+cost = { input = 0.6, output = 1.2, cacheRead = 0.6, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen-3-30b"]
+name = "Qwen3-30B-A3B"
+reasoning = true
+input = ["text"]
+context_window = 40960
+max_tokens = 16384
+cost = { input = 0.08, output = 0.29, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen-3-32b"]
+name = "Qwen 3 32B"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.16, output = 0.64, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen-3.6-max-preview"]
+name = "Qwen 3.6 Max Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 240000
+max_tokens = 64000
+cost = { input = 1.3, output = 7.8, cacheRead = 0.26, cacheWrite = 1.625 }
+
+[providers.model_metadata."alibaba/qwen3-235b-a22b-thinking"]
+name = "Qwen3 VL 235B A22B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.39999999999999997, output = 4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-coder"]
+name = "Qwen3 Coder 480B A35B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 1.5, output = 7.5, cacheRead = 0.3, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-coder-30b-a3b"]
+name = "Qwen 3 Coder 30B A3B Instruct"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 8192
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-coder-next"]
+name = "Qwen3 Coder Next"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.5, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-coder-plus"]
+name = "Qwen3 Coder Plus"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 1, output = 5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-max"]
+name = "Qwen3 Max"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 1.2, output = 6, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-max-preview"]
+name = "Qwen3 Max Preview"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 1.2, output = 6, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-max-thinking"]
+name = "Qwen 3 Max Thinking"
+reasoning = true
+input = ["text"]
+context_window = 256000
+max_tokens = 65536
+cost = { input = 1.2, output = 6, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3-vl-thinking"]
+name = "Qwen3 VL 235B A22B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.39999999999999997, output = 4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3.5-flash"]
+name = "Qwen 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.001, cacheWrite = 0.125 }
+
+[providers.model_metadata."alibaba/qwen3.5-plus"]
+name = "Qwen 3.5 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 0.39999999999999997, output = 2.4, cacheRead = 0.04, cacheWrite = 0.5 }
+
+[providers.model_metadata."alibaba/qwen3.6-27b"]
+name = "Qwen 3.6 27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.6, output = 3.5999999999999996, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."alibaba/qwen3.6-plus"]
+name = "Qwen 3.6 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 0.5, output = 3, cacheRead = 0.09999999999999999, cacheWrite = 0.625 }
+
+[providers.model_metadata."alibaba/qwen3.7-max"]
+name = "Qwen 3.7 Max"
+reasoning = true
+input = ["text", "image"]
+context_window = 991000
+max_tokens = 64000
+cost = { input = 1.25, output = 3.75, cacheRead = 0.25, cacheWrite = 1.5625 }
+
+[providers.model_metadata."anthropic/claude-3-haiku"]
+name = "Claude 3 Haiku"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 4096
+cost = { input = 0.25, output = 1.25, cacheRead = 0.03, cacheWrite = 0.3 }
+
+[providers.model_metadata."anthropic/claude-3.5-haiku"]
+name = "Claude 3.5 Haiku"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8192
+cost = { input = 0.7999999999999999, output = 4, cacheRead = 0.08, cacheWrite = 1 }
+
+[providers.model_metadata."anthropic/claude-haiku-4.5"]
+name = "Claude Haiku 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.09999999999999999, cacheWrite = 1.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4"]
+name = "Claude Opus 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata."anthropic/claude-opus-4.1"]
+name = "Claude Opus 4.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 32000
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+
+[providers.model_metadata."anthropic/claude-opus-4.5"]
+name = "Claude Opus 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4.6"]
+name = "Claude Opus 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "max" }
+
+[providers.model_metadata."anthropic/claude-opus-4.7"]
+name = "Claude Opus 4.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."anthropic/claude-sonnet-4"]
+name = "Claude Sonnet 4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.5"]
+name = "Claude Sonnet 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.6"]
+name = "Claude Sonnet 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."arcee-ai/trinity-large-preview"]
+name = "Trinity Large Preview"
+reasoning = false
+input = ["text"]
+context_window = 131000
+max_tokens = 131000
+cost = { input = 0.25, output = 1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."arcee-ai/trinity-large-thinking"]
+name = "Trinity Large Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262100
+max_tokens = 80000
+cost = { input = 0.25, output = 0.8999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."bytedance/seed-1.6"]
+name = "Seed 1.6"
+reasoning = true
+input = ["text"]
+context_window = 256000
+max_tokens = 32000
+cost = { input = 0.25, output = 2, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."cohere/command-a"]
+name = "Command A"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 8000
+cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-r1"]
+name = "DeepSeek-R1"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 1.35, output = 5.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3"]
+name = "DeepSeek V3 0324"
+reasoning = false
+input = ["text"]
+context_window = 163840
+max_tokens = 16384
+cost = { input = 0.77, output = 0.77, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.1"]
+name = "DeepSeek-V3.1"
+reasoning = true
+input = ["text"]
+context_window = 163840
+max_tokens = 8192
+cost = { input = 0.56, output = 1.68, cacheRead = 0.28, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.1-terminus"]
+name = "DeepSeek V3.1 Terminus"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.27, output = 1, cacheRead = 0.135, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.2"]
+name = "DeepSeek V3.2"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 8000
+cost = { input = 0.28, output = 0.42, cacheRead = 0.028, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v3.2-thinking"]
+name = "DeepSeek V3.2 Thinking"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 8000
+cost = { input = 0.62, output = 1.85, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-flash"]
+name = "DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+cost = { input = 0.14, output = 0.28, cacheRead = 0.0028, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-pro"]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+cost = { input = 0.435, output = 0.87, cacheRead = 0.0036, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.0-flash"]
+name = "Gemini 2.0 Flash"
+reasoning = false
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 8192
+cost = { input = 0.15, output = 0.6, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.0-flash-lite"]
+name = "Gemini 2.0 Flash Lite"
+reasoning = false
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 8192
+cost = { input = 0.075, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash"]
+name = "Gemini 2.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash-lite"]
+name = "Gemini 2.5 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-pro"]
+name = "Gemini 2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3-flash"]
+name = "Gemini 3 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65000
+cost = { input = 0.5, output = 3, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3-pro-preview"]
+name = "Gemini 3 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 2, output = 12, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-flash-lite"]
+name = "Gemini 3.1 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65000
+cost = { input = 0.25, output = 1.5, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-flash-lite-preview"]
+name = "Gemini 3.1 Flash Lite Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65000
+cost = { input = 0.25, output = 1.5, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-pro-preview"]
+name = "Gemini 3.1 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 2, output = 12, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.5-flash"]
+name = "Gemini 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-26b-a4b-it"]
+name = "Gemma 4 26B A4B IT"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+cost = { input = 0.13, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-31b-it"]
+name = "Gemma 4 31B IT"
+reasoning = false
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+cost = { input = 0.14, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."inception/mercury-2"]
+name = "Mercury 2"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 128000
+cost = { input = 0.25, output = 0.75, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."inception/mercury-coder-small"]
+name = "Mercury Coder Small Beta"
+reasoning = false
+input = ["text"]
+context_window = 32000
+max_tokens = 16384
+cost = { input = 0.25, output = 1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."kwaipilot/kat-coder-pro-v2"]
+name = "Kat Coder Pro V2"
+reasoning = true
+input = ["text"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+
+[providers.model_metadata."meituan/longcat-flash-chat"]
+name = "LongCat Flash Chat"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 100000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-3.1-70b"]
+name = "Llama 3.1 70B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.72, output = 0.72, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-3.1-8b"]
+name = "Llama 3.1 8B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.22, output = 0.22, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-3.2-11b"]
+name = "Llama 3.2 11B Vision Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.16, output = 0.16, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-3.2-90b"]
+name = "Llama 3.2 90B Vision Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.72, output = 0.72, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-3.3-70b"]
+name = "Llama 3.3 70B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.72, output = 0.72, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-4-maverick"]
+name = "Llama 4 Maverick 17B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.24, output = 0.9700000000000001, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta/llama-4-scout"]
+name = "Llama 4 Scout 17B Instruct"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 8192
+cost = { input = 0.16999999999999998, output = 0.66, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2"]
+name = "MiniMax M2"
+reasoning = true
+input = ["text"]
+context_window = 205000
+max_tokens = 205000
+cost = { input = 0.3, output = 1.2, cacheRead = 0.03, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.1"]
+name = "MiniMax M2.1"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.3, output = 1.2, cacheRead = 0.03, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.1-lightning"]
+name = "MiniMax M2.1 Lightning"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+cost = { input = 0.3, output = 2.4, cacheRead = 0.03, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.5"]
+name = "MiniMax M2.5"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131000
+cost = { input = 0.3, output = 1.2, cacheRead = 0.03, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.5-highspeed"]
+name = "MiniMax M2.5 High Speed"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131000
+cost = { input = 0.6, output = 2.4, cacheRead = 0.03, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.7"]
+name = "MiniMax M2.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 204800
+max_tokens = 131000
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[providers.model_metadata."minimax/minimax-m2.7-highspeed"]
+name = "MiniMax M2.7 High Speed"
+reasoning = true
+input = ["text", "image"]
+context_window = 204800
+max_tokens = 131100
+cost = { input = 0.6, output = 2.4, cacheRead = 0.06, cacheWrite = 0.375 }
+
+[providers.model_metadata."mistral/codestral"]
+name = "Mistral Codestral"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 0.3, output = 0.8999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/devstral-2"]
+name = "Devstral 2"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/devstral-small"]
+name = "Devstral Small 1.1"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 64000
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/devstral-small-2"]
+name = "Devstral Small 2"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/ministral-3b"]
+name = "Ministral 3B"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 0.09999999999999999, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/ministral-8b"]
+name = "Ministral 8B"
+reasoning = false
+input = ["text"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/mistral-medium"]
+name = "Mistral Medium 3.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 64000
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/mistral-medium-3.5"]
+name = "Mistral Medium Latest"
+reasoning = true
+input = ["text"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/mistral-small"]
+name = "Mistral Small"
+reasoning = false
+input = ["text", "image"]
+context_window = 32000
+max_tokens = 4000
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/pixtral-12b"]
+name = "Pixtral 12B 2409"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."mistral/pixtral-large"]
+name = "Pixtral Large"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4000
+cost = { input = 2, output = 6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2"]
+name = "Kimi K2 Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.5700000000000001, output = 2.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-thinking"]
+name = "Kimi K2 Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262114
+max_tokens = 262114
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-thinking-turbo"]
+name = "Kimi K2 Thinking Turbo"
+reasoning = true
+input = ["text"]
+context_window = 262114
+max_tokens = 262114
+cost = { input = 1.15, output = 8, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2-turbo"]
+name = "Kimi K2 Turbo"
+reasoning = false
+input = ["text"]
+context_window = 256000
+max_tokens = 16384
+cost = { input = 1.15, output = 8, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2.5"]
+name = "Kimi K2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262114
+max_tokens = 262114
+cost = { input = 0.6, output = 3, cacheRead = 0.09999999999999999, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/kimi-k2.6"]
+name = "Kimi K2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262000
+max_tokens = 262000
+cost = { input = 0.95, output = 4, cacheRead = 0.16, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-nano-12b-v2-vl"]
+name = "Nvidia Nemotron Nano 12B V2 VL"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.19999999999999998, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."nvidia/nemotron-nano-9b-v2"]
+name = "Nvidia Nemotron Nano 9B V2"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 131072
+cost = { input = 0.06, output = 0.22999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-turbo"]
+name = "GPT-4 Turbo"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1"]
+name = "GPT-4.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-mini"]
+name = "GPT-4.1 mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.39999999999999997, output = 1.5999999999999999, cacheRead = 0.09999999999999999, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-nano"]
+name = "GPT-4.1 nano"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o"]
+name = "GPT-4o"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini"]
+name = "GPT-4o mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5"]
+name = "GPT-5"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-chat"]
+name = "GPT 5 Chat"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-codex"]
+name = "GPT-5-Codex"
+reasoning = true
+input = ["text"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-mini"]
+name = "GPT-5 mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-nano"]
+name = "GPT-5 nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.049999999999999996, output = 0.39999999999999997, cacheRead = 0.005, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-pro"]
+name = "GPT-5 pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 272000
+cost = { input = 15, output = 120, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex"]
+name = "GPT-5.1-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex-max"]
+name = "GPT 5.1 Codex Max"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex-mini"]
+name = "GPT 5.1 Codex Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.024999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-instant"]
+name = "GPT-5.1 Instant"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-thinking"]
+name = "GPT 5.1 Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2"]
+name = "GPT 5.2"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-chat"]
+name = "GPT 5.2 Chat"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-codex"]
+name = "GPT 5.2 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.2-pro"]
+name = "GPT 5.2 "
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 21, output = 168, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.3-chat"]
+name = "GPT-5.3 Chat"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.3-codex"]
+name = "GPT 5.3 Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4"]
+name = "GPT 5.4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-mini"]
+name = "GPT 5.4 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-nano"]
+name = "GPT 5.4 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.19999999999999998, output = 1.25, cacheRead = 0.02, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.4-pro"]
+name = "GPT 5.4 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.5"]
+name = "GPT 5.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-5.5-pro"]
+name = "GPT 5.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "xhigh" }
+
+[providers.model_metadata."openai/gpt-oss-20b"]
+name = "GPT OSS 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 8192
+cost = { input = 0.049999999999999996, output = 0.19999999999999998, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-safeguard-20b"]
+name = "GPT OSS Safeguard 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 65536
+cost = { input = 0.075, output = 0.3, cacheRead = 0.037, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o1"]
+name = "o1"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 15, output = 60, cacheRead = 7.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3"]
+name = "o3"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-deep-research"]
+name = "o3-deep-research"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 10, output = 40, cacheRead = 2.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-mini"]
+name = "o3-mini"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o3-pro"]
+name = "o3 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 20, output = 80, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/o4-mini"]
+name = "o4-mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 100000
+cost = { input = 1.1, output = 4.4, cacheRead = 0.275, cacheWrite = 0 }
+
+[providers.model_metadata."perplexity/sonar"]
+name = "Sonar"
+reasoning = false
+input = ["text", "image"]
+context_window = 127000
+max_tokens = 8000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."perplexity/sonar-pro"]
+name = "Sonar Pro"
+reasoning = false
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 8000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.1-fast-non-reasoning"]
+name = "Grok 4.1 Fast Non-Reasoning"
+reasoning = false
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 1000000
+cost = { input = 0.19999999999999998, output = 0.5, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.1-fast-reasoning"]
+name = "Grok 4.1 Fast Reasoning"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 1000000
+cost = { input = 0.19999999999999998, output = 0.5, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-multi-agent"]
+name = "Grok 4.20 Multi-Agent"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-multi-agent-beta"]
+name = "Grok 4.20 Multi Agent Beta"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-non-reasoning"]
+name = "Grok 4.20 Non-Reasoning"
+reasoning = false
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-non-reasoning-beta"]
+name = "Grok 4.20 Beta Non-Reasoning"
+reasoning = false
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-reasoning"]
+name = "Grok 4.20 Reasoning"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.20-reasoning-beta"]
+name = "Grok 4.20 Beta Reasoning"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 2000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-4.3"]
+name = "Grok 4.3"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 1000000
+cost = { input = 1.25, output = 2.5, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xai/grok-build-0.1"]
+name = "Grok Build 0.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 256000
+max_tokens = 256000
+cost = { input = 1, output = 2, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2-flash"]
+name = "MiMo V2 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 32000
+cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2-pro"]
+name = "MiMo V2 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2.5"]
+name = "MiMo M2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 131100
+cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."xiaomi/mimo-v2.5-pro"]
+name = "MiMo V2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 131000
+cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.5"]
+name = "GLM-4.5"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 96000
+cost = { input = 0.6, output = 2.2, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.5-air"]
+name = "GLM 4.5 Air"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 96000
+cost = { input = 0.19999999999999998, output = 1.1, cacheRead = 0.03, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.5v"]
+name = "GLM 4.5V"
+reasoning = false
+input = ["text", "image"]
+context_window = 66000
+max_tokens = 16000
+cost = { input = 0.6, output = 1.7999999999999998, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.6"]
+name = "GLM 4.6"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 96000
+cost = { input = 0.6, output = 2.2, cacheRead = 0.11, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.6v"]
+name = "GLM-4.6V"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 24000
+cost = { input = 0.3, output = 0.8999999999999999, cacheRead = 0.049999999999999996, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.6v-flash"]
+name = "GLM-4.6V-Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 24000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.7"]
+name = "GLM 4.7"
+reasoning = true
+input = ["text"]
+context_window = 131000
+max_tokens = 40000
+cost = { input = 2.25, output = 2.75, cacheRead = 2.25, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.7-flash"]
+name = "GLM 4.7 Flash"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 131000
+cost = { input = 0.07, output = 0.39999999999999997, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-4.7-flashx"]
+name = "GLM 4.7 FlashX"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 0.06, output = 0.39999999999999997, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-5"]
+name = "GLM 5"
+reasoning = true
+input = ["text"]
+context_window = 202800
+max_tokens = 131100
+cost = { input = 1, output = 3.1999999999999997, cacheRead = 0.19999999999999998, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-5-turbo"]
+name = "GLM 5 Turbo"
+reasoning = true
+input = ["text"]
+context_window = 202800
+max_tokens = 131100
+cost = { input = 1.2, output = 4, cacheRead = 0.24, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-5.1"]
+name = "GLM 5.1"
+reasoning = true
+input = ["text"]
+context_window = 202800
+max_tokens = 64000
+cost = { input = 1.4, output = 4.4, cacheRead = 0.26, cacheWrite = 0 }
+
+[providers.model_metadata."zai/glm-5v-turbo"]
+name = "GLM 5V Turbo"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 1.2, output = 4, cacheRead = 0.24, cacheWrite = 0 }
+
+[[providers]]
+name = "xiaomi"
+display_name = "Xiaomi MiMo"
+kind = "openai-compatible"
+base_url = "https://api.xiaomimimo.com/v1"
+api = "openai-completions"
+api_key_env = "XIAOMI_API_KEY"
+credential_name = "xiaomi"
+models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
+default_model = "mimo-v2.5-pro"
+docs_url = "https://platform.mimo.xiaomi.com"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+mimo-v2-flash = 262144
+mimo-v2-omni = 262144
+mimo-v2-pro = 1048576
+"mimo-v2.5" = 1048576
+"mimo-v2.5-pro" = 1048576
+
+[providers.model_metadata.mimo-v2-flash]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-omni]
+name = "MiMo-V2-Omni"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-pro]
+name = "MiMo-V2-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5"]
+name = "MiMo-V2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5-pro"]
+name = "MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "xiaomi-token-plan-cn"
+display_name = "Xiaomi MiMo Token Plan (China)"
+kind = "openai-compatible"
+base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+api = "openai-completions"
+api_key_env = "XIAOMI_TOKEN_PLAN_CN_API_KEY"
+credential_name = "xiaomi-token-plan-cn"
+models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
+default_model = "mimo-v2.5-pro"
+docs_url = "https://platform.mimo.xiaomi.com"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+mimo-v2-flash = 262144
+mimo-v2-omni = 262144
+mimo-v2-pro = 1048576
+"mimo-v2.5" = 1048576
+"mimo-v2.5-pro" = 1048576
+
+[providers.model_metadata.mimo-v2-flash]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-omni]
+name = "MiMo-V2-Omni"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-pro]
+name = "MiMo-V2-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5"]
+name = "MiMo-V2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5-pro"]
+name = "MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "xiaomi-token-plan-ams"
+display_name = "Xiaomi MiMo Token Plan (Amsterdam)"
+kind = "openai-compatible"
+base_url = "https://token-plan-ams.xiaomimimo.com/v1"
+api = "openai-completions"
+api_key_env = "XIAOMI_TOKEN_PLAN_AMS_API_KEY"
+credential_name = "xiaomi-token-plan-ams"
+models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
+default_model = "mimo-v2.5-pro"
+docs_url = "https://platform.mimo.xiaomi.com"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+mimo-v2-flash = 262144
+mimo-v2-omni = 262144
+mimo-v2-pro = 1048576
+"mimo-v2.5" = 1048576
+"mimo-v2.5-pro" = 1048576
+
+[providers.model_metadata.mimo-v2-flash]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-omni]
+name = "MiMo-V2-Omni"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-pro]
+name = "MiMo-V2-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5"]
+name = "MiMo-V2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5-pro"]
+name = "MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "xiaomi-token-plan-sgp"
+display_name = "Xiaomi MiMo Token Plan (Singapore)"
+kind = "openai-compatible"
+base_url = "https://token-plan-sgp.xiaomimimo.com/v1"
+api = "openai-completions"
+api_key_env = "XIAOMI_TOKEN_PLAN_SGP_API_KEY"
+credential_name = "xiaomi-token-plan-sgp"
+models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
+default_model = "mimo-v2.5-pro"
+docs_url = "https://platform.mimo.xiaomi.com"
+thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+mimo-v2-flash = 262144
+mimo-v2-omni = 262144
+mimo-v2-pro = 1048576
+"mimo-v2.5" = 1048576
+"mimo-v2.5-pro" = 1048576
+
+[providers.model_metadata.mimo-v2-flash]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-omni]
+name = "MiMo-V2-Omni"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata.mimo-v2-pro]
+name = "MiMo-V2-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5"]
+name = "MiMo-V2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 0.4, output = 2, cacheRead = 0.08, cacheWrite = 0 }
+
+[providers.model_metadata."mimo-v2.5-pro"]
+name = "MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
+cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -8,12 +8,12 @@ name = "openai"
 display_name = "OpenAI"
 kind = "openai-compatible"
 base_url = "https://api.openai.com/v1"
-api = "openai-responses"
 api_key_env = "OPENAI_API_KEY"
 credential_name = "openai"
-models = ["gpt-4", "gpt-4-turbo", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20", "gpt-4o-mini", "gpt-5", "gpt-5-chat-latest", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.1", "gpt-5.1-chat-latest", "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-chat-latest", "gpt-5.2-codex", "gpt-5.2-pro", "gpt-5.3-chat-latest", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "o1", "o1-pro", "o3", "o3-deep-research", "o3-mini", "o3-pro", "o4-mini", "o4-mini-deep-research"]
+models = ["gpt-4", "gpt-4-turbo", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20", "gpt-4o-mini", "gpt-5", "gpt-5-chat-latest", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.1", "gpt-5.1-chat-latest", "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-chat-latest", "gpt-5.2-codex", "gpt-5.2-pro", "gpt-5.3-chat-latest", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "o1", "o1-pro", "o3", "o3-mini", "o3-pro", "o4-mini"]
 default_model = "gpt-5.4"
 docs_url = "https://platform.openai.com/docs"
+api = "openai-responses"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -46,7 +46,6 @@ gpt-5-pro = 400000
 "gpt-5.2-pro" = 400000
 "gpt-5.3-chat-latest" = 128000
 "gpt-5.3-codex" = 400000
-"gpt-5.3-codex-spark" = 128000
 "gpt-5.4" = 272000
 "gpt-5.4-mini" = 400000
 "gpt-5.4-nano" = 400000
@@ -56,11 +55,9 @@ gpt-5-pro = 400000
 o1 = 200000
 o1-pro = 200000
 o3 = 200000
-o3-deep-research = 200000
 o3-mini = 200000
 o3-pro = 200000
 o4-mini = 200000
-o4-mini-deep-research = 200000
 
 [providers.model_metadata.gpt-4]
 name = "GPT-4"
@@ -167,7 +164,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 128000
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata.gpt-5-mini]
 name = "GPT-5 Mini"
@@ -194,7 +191,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 272000
 cost = { input = 15, output = 120, cacheRead = 0, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
 
 [providers.model_metadata."gpt-5.1"]
 name = "GPT-5.1"
@@ -204,6 +201,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 1.25, output = 10, cacheRead = 0.13, cacheWrite = 0 }
 thinking_level_map = { off = "none" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.1-chat-latest"]
 name = "GPT-5.1 Chat"
@@ -212,7 +210,7 @@ input = ["text", "image"]
 context_window = 128000
 max_tokens = 16384
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low", "high"]
 
 [providers.model_metadata."gpt-5.1-codex"]
 name = "GPT-5.1 Codex"
@@ -221,7 +219,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 128000
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata."gpt-5.1-codex-max"]
 name = "GPT-5.1 Codex Max"
@@ -230,7 +228,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 128000
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata."gpt-5.1-codex-mini"]
 name = "GPT-5.1 Codex mini"
@@ -239,7 +237,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 128000
 cost = { input = 0.25, output = 2, cacheRead = 0.025, cacheWrite = 0 }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata."gpt-5.2"]
 name = "GPT-5.2"
@@ -249,6 +247,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.2-chat-latest"]
 name = "GPT-5.2 Chat"
@@ -258,7 +257,7 @@ context_window = 128000
 max_tokens = 16384
 cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low", "high", "xhigh"]
 
 [providers.model_metadata."gpt-5.2-codex"]
 name = "GPT-5.2 Codex"
@@ -268,7 +267,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata."gpt-5.2-pro"]
 name = "GPT-5.2 Pro"
@@ -278,7 +277,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 21, output = 168, cacheRead = 0, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low"]
 
 [providers.model_metadata."gpt-5.3-chat-latest"]
 name = "GPT-5.3 Chat (latest)"
@@ -298,16 +297,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
-
-[providers.model_metadata."gpt-5.3-codex-spark"]
-name = "GPT-5.3 Codex Spark"
-reasoning = true
-input = ["text", "image"]
-context_window = 128000
-max_tokens = 32000
-cost = { input = 1.75, output = 14, cacheRead = 0.175, cacheWrite = 0 }
-thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.4"]
 name = "GPT-5.4"
@@ -317,6 +307,7 @@ context_window = 272000
 max_tokens = 128000
 cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.4-mini"]
 name = "GPT-5.4 mini"
@@ -326,6 +317,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.4-nano"]
 name = "GPT-5.4 nano"
@@ -335,6 +327,7 @@ context_window = 400000
 max_tokens = 128000
 cost = { input = 0.2, output = 1.25, cacheRead = 0.02, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.4-pro"]
 name = "GPT-5.4 Pro"
@@ -344,7 +337,7 @@ context_window = 1050000
 max_tokens = 128000
 cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low"]
 
 [providers.model_metadata."gpt-5.5"]
 name = "GPT-5.5"
@@ -354,6 +347,7 @@ context_window = 272000
 max_tokens = 128000
 cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.5-pro"]
 name = "GPT-5.5 Pro"
@@ -363,7 +357,7 @@ context_window = 1050000
 max_tokens = 128000
 cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
-unsupported_thinking_levels = ["off"]
+unsupported_thinking_levels = ["off", "minimal", "low"]
 
 [providers.model_metadata.o1]
 reasoning = true
@@ -371,6 +365,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 15, output = 60, cacheRead = 7.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.o1-pro]
 reasoning = true
@@ -378,6 +373,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 150, output = 600, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.o3]
 reasoning = true
@@ -385,13 +381,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
-
-[providers.model_metadata.o3-deep-research]
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 100000
-cost = { input = 10, output = 40, cacheRead = 2.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.o3-mini]
 reasoning = true
@@ -399,6 +389,7 @@ input = ["text"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.o3-pro]
 reasoning = true
@@ -406,6 +397,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 20, output = 80, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.o4-mini]
 reasoning = true
@@ -413,14 +405,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 1.1, output = 4.4, cacheRead = 0.28, cacheWrite = 0 }
-
-[providers.model_metadata.o4-mini-deep-research]
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 100000
-cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
-
+unsupported_thinking_levels = ["minimal"]
 
 [[providers]]
 name = "openai-codex"
@@ -450,104 +435,28 @@ name = "anthropic"
 display_name = "Anthropic"
 kind = "anthropic"
 base_url = "https://api.anthropic.com"
-api = "anthropic-messages"
 api_key_env = "ANTHROPIC_API_KEY"
 credential_name = "anthropic"
-models = ["claude-3-5-haiku-20241022", "claude-3-5-haiku-latest", "claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022", "claude-3-7-sonnet-20250219", "claude-3-haiku-20240307", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-0", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-20250514", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-0", "claude-sonnet-4-20250514", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6"]
-default_model = "claude-opus-4-7"
+models = ["claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6"]
+default_model = "claude-sonnet-4-6"
 docs_url = "https://docs.anthropic.com"
+api = "anthropic-messages"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
 
 [providers.context_windows]
-claude-3-5-haiku-20241022 = 200000
-claude-3-5-haiku-latest = 200000
-claude-3-5-sonnet-20240620 = 200000
-claude-3-5-sonnet-20241022 = 200000
-claude-3-7-sonnet-20250219 = 200000
-claude-3-haiku-20240307 = 200000
-claude-3-opus-20240229 = 200000
-claude-3-sonnet-20240229 = 200000
 claude-haiku-4-5 = 200000
 claude-haiku-4-5-20251001 = 200000
-claude-opus-4-0 = 200000
 claude-opus-4-1 = 200000
 claude-opus-4-1-20250805 = 200000
-claude-opus-4-20250514 = 200000
 claude-opus-4-5 = 200000
 claude-opus-4-5-20251101 = 200000
 claude-opus-4-6 = 1000000
 claude-opus-4-7 = 1000000
-claude-sonnet-4-0 = 200000
-claude-sonnet-4-20250514 = 200000
 claude-sonnet-4-5 = 200000
 claude-sonnet-4-5-20250929 = 200000
 claude-sonnet-4-6 = 1000000
-
-[providers.model_metadata.claude-3-5-haiku-20241022]
-name = "Claude Haiku 3.5"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 8192
-cost = { input = 0.8, output = 4, cacheRead = 0.08, cacheWrite = 1 }
-
-[providers.model_metadata.claude-3-5-haiku-latest]
-name = "Claude Haiku 3.5 (latest)"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 8192
-cost = { input = 0.8, output = 4, cacheRead = 0.08, cacheWrite = 1 }
-
-[providers.model_metadata.claude-3-5-sonnet-20240620]
-name = "Claude Sonnet 3.5"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 8192
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
-
-[providers.model_metadata.claude-3-5-sonnet-20241022]
-name = "Claude Sonnet 3.5 v2"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 8192
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
-
-[providers.model_metadata.claude-3-7-sonnet-20250219]
-name = "Claude Sonnet 3.7"
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 64000
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
-
-[providers.model_metadata.claude-3-haiku-20240307]
-name = "Claude Haiku 3"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 4096
-cost = { input = 0.25, output = 1.25, cacheRead = 0.03, cacheWrite = 0.3 }
-
-[providers.model_metadata.claude-3-opus-20240229]
-name = "Claude Opus 3"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 4096
-cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
-
-[providers.model_metadata.claude-3-sonnet-20240229]
-name = "Claude Sonnet 3"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 4096
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 0.3 }
 
 [providers.model_metadata.claude-haiku-4-5]
 name = "Claude Haiku 4.5 (latest)"
@@ -565,14 +474,6 @@ context_window = 200000
 max_tokens = 64000
 cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
 
-[providers.model_metadata.claude-opus-4-0]
-name = "Claude Opus 4 (latest)"
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 32000
-cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
-
 [providers.model_metadata.claude-opus-4-1]
 name = "Claude Opus 4.1 (latest)"
 reasoning = true
@@ -583,14 +484,6 @@ cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
 
 [providers.model_metadata.claude-opus-4-1-20250805]
 name = "Claude Opus 4.1"
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 32000
-cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
-
-[providers.model_metadata.claude-opus-4-20250514]
-name = "Claude Opus 4"
 reasoning = true
 input = ["text", "image"]
 context_window = 200000
@@ -622,6 +515,7 @@ max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
 cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
 thinking_level_map = { xhigh = "max" }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.claude-opus-4-7]
 name = "Claude Opus 4.7"
@@ -632,22 +526,7 @@ max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
 cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
 thinking_level_map = { xhigh = "xhigh" }
-
-[providers.model_metadata.claude-sonnet-4-0]
-name = "Claude Sonnet 4 (latest)"
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 64000
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
-
-[providers.model_metadata.claude-sonnet-4-20250514]
-name = "Claude Sonnet 4"
-reasoning = true
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 64000
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.claude-sonnet-4-5]
 name = "Claude Sonnet 4.5 (latest)"
@@ -673,30 +552,28 @@ context_window = 1000000
 max_tokens = 64000
 compat = { forceAdaptiveThinking = true }
 cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+unsupported_thinking_levels = ["minimal"]
 
 [[providers]]
 name = "google"
 display_name = "Google Gemini"
 kind = "google-generative-ai"
 base_url = "https://generativelanguage.googleapis.com/v1beta"
-api = "google-generative-ai"
 api_key_env = "GEMINI_API_KEY"
 credential_name = "google"
-models = ["gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3-pro-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools", "gemini-3.5-flash", "gemini-flash-latest", "gemini-flash-lite-latest", "gemma-4-26b-a4b-it", "gemma-4-31b-it"]
-default_model = "gemini-3.1-pro-preview"
+models = ["gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools", "gemini-3.5-flash", "gemini-flash-latest", "gemini-flash-lite-latest", "gemma-4-26b-a4b-it", "gemma-4-31b-it"]
+default_model = "gemini-flash-latest"
 docs_url = "https://ai.google.dev/gemini-api/docs"
+api = "google-generative-ai"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-"gemini-2.0-flash" = 1048576
-"gemini-2.0-flash-lite" = 1048576
 "gemini-2.5-flash" = 1048576
 "gemini-2.5-flash-lite" = 1048576
 "gemini-2.5-pro" = 1048576
 gemini-3-flash-preview = 1048576
-gemini-3-pro-preview = 1048576
 "gemini-3.1-flash-lite" = 1048576
 "gemini-3.1-flash-lite-preview" = 1048576
 "gemini-3.1-pro-preview" = 1048576
@@ -706,22 +583,6 @@ gemini-flash-latest = 1048576
 gemini-flash-lite-latest = 1048576
 gemma-4-26b-a4b-it = 262144
 gemma-4-31b-it = 262144
-
-[providers.model_metadata."gemini-2.0-flash"]
-name = "Gemini 2.0 Flash"
-reasoning = false
-input = ["text", "image"]
-context_window = 1048576
-max_tokens = 8192
-cost = { input = 0.1, output = 0.4, cacheRead = 0.025, cacheWrite = 0 }
-
-[providers.model_metadata."gemini-2.0-flash-lite"]
-name = "Gemini 2.0 Flash-Lite"
-reasoning = false
-input = ["text", "image"]
-context_window = 1048576
-max_tokens = 8192
-cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."gemini-2.5-flash"]
 name = "Gemini 2.5 Flash"
@@ -746,6 +607,7 @@ input = ["text", "image"]
 context_window = 1048576
 max_tokens = 65536
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
 
 [providers.model_metadata.gemini-3-flash-preview]
 name = "Gemini 3 Flash Preview"
@@ -755,16 +617,6 @@ context_window = 1048576
 max_tokens = 65536
 cost = { input = 0.5, output = 3, cacheRead = 0.05, cacheWrite = 0 }
 unsupported_thinking_levels = ["off"]
-
-[providers.model_metadata.gemini-3-pro-preview]
-name = "Gemini 3 Pro Preview"
-reasoning = true
-input = ["text", "image"]
-context_window = 1048576
-max_tokens = 65536
-cost = { input = 2, output = 12, cacheRead = 0.2, cacheWrite = 0 }
-thinking_level_map = { low = "LOW", high = "HIGH" }
-unsupported_thinking_levels = ["off", "minimal", "medium"]
 
 [providers.model_metadata."gemini-3.1-flash-lite"]
 name = "Gemini 3.1 Flash Lite"
@@ -854,12 +706,12 @@ name = "deepseek"
 display_name = "DeepSeek"
 kind = "openai-compatible"
 base_url = "https://api.deepseek.com"
-api = "openai-completions"
 api_key_env = "DEEPSEEK_API_KEY"
 credential_name = "deepseek"
 models = ["deepseek-v4-flash", "deepseek-v4-pro"]
 default_model = "deepseek-v4-pro"
 docs_url = "https://api-docs.deepseek.com"
+api = "openai-completions"
 thinking_levels = ["off", "high", "xhigh"]
 thinking_default = "off"
 thinking_parameter = "reasoning_effort"
@@ -895,12 +747,12 @@ name = "xai"
 display_name = "xAI"
 kind = "openai-compatible"
 base_url = "https://api.x.ai/v1"
-api = "openai-completions"
 api_key_env = "XAI_API_KEY"
 credential_name = "xai"
 models = ["grok-3", "grok-3-fast", "grok-4.20-0309-non-reasoning", "grok-4.20-0309-reasoning", "grok-4.3", "grok-build-0.1", "grok-code-fast-1"]
 default_model = "grok-4.20-0309-reasoning"
 docs_url = "https://docs.x.ai"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -975,51 +827,26 @@ name = "groq"
 display_name = "Groq"
 kind = "openai-compatible"
 base_url = "https://api.groq.com/openai/v1"
-api = "openai-completions"
 api_key_env = "GROQ_API_KEY"
 credential_name = "groq"
-models = ["deepseek-r1-distill-llama-70b", "gemma2-9b-it", "groq/compound", "groq/compound-mini", "llama-3.1-8b-instant", "llama-3.3-70b-versatile", "llama3-70b-8192", "llama3-8b-8192", "meta-llama/llama-4-maverick-17b-128e-instruct", "meta-llama/llama-4-scout-17b-16e-instruct", "mistral-saba-24b", "moonshotai/kimi-k2-instruct", "moonshotai/kimi-k2-instruct-0905", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "qwen-qwq-32b", "qwen/qwen3-32b"]
+models = ["groq/compound", "groq/compound-mini", "llama-3.1-8b-instant", "llama-3.3-70b-versatile", "meta-llama/llama-4-scout-17b-16e-instruct", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "qwen/qwen3-32b"]
 default_model = "openai/gpt-oss-120b"
 docs_url = "https://console.groq.com/docs"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-deepseek-r1-distill-llama-70b = 131072
-gemma2-9b-it = 8192
 "groq/compound" = 131072
 "groq/compound-mini" = 131072
 "llama-3.1-8b-instant" = 131072
 "llama-3.3-70b-versatile" = 131072
-llama3-70b-8192 = 8192
-llama3-8b-8192 = 8192
-"meta-llama/llama-4-maverick-17b-128e-instruct" = 131072
 "meta-llama/llama-4-scout-17b-16e-instruct" = 131072
-mistral-saba-24b = 32768
-"moonshotai/kimi-k2-instruct" = 131072
-"moonshotai/kimi-k2-instruct-0905" = 262144
 "openai/gpt-oss-120b" = 131072
 "openai/gpt-oss-20b" = 131072
 "openai/gpt-oss-safeguard-20b" = 131072
-qwen-qwq-32b = 131072
 "qwen/qwen3-32b" = 131072
-
-[providers.model_metadata.deepseek-r1-distill-llama-70b]
-name = "DeepSeek R1 Distill Llama 70B"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 8192
-cost = { input = 0.75, output = 0.99, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata.gemma2-9b-it]
-name = "Gemma 2 9B"
-reasoning = false
-input = ["text"]
-context_window = 8192
-max_tokens = 8192
-cost = { input = 0.2, output = 0.2, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."groq/compound"]
 name = "Compound"
@@ -1028,6 +855,7 @@ input = ["text"]
 context_window = 131072
 max_tokens = 8192
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium", "high"]
 
 [providers.model_metadata."groq/compound-mini"]
 name = "Compound Mini"
@@ -1036,6 +864,7 @@ input = ["text"]
 context_window = 131072
 max_tokens = 8192
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "medium", "high"]
 
 [providers.model_metadata."llama-3.1-8b-instant"]
 name = "Llama 3.1 8B Instant"
@@ -1053,30 +882,6 @@ context_window = 131072
 max_tokens = 32768
 cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata.llama3-70b-8192]
-name = "Llama 3 70B"
-reasoning = false
-input = ["text"]
-context_window = 8192
-max_tokens = 8192
-cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata.llama3-8b-8192]
-name = "Llama 3 8B"
-reasoning = false
-input = ["text"]
-context_window = 8192
-max_tokens = 8192
-cost = { input = 0.05, output = 0.08, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."meta-llama/llama-4-maverick-17b-128e-instruct"]
-name = "Llama 4 Maverick 17B"
-reasoning = false
-input = ["text", "image"]
-context_window = 131072
-max_tokens = 8192
-cost = { input = 0.2, output = 0.6, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."meta-llama/llama-4-scout-17b-16e-instruct"]
 name = "Llama 4 Scout 17B"
 reasoning = false
@@ -1085,30 +890,6 @@ context_window = 131072
 max_tokens = 8192
 cost = { input = 0.11, output = 0.34, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata.mistral-saba-24b]
-name = "Mistral Saba 24B"
-reasoning = false
-input = ["text"]
-context_window = 32768
-max_tokens = 32768
-cost = { input = 0.79, output = 0.79, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."moonshotai/kimi-k2-instruct"]
-name = "Kimi K2 Instruct"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 16384
-cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."moonshotai/kimi-k2-instruct-0905"]
-name = "Kimi K2 Instruct 0905"
-reasoning = false
-input = ["text"]
-context_window = 262144
-max_tokens = 16384
-cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."openai/gpt-oss-120b"]
 name = "GPT OSS 120B"
 reasoning = true
@@ -1116,6 +897,7 @@ input = ["text"]
 context_window = 131072
 max_tokens = 65536
 cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/gpt-oss-20b"]
 name = "GPT OSS 20B"
@@ -1124,6 +906,7 @@ input = ["text"]
 context_window = 131072
 max_tokens = 65536
 cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/gpt-oss-safeguard-20b"]
 name = "Safety GPT OSS 20B"
@@ -1132,14 +915,7 @@ input = ["text"]
 context_window = 131072
 max_tokens = 65536
 cost = { input = 0.075, output = 0.3, cacheRead = 0.037, cacheWrite = 0 }
-
-[providers.model_metadata.qwen-qwq-32b]
-name = "Qwen QwQ 32B"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 16384
-cost = { input = 0.29, output = 0.39, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."qwen/qwen3-32b"]
 name = "Qwen3 32B"
@@ -1156,12 +932,12 @@ name = "cerebras"
 display_name = "Cerebras"
 kind = "openai-compatible"
 base_url = "https://api.cerebras.ai/v1"
-api = "openai-completions"
 api_key_env = "CEREBRAS_API_KEY"
 credential_name = "cerebras"
 models = ["gpt-oss-120b", "llama3.1-8b", "qwen-3-235b-a22b-instruct-2507", "zai-glm-4.7"]
 default_model = "zai-glm-4.7"
 docs_url = "https://inference-docs.cerebras.ai"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -1209,45 +985,37 @@ name = "openrouter"
 display_name = "OpenRouter"
 kind = "openai-compatible"
 base_url = "https://openrouter.ai/api/v1"
-api = "openai-completions"
 api_key_env = "OPENROUTER_API_KEY"
 credential_name = "openrouter"
-models = ["ai21/jamba-large-1.7", "alibaba/tongyi-deepresearch-30b-a3b", "amazon/nova-2-lite-v1", "amazon/nova-lite-v1", "amazon/nova-micro-v1", "amazon/nova-premier-v1", "amazon/nova-pro-v1", "anthropic/claude-3-haiku", "anthropic/claude-3.5-haiku", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4", "anthropic/claude-opus-4.1", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.6-fast", "anthropic/claude-opus-4.7", "anthropic/claude-opus-4.7-fast", "anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.6", "arcee-ai/trinity-large-thinking", "arcee-ai/trinity-large-thinking:free", "arcee-ai/trinity-mini", "arcee-ai/virtuoso-large", "auto", "baidu/cobuddy:free", "baidu/ernie-4.5-21b-a3b", "baidu/ernie-4.5-vl-28b-a3b", "bytedance-seed/seed-1.6", "bytedance-seed/seed-1.6-flash", "bytedance-seed/seed-2.0-lite", "bytedance-seed/seed-2.0-mini", "cohere/command-r-08-2024", "cohere/command-r-plus-08-2024", "deepseek/deepseek-chat", "deepseek/deepseek-chat-v3-0324", "deepseek/deepseek-chat-v3.1", "deepseek/deepseek-r1", "deepseek/deepseek-r1-0528", "deepseek/deepseek-v3.1-terminus", "deepseek/deepseek-v3.2", "deepseek/deepseek-v3.2-exp", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash:free", "deepseek/deepseek-v4-pro", "essentialai/rnj-1-instruct", "google/gemini-2.0-flash-001", "google/gemini-2.0-flash-lite-001", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash-lite-preview-09-2025", "google/gemini-2.5-pro", "google/gemini-2.5-pro-preview", "google/gemini-2.5-pro-preview-05-06", "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.1-pro-preview-customtools", "google/gemini-3.5-flash", "google/gemma-3-12b-it", "google/gemma-3-27b-it", "google/gemma-4-26b-a4b-it", "google/gemma-4-26b-a4b-it:free", "google/gemma-4-31b-it", "google/gemma-4-31b-it:free", "ibm-granite/granite-4.1-8b", "inception/mercury-2", "inclusionai/ling-2.6-1t", "inclusionai/ling-2.6-flash", "inclusionai/ring-2.6-1t", "kwaipilot/kat-coder-pro-v2", "meta-llama/llama-3.1-70b-instruct", "meta-llama/llama-3.1-8b-instruct", "meta-llama/llama-3.3-70b-instruct", "meta-llama/llama-3.3-70b-instruct:free", "meta-llama/llama-4-scout", "minimax/minimax-m1", "minimax/minimax-m2", "minimax/minimax-m2.1", "minimax/minimax-m2.5", "minimax/minimax-m2.5:free", "minimax/minimax-m2.7", "mistralai/codestral-2508", "mistralai/devstral-2512", "mistralai/devstral-medium", "mistralai/devstral-small", "mistralai/ministral-14b-2512", "mistralai/ministral-3b-2512", "mistralai/ministral-8b-2512", "mistralai/mistral-large", "mistralai/mistral-large-2407", "mistralai/mistral-large-2411", "mistralai/mistral-large-2512", "mistralai/mistral-medium-3", "mistralai/mistral-medium-3-5", "mistralai/mistral-medium-3.1", "mistralai/mistral-nemo", "mistralai/mistral-saba", "mistralai/mistral-small-2603", "mistralai/mistral-small-3.2-24b-instruct", "mistralai/mixtral-8x22b-instruct", "mistralai/pixtral-large-2411", "mistralai/voxtral-small-24b-2507", "moonshotai/kimi-k2", "moonshotai/kimi-k2-0905", "moonshotai/kimi-k2-thinking", "moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "nex-agi/deepseek-v3.1-nex-n1", "nvidia/llama-3.3-nemotron-super-49b-v1.5", "nvidia/nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-nano-30b-a3b:free", "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free", "nvidia/nemotron-3-super-120b-a12b", "nvidia/nemotron-3-super-120b-a12b:free", "nvidia/nemotron-nano-12b-v2-vl:free", "nvidia/nemotron-nano-9b-v2", "nvidia/nemotron-nano-9b-v2:free", "openai/gpt-3.5-turbo", "openai/gpt-3.5-turbo-0613", "openai/gpt-3.5-turbo-16k", "openai/gpt-4", "openai/gpt-4-0314", "openai/gpt-4-1106-preview", "openai/gpt-4-turbo", "openai/gpt-4-turbo-preview", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4.1-nano", "openai/gpt-4o", "openai/gpt-4o-2024-05-13", "openai/gpt-4o-2024-08-06", "openai/gpt-4o-2024-11-20", "openai/gpt-4o-audio-preview", "openai/gpt-4o-mini", "openai/gpt-4o-mini-2024-07-18", "openai/gpt-5", "openai/gpt-5-codex", "openai/gpt-5-mini", "openai/gpt-5-nano", "openai/gpt-5-pro", "openai/gpt-5.1", "openai/gpt-5.1-chat", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-max", "openai/gpt-5.1-codex-mini", "openai/gpt-5.2", "openai/gpt-5.2-chat", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.3-chat", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-audio", "openai/gpt-audio-mini", "openai/gpt-chat-latest", "openai/gpt-oss-120b", "openai/gpt-oss-120b:free", "openai/gpt-oss-20b", "openai/gpt-oss-20b:free", "openai/gpt-oss-safeguard-20b", "openai/o1", "openai/o3", "openai/o3-deep-research", "openai/o3-mini", "openai/o3-mini-high", "openai/o3-pro", "openai/o4-mini", "openai/o4-mini-deep-research", "openai/o4-mini-high", "openrouter/auto", "openrouter/free", "openrouter/owl-alpha", "poolside/laguna-m.1:free", "poolside/laguna-xs.2:free", "prime-intellect/intellect-3", "qwen/qwen-2.5-72b-instruct", "qwen/qwen-2.5-7b-instruct", "qwen/qwen-plus", "qwen/qwen-plus-2025-07-28", "qwen/qwen-plus-2025-07-28:thinking", "qwen/qwen3-14b", "qwen/qwen3-235b-a22b", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-235b-a22b-thinking-2507", "qwen/qwen3-30b-a3b", "qwen/qwen3-30b-a3b-instruct-2507", "qwen/qwen3-30b-a3b-thinking-2507", "qwen/qwen3-32b", "qwen/qwen3-8b", "qwen/qwen3-coder", "qwen/qwen3-coder-30b-a3b-instruct", "qwen/qwen3-coder-flash", "qwen/qwen3-coder-next", "qwen/qwen3-coder-plus", "qwen/qwen3-coder:free", "qwen/qwen3-max", "qwen/qwen3-max-thinking", "qwen/qwen3-next-80b-a3b-instruct", "qwen/qwen3-next-80b-a3b-instruct:free", "qwen/qwen3-next-80b-a3b-thinking", "qwen/qwen3-vl-235b-a22b-instruct", "qwen/qwen3-vl-235b-a22b-thinking", "qwen/qwen3-vl-30b-a3b-instruct", "qwen/qwen3-vl-30b-a3b-thinking", "qwen/qwen3-vl-32b-instruct", "qwen/qwen3-vl-8b-instruct", "qwen/qwen3-vl-8b-thinking", "qwen/qwen3.5-122b-a10b", "qwen/qwen3.5-27b", "qwen/qwen3.5-35b-a3b", "qwen/qwen3.5-397b-a17b", "qwen/qwen3.5-9b", "qwen/qwen3.5-flash-02-23", "qwen/qwen3.5-plus-02-15", "qwen/qwen3.5-plus-20260420", "qwen/qwen3.6-27b", "qwen/qwen3.6-35b-a3b", "qwen/qwen3.6-flash", "qwen/qwen3.6-max-preview", "qwen/qwen3.6-plus", "qwen/qwen3.7-max", "rekaai/reka-edge", "relace/relace-search", "sao10k/l3-euryale-70b", "sao10k/l3.1-euryale-70b", "stepfun/step-3.5-flash", "tencent/hy3-preview", "thedrummer/rocinante-12b", "thedrummer/unslopnemo-12b", "upstage/solar-pro-3", "x-ai/grok-4.20", "x-ai/grok-4.3", "x-ai/grok-build-0.1", "xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-omni", "xiaomi/mimo-v2-pro", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro", "z-ai/glm-4-32b", "z-ai/glm-4.5", "z-ai/glm-4.5-air", "z-ai/glm-4.5-air:free", "z-ai/glm-4.5v", "z-ai/glm-4.6", "z-ai/glm-4.6v", "z-ai/glm-4.7", "z-ai/glm-4.7-flash", "z-ai/glm-5", "z-ai/glm-5-turbo", "z-ai/glm-5.1", "z-ai/glm-5v-turbo", "~anthropic/claude-haiku-latest", "~anthropic/claude-opus-latest", "~anthropic/claude-sonnet-latest", "~google/gemini-flash-latest", "~google/gemini-pro-latest", "~moonshotai/kimi-latest", "~openai/gpt-latest", "~openai/gpt-mini-latest"]
-default_model = "moonshotai/kimi-k2.6"
+models = ["ai21/jamba-large-1.7", "amazon/nova-2-lite-v1", "amazon/nova-lite-v1", "amazon/nova-micro-v1", "amazon/nova-premier-v1", "amazon/nova-pro-v1", "anthropic/claude-3-haiku", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4", "anthropic/claude-opus-4.1", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.7", "anthropic/claude-opus-4.7-fast", "anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.6", "arcee-ai/trinity-large-thinking", "arcee-ai/trinity-mini", "auto", "bytedance-seed/seed-1.6", "bytedance-seed/seed-1.6-flash", "bytedance-seed/seed-2.0-lite", "bytedance-seed/seed-2.0-mini", "cohere/command-r-08-2024", "cohere/command-r-plus-08-2024", "deepseek/deepseek-chat", "deepseek/deepseek-chat-v3-0324", "deepseek/deepseek-chat-v3.1", "deepseek/deepseek-r1", "deepseek/deepseek-r1-0528", "deepseek/deepseek-v3.1-terminus", "deepseek/deepseek-v3.2", "deepseek/deepseek-v3.2-exp", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash-lite-preview-09-2025", "google/gemini-2.5-pro", "google/gemini-2.5-pro-preview", "google/gemini-2.5-pro-preview-05-06", "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.1-pro-preview-customtools", "google/gemini-3.5-flash", "google/gemma-3-12b-it", "google/gemma-3-27b-it", "google/gemma-4-26b-a4b-it", "google/gemma-4-26b-a4b-it:free", "google/gemma-4-31b-it", "google/gemma-4-31b-it:free", "ibm-granite/granite-4.1-8b", "inception/mercury-2", "inclusionai/ling-2.6-1t", "inclusionai/ling-2.6-flash", "inclusionai/ring-2.6-1t", "kwaipilot/kat-coder-pro-v2", "meta-llama/llama-3.1-70b-instruct", "meta-llama/llama-3.1-8b-instruct", "meta-llama/llama-3.3-70b-instruct", "meta-llama/llama-3.3-70b-instruct:free", "meta-llama/llama-4-scout", "minimax/minimax-m1", "minimax/minimax-m2", "minimax/minimax-m2.1", "minimax/minimax-m2.5", "minimax/minimax-m2.7", "mistralai/codestral-2508", "mistralai/devstral-2512", "mistralai/ministral-14b-2512", "mistralai/ministral-3b-2512", "mistralai/ministral-8b-2512", "mistralai/mistral-large", "mistralai/mistral-large-2407", "mistralai/mistral-large-2512", "mistralai/mistral-medium-3", "mistralai/mistral-medium-3-5", "mistralai/mistral-medium-3.1", "mistralai/mistral-nemo", "mistralai/mistral-saba", "mistralai/mistral-small-2603", "mistralai/mistral-small-3.2-24b-instruct", "mistralai/mixtral-8x22b-instruct", "mistralai/voxtral-small-24b-2507", "moonshotai/kimi-k2", "moonshotai/kimi-k2-0905", "moonshotai/kimi-k2-thinking", "moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "nvidia/llama-3.3-nemotron-super-49b-v1.5", "nvidia/nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-nano-30b-a3b:free", "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free", "nvidia/nemotron-3-super-120b-a12b", "nvidia/nemotron-3-super-120b-a12b:free", "nvidia/nemotron-nano-12b-v2-vl:free", "nvidia/nemotron-nano-9b-v2:free", "openai/gpt-3.5-turbo", "openai/gpt-3.5-turbo-0613", "openai/gpt-3.5-turbo-16k", "openai/gpt-4", "openai/gpt-4-turbo", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4.1-nano", "openai/gpt-4o", "openai/gpt-4o-2024-05-13", "openai/gpt-4o-2024-08-06", "openai/gpt-4o-2024-11-20", "openai/gpt-4o-mini", "openai/gpt-4o-mini-2024-07-18", "openai/gpt-5", "openai/gpt-5-codex", "openai/gpt-5-mini", "openai/gpt-5-nano", "openai/gpt-5-pro", "openai/gpt-5.1", "openai/gpt-5.1-chat", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-max", "openai/gpt-5.1-codex-mini", "openai/gpt-5.2", "openai/gpt-5.2-chat", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.3-chat", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-chat-latest", "openai/gpt-oss-120b", "openai/gpt-oss-120b:free", "openai/gpt-oss-20b", "openai/gpt-oss-20b:free", "openai/gpt-oss-safeguard-20b", "openai/o1", "openai/o3", "openai/o3-deep-research", "openai/o3-mini", "openai/o3-mini-high", "openai/o3-pro", "openai/o4-mini", "openai/o4-mini-deep-research", "openai/o4-mini-high", "openrouter/auto", "openrouter/free", "poolside/laguna-m.1:free", "poolside/laguna-xs.2:free", "qwen/qwen-2.5-72b-instruct", "qwen/qwen-2.5-7b-instruct", "qwen/qwen-plus", "qwen/qwen-plus-2025-07-28", "qwen/qwen-plus-2025-07-28:thinking", "qwen/qwen3-14b", "qwen/qwen3-235b-a22b", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-235b-a22b-thinking-2507", "qwen/qwen3-30b-a3b", "qwen/qwen3-30b-a3b-instruct-2507", "qwen/qwen3-30b-a3b-thinking-2507", "qwen/qwen3-32b", "qwen/qwen3-8b", "qwen/qwen3-coder", "qwen/qwen3-coder-30b-a3b-instruct", "qwen/qwen3-coder-flash", "qwen/qwen3-coder-next", "qwen/qwen3-coder-plus", "qwen/qwen3-coder:free", "qwen/qwen3-max", "qwen/qwen3-max-thinking", "qwen/qwen3-next-80b-a3b-instruct", "qwen/qwen3-next-80b-a3b-instruct:free", "qwen/qwen3-next-80b-a3b-thinking", "qwen/qwen3-vl-235b-a22b-instruct", "qwen/qwen3-vl-235b-a22b-thinking", "qwen/qwen3-vl-30b-a3b-instruct", "qwen/qwen3-vl-30b-a3b-thinking", "qwen/qwen3-vl-32b-instruct", "qwen/qwen3-vl-8b-instruct", "qwen/qwen3-vl-8b-thinking", "qwen/qwen3.5-122b-a10b", "qwen/qwen3.5-27b", "qwen/qwen3.5-35b-a3b", "qwen/qwen3.5-397b-a17b", "qwen/qwen3.5-9b", "qwen/qwen3.5-flash-02-23", "qwen/qwen3.5-plus-02-15", "qwen/qwen3.5-plus-20260420", "qwen/qwen3.6-27b", "qwen/qwen3.6-35b-a3b", "qwen/qwen3.6-flash", "qwen/qwen3.6-max-preview", "qwen/qwen3.6-plus", "qwen/qwen3.7-max", "rekaai/reka-edge", "relace/relace-search", "sao10k/l3.1-euryale-70b", "stepfun/step-3.5-flash", "tencent/hy3-preview", "thedrummer/rocinante-12b", "thedrummer/unslopnemo-12b", "upstage/solar-pro-3", "x-ai/grok-4.20", "x-ai/grok-4.3", "x-ai/grok-build-0.1", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro", "z-ai/glm-4.5", "z-ai/glm-4.5-air", "z-ai/glm-4.5v", "z-ai/glm-4.6", "z-ai/glm-4.6v", "z-ai/glm-4.7", "z-ai/glm-4.7-flash", "z-ai/glm-5", "z-ai/glm-5-turbo", "z-ai/glm-5.1", "z-ai/glm-5v-turbo", "~anthropic/claude-haiku-latest", "~anthropic/claude-opus-latest", "~anthropic/claude-sonnet-latest", "~google/gemini-flash-latest", "~google/gemini-pro-latest", "~moonshotai/kimi-latest", "~openai/gpt-latest", "~openai/gpt-mini-latest"]
+default_model = "qwen/qwen3.7-max"
 docs_url = "https://openrouter.ai/docs"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
 "ai21/jamba-large-1.7" = 256000
-"alibaba/tongyi-deepresearch-30b-a3b" = 131072
 "amazon/nova-2-lite-v1" = 1000000
 "amazon/nova-lite-v1" = 300000
 "amazon/nova-micro-v1" = 128000
 "amazon/nova-premier-v1" = 1000000
 "amazon/nova-pro-v1" = 300000
 "anthropic/claude-3-haiku" = 200000
-"anthropic/claude-3.5-haiku" = 200000
 "anthropic/claude-haiku-4.5" = 200000
 "anthropic/claude-opus-4" = 200000
 "anthropic/claude-opus-4.1" = 200000
 "anthropic/claude-opus-4.5" = 200000
 "anthropic/claude-opus-4.6" = 1000000
-"anthropic/claude-opus-4.6-fast" = 1000000
 "anthropic/claude-opus-4.7" = 1000000
 "anthropic/claude-opus-4.7-fast" = 1000000
 "anthropic/claude-sonnet-4" = 1000000
 "anthropic/claude-sonnet-4.5" = 1000000
 "anthropic/claude-sonnet-4.6" = 1000000
 "arcee-ai/trinity-large-thinking" = 262144
-"arcee-ai/trinity-large-thinking:free" = 262144
 "arcee-ai/trinity-mini" = 131072
-"arcee-ai/virtuoso-large" = 131072
 auto = 2000000
-"baidu/cobuddy:free" = 131072
-"baidu/ernie-4.5-21b-a3b" = 131072
-"baidu/ernie-4.5-vl-28b-a3b" = 131072
 "bytedance-seed/seed-1.6" = 262144
 "bytedance-seed/seed-1.6-flash" = 262144
 "bytedance-seed/seed-2.0-lite" = 262144
@@ -1263,11 +1031,7 @@ auto = 2000000
 "deepseek/deepseek-v3.2" = 131072
 "deepseek/deepseek-v3.2-exp" = 163840
 "deepseek/deepseek-v4-flash" = 1048576
-"deepseek/deepseek-v4-flash:free" = 1048576
 "deepseek/deepseek-v4-pro" = 1048576
-"essentialai/rnj-1-instruct" = 32768
-"google/gemini-2.0-flash-001" = 1000000
-"google/gemini-2.0-flash-lite-001" = 1048576
 "google/gemini-2.5-flash" = 1048576
 "google/gemini-2.5-flash-lite" = 1048576
 "google/gemini-2.5-flash-lite-preview-09-2025" = 1048576
@@ -1301,18 +1065,14 @@ auto = 2000000
 "minimax/minimax-m2" = 204800
 "minimax/minimax-m2.1" = 204800
 "minimax/minimax-m2.5" = 204800
-"minimax/minimax-m2.5:free" = 204800
 "minimax/minimax-m2.7" = 204800
 "mistralai/codestral-2508" = 256000
 "mistralai/devstral-2512" = 262144
-"mistralai/devstral-medium" = 131072
-"mistralai/devstral-small" = 131072
 "mistralai/ministral-14b-2512" = 262144
 "mistralai/ministral-3b-2512" = 131072
 "mistralai/ministral-8b-2512" = 262144
 "mistralai/mistral-large" = 128000
 "mistralai/mistral-large-2407" = 131072
-"mistralai/mistral-large-2411" = 131072
 "mistralai/mistral-large-2512" = 262144
 "mistralai/mistral-medium-3" = 131072
 "mistralai/mistral-medium-3-5" = 262144
@@ -1322,14 +1082,12 @@ auto = 2000000
 "mistralai/mistral-small-2603" = 262144
 "mistralai/mistral-small-3.2-24b-instruct" = 128000
 "mistralai/mixtral-8x22b-instruct" = 65536
-"mistralai/pixtral-large-2411" = 131072
 "mistralai/voxtral-small-24b-2507" = 32000
 "moonshotai/kimi-k2" = 131072
 "moonshotai/kimi-k2-0905" = 262144
 "moonshotai/kimi-k2-thinking" = 262144
 "moonshotai/kimi-k2.5" = 262144
 "moonshotai/kimi-k2.6" = 262144
-"nex-agi/deepseek-v3.1-nex-n1" = 131072
 "nvidia/llama-3.3-nemotron-super-49b-v1.5" = 131072
 "nvidia/nemotron-3-nano-30b-a3b" = 262144
 "nvidia/nemotron-3-nano-30b-a3b:free" = 256000
@@ -1337,16 +1095,12 @@ auto = 2000000
 "nvidia/nemotron-3-super-120b-a12b" = 1000000
 "nvidia/nemotron-3-super-120b-a12b:free" = 1000000
 "nvidia/nemotron-nano-12b-v2-vl:free" = 128000
-"nvidia/nemotron-nano-9b-v2" = 131072
 "nvidia/nemotron-nano-9b-v2:free" = 128000
 "openai/gpt-3.5-turbo" = 16385
 "openai/gpt-3.5-turbo-0613" = 4095
 "openai/gpt-3.5-turbo-16k" = 16385
 "openai/gpt-4" = 8191
-"openai/gpt-4-0314" = 8191
-"openai/gpt-4-1106-preview" = 128000
 "openai/gpt-4-turbo" = 128000
-"openai/gpt-4-turbo-preview" = 128000
 "openai/gpt-4.1" = 1047576
 "openai/gpt-4.1-mini" = 1047576
 "openai/gpt-4.1-nano" = 1047576
@@ -1354,7 +1108,6 @@ auto = 2000000
 "openai/gpt-4o-2024-05-13" = 128000
 "openai/gpt-4o-2024-08-06" = 128000
 "openai/gpt-4o-2024-11-20" = 128000
-"openai/gpt-4o-audio-preview" = 128000
 "openai/gpt-4o-mini" = 128000
 "openai/gpt-4o-mini-2024-07-18" = 128000
 "openai/gpt-5" = 400000
@@ -1379,8 +1132,6 @@ auto = 2000000
 "openai/gpt-5.4-pro" = 1050000
 "openai/gpt-5.5" = 1050000
 "openai/gpt-5.5-pro" = 1050000
-"openai/gpt-audio" = 128000
-"openai/gpt-audio-mini" = 128000
 "openai/gpt-chat-latest" = 400000
 "openai/gpt-oss-120b" = 131072
 "openai/gpt-oss-120b:free" = 131072
@@ -1398,10 +1149,8 @@ auto = 2000000
 "openai/o4-mini-high" = 200000
 "openrouter/auto" = 2000000
 "openrouter/free" = 200000
-"openrouter/owl-alpha" = 1048756
 "poolside/laguna-m.1:free" = 131072
 "poolside/laguna-xs.2:free" = 131072
-"prime-intellect/intellect-3" = 131072
 "qwen/qwen-2.5-72b-instruct" = 131072
 "qwen/qwen-2.5-7b-instruct" = 131072
 "qwen/qwen-plus" = 1000000
@@ -1450,7 +1199,6 @@ auto = 2000000
 "qwen/qwen3.7-max" = 1000000
 "rekaai/reka-edge" = 16384
 "relace/relace-search" = 256000
-"sao10k/l3-euryale-70b" = 8192
 "sao10k/l3.1-euryale-70b" = 131072
 "stepfun/step-3.5-flash" = 262144
 "tencent/hy3-preview" = 262144
@@ -1460,15 +1208,10 @@ auto = 2000000
 "x-ai/grok-4.20" = 2000000
 "x-ai/grok-4.3" = 1000000
 "x-ai/grok-build-0.1" = 256000
-"xiaomi/mimo-v2-flash" = 262144
-"xiaomi/mimo-v2-omni" = 262144
-"xiaomi/mimo-v2-pro" = 1048576
 "xiaomi/mimo-v2.5" = 1048576
 "xiaomi/mimo-v2.5-pro" = 1048576
-"z-ai/glm-4-32b" = 128000
 "z-ai/glm-4.5" = 131072
 "z-ai/glm-4.5-air" = 131072
-"z-ai/glm-4.5-air:free" = 131072
 "z-ai/glm-4.5v" = 65536
 "z-ai/glm-4.6" = 202752
 "z-ai/glm-4.6v" = 131072
@@ -1494,14 +1237,6 @@ input = ["text"]
 context_window = 256000
 max_tokens = 4096
 cost = { input = 2, output = 8, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."alibaba/tongyi-deepresearch-30b-a3b"]
-name = "Tongyi DeepResearch 30B A3B"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 131072
-cost = { input = 0.09, output = 0.44999999999999996, cacheRead = 0.09, cacheWrite = 0 }
 
 [providers.model_metadata."amazon/nova-2-lite-v1"]
 name = "Amazon: Nova 2 Lite"
@@ -1551,14 +1286,6 @@ context_window = 200000
 max_tokens = 4096
 cost = { input = 0.25, output = 1.25, cacheRead = 0.03, cacheWrite = 0.3 }
 
-[providers.model_metadata."anthropic/claude-3.5-haiku"]
-name = "Anthropic: Claude 3.5 Haiku"
-reasoning = false
-input = ["text", "image"]
-context_window = 200000
-max_tokens = 8192
-cost = { input = 0.7999999999999999, output = 4, cacheRead = 0.08, cacheWrite = 1 }
-
 [providers.model_metadata."anthropic/claude-haiku-4.5"]
 name = "Anthropic: Claude Haiku 4.5"
 reasoning = true
@@ -1598,15 +1325,6 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
-thinking_level_map = { xhigh = "max" }
-
-[providers.model_metadata."anthropic/claude-opus-4.6-fast"]
-name = "Anthropic: Claude Opus 4.6 (Fast)"
-reasoning = true
-input = ["text", "image"]
-context_window = 1000000
-max_tokens = 128000
-cost = { input = 30, output = 150, cacheRead = 3, cacheWrite = 37.5 }
 thinking_level_map = { xhigh = "max" }
 
 [providers.model_metadata."anthropic/claude-opus-4.7"]
@@ -1659,14 +1377,6 @@ context_window = 262144
 max_tokens = 262144
 cost = { input = 0.22, output = 0.85, cacheRead = 0.06, cacheWrite = 0 }
 
-[providers.model_metadata."arcee-ai/trinity-large-thinking:free"]
-name = "Arcee AI: Trinity Large Thinking (free)"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 80000
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."arcee-ai/trinity-mini"]
 name = "Arcee AI: Trinity Mini"
 reasoning = true
@@ -1675,14 +1385,6 @@ context_window = 131072
 max_tokens = 131072
 cost = { input = 0.045, output = 0.15, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."arcee-ai/virtuoso-large"]
-name = "Arcee AI: Virtuoso Large"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 64000
-cost = { input = 0.75, output = 1.2, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata.auto]
 name = "Auto"
 reasoning = true
@@ -1690,30 +1392,6 @@ input = ["text", "image"]
 context_window = 2000000
 max_tokens = 30000
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."baidu/cobuddy:free"]
-name = "Baidu Qianfan: CoBuddy (free)"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 65536
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."baidu/ernie-4.5-21b-a3b"]
-name = "Baidu: ERNIE 4.5 21B A3B"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 8000
-cost = { input = 0.07, output = 0.28, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."baidu/ernie-4.5-vl-28b-a3b"]
-name = "Baidu: ERNIE 4.5 VL 28B A3B"
-reasoning = true
-input = ["text", "image"]
-context_window = 131072
-max_tokens = 8000
-cost = { input = 0.14, output = 0.56, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."bytedance-seed/seed-1.6"]
 name = "ByteDance Seed: Seed 1.6"
@@ -1838,17 +1516,6 @@ cost = { input = 0.09999999999999999, output = 0.19999999999999998, cacheRead = 
 thinking_level_map = { high = "high", xhigh = "max" }
 unsupported_thinking_levels = ["minimal", "low", "medium"]
 
-[providers.model_metadata."deepseek/deepseek-v4-flash:free"]
-name = "DeepSeek: DeepSeek V4 Flash (free)"
-reasoning = true
-input = ["text"]
-context_window = 1048576
-max_tokens = 384000
-compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-thinking_level_map = { high = "high", xhigh = "max" }
-unsupported_thinking_levels = ["minimal", "low", "medium"]
-
 [providers.model_metadata."deepseek/deepseek-v4-pro"]
 name = "DeepSeek: DeepSeek V4 Pro"
 reasoning = true
@@ -1859,30 +1526,6 @@ compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = 
 cost = { input = 0.435, output = 0.87, cacheRead = 0.003625, cacheWrite = 0 }
 thinking_level_map = { high = "high", xhigh = "max" }
 unsupported_thinking_levels = ["minimal", "low", "medium"]
-
-[providers.model_metadata."essentialai/rnj-1-instruct"]
-name = "EssentialAI: Rnj 1 Instruct"
-reasoning = false
-input = ["text"]
-context_window = 32768
-max_tokens = 4096
-cost = { input = 0.15, output = 0.15, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."google/gemini-2.0-flash-001"]
-name = "Google: Gemini 2.0 Flash"
-reasoning = false
-input = ["text", "image"]
-context_window = 1000000
-max_tokens = 8192
-cost = { input = 0.09999999999999999, output = 0.39999999999999997, cacheRead = 0.024999999999999998, cacheWrite = 0.08333333333333334 }
-
-[providers.model_metadata."google/gemini-2.0-flash-lite-001"]
-name = "Google: Gemini 2.0 Flash Lite"
-reasoning = false
-input = ["text", "image"]
-context_window = 1048576
-max_tokens = 8192
-cost = { input = 0.075, output = 0.3, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."google/gemini-2.5-flash"]
 name = "Google: Gemini 2.5 Flash"
@@ -2149,14 +1792,6 @@ context_window = 204800
 max_tokens = 196608
 cost = { input = 0.15, output = 1.15, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."minimax/minimax-m2.5:free"]
-name = "MiniMax: MiniMax M2.5 (free)"
-reasoning = true
-input = ["text"]
-context_window = 204800
-max_tokens = 8192
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."minimax/minimax-m2.7"]
 name = "MiniMax: MiniMax M2.7"
 reasoning = true
@@ -2180,22 +1815,6 @@ input = ["text"]
 context_window = 262144
 max_tokens = 4096
 cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
-
-[providers.model_metadata."mistralai/devstral-medium"]
-name = "Mistral: Devstral Medium"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 4096
-cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.04, cacheWrite = 0 }
-
-[providers.model_metadata."mistralai/devstral-small"]
-name = "Mistral: Devstral Small 1.1"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 4096
-cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
 
 [providers.model_metadata."mistralai/ministral-14b-2512"]
 name = "Mistral: Ministral 3 14B 2512"
@@ -2231,14 +1850,6 @@ cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 
 
 [providers.model_metadata."mistralai/mistral-large-2407"]
 name = "Mistral Large 2407"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 4096
-cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
-
-[providers.model_metadata."mistralai/mistral-large-2411"]
-name = "Mistral Large 2411"
 reasoning = false
 input = ["text"]
 context_window = 131072
@@ -2317,14 +1928,6 @@ context_window = 65536
 max_tokens = 4096
 cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
 
-[providers.model_metadata."mistralai/pixtral-large-2411"]
-name = "Mistral: Pixtral Large 2411"
-reasoning = false
-input = ["text", "image"]
-context_window = 131072
-max_tokens = 4096
-cost = { input = 2, output = 6, cacheRead = 0.19999999999999998, cacheWrite = 0 }
-
 [providers.model_metadata."mistralai/voxtral-small-24b-2507"]
 name = "Mistral: Voxtral Small 24B 2507"
 reasoning = false
@@ -2356,6 +1959,7 @@ input = ["text"]
 context_window = 262144
 max_tokens = 262144
 cost = { input = 0.6, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."moonshotai/kimi-k2.5"]
 name = "MoonshotAI: Kimi K2.5"
@@ -2372,14 +1976,6 @@ input = ["text", "image"]
 context_window = 262144
 max_tokens = 262142
 cost = { input = 0.73, output = 3.49, cacheRead = 0.25, cacheWrite = 0 }
-
-[providers.model_metadata."nex-agi/deepseek-v3.1-nex-n1"]
-name = "Nex AGI: DeepSeek V3.1 Nex N1"
-reasoning = false
-input = ["text"]
-context_window = 131072
-max_tokens = 163840
-cost = { input = 0.135, output = 0.5, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."nvidia/llama-3.3-nemotron-super-49b-v1.5"]
 name = "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5"
@@ -2420,6 +2016,7 @@ input = ["text"]
 context_window = 1000000
 max_tokens = 4096
 cost = { input = 0.09, output = 0.44999999999999996, cacheRead = 0, cacheWrite = 0 }
+compat = { openrouterProvider = { ignore = ["Nebius"] } }
 
 [providers.model_metadata."nvidia/nemotron-3-super-120b-a12b:free"]
 name = "NVIDIA: Nemotron 3 Super (free)"
@@ -2436,14 +2033,6 @@ input = ["text", "image"]
 context_window = 128000
 max_tokens = 128000
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."nvidia/nemotron-nano-9b-v2"]
-name = "NVIDIA: Nemotron Nano 9B V2"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 16384
-cost = { input = 0.04, output = 0.16, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."nvidia/nemotron-nano-9b-v2:free"]
 name = "NVIDIA: Nemotron Nano 9B V2 (free)"
@@ -2485,34 +2074,10 @@ context_window = 8191
 max_tokens = 4096
 cost = { input = 30, output = 60, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."openai/gpt-4-0314"]
-name = "OpenAI: GPT-4 (older v0314)"
-reasoning = false
-input = ["text"]
-context_window = 8191
-max_tokens = 4096
-cost = { input = 30, output = 60, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."openai/gpt-4-1106-preview"]
-name = "OpenAI: GPT-4 Turbo (older v1106)"
-reasoning = false
-input = ["text"]
-context_window = 128000
-max_tokens = 4096
-cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."openai/gpt-4-turbo"]
 name = "OpenAI: GPT-4 Turbo"
 reasoning = false
 input = ["text", "image"]
-context_window = 128000
-max_tokens = 4096
-cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."openai/gpt-4-turbo-preview"]
-name = "OpenAI: GPT-4 Turbo Preview"
-reasoning = false
-input = ["text"]
 context_window = 128000
 max_tokens = 4096
 cost = { input = 10, output = 30, cacheRead = 0, cacheWrite = 0 }
@@ -2573,14 +2138,6 @@ context_window = 128000
 max_tokens = 16384
 cost = { input = 2.5, output = 10, cacheRead = 1.25, cacheWrite = 0 }
 
-[providers.model_metadata."openai/gpt-4o-audio-preview"]
-name = "OpenAI: GPT-4o Audio"
-reasoning = false
-input = ["text"]
-context_window = 128000
-max_tokens = 16384
-cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."openai/gpt-4o-mini"]
 name = "OpenAI: GPT-4o-mini"
 reasoning = false
@@ -2612,6 +2169,7 @@ input = ["text", "image"]
 context_window = 400000
 max_tokens = 128000
 cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/gpt-5-mini"]
 name = "OpenAI: GPT-5 Mini"
@@ -2785,22 +2343,6 @@ max_tokens = 128000
 cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
 
-[providers.model_metadata."openai/gpt-audio"]
-name = "OpenAI: GPT Audio"
-reasoning = false
-input = ["text"]
-context_window = 128000
-max_tokens = 16384
-cost = { input = 2.5, output = 10, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."openai/gpt-audio-mini"]
-name = "OpenAI: GPT Audio Mini"
-reasoning = false
-input = ["text"]
-context_window = 128000
-max_tokens = 16384
-cost = { input = 0.6, output = 2.4, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."openai/gpt-chat-latest"]
 name = "OpenAI: GPT Chat Latest"
 reasoning = false
@@ -2856,6 +2398,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 15, output = 60, cacheRead = 7.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/o3"]
 name = "OpenAI: o3"
@@ -2864,6 +2407,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/o3-deep-research"]
 name = "OpenAI: o3 Deep Research"
@@ -2872,6 +2416,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 10, output = 40, cacheRead = 2.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "high"]
 
 [providers.model_metadata."openai/o3-mini"]
 name = "OpenAI: o3 Mini"
@@ -2880,6 +2425,7 @@ input = ["text"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 1.1, output = 4.4, cacheRead = 0.55, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/o3-mini-high"]
 name = "OpenAI: o3 Mini High"
@@ -2896,6 +2442,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 20, output = 80, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/o4-mini"]
 name = "OpenAI: o4 Mini"
@@ -2904,6 +2451,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 1.1, output = 4.4, cacheRead = 0.275, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."openai/o4-mini-deep-research"]
 name = "OpenAI: o4 Mini Deep Research"
@@ -2912,6 +2460,7 @@ input = ["text", "image"]
 context_window = 200000
 max_tokens = 100000
 cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+unsupported_thinking_levels = ["minimal", "low", "high"]
 
 [providers.model_metadata."openai/o4-mini-high"]
 name = "OpenAI: o4 Mini High"
@@ -2936,14 +2485,6 @@ context_window = 200000
 max_tokens = 4096
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."openrouter/owl-alpha"]
-name = "Owl Alpha"
-reasoning = false
-input = ["text"]
-context_window = 1048756
-max_tokens = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."poolside/laguna-m.1:free"]
 name = "Poolside: Laguna M.1 (free)"
 reasoning = true
@@ -2959,14 +2500,6 @@ input = ["text"]
 context_window = 131072
 max_tokens = 8192
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."prime-intellect/intellect-3"]
-name = "Prime Intellect: INTELLECT-3"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 131072
-cost = { input = 0.19999999999999998, output = 1.1, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."qwen/qwen-2.5-72b-instruct"]
 name = "Qwen2.5 72B Instruct"
@@ -3352,14 +2885,6 @@ context_window = 256000
 max_tokens = 128000
 cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."sao10k/l3-euryale-70b"]
-name = "Sao10k: Llama 3 Euryale 70B v2.1"
-reasoning = false
-input = ["text"]
-context_window = 8192
-max_tokens = 8192
-cost = { input = 1.48, output = 1.48, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."sao10k/l3.1-euryale-70b"]
 name = "Sao10K: Llama 3.1 Euryale 70B v2.2"
 reasoning = false
@@ -3432,30 +2957,6 @@ context_window = 256000
 max_tokens = 4096
 cost = { input = 1, output = 2, cacheRead = 0.19999999999999998, cacheWrite = 0 }
 
-[providers.model_metadata."xiaomi/mimo-v2-flash"]
-name = "Xiaomi: MiMo-V2-Flash"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 65536
-cost = { input = 0.09999999999999999, output = 0.3, cacheRead = 0.01, cacheWrite = 0 }
-
-[providers.model_metadata."xiaomi/mimo-v2-omni"]
-name = "Xiaomi: MiMo-V2-Omni"
-reasoning = true
-input = ["text", "image"]
-context_window = 262144
-max_tokens = 65536
-cost = { input = 0.39999999999999997, output = 2, cacheRead = 0.08, cacheWrite = 0 }
-
-[providers.model_metadata."xiaomi/mimo-v2-pro"]
-name = "Xiaomi: MiMo-V2-Pro"
-reasoning = true
-input = ["text"]
-context_window = 1048576
-max_tokens = 131072
-cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
-
 [providers.model_metadata."xiaomi/mimo-v2.5"]
 name = "Xiaomi: MiMo-V2.5"
 reasoning = true
@@ -3472,14 +2973,6 @@ context_window = 1048576
 max_tokens = 16384
 cost = { input = 1, output = 3, cacheRead = 0.19999999999999998, cacheWrite = 0 }
 
-[providers.model_metadata."z-ai/glm-4-32b"]
-name = "Z.ai: GLM 4 32B "
-reasoning = false
-input = ["text"]
-context_window = 128000
-max_tokens = 4096
-cost = { input = 0.09999999999999999, output = 0.09999999999999999, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."z-ai/glm-4.5"]
 name = "Z.ai: GLM 4.5"
 reasoning = true
@@ -3495,14 +2988,6 @@ input = ["text"]
 context_window = 131072
 max_tokens = 98304
 cost = { input = 0.13, output = 0.85, cacheRead = 0.024999999999999998, cacheWrite = 0 }
-
-[providers.model_metadata."z-ai/glm-4.5-air:free"]
-name = "Z.ai: GLM 4.5 Air (free)"
-reasoning = true
-input = ["text"]
-context_window = 131072
-max_tokens = 96000
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."z-ai/glm-4.5v"]
 name = "Z.ai: GLM 4.5V"
@@ -3645,12 +3130,12 @@ name = "zai"
 display_name = "ZAI"
 kind = "openai-compatible"
 base_url = "https://api.z.ai/api/coding/paas/v4"
-api = "openai-completions"
 api_key_env = "ZAI_API_KEY"
 credential_name = "zai"
 models = ["glm-4.5-air", "glm-4.7", "glm-5-turbo", "glm-5.1", "glm-5v-turbo"]
 default_model = "glm-5.1"
 docs_url = "https://docs.z.ai"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -3712,12 +3197,12 @@ name = "mistral"
 display_name = "Mistral"
 kind = "mistral-conversations"
 base_url = "https://api.mistral.ai"
-api = "mistral-conversations"
 api_key_env = "MISTRAL_API_KEY"
 credential_name = "mistral"
 models = ["codestral-latest", "devstral-2512", "devstral-medium-2507", "devstral-medium-latest", "devstral-small-2505", "devstral-small-2507", "labs-devstral-small-2512", "magistral-medium-latest", "magistral-small", "ministral-3b-latest", "ministral-8b-latest", "mistral-large-2411", "mistral-large-2512", "mistral-large-latest", "mistral-medium-2505", "mistral-medium-2508", "mistral-medium-2604", "mistral-medium-3.5", "mistral-medium-latest", "mistral-nemo", "mistral-small-2506", "mistral-small-2603", "mistral-small-latest", "open-mistral-7b", "open-mixtral-8x22b", "open-mixtral-8x7b", "pixtral-12b", "pixtral-large-latest"]
 default_model = "devstral-medium-latest"
 docs_url = "https://docs.mistral.ai"
+api = "mistral-conversations"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -3981,12 +3466,12 @@ name = "minimax"
 display_name = "MiniMax"
 kind = "anthropic"
 base_url = "https://api.minimax.io/anthropic"
-api = "anthropic-messages"
 api_key_env = "MINIMAX_API_KEY"
 credential_name = "minimax"
 models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
 default_model = "MiniMax-M2.7"
 docs_url = "https://www.minimax.io/platform/document"
+api = "anthropic-messages"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
@@ -4014,12 +3499,12 @@ name = "minimax-cn"
 display_name = "MiniMax (China)"
 kind = "anthropic"
 base_url = "https://api.minimaxi.com/anthropic"
-api = "anthropic-messages"
 api_key_env = "MINIMAX_CN_API_KEY"
 credential_name = "minimax-cn"
 models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
 default_model = "MiniMax-M2.7"
 docs_url = "https://www.minimaxi.com/document"
+api = "anthropic-messages"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
@@ -4047,12 +3532,12 @@ name = "moonshotai"
 display_name = "Moonshot AI"
 kind = "openai-compatible"
 base_url = "https://api.moonshot.ai/v1"
-api = "openai-completions"
 api_key_env = "MOONSHOT_API_KEY"
 credential_name = "moonshotai"
 models = ["kimi-k2-0711-preview", "kimi-k2-0905-preview", "kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo-preview", "kimi-k2.5", "kimi-k2.6"]
 default_model = "kimi-k2.6"
 docs_url = "https://platform.moonshot.ai/docs"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -4134,12 +3619,12 @@ name = "moonshotai-cn"
 display_name = "Moonshot AI (China)"
 kind = "openai-compatible"
 base_url = "https://api.moonshot.cn/v1"
-api = "openai-completions"
 api_key_env = "MOONSHOT_API_KEY"
 credential_name = "moonshotai-cn"
 models = ["kimi-k2-0711-preview", "kimi-k2-0905-preview", "kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo-preview", "kimi-k2.5", "kimi-k2.6"]
 default_model = "kimi-k2.6"
 docs_url = "https://platform.moonshot.cn/docs"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -4221,12 +3706,12 @@ name = "huggingface"
 display_name = "Hugging Face"
 kind = "openai-compatible"
 base_url = "https://router.huggingface.co/v1"
-api = "openai-completions"
 api_key_env = "HF_TOKEN"
 credential_name = "huggingface"
-models = ["MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3-Next-80B-A3B-Thinking", "Qwen/Qwen3.5-397B-A17B", "XiaomiMiMo/MiMo-V2-Flash", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Pro", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2-Thinking", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1"]
+models = ["MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3.5-397B-A17B", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1"]
 default_model = "moonshotai/Kimi-K2.6"
 docs_url = "https://huggingface.co/docs/inference-providers"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -4239,15 +3724,11 @@ thinking_parameter = "reasoning_effort"
 "Qwen/Qwen3-Coder-480B-A35B-Instruct" = 262144
 "Qwen/Qwen3-Coder-Next" = 262144
 "Qwen/Qwen3-Next-80B-A3B-Instruct" = 262144
-"Qwen/Qwen3-Next-80B-A3B-Thinking" = 262144
 "Qwen/Qwen3.5-397B-A17B" = 262144
-"XiaomiMiMo/MiMo-V2-Flash" = 262144
 "deepseek-ai/DeepSeek-R1-0528" = 163840
 "deepseek-ai/DeepSeek-V3.2" = 163840
-"deepseek-ai/DeepSeek-V4-Pro" = 1048576
 "moonshotai/Kimi-K2-Instruct" = 131072
 "moonshotai/Kimi-K2-Instruct-0905" = 262144
-"moonshotai/Kimi-K2-Thinking" = 262144
 "moonshotai/Kimi-K2.5" = 262144
 "moonshotai/Kimi-K2.6" = 262144
 "zai-org/GLM-4.7" = 204800
@@ -4318,15 +3799,6 @@ max_tokens = 66536
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.25, output = 1, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."Qwen/Qwen3-Next-80B-A3B-Thinking"]
-name = "Qwen3-Next-80B-A3B-Thinking"
-reasoning = false
-input = ["text"]
-context_window = 262144
-max_tokens = 131072
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.3, output = 2, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."Qwen/Qwen3.5-397B-A17B"]
 name = "Qwen3.5-397B-A17B"
 reasoning = true
@@ -4335,15 +3807,6 @@ context_window = 262144
 max_tokens = 32768
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.6, output = 3.6, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."XiaomiMiMo/MiMo-V2-Flash"]
-name = "MiMo-V2-Flash"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 4096
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."deepseek-ai/DeepSeek-R1-0528"]
 name = "DeepSeek-R1-0528"
@@ -4363,15 +3826,6 @@ max_tokens = 65536
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.28, output = 0.4, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."deepseek-ai/DeepSeek-V4-Pro"]
-name = "DeepSeek V4 Pro"
-reasoning = true
-input = ["text"]
-context_window = 1048576
-max_tokens = 393216
-compat = { supportsDeveloperRole = false }
-cost = { input = 1.74, output = 3.48, cacheRead = 0.145, cacheWrite = 0 }
-
 [providers.model_metadata."moonshotai/Kimi-K2-Instruct"]
 name = "Kimi-K2-Instruct"
 reasoning = false
@@ -4389,15 +3843,6 @@ context_window = 262144
 max_tokens = 16384
 compat = { supportsDeveloperRole = false }
 cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."moonshotai/Kimi-K2-Thinking"]
-name = "Kimi-K2-Thinking"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 262144
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
 
 [providers.model_metadata."moonshotai/Kimi-K2.5"]
 name = "Kimi-K2.5"
@@ -4458,12 +3903,12 @@ name = "fireworks"
 display_name = "Fireworks"
 kind = "anthropic"
 base_url = "https://api.fireworks.ai/inference"
-api = "anthropic-messages"
 api_key_env = "FIREWORKS_API_KEY"
 credential_name = "fireworks"
 models = ["accounts/fireworks/models/deepseek-v4-flash", "accounts/fireworks/models/deepseek-v4-pro", "accounts/fireworks/models/glm-5p1", "accounts/fireworks/models/gpt-oss-120b", "accounts/fireworks/models/gpt-oss-20b", "accounts/fireworks/models/kimi-k2p5", "accounts/fireworks/models/kimi-k2p6", "accounts/fireworks/models/minimax-m2p5", "accounts/fireworks/models/minimax-m2p7", "accounts/fireworks/models/qwen3p6-plus", "accounts/fireworks/routers/glm-5p1-fast", "accounts/fireworks/routers/kimi-k2p6-turbo"]
 default_model = "accounts/fireworks/models/kimi-k2p6"
 docs_url = "https://docs.fireworks.ai"
+api = "anthropic-messages"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
@@ -4595,12 +4040,12 @@ name = "together"
 display_name = "Together AI"
 kind = "openai-compatible"
 base_url = "https://api.together.ai/v1"
-api = "openai-completions"
 api_key_env = "TOGETHER_API_KEY"
 credential_name = "together"
 models = ["MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Instruct-2507-tput", "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8", "Qwen/Qwen3-Coder-Next-FP8", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.6-Plus", "Qwen/Qwen3.7-Max", "deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-V3-1", "deepseek-ai/DeepSeek-V4-Pro", "essentialai/Rnj-1-Instruct", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct-Turbo", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "openai/gpt-oss-120b", "zai-org/GLM-5.1"]
 default_model = "moonshotai/Kimi-K2.6"
 docs_url = "https://docs.together.ai"
+api = "openai-completions"
 thinking_levels = ["off", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -4808,12 +4253,12 @@ name = "vercel-ai-gateway"
 display_name = "Vercel AI Gateway"
 kind = "anthropic"
 base_url = "https://ai-gateway.vercel.sh"
-api = "anthropic-messages"
 api_key_env = "AI_GATEWAY_API_KEY"
 credential_name = "vercel-ai-gateway"
 models = ["alibaba/qwen-3-14b", "alibaba/qwen-3-235b", "alibaba/qwen-3-30b", "alibaba/qwen-3-32b", "alibaba/qwen-3.6-max-preview", "alibaba/qwen3-235b-a22b-thinking", "alibaba/qwen3-coder", "alibaba/qwen3-coder-30b-a3b", "alibaba/qwen3-coder-next", "alibaba/qwen3-coder-plus", "alibaba/qwen3-max", "alibaba/qwen3-max-preview", "alibaba/qwen3-max-thinking", "alibaba/qwen3-vl-thinking", "alibaba/qwen3.5-flash", "alibaba/qwen3.5-plus", "alibaba/qwen3.6-27b", "alibaba/qwen3.6-plus", "alibaba/qwen3.7-max", "anthropic/claude-3-haiku", "anthropic/claude-3.5-haiku", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4", "anthropic/claude-opus-4.1", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.7", "anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5", "anthropic/claude-sonnet-4.6", "arcee-ai/trinity-large-preview", "arcee-ai/trinity-large-thinking", "bytedance/seed-1.6", "cohere/command-a", "deepseek/deepseek-r1", "deepseek/deepseek-v3", "deepseek/deepseek-v3.1", "deepseek/deepseek-v3.1-terminus", "deepseek/deepseek-v3.2", "deepseek/deepseek-v3.2-thinking", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro", "google/gemini-2.0-flash", "google/gemini-2.0-flash-lite", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-pro", "google/gemini-3-flash", "google/gemini-3-pro-preview", "google/gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.5-flash", "google/gemma-4-26b-a4b-it", "google/gemma-4-31b-it", "inception/mercury-2", "inception/mercury-coder-small", "kwaipilot/kat-coder-pro-v2", "meituan/longcat-flash-chat", "meta/llama-3.1-70b", "meta/llama-3.1-8b", "meta/llama-3.2-11b", "meta/llama-3.2-90b", "meta/llama-3.3-70b", "meta/llama-4-maverick", "meta/llama-4-scout", "minimax/minimax-m2", "minimax/minimax-m2.1", "minimax/minimax-m2.1-lightning", "minimax/minimax-m2.5", "minimax/minimax-m2.5-highspeed", "minimax/minimax-m2.7", "minimax/minimax-m2.7-highspeed", "mistral/codestral", "mistral/devstral-2", "mistral/devstral-small", "mistral/devstral-small-2", "mistral/ministral-3b", "mistral/ministral-8b", "mistral/mistral-medium", "mistral/mistral-medium-3.5", "mistral/mistral-small", "mistral/pixtral-12b", "mistral/pixtral-large", "moonshotai/kimi-k2", "moonshotai/kimi-k2-thinking", "moonshotai/kimi-k2-thinking-turbo", "moonshotai/kimi-k2-turbo", "moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "nvidia/nemotron-nano-12b-v2-vl", "nvidia/nemotron-nano-9b-v2", "openai/gpt-4-turbo", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4.1-nano", "openai/gpt-4o", "openai/gpt-4o-mini", "openai/gpt-5", "openai/gpt-5-chat", "openai/gpt-5-codex", "openai/gpt-5-mini", "openai/gpt-5-nano", "openai/gpt-5-pro", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-max", "openai/gpt-5.1-codex-mini", "openai/gpt-5.1-instant", "openai/gpt-5.1-thinking", "openai/gpt-5.2", "openai/gpt-5.2-chat", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.3-chat", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-oss-20b", "openai/gpt-oss-safeguard-20b", "openai/o1", "openai/o3", "openai/o3-deep-research", "openai/o3-mini", "openai/o3-pro", "openai/o4-mini", "perplexity/sonar", "perplexity/sonar-pro", "xai/grok-4.1-fast-non-reasoning", "xai/grok-4.1-fast-reasoning", "xai/grok-4.20-multi-agent", "xai/grok-4.20-multi-agent-beta", "xai/grok-4.20-non-reasoning", "xai/grok-4.20-non-reasoning-beta", "xai/grok-4.20-reasoning", "xai/grok-4.20-reasoning-beta", "xai/grok-4.3", "xai/grok-build-0.1", "xiaomi/mimo-v2-flash", "xiaomi/mimo-v2-pro", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro", "zai/glm-4.5", "zai/glm-4.5-air", "zai/glm-4.5v", "zai/glm-4.6", "zai/glm-4.6v", "zai/glm-4.6v-flash", "zai/glm-4.7", "zai/glm-4.7-flash", "zai/glm-4.7-flashx", "zai/glm-5", "zai/glm-5-turbo", "zai/glm-5.1", "zai/glm-5v-turbo"]
 default_model = "zai/glm-5.1"
 docs_url = "https://vercel.com/docs/ai-gateway"
+api = "anthropic-messages"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
@@ -6264,12 +5709,12 @@ name = "xiaomi"
 display_name = "Xiaomi MiMo"
 kind = "openai-compatible"
 base_url = "https://api.xiaomimimo.com/v1"
-api = "openai-completions"
 api_key_env = "XIAOMI_API_KEY"
 credential_name = "xiaomi"
 models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
 default_model = "mimo-v2.5-pro"
 docs_url = "https://platform.mimo.xiaomi.com"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -6331,12 +5776,12 @@ name = "xiaomi-token-plan-cn"
 display_name = "Xiaomi MiMo Token Plan (China)"
 kind = "openai-compatible"
 base_url = "https://token-plan-cn.xiaomimimo.com/v1"
-api = "openai-completions"
 api_key_env = "XIAOMI_TOKEN_PLAN_CN_API_KEY"
 credential_name = "xiaomi-token-plan-cn"
 models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
 default_model = "mimo-v2.5-pro"
 docs_url = "https://platform.mimo.xiaomi.com"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -6398,12 +5843,12 @@ name = "xiaomi-token-plan-ams"
 display_name = "Xiaomi MiMo Token Plan (Amsterdam)"
 kind = "openai-compatible"
 base_url = "https://token-plan-ams.xiaomimimo.com/v1"
-api = "openai-completions"
 api_key_env = "XIAOMI_TOKEN_PLAN_AMS_API_KEY"
 credential_name = "xiaomi-token-plan-ams"
 models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
 default_model = "mimo-v2.5-pro"
 docs_url = "https://platform.mimo.xiaomi.com"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
@@ -6465,12 +5910,12 @@ name = "xiaomi-token-plan-sgp"
 display_name = "Xiaomi MiMo Token Plan (Singapore)"
 kind = "openai-compatible"
 base_url = "https://token-plan-sgp.xiaomimimo.com/v1"
-api = "openai-completions"
 api_key_env = "XIAOMI_TOKEN_PLAN_SGP_API_KEY"
 credential_name = "xiaomi-token-plan-sgp"
 models = ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro"]
 default_model = "mimo-v2.5-pro"
 docs_url = "https://platform.mimo.xiaomi.com"
+api = "openai-completions"
 thinking_levels = ["off", "minimal", "low", "medium", "high"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -2,12 +2,46 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
+from tau_agent.types import JSONValue
 from tau_coding.thinking import ThinkingLevel, ThinkingParameter
 
-ProviderKind = Literal["openai-compatible", "anthropic", "openai-codex"]
+ProviderKind = Literal[
+    "openai-compatible",
+    "anthropic",
+    "openai-codex",
+    "google-generative-ai",
+    "mistral-conversations",
+]
+ProviderApi = Literal[
+    "openai-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "openai-codex-responses",
+    "google-generative-ai",
+    "mistral-conversations",
+]
+ModelInput = Literal["text", "image"]
+ThinkingLevelMap = dict[ThinkingLevel, str | None]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogMetadata:
+    """Provider-catalog metadata for a single model."""
+
+    name: str | None = None
+    api: ProviderApi | None = None
+    base_url: str | None = None
+    reasoning: bool | None = None
+    input: tuple[ModelInput, ...] = ()
+    cost: dict[str, float] | None = None
+    context_window: int | None = None
+    max_tokens: int | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    compat: dict[str, JSONValue] = field(default_factory=dict)
+    thinking_level_map: ThinkingLevelMap = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,7 +57,11 @@ class ProviderCatalogEntry:
     models: tuple[str, ...]
     default_model: str
     docs_url: str
+    api: ProviderApi | None = None
     context_windows: dict[str, int] | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    compat: dict[str, JSONValue] = field(default_factory=dict)
+    model_metadata: dict[str, ModelCatalogMetadata] = field(default_factory=dict)
     thinking_levels: tuple[ThinkingLevel, ...] | None = None
     thinking_models: tuple[str, ...] = ()
     thinking_default: ThinkingLevel | None = None

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -9,7 +9,7 @@ from os import environ
 from pathlib import Path
 from shutil import copy2
 from tempfile import NamedTemporaryFile
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from tau_ai import (
     DEFAULT_ANTHROPIC_BASE_URL,
@@ -26,6 +26,8 @@ from tau_coding.credentials import FileCredentialStore, credentials_path
 from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
+    ModelCatalogMetadata,
+    ProviderApi,
     ProviderCatalogEntry,
     ProviderKind,
 )
@@ -40,7 +42,7 @@ from tau_coding.thinking import (
 )
 
 DEFAULT_PROVIDER_NAME = "openai"
-DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_MODEL = "gpt-5.4"
 
 
 class ProviderConfigError(ValueError):
@@ -54,17 +56,53 @@ class CredentialReader(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class ProviderModelMetadata:
+    """Runtime metadata for one configured model."""
+
+    name: str | None = None
+    api: ProviderApi | None = None
+    base_url: str | None = None
+    reasoning: bool | None = None
+    input: tuple[str, ...] = ()
+    cost: dict[str, float] = field(default_factory=dict)
+    context_window: int | None = None
+    max_tokens: int | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    compat: dict[str, Any] = field(default_factory=dict)
+    thinking_level_map: dict[ThinkingLevel, str | None] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        """Serialize this model metadata to JSON-compatible data."""
+        return {
+            "name": self.name,
+            "api": self.api,
+            "base_url": self.base_url,
+            "reasoning": self.reasoning,
+            "input": list(self.input),
+            "cost": dict(self.cost),
+            "context_window": self.context_window,
+            "max_tokens": self.max_tokens,
+            "headers": dict(self.headers),
+            "compat": dict(self.compat),
+            "thinking_level_map": dict(self.thinking_level_map),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class OpenAICompatibleProviderConfig:
     """Durable settings for one OpenAI-compatible provider."""
 
     name: str
     base_url: str = DEFAULT_OPENAI_COMPATIBLE_BASE_URL
+    api: ProviderApi = "openai-completions"
     api_key_env: str = "OPENAI_API_KEY"
     credential_name: str | None = None
     models: tuple[str, ...] = (DEFAULT_MODEL,)
     default_model: str = DEFAULT_MODEL
     context_windows: dict[str, int] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
+    compat: dict[str, Any] = field(default_factory=dict)
+    model_metadata: dict[str, ProviderModelMetadata] = field(default_factory=dict)
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
@@ -81,6 +119,8 @@ class OpenAICompatibleProviderConfig:
             max_retry_delay_seconds=self.max_retry_delay_seconds,
         )
         _validate_context_windows(self.context_windows)
+        _validate_model_metadata(self.models, self.model_metadata)
+        _validate_json_object(self.compat, "Provider compat")
         _validate_thinking_config(
             thinking_levels=self.thinking_levels,
             thinking_models=self.thinking_models,
@@ -95,12 +135,17 @@ class OpenAICompatibleProviderConfig:
             "name": self.name,
             "type": "openai-compatible",
             "base_url": self.base_url,
+            "api": self.api,
             "api_key_env": self.api_key_env,
             "credential_name": self.credential_name,
             "models": list(self.models),
             "default_model": self.default_model,
             "context_windows": dict(self.context_windows),
             "headers": dict(self.headers),
+            "compat": dict(self.compat),
+            "model_metadata": {
+                model: metadata.to_json() for model, metadata in self.model_metadata.items()
+            },
             "timeout_seconds": self.timeout_seconds,
             "max_retries": self.max_retries,
             "max_retry_delay_seconds": self.max_retry_delay_seconds,
@@ -120,12 +165,15 @@ class AnthropicProviderConfig:
 
     name: str = "anthropic"
     base_url: str = DEFAULT_ANTHROPIC_BASE_URL
+    api: ProviderApi = "anthropic-messages"
     api_key_env: str = "ANTHROPIC_API_KEY"
     credential_name: str | None = "anthropic"
     models: tuple[str, ...] = ("claude-sonnet-4-6",)
     default_model: str = "claude-sonnet-4-6"
     context_windows: dict[str, int] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
+    compat: dict[str, Any] = field(default_factory=dict)
+    model_metadata: dict[str, ProviderModelMetadata] = field(default_factory=dict)
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
@@ -142,6 +190,8 @@ class AnthropicProviderConfig:
             max_retry_delay_seconds=self.max_retry_delay_seconds,
         )
         _validate_context_windows(self.context_windows)
+        _validate_model_metadata(self.models, self.model_metadata)
+        _validate_json_object(self.compat, "Provider compat")
         _validate_thinking_config(
             thinking_levels=self.thinking_levels,
             thinking_models=self.thinking_models,
@@ -156,12 +206,17 @@ class AnthropicProviderConfig:
             "name": self.name,
             "type": "anthropic",
             "base_url": self.base_url,
+            "api": self.api,
             "api_key_env": self.api_key_env,
             "credential_name": self.credential_name,
             "models": list(self.models),
             "default_model": self.default_model,
             "context_windows": dict(self.context_windows),
             "headers": dict(self.headers),
+            "compat": dict(self.compat),
+            "model_metadata": {
+                model: metadata.to_json() for model, metadata in self.model_metadata.items()
+            },
             "timeout_seconds": self.timeout_seconds,
             "max_retries": self.max_retries,
             "max_retry_delay_seconds": self.max_retry_delay_seconds,
@@ -315,15 +370,20 @@ def provider_config_from_catalog_entry(name: str) -> ProviderConfig:
 def provider_config_from_entry(entry: ProviderCatalogEntry) -> ProviderConfig:
     """Create a durable provider config from a catalog entry."""
     context_windows = dict(entry.context_windows or {})
+    model_metadata = _provider_model_metadata_from_catalog(entry.model_metadata)
     if entry.kind == "anthropic":
         return AnthropicProviderConfig(
             name=entry.name,
             base_url=entry.base_url,
+            api=_default_api_for_kind(entry.kind),
             api_key_env=entry.api_key_env,
             credential_name=entry.credential_name,
             models=entry.models,
             default_model=entry.default_model,
             context_windows=context_windows,
+            headers=dict(entry.headers),
+            compat=dict(entry.compat),
+            model_metadata=model_metadata,
             thinking_levels=entry.thinking_levels,
             thinking_models=entry.thinking_models,
             thinking_default=entry.thinking_default,
@@ -348,17 +408,54 @@ def provider_config_from_entry(entry: ProviderCatalogEntry) -> ProviderConfig:
     return OpenAICompatibleProviderConfig(
         name=entry.name,
         base_url=entry.base_url,
+        api=entry.api or _default_api_for_kind(entry.kind),
         api_key_env=entry.api_key_env,
         credential_name=entry.credential_name,
         models=entry.models,
         default_model=entry.default_model,
         context_windows=context_windows,
+        headers=dict(entry.headers),
+        compat=dict(entry.compat),
+        model_metadata=model_metadata,
         thinking_levels=entry.thinking_levels,
         thinking_models=entry.thinking_models,
         thinking_default=entry.thinking_default,
         thinking_parameter=entry.thinking_parameter,
         thinking_defaults={},
     )
+
+
+def _default_api_for_kind(kind: str) -> ProviderApi:
+    if kind == "anthropic":
+        return "anthropic-messages"
+    if kind == "openai-codex":
+        return "openai-codex-responses"
+    if kind == "google-generative-ai":
+        return "google-generative-ai"
+    if kind == "mistral-conversations":
+        return "mistral-conversations"
+    return "openai-completions"
+
+
+def _provider_model_metadata_from_catalog(
+    model_metadata: dict[str, ModelCatalogMetadata],
+) -> dict[str, ProviderModelMetadata]:
+    return {
+        model: ProviderModelMetadata(
+            name=metadata.name,
+            api=metadata.api,
+            base_url=metadata.base_url,
+            reasoning=metadata.reasoning,
+            input=tuple(metadata.input),
+            cost=dict(metadata.cost or {}),
+            context_window=metadata.context_window,
+            max_tokens=metadata.max_tokens,
+            headers=dict(metadata.headers),
+            compat=dict(metadata.compat),
+            thinking_level_map=dict(metadata.thinking_level_map),
+        )
+        for model, metadata in model_metadata.items()
+    }
 
 
 def default_openai_provider_config() -> OpenAICompatibleProviderConfig:
@@ -626,50 +723,173 @@ def _merge_provider_config(existing: ProviderConfig, incoming: ProviderConfig) -
     """Merge a replacement provider config without losing local customizations."""
     if type(existing) is not type(incoming):
         return incoming
-    if isinstance(incoming, OpenAICodexProviderConfig):
-        models = incoming.models
-    else:
-        models = _unique_strings((*incoming.models, *existing.models))
-    default_model = (
-        existing.default_model if existing.default_model in models else incoming.default_model
-    )
-    headers = {**incoming.headers, **existing.headers}
-    context_windows = {**incoming.context_windows, **existing.context_windows}
-    thinking_levels = (
-        existing.thinking_levels
-        if existing.thinking_levels is not None
-        else incoming.thinking_levels
-    )
-    thinking_models = (
-        existing.thinking_models
-        if existing.thinking_levels is not None
-        else incoming.thinking_models
-    )
-    thinking_default = (
-        existing.thinking_default
-        if existing.thinking_levels is not None
-        else incoming.thinking_default
-    )
-    thinking_parameter = (
-        existing.thinking_parameter
-        if existing.thinking_levels is not None
-        else incoming.thinking_parameter
-    )
+
+    if isinstance(existing, OpenAICodexProviderConfig) and isinstance(
+        incoming, OpenAICodexProviderConfig
+    ):
+        return replace(
+            incoming,
+            default_model=(
+                existing.default_model
+                if existing.default_model in incoming.models
+                else incoming.default_model
+            ),
+            headers={**incoming.headers, **existing.headers},
+            timeout_seconds=existing.timeout_seconds,
+            max_retries=existing.max_retries,
+            max_retry_delay_seconds=existing.max_retry_delay_seconds,
+            context_windows={**incoming.context_windows, **existing.context_windows},
+            thinking_levels=(
+                existing.thinking_levels
+                if existing.thinking_levels is not None
+                else incoming.thinking_levels
+            ),
+            thinking_models=(
+                existing.thinking_models
+                if existing.thinking_levels is not None
+                else incoming.thinking_models
+            ),
+            thinking_default=(
+                existing.thinking_default
+                if existing.thinking_levels is not None
+                else incoming.thinking_default
+            ),
+            thinking_parameter=(
+                existing.thinking_parameter
+                if existing.thinking_levels is not None
+                else incoming.thinking_parameter
+            ),
+            thinking_defaults=existing.thinking_defaults,
+        )
+
+    if isinstance(existing, OpenAICompatibleProviderConfig) and isinstance(
+        incoming, OpenAICompatibleProviderConfig
+    ):
+        return _merge_openai_compatible_provider(existing, incoming)
+
+    if isinstance(existing, AnthropicProviderConfig) and isinstance(
+        incoming, AnthropicProviderConfig
+    ):
+        return _merge_anthropic_provider(existing, incoming)
+
+    return incoming
+
+
+def _merge_openai_compatible_provider(
+    existing: OpenAICompatibleProviderConfig,
+    incoming: OpenAICompatibleProviderConfig,
+) -> OpenAICompatibleProviderConfig:
+    models = _unique_strings((*incoming.models, *existing.models))
     return replace(
         incoming,
         models=models,
-        default_model=default_model,
-        headers=headers,
+        default_model=(
+            existing.default_model if existing.default_model in models else incoming.default_model
+        ),
+        headers={**incoming.headers, **existing.headers},
+        compat={**incoming.compat, **existing.compat},
+        model_metadata=_merge_provider_model_metadata(
+            incoming.model_metadata,
+            existing.model_metadata,
+        ),
         timeout_seconds=existing.timeout_seconds,
         max_retries=existing.max_retries,
         max_retry_delay_seconds=existing.max_retry_delay_seconds,
-        context_windows=context_windows,
-        thinking_levels=thinking_levels,
-        thinking_models=thinking_models,
-        thinking_default=thinking_default,
-        thinking_parameter=thinking_parameter,
+        context_windows={**incoming.context_windows, **existing.context_windows},
+        thinking_levels=(
+            existing.thinking_levels
+            if existing.thinking_levels is not None
+            else incoming.thinking_levels
+        ),
+        thinking_models=(
+            existing.thinking_models
+            if existing.thinking_levels is not None
+            else incoming.thinking_models
+        ),
+        thinking_default=(
+            existing.thinking_default
+            if existing.thinking_levels is not None
+            else incoming.thinking_default
+        ),
+        thinking_parameter=(
+            existing.thinking_parameter
+            if existing.thinking_levels is not None
+            else incoming.thinking_parameter
+        ),
         thinking_defaults=existing.thinking_defaults,
     )
+
+
+def _merge_anthropic_provider(
+    existing: AnthropicProviderConfig,
+    incoming: AnthropicProviderConfig,
+) -> AnthropicProviderConfig:
+    models = _unique_strings((*incoming.models, *existing.models))
+    return replace(
+        incoming,
+        models=models,
+        default_model=(
+            existing.default_model if existing.default_model in models else incoming.default_model
+        ),
+        headers={**incoming.headers, **existing.headers},
+        compat={**incoming.compat, **existing.compat},
+        model_metadata=_merge_provider_model_metadata(
+            incoming.model_metadata,
+            existing.model_metadata,
+        ),
+        timeout_seconds=existing.timeout_seconds,
+        max_retries=existing.max_retries,
+        max_retry_delay_seconds=existing.max_retry_delay_seconds,
+        context_windows={**incoming.context_windows, **existing.context_windows},
+        thinking_levels=(
+            existing.thinking_levels
+            if existing.thinking_levels is not None
+            else incoming.thinking_levels
+        ),
+        thinking_models=(
+            existing.thinking_models
+            if existing.thinking_levels is not None
+            else incoming.thinking_models
+        ),
+        thinking_default=(
+            existing.thinking_default
+            if existing.thinking_levels is not None
+            else incoming.thinking_default
+        ),
+        thinking_parameter=(
+            existing.thinking_parameter
+            if existing.thinking_levels is not None
+            else incoming.thinking_parameter
+        ),
+        thinking_defaults=existing.thinking_defaults,
+    )
+
+
+def _merge_provider_model_metadata(
+    incoming: dict[str, ProviderModelMetadata],
+    existing: dict[str, ProviderModelMetadata],
+) -> dict[str, ProviderModelMetadata]:
+    merged = dict(incoming)
+    for model, metadata in existing.items():
+        if model not in merged:
+            merged[model] = metadata
+            continue
+        base = merged[model]
+        merged[model] = replace(
+            base,
+            name=metadata.name or base.name,
+            api=metadata.api or base.api,
+            base_url=metadata.base_url or base.base_url,
+            reasoning=metadata.reasoning if metadata.reasoning is not None else base.reasoning,
+            input=metadata.input or base.input,
+            cost={**base.cost, **metadata.cost},
+            context_window=metadata.context_window or base.context_window,
+            max_tokens=metadata.max_tokens or base.max_tokens,
+            headers={**base.headers, **metadata.headers},
+            compat={**base.compat, **metadata.compat},
+            thinking_level_map={**base.thinking_level_map, **metadata.thinking_level_map},
+        )
+    return merged
 
 
 def _unique_strings(values: tuple[str, ...]) -> tuple[str, ...]:
@@ -743,7 +963,15 @@ def _provider_definition_differs_from_catalog(
         return True
     if provider.models != entry.models:
         return True
+    if getattr(provider, "api", None) != entry.api and entry.api is not None:
+        return True
     if provider.context_windows != dict(entry.context_windows or {}):
+        return True
+    if provider.headers != dict(entry.headers):
+        return True
+    if getattr(provider, "compat", {}) != dict(entry.compat):
+        return True
+    if _catalog_model_metadata_from_provider(provider) != entry.model_metadata:
         return True
     if provider.thinking_levels != entry.thinking_levels:
         return True
@@ -766,6 +994,7 @@ def _catalog_entry_from_provider(
         kind=provider_kind(provider),
         base_url=provider.base_url,
         api_key_env=provider.api_key_env,
+        api=getattr(provider, "api", None),
         credential_name=provider.credential_name,
         models=provider.models,
         default_model=(
@@ -775,11 +1004,36 @@ def _catalog_entry_from_provider(
         ),
         docs_url=existing.docs_url if existing is not None else provider.base_url,
         context_windows=dict(provider.context_windows) or None,
+        headers=dict(provider.headers),
+        compat=dict(getattr(provider, "compat", {})),
+        model_metadata=_catalog_model_metadata_from_provider(provider),
         thinking_levels=provider.thinking_levels,
         thinking_models=provider.thinking_models,
         thinking_default=provider.thinking_default,
         thinking_parameter=provider.thinking_parameter,
     )
+
+
+def _catalog_model_metadata_from_provider(
+    provider: ProviderConfig,
+) -> dict[str, ModelCatalogMetadata]:
+    metadata_by_model = getattr(provider, "model_metadata", {})
+    return {
+        model: ModelCatalogMetadata(
+            name=metadata.name,
+            api=metadata.api,
+            base_url=metadata.base_url,
+            reasoning=metadata.reasoning,
+            input=tuple(item for item in metadata.input if item in {"text", "image"}),
+            cost=dict(metadata.cost) or None,
+            context_window=metadata.context_window,
+            max_tokens=metadata.max_tokens,
+            headers=dict(metadata.headers),
+            compat=dict(metadata.compat),
+            thinking_level_map=dict(metadata.thinking_level_map),
+        )
+        for model, metadata in metadata_by_model.items()
+    }
 
 
 def provider_settings_from_json(
@@ -1010,12 +1264,21 @@ def provider_thinking_levels(
     model: str | None = None,
 ) -> tuple[ThinkingLevel, ...]:
     """Return thinking levels supported by a provider/model pair."""
-    if provider.thinking_levels is None:
-        return ()
     selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is not None and metadata.reasoning is False:
+        return ()
+    if provider.thinking_levels is None:
+        if metadata is None or metadata.reasoning is not True:
+            return ()
+        return _levels_from_thinking_map(metadata.thinking_level_map)
     if provider.thinking_models and selected_model not in provider.thinking_models:
         return ()
-    return provider.thinking_levels
+    return tuple(
+        level
+        for level in provider.thinking_levels
+        if metadata is None or _metadata_supports_thinking_level(metadata, level)
+    )
 
 
 def provider_thinking_unavailable_reason(
@@ -1025,7 +1288,12 @@ def provider_thinking_unavailable_reason(
 ) -> str | None:
     """Explain why a provider/model pair has no configurable thinking modes."""
     selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is not None and metadata.reasoning is False:
+        return f"{provider.name}:{selected_model} is not a reasoning model"
     if provider.thinking_levels is None:
+        if metadata is not None and metadata.reasoning is True:
+            return None
         if isinstance(provider, OpenAICodexProviderConfig):
             return (
                 "OpenAI Codex subscription can stream reasoning output, but Tau does "
@@ -1036,6 +1304,105 @@ def provider_thinking_unavailable_reason(
     if provider.thinking_models and selected_model not in provider.thinking_models:
         return f"{provider.name}:{selected_model} is not declared in thinking_models"
     return None
+
+
+def _levels_from_thinking_map(
+    thinking_level_map: dict[ThinkingLevel, str | None],
+) -> tuple[ThinkingLevel, ...]:
+    levels: tuple[ThinkingLevel, ...] = ("off", "minimal", "low", "medium", "high", "xhigh")
+    return tuple(
+        level for level in levels if _thinking_level_map_supports(thinking_level_map, level)
+    )
+
+
+def _metadata_supports_thinking_level(
+    metadata: ProviderModelMetadata,
+    level: ThinkingLevel,
+) -> bool:
+    return _thinking_level_map_supports(metadata.thinking_level_map, level)
+
+
+def _thinking_level_map_supports(
+    thinking_level_map: dict[ThinkingLevel, str | None],
+    level: ThinkingLevel,
+) -> bool:
+    if level in thinking_level_map:
+        return thinking_level_map[level] is not None
+    return level != "xhigh"
+
+
+def _metadata_for_model(provider: ProviderConfig, model: str) -> ProviderModelMetadata | None:
+    return getattr(provider, "model_metadata", {}).get(model)
+
+
+def _provider_api(provider: ProviderConfig, model: str | None = None) -> ProviderApi | str:
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is not None and metadata.api is not None:
+        return metadata.api
+    if isinstance(provider, OpenAICodexProviderConfig):
+        return "openai-codex-responses"
+    return getattr(provider, "api", "openai-completions")
+
+
+def _model_base_url(provider: ProviderConfig, model: str | None = None) -> str:
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    return metadata.base_url if metadata is not None and metadata.base_url else provider.base_url
+
+
+def _model_headers(provider: ProviderConfig, model: str | None = None) -> dict[str, str]:
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    return {**provider.headers, **(metadata.headers if metadata is not None else {})}
+
+
+def _model_compat(provider: ProviderConfig, model: str | None = None) -> dict[str, Any]:
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    return {
+        **_detected_compat(provider, selected_model),
+        **getattr(provider, "compat", {}),
+        **(metadata.compat if metadata is not None else {}),
+    }
+
+
+def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
+    base_url = _model_base_url(provider, model)
+    is_together = provider.name == "together" or "api.together.ai" in base_url
+    is_zai = provider.name == "zai" or "api.z.ai" in base_url
+    is_moonshot = provider.name in {"moonshotai", "moonshotai-cn"} or "moonshot." in base_url
+    is_grok = provider.name == "xai" or "api.x.ai" in base_url
+    is_deepseek = provider.name == "deepseek" or "deepseek.com" in base_url
+    is_cerebras = provider.name == "cerebras" or "cerebras.ai" in base_url
+    is_openrouter = provider.name == "openrouter" or "openrouter.ai" in base_url
+    is_nonstandard = is_cerebras or is_grok or is_together or is_deepseek or is_zai or is_moonshot
+    use_max_tokens = is_moonshot or is_together
+    return {
+        "supportsStore": not is_nonstandard,
+        "supportsReasoningEffort": not (is_grok or is_zai or is_moonshot or is_together),
+        "supportsUsageInStreaming": True,
+        "maxTokensField": "max_tokens" if use_max_tokens else "max_completion_tokens",
+        "thinkingFormat": (
+            "deepseek"
+            if is_deepseek
+            else "zai"
+            if is_zai
+            else "together"
+            if is_together
+            else "openrouter"
+            if is_openrouter
+            else "openai"
+        ),
+        "supportsStrictMode": not (is_moonshot or is_together),
+        "supportsLongCacheRetention": not is_together,
+    }
+
+
+def _model_max_tokens(provider: ProviderConfig, model: str | None = None) -> int | None:
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    return metadata.max_tokens if metadata is not None else None
 
 
 def provider_default_thinking_level(
@@ -1063,24 +1430,34 @@ def openai_compatible_config_from_provider(
 ) -> OpenAICompatibleConfig:
     """Build OpenAI-compatible runtime config from durable settings."""
     api_key = _api_key_from_provider(provider, credential_reader=credential_reader)
-    base_url = provider.base_url
+    selected_model = model or provider.default_model
+    base_url = _model_base_url(provider, selected_model)
     if provider.name == DEFAULT_PROVIDER_NAME and provider.api_key_env == "OPENAI_API_KEY":
-        base_url = environ.get("OPENAI_BASE_URL", provider.base_url)
+        base_url = environ.get("OPENAI_BASE_URL", base_url)
     reasoning_effort = _reasoning_effort_from_provider(
         provider,
-        model=model,
+        model=selected_model,
         thinking_level=thinking_level,
     )
+    compat = _model_compat(provider, selected_model)
     return OpenAICompatibleConfig(
         api_key=api_key,
         provider_name=provider.name,
+        api=str(_provider_api(provider, selected_model)),
         base_url=base_url.rstrip("/"),
-        headers=provider.headers,
+        headers=_model_headers(provider, selected_model),
         timeout_seconds=provider.timeout_seconds,
         max_retries=provider.max_retries,
         max_retry_delay_seconds=provider.max_retry_delay_seconds,
         reasoning_effort=reasoning_effort,
         reasoning_effort_parameter=provider.thinking_parameter or "reasoning_effort",
+        thinking_format=_thinking_format(provider, selected_model),
+        compat=compat,
+        include_reasoning_effort_none=_include_reasoning_effort_none(
+            provider,
+            model=selected_model,
+            thinking_level=thinking_level,
+        ),
     )
 
 
@@ -1088,23 +1465,32 @@ def anthropic_config_from_provider(
     provider: AnthropicProviderConfig,
     *,
     credential_reader: CredentialReader | None = None,
+    model: str | None = None,
     thinking_level: ThinkingLevel | None = None,
 ) -> AnthropicConfig:
     """Build Anthropic runtime config from durable settings."""
     api_key = _api_key_from_provider(provider, credential_reader=credential_reader)
+    selected_model = model or provider.default_model
     thinking_budget_tokens = _anthropic_thinking_budget_from_provider(
         provider,
+        model=selected_model,
         thinking_level=thinking_level,
     )
     return AnthropicConfig(
         api_key=api_key,
         provider_name=provider.name,
-        base_url=provider.base_url.rstrip("/"),
-        headers=provider.headers,
+        base_url=_normalize_anthropic_base_url(_model_base_url(provider, selected_model)),
+        headers=_model_headers(provider, selected_model),
         timeout_seconds=provider.timeout_seconds,
         max_retries=provider.max_retries,
         max_retry_delay_seconds=provider.max_retry_delay_seconds,
         thinking_budget_tokens=thinking_budget_tokens,
+        thinking_effort=_reasoning_effort_from_anthropic_provider(
+            provider,
+            model=selected_model,
+            thinking_level=thinking_level,
+        ),
+        thinking_mode=_anthropic_thinking_mode(provider, selected_model),
     )
 
 
@@ -1114,6 +1500,11 @@ def provider_kind(provider: ProviderConfig) -> ProviderKind:
         return "anthropic"
     if isinstance(provider, OpenAICodexProviderConfig):
         return "openai-codex"
+    if isinstance(provider, OpenAICompatibleProviderConfig):
+        if provider.api == "google-generative-ai":
+            return "google-generative-ai"
+        if provider.api == "mistral-conversations":
+            return "mistral-conversations"
     return "openai-compatible"
 
 
@@ -1149,26 +1540,34 @@ def _reasoning_effort_from_provider(
     if not levels:
         return None
 
+    selected_model = model or provider.default_model
     normalized = normalize_thinking_level(thinking_level)
     if normalized not in levels:
-        selected_model = model or provider.default_model
         available = ", ".join(levels)
         raise ProviderConfigError(
             f"Thinking mode {normalized} is not available for "
             f"{provider.name}:{selected_model}. Available modes: {available}"
         )
+    mapped = _metadata_thinking_value(provider, selected_model, normalized)
+    if mapped is not None:
+        return mapped
     return reasoning_effort_for_level(normalized)
 
 
 def _anthropic_thinking_budget_from_provider(
     provider: AnthropicProviderConfig,
     *,
+    model: str | None,
     thinking_level: ThinkingLevel | None,
 ) -> int | None:
     if thinking_level is None or provider.thinking_parameter != "anthropic.thinking":
         return None
 
-    levels = provider_thinking_levels(provider)
+    selected_model = model or provider.default_model
+    if _anthropic_thinking_mode(provider, selected_model) == "adaptive":
+        return None
+
+    levels = provider_thinking_levels(provider, model=selected_model)
     if not levels:
         return None
 
@@ -1177,19 +1576,102 @@ def _anthropic_thinking_budget_from_provider(
         available = ", ".join(levels)
         raise ProviderConfigError(
             f"Thinking mode {normalized} is not available for "
-            f"{provider.name}:{provider.default_model}. Available modes: {available}"
+            f"{provider.name}:{selected_model}. Available modes: {available}"
         )
     return anthropic_thinking_budget_for_level(normalized)
+
+
+def _metadata_thinking_value(
+    provider: ProviderConfig,
+    model: str,
+    level: ThinkingLevel,
+) -> str | None:
+    metadata = _metadata_for_model(provider, model)
+    if metadata is None:
+        return None
+    value = metadata.thinking_level_map.get(level)
+    return value if isinstance(value, str) else None
+
+
+def _thinking_format(provider: ProviderConfig, model: str) -> str:
+    compat = _model_compat(provider, model)
+    value = compat.get("thinkingFormat")
+    if isinstance(value, str) and value:
+        return value
+    base_url = _model_base_url(provider, model)
+    if provider.name == "deepseek" or "deepseek.com" in base_url:
+        return "deepseek"
+    if provider.name == "zai" or "api.z.ai" in base_url:
+        return "zai"
+    if provider.name == "together" or "api.together.ai" in base_url:
+        return "together"
+    if provider.name == "openrouter" or "openrouter.ai" in base_url:
+        return "openrouter"
+    return "openai"
+
+
+def _include_reasoning_effort_none(
+    provider: ProviderConfig,
+    *,
+    model: str,
+    thinking_level: ThinkingLevel | None,
+) -> bool:
+    if thinking_level is None:
+        return False
+    try:
+        normalized = normalize_thinking_level(thinking_level)
+    except ValueError:
+        return False
+    if normalized != "off":
+        return False
+    return _metadata_thinking_value(provider, model, "off") == "none"
+
+
+def _reasoning_effort_from_anthropic_provider(
+    provider: AnthropicProviderConfig,
+    *,
+    model: str,
+    thinking_level: ThinkingLevel | None,
+) -> str | None:
+    if thinking_level is None:
+        return None
+    selected_model = model
+    normalized = normalize_thinking_level(thinking_level)
+    if normalized == "off":
+        return None
+    mapped = _metadata_thinking_value(provider, selected_model, normalized)
+    return mapped or normalized
+
+
+def _anthropic_thinking_mode(provider: AnthropicProviderConfig, model: str) -> str:
+    compat = _model_compat(provider, model)
+    if compat.get("forceAdaptiveThinking") is True:
+        return "adaptive"
+    return "budget"
+
+
+def _normalize_anthropic_base_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
 
 
 def _provider_from_json(data: object) -> ProviderConfig:
     if not isinstance(data, dict):
         raise ProviderConfigError("Provider entries must be JSON objects")
     provider_type = _string(data.get("type"), "providers[].type")
-    if provider_type not in {"openai-compatible", "anthropic", "openai-codex"}:
+    if provider_type not in {
+        "openai-compatible",
+        "anthropic",
+        "openai-codex",
+        "google-generative-ai",
+        "mistral-conversations",
+    }:
         raise ProviderConfigError(f"Unsupported provider type: {provider_type}")
     name = _string(data.get("name"), "providers[].name")
     base_url = _string(data.get("base_url"), f"providers[{name}].base_url").rstrip("/")
+    api = _optional_provider_api(data.get("api"), f"providers[{name}].api")
     api_key_env = _string(data.get("api_key_env"), f"providers[{name}].api_key_env")
     credential_name = _optional_string(
         data.get("credential_name"), f"providers[{name}].credential_name"
@@ -1200,6 +1682,12 @@ def _provider_from_json(data: object) -> ProviderConfig:
         data.get("context_windows", {}), f"providers[{name}].context_windows"
     )
     headers = _string_dict(data.get("headers", {}), f"providers[{name}].headers")
+    compat = _json_dict(data.get("compat", {}), f"providers[{name}].compat")
+    model_metadata = _model_metadata_dict(
+        data.get("model_metadata", {}),
+        models,
+        f"providers[{name}].model_metadata",
+    )
     timeout_seconds = _positive_float(
         data.get("timeout_seconds", DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS),
         f"providers[{name}].timeout_seconds",
@@ -1236,12 +1724,15 @@ def _provider_from_json(data: object) -> ProviderConfig:
         return AnthropicProviderConfig(
             name=name,
             base_url=base_url,
+            api=api or "anthropic-messages",
             api_key_env=api_key_env,
             credential_name=credential_name,
             models=models,
             default_model=default_model,
             context_windows=context_windows,
             headers=headers,
+            compat=compat,
+            model_metadata=model_metadata,
             timeout_seconds=timeout_seconds,
             max_retries=max_retries,
             max_retry_delay_seconds=max_retry_delay_seconds,
@@ -1252,6 +1743,7 @@ def _provider_from_json(data: object) -> ProviderConfig:
             thinking_defaults=thinking_defaults,
         )
     if provider_type == "openai-codex":
+        _reject_catalog_only_legacy_metadata(compat, model_metadata)
         return OpenAICodexProviderConfig(
             name=name,
             base_url=base_url,
@@ -1273,12 +1765,15 @@ def _provider_from_json(data: object) -> ProviderConfig:
     return OpenAICompatibleProviderConfig(
         name=name,
         base_url=base_url,
+        api=api or _default_api_for_kind(provider_type),
         api_key_env=api_key_env,
         credential_name=credential_name,
         models=models,
         default_model=default_model,
         context_windows=context_windows,
         headers=headers,
+        compat=compat,
+        model_metadata=model_metadata,
         timeout_seconds=timeout_seconds,
         max_retries=max_retries,
         max_retry_delay_seconds=max_retry_delay_seconds,
@@ -1337,6 +1832,71 @@ def _validate_context_windows(context_windows: dict[str, int]) -> None:
             raise ProviderConfigError("Provider context_windows values must be positive integers")
 
 
+def _validate_model_metadata(
+    models: tuple[str, ...],
+    model_metadata: dict[str, ProviderModelMetadata],
+) -> None:
+    model_names = set(models)
+    for model, metadata in model_metadata.items():
+        if model not in model_names:
+            raise ProviderConfigError(f"Provider model_metadata key is not in models: {model}")
+        if metadata.context_window is not None and metadata.context_window <= 0:
+            raise ProviderConfigError("Provider model_metadata context_window must be positive")
+        if metadata.max_tokens is not None and metadata.max_tokens <= 0:
+            raise ProviderConfigError("Provider model_metadata max_tokens must be positive")
+        if any(item not in {"text", "image"} for item in metadata.input):
+            raise ProviderConfigError("Provider model_metadata input must contain text or image")
+        if any(value < 0 for value in metadata.cost.values()):
+            raise ProviderConfigError("Provider model_metadata cost values must be non-negative")
+        _validate_json_object(metadata.compat, "Provider model_metadata compat")
+        _validate_string_dict(metadata.headers, "Provider model_metadata headers")
+        for level, value in metadata.thinking_level_map.items():
+            normalize_thinking_level(level)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ProviderConfigError(
+                    "Provider model_metadata thinking_level_map values must be strings or null"
+                )
+
+
+def _validate_string_dict(value: dict[str, str], field_name: str) -> None:
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ProviderConfigError(f"{field_name} keys must be non-empty strings")
+        if not isinstance(item, str) or not item.strip():
+            raise ProviderConfigError(f"{field_name} values must be non-empty strings")
+
+
+def _validate_json_object(value: dict[str, Any], field_name: str) -> None:
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ProviderConfigError(f"{field_name} keys must be non-empty strings")
+        _validate_json_value(item, f"{field_name}.{key}")
+
+
+def _validate_json_value(value: object, field_name: str) -> None:
+    if value is None or isinstance(value, str | int | float | bool):
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item, field_name)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ProviderConfigError(f"{field_name} object keys must be strings")
+            _validate_json_value(item, f"{field_name}.{key}")
+        return
+    raise ProviderConfigError(f"{field_name} must be JSON-compatible")
+
+
+def _reject_catalog_only_legacy_metadata(
+    compat: dict[str, Any],
+    model_metadata: dict[str, ProviderModelMetadata],
+) -> None:
+    if compat or model_metadata:
+        raise ProviderConfigError("OpenAI Codex legacy provider metadata is not supported")
+
+
 def _validate_thinking_defaults(thinking_defaults: dict[str, ThinkingLevel]) -> None:
     for model, thinking_level in thinking_defaults.items():
         if not isinstance(model, str) or not model.strip():
@@ -1389,6 +1949,21 @@ def _reject_unimplemented_thinking_config(
 ) -> None:
     if thinking_levels is not None:
         raise ProviderConfigError(f"{provider_type} thinking controls are not implemented yet")
+
+
+def _optional_provider_api(value: object, field_name: str) -> ProviderApi | None:
+    if value is None:
+        return None
+    if value in {
+        "openai-completions",
+        "openai-responses",
+        "anthropic-messages",
+        "openai-codex-responses",
+        "google-generative-ai",
+        "mistral-conversations",
+    }:
+        return cast(ProviderApi, value)
+    raise ProviderConfigError(f"Provider field has unsupported API: {field_name}")
 
 
 def _optional_string(value: object, field_name: str) -> str | None:
@@ -1479,6 +2054,106 @@ def _string_dict(value: object, field_name: str) -> dict[str, str]:
             raise ProviderConfigError(f"Provider field must be a string object: {field_name}")
         items[key.strip()] = item.strip()
     return items
+
+
+def _json_dict(value: object, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProviderConfigError(f"Provider field must be an object: {field_name}")
+    items: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ProviderConfigError(f"Provider field must have string keys: {field_name}")
+        _validate_json_value(item, f"{field_name}.{key}")
+        items[key.strip()] = item
+    return items
+
+
+def _model_metadata_dict(
+    value: object,
+    models: tuple[str, ...],
+    field_name: str,
+) -> dict[str, ProviderModelMetadata]:
+    if not isinstance(value, dict):
+        raise ProviderConfigError(f"Provider field must be an object: {field_name}")
+    model_names = set(models)
+    items: dict[str, ProviderModelMetadata] = {}
+    for key, item in value.items():
+        model = _string(key, field_name)
+        if model not in model_names:
+            raise ProviderConfigError(f"Provider model_metadata key is not in models: {model}")
+        if not isinstance(item, dict):
+            raise ProviderConfigError(
+                f"Provider model_metadata entries must be objects: {field_name}"
+            )
+        items[model] = ProviderModelMetadata(
+            name=_optional_string(item.get("name"), f"{field_name}.{model}.name"),
+            api=_optional_provider_api(item.get("api"), f"{field_name}.{model}.api"),
+            base_url=_optional_string(item.get("base_url"), f"{field_name}.{model}.base_url"),
+            reasoning=_optional_bool(item.get("reasoning"), f"{field_name}.{model}.reasoning"),
+            input=_optional_string_tuple(item.get("input"), f"{field_name}.{model}.input"),
+            cost=_float_dict(item.get("cost", {}), f"{field_name}.{model}.cost"),
+            context_window=_optional_positive_int(
+                item.get("context_window"), f"{field_name}.{model}.context_window"
+            ),
+            max_tokens=_optional_positive_int(
+                item.get("max_tokens"), f"{field_name}.{model}.max_tokens"
+            ),
+            headers=_string_dict(item.get("headers", {}), f"{field_name}.{model}.headers"),
+            compat=_json_dict(item.get("compat", {}), f"{field_name}.{model}.compat"),
+            thinking_level_map=_thinking_level_map_dict(
+                item.get("thinking_level_map", {}),
+                f"{field_name}.{model}.thinking_level_map",
+            ),
+        )
+    return items
+
+
+def _thinking_level_map_dict(
+    value: object,
+    field_name: str,
+) -> dict[ThinkingLevel, str | None]:
+    if not isinstance(value, dict):
+        raise ProviderConfigError(f"Provider field must be an object: {field_name}")
+    items: dict[ThinkingLevel, str | None] = {}
+    for key, item in value.items():
+        level = _optional_thinking_level(key, field_name)
+        if level is None:
+            raise ProviderConfigError(f"Provider field must be a thinking mode: {field_name}")
+        if item is not None and (not isinstance(item, str) or not item.strip()):
+            raise ProviderConfigError(
+                f"Provider field values must be strings or null: {field_name}"
+            )
+        items[level] = item.strip() if isinstance(item, str) else None
+    return items
+
+
+def _float_dict(value: object, field_name: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise ProviderConfigError(f"Provider field must be a number object: {field_name}")
+    items: dict[str, float] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ProviderConfigError(f"Provider field must be a number object: {field_name}")
+        if not isinstance(item, int | float) or isinstance(item, bool) or item < 0:
+            raise ProviderConfigError(f"Provider field values must be non-negative: {field_name}")
+        items[key.strip()] = float(item)
+    return items
+
+
+def _optional_bool(value: object, field_name: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ProviderConfigError(f"Provider field must be a boolean: {field_name}")
+    return value
+
+
+def _optional_positive_int(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ProviderConfigError(f"Provider field must be a positive integer: {field_name}")
+    return value
 
 
 def _context_window_dict(value: object, field_name: str) -> dict[str, int]:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1551,6 +1551,10 @@ def _reasoning_effort_from_provider(
     mapped = _metadata_thinking_value(provider, selected_model, normalized)
     if mapped is not None:
         return mapped
+    if provider.name == "huggingface" and normalized == "minimal":
+        # Hugging Face's router currently accepts low/medium/high/xhigh/max/none
+        # for reasoning_effort, but rejects Pi/Tau's "minimal" label.
+        return "low"
     return reasoning_effort_for_level(normalized)
 
 

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -7,6 +7,8 @@ from typing import Protocol
 
 from tau_ai import (
     AnthropicProvider,
+    GoogleGenerativeAIProvider,
+    MistralConversationsProvider,
     ModelProvider,
     OpenAICodexConfig,
     OpenAICodexCredentials,
@@ -22,6 +24,7 @@ from tau_coding.oauth import (
 from tau_coding.provider_config import (
     AnthropicProviderConfig,
     OpenAICodexProviderConfig,
+    OpenAICompatibleProviderConfig,
     ProviderConfig,
     ProviderConfigError,
     anthropic_config_from_provider,
@@ -56,6 +59,7 @@ def create_model_provider(
             anthropic_config_from_provider(
                 provider,
                 credential_reader=credentials,
+                model=model,
                 thinking_level=thinking_level,
             )
         )
@@ -79,14 +83,19 @@ def create_model_provider(
                 ),
             )
         )
-    return OpenAICompatibleProvider(
-        openai_compatible_config_from_provider(
+    if isinstance(provider, OpenAICompatibleProviderConfig):
+        config = openai_compatible_config_from_provider(
             provider,
             credential_reader=credentials,
             model=model,
             thinking_level=thinking_level,
         )
-    )
+        if provider.api == "google-generative-ai":
+            return GoogleGenerativeAIProvider(config)
+        if provider.api == "mistral-conversations":
+            return MistralConversationsProvider(config)
+        return OpenAICompatibleProvider(config)
+    raise ProviderConfigError(f"Unsupported provider config: {provider.name}")
 
 
 def _codex_reasoning_effort(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -902,11 +902,11 @@ def test_providers_command_lists_default_provider(
     result = CliRunner().invoke(app, ["providers"])
 
     assert result.exit_code == 0
-    assert "*\topenai\topenai-compatible\tgpt-5.5" in result.stdout
+    assert "*\topenai\topenai-compatible\tgpt-5.4" in result.stdout
     assert " \topenai-codex\topenai-codex\tgpt-5.5" in result.stdout
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
-    assert " \topenrouter\topenai-compatible\topenai/gpt-5.5" in result.stdout
-    assert " \thuggingface\topenai-compatible\topenai/gpt-oss-120b" in result.stdout
+    assert " \topenrouter\topenai-compatible\tqwen/qwen3.7-max" in result.stdout
+    assert " \thuggingface\topenai-compatible\tmoonshotai/Kimi-K2.6" in result.stdout
 
 
 def test_render_provider_settings_shows_credential_source(
@@ -944,7 +944,7 @@ def test_render_provider_settings_shows_credential_source(
     cli.render_provider_settings(settings, credential_reader=FakeCredentials())
 
     output = capsys.readouterr().out
-    assert "*\tstored\topenai-compatible\tgpt-5.5" in output
+    assert "*\tstored\topenai-compatible\tgpt-5.4" in output
     assert "\tSTORED_API_KEY\tstored:stored\t" in output
     assert "\tENV_API_KEY\tenv:ENV_API_KEY\t" in output
     assert "\tMISSING_API_KEY\tmissing\t" in output

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2353,7 +2353,7 @@ async def test_available_model_choices_include_stored_credentials(
     )
 
     assert session.available_providers == ("openai",)
-    assert ("openai", "gpt-5.5") in [
+    assert ("openai", "gpt-5.4") in [
         (choice.provider_name, choice.model) for choice in session.available_model_choices
     ]
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -47,7 +47,31 @@ def _write_user_catalog(tau_home: Path, body: str) -> TauPaths:
 
 def test_builtin_catalog_matches_expected_providers() -> None:
     names = [entry.name for entry in BUILTIN_PROVIDER_CATALOG]
-    assert names == ["openai", "openai-codex", "anthropic", "openrouter", "huggingface"]
+    assert names == [
+        "openai",
+        "openai-codex",
+        "anthropic",
+        "google",
+        "deepseek",
+        "xai",
+        "groq",
+        "cerebras",
+        "openrouter",
+        "zai",
+        "mistral",
+        "minimax",
+        "minimax-cn",
+        "moonshotai",
+        "moonshotai-cn",
+        "huggingface",
+        "fireworks",
+        "together",
+        "vercel-ai-gateway",
+        "xiaomi",
+        "xiaomi-token-plan-cn",
+        "xiaomi-token-plan-ams",
+        "xiaomi-token-plan-sgp",
+    ]
 
 
 def test_builtin_catalog_golden_anthropic_entry() -> None:
@@ -55,19 +79,39 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
     assert entry is not None
     assert entry.display_name == "Anthropic"
     assert entry.kind == "anthropic"
-    assert entry.base_url == "https://api.anthropic.com/v1"
+    assert entry.base_url == "https://api.anthropic.com"
     assert entry.api_key_env == "ANTHROPIC_API_KEY"
     assert entry.credential_name == "anthropic"
-    assert entry.models == ("claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5")
+    assert entry.models == (
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+        "claude-opus-4-1",
+        "claude-opus-4-1-20250805",
+        "claude-opus-4-5",
+        "claude-opus-4-5-20251101",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-5-20250929",
+        "claude-sonnet-4-6",
+    )
     assert entry.default_model == "claude-sonnet-4-6"
     assert entry.docs_url == "https://docs.anthropic.com"
     assert entry.context_windows == {
-        "claude-sonnet-4-6": 1_000_000,
-        "claude-opus-4-8": 200_000,
         "claude-haiku-4-5": 200_000,
+        "claude-haiku-4-5-20251001": 200_000,
+        "claude-opus-4-1": 200_000,
+        "claude-opus-4-1-20250805": 200_000,
+        "claude-opus-4-5": 200_000,
+        "claude-opus-4-5-20251101": 200_000,
+        "claude-opus-4-6": 1_000_000,
+        "claude-opus-4-7": 1_000_000,
+        "claude-sonnet-4-5": 200_000,
+        "claude-sonnet-4-5-20250929": 200_000,
+        "claude-sonnet-4-6": 1_000_000,
     }
     assert entry.thinking_levels == ("off", "minimal", "low", "medium", "high", "xhigh")
-    assert entry.thinking_models == ("claude-sonnet-4-6", "claude-opus-4-8")
+    assert entry.thinking_models == ()
     assert entry.thinking_default == "medium"
     assert entry.thinking_parameter == "anthropic.thinking"
 
@@ -121,9 +165,9 @@ default_model = "claude-next-1"
     assert entry.default_model == "claude-next-1"
     assert entry.context_windows is not None
     assert entry.context_windows["claude-next-1"] == 500_000
-    assert entry.context_windows["claude-opus-4-8"] == 200_000
+    assert entry.context_windows["claude-opus-4-7"] == 1_000_000
     # Untouched fields come from the builtin entry.
-    assert entry.base_url == "https://api.anthropic.com/v1"
+    assert entry.base_url == "https://api.anthropic.com"
     assert entry.thinking_parameter == "anthropic.thinking"
 
 

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -37,8 +37,26 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "openai",
         "openai-codex",
         "anthropic",
+        "google",
+        "deepseek",
+        "xai",
+        "groq",
+        "cerebras",
         "openrouter",
+        "zai",
+        "mistral",
+        "minimax",
+        "minimax-cn",
+        "moonshotai",
+        "moonshotai-cn",
         "huggingface",
+        "fireworks",
+        "together",
+        "vercel-ai-gateway",
+        "xiaomi",
+        "xiaomi-token-plan-cn",
+        "xiaomi-token-plan-ams",
+        "xiaomi-token-plan-sgp",
     ]
     assert settings.providers[0].default_model == DEFAULT_MODEL
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"
@@ -70,30 +88,36 @@ def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:
     assert provider_thinking_levels(openai, model="gpt-4.1") == ()
     assert (
         provider_thinking_unavailable_reason(openai, model="gpt-4.1")
-        == "openai:gpt-4.1 is not declared in thinking_models"
+        == "openai:gpt-4.1 is not a reasoning model"
     )
     assert provider_thinking_levels(openrouter, model="openai/gpt-5.5") == (
         "off",
+        "minimal",
         "low",
         "medium",
         "high",
         "xhigh",
     )
     assert provider_thinking_unavailable_reason(openrouter, model="openai/gpt-5.5") is None
-    assert provider_thinking_levels(openrouter, model="anthropic/claude-sonnet-4.6") == ()
-    assert (
-        provider_thinking_unavailable_reason(
-            openrouter,
-            model="anthropic/claude-sonnet-4.6",
-        )
-        == "openrouter:anthropic/claude-sonnet-4.6 is not declared in thinking_models"
-    )
-    assert provider_thinking_levels(huggingface, model="openai/gpt-oss-120b") == (
+    assert provider_thinking_levels(openrouter, model="anthropic/claude-sonnet-4.6") == (
+        "off",
+        "minimal",
         "low",
         "medium",
         "high",
     )
-    assert provider_thinking_unavailable_reason(huggingface, model="openai/gpt-oss-120b") is None
+    assert (
+        provider_thinking_unavailable_reason(openrouter, model="anthropic/claude-sonnet-4.6")
+        is None
+    )
+    assert provider_thinking_levels(huggingface, model="MiniMaxAI/MiniMax-M2.7") == (
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+    )
+    assert provider_thinking_unavailable_reason(huggingface, model="MiniMaxAI/MiniMax-M2.7") is None
     assert provider_thinking_levels(codex, model="gpt-5.5") == (
         "off",
         "minimal",
@@ -105,14 +129,18 @@ def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:
     assert provider_thinking_unavailable_reason(codex, model="gpt-5.5") is None
     assert provider_thinking_levels(anthropic, model="claude-sonnet-4-6") == (
         "off",
+        "low",
+        "medium",
+        "high",
+    )
+    assert provider_thinking_unavailable_reason(anthropic, model="claude-sonnet-4-6") is None
+    assert provider_thinking_levels(anthropic, model="claude-haiku-4-5") == (
+        "off",
         "minimal",
         "low",
         "medium",
         "high",
-        "xhigh",
     )
-    assert provider_thinking_unavailable_reason(anthropic, model="claude-sonnet-4-6") is None
-    assert provider_thinking_levels(anthropic, model="claude-haiku-4-5") == ()
 
 
 def test_load_provider_settings_accepts_provider_preferences_with_user_catalog(
@@ -286,14 +314,9 @@ def test_upsert_openai_compatible_provider_replaces_and_sets_default() -> None:
     )
 
     assert updated.default_provider == "local"
-    assert [item.name for item in updated.providers] == [
-        "anthropic",
-        "huggingface",
-        "local",
-        "openai",
-        "openai-codex",
-        "openrouter",
-    ]
+    assert [item.name for item in updated.providers] == sorted(
+        [provider.name for provider in settings.providers] + ["local"]
+    )
     assert replaced.get_provider("local").default_model == "llama"
     assert replaced.scoped_models == settings.scoped_models
 
@@ -830,8 +853,8 @@ def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> 
       "base_url": "https://router.huggingface.co/v1",
       "api_key_env": "HF_TOKEN",
       "credential_name": "huggingface",
-      "models": ["openai/gpt-oss-120b", "custom/coder"],
-      "default_model": "openai/gpt-oss-120b",
+      "models": ["MiniMaxAI/MiniMax-M2.7", "custom/coder"],
+      "default_model": "MiniMaxAI/MiniMax-M2.7",
       "headers": {"X-HF-Bill-To": "my-org"}
     }
   ]
@@ -843,12 +866,11 @@ def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> 
     settings = load_provider_settings(TauPaths(home=tau_home))
 
     provider = settings.get_provider("huggingface")
-    assert provider.default_model == "openai/gpt-oss-120b"
+    assert provider.default_model == "MiniMaxAI/MiniMax-M2.7"
     assert provider.headers == {"X-HF-Bill-To": "my-org"}
-    assert provider.context_windows["openai/gpt-oss-120b"] == 131_072
+    assert provider.context_windows["MiniMaxAI/MiniMax-M2.7"] == 204_800
     assert "Qwen/Qwen3-Coder-480B-A35B-Instruct" in provider.models
-    assert "MiniMaxAI/MiniMax-M3" in provider.models
-    assert "moonshotai/Kimi-K2.7-Code" in provider.models
+    assert "moonshotai/Kimi-K2.6" in provider.models
     assert "custom/coder" in provider.models
 
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -18,6 +18,7 @@ from tau_ai import (
     AnthropicConfig,
     AnthropicProvider,
     FakeProvider,
+    GoogleGenerativeAIProvider,
     OpenAICodexConfig,
     OpenAICodexCredentials,
     OpenAICodexProvider,
@@ -211,6 +212,40 @@ async def test_openai_compatible_provider_includes_configured_reasoning_effort()
 
 
 @pytest.mark.anyio
+async def test_openai_compatible_provider_includes_openrouter_provider_routing() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                compat={"openrouterProvider": {"ignore": ["Nebius"]}},
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="nvidia/nemotron-3-super-120b-a12b",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert loads(requests[0].content)["provider"] == {"ignore": ["Nebius"]}
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_supports_nested_reasoning_effort_parameter() -> None:
     requests: list[httpx.Request] = []
 
@@ -247,6 +282,49 @@ async def test_openai_compatible_provider_supports_nested_reasoning_effort_param
     assert requests[0].url == "https://example.test/v1/chat/completions"
     assert loads(requests[0].content)["reasoning"] == {"effort": "high"}
     assert "reasoning_effort" not in loads(requests[0].content)
+
+
+@pytest.mark.anyio
+async def test_google_provider_sends_system_instruction_at_top_level() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},'
+                '"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+                reasoning_effort="low",
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    assert payload["systemInstruction"] == {"parts": [{"text": "You are Tau."}]}
+    assert "systemInstruction" not in payload["generationConfig"]
+    assert payload["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": True,
+        "thinkingBudget": 2048,
+    }
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -5338,7 +5338,7 @@ async def test_run_tui_app_opens_when_provider_login_is_missing(
         startup_notice="Tau 0.2.0 is available",
     )
 
-    assert calls == [f"prepare:{tmp_path}:gpt-5.5:openai", "load:LoginRequiredProvider", "run"]
+    assert calls == [f"prepare:{tmp_path}:gpt-5.4:openai", "load:LoginRequiredProvider", "run"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Adds Pi-derived API-based providers to Tau's built-in catalog.
- Extends catalog metadata for provider API type, compat flags, headers, per-model reasoning metadata, thinking maps, context windows, max tokens, costs, and modalities.
- Adds runtime support scaffolding for OpenAI Responses/OpenAI-compatible formats, Anthropic adaptive thinking, Google Generative AI, and Mistral Conversations.

## Validation

- `uv run ruff check .`
- `uv run mypy`

## Notes

This is a draft follow-up to the config-driven catalog work. The full test suite still needs expectation updates for the expanded built-in catalog and Pi-derived defaults.
