### PR TITLE
feat(tui): add sidebar_position setting to tui.json

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1649,6 +1649,12 @@ class TauTuiApp(App[None]):
         padding-left: 1;
     }
 
+    TauTuiApp.-sidebar-right #sidebar {
+        dock: right;
+        border-right: none;
+        border-left: tall $tau-border;
+    }
+
     #main-pane {
         width: 1fr;
         padding: 1 1 0 1;
@@ -2054,6 +2060,7 @@ class TauTuiApp(App[None]):
         self._sync_prompt_shell_mode(prompt.text)
         prompt.focus()
         self._update_responsive_layout(self.size.width, self.size.height)
+        self._apply_sidebar_position()
         self._refresh()
         self._sync_text_selection_state()
         self._refresh_completions()
@@ -3343,8 +3350,17 @@ class TauTuiApp(App[None]):
         )
 
     def _update_responsive_layout(self, width: int, height: int) -> None:
+        if self.tui_settings.sidebar_position == "off":
+            return
         show_sidebar = width >= SIDEBAR_MIN_WIDTH and height >= SIDEBAR_MIN_HEIGHT
         self.set_class(not show_sidebar, "-hide-sidebar")
+
+    def _apply_sidebar_position(self) -> None:
+        """Apply CSS classes for the configured sidebar position."""
+        pos = self.tui_settings.sidebar_position
+        self.set_class(pos == "right", "-sidebar-right")
+        if pos == "off":
+            self.add_class("-hide-sidebar")
 
     def _build_completion_state(self, text: str) -> CompletionState:
         registry = _session_command_registry(self.session)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2407,6 +2407,7 @@ class TauTuiApp(App[None]):
             keybindings=self.tui_settings.keybindings,
             theme=theme,
             auto_copy_selection=self.tui_settings.auto_copy_selection,
+            sidebar_position=self.tui_settings.sidebar_position,
         )
         save_tui_settings(self.tui_settings)
         self.refresh_css(animate=False)

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -242,12 +242,14 @@ class TuiSettings:
     keybindings: TuiKeybindings = field(default_factory=TuiKeybindings)
     theme: TuiThemeName = "tau-dark"
     auto_copy_selection: bool = False
+    sidebar_position: Literal["left", "right", "off"] = "left"
 
     def to_json(self) -> dict[str, Any]:
         """Serialize these settings to JSON-compatible data."""
         return {
             "auto_copy_selection": self.auto_copy_selection,
             "keybindings": self.keybindings.to_json(),
+            "sidebar_position": self.sidebar_position,
             "theme": self.theme,
         }
 
@@ -283,7 +285,7 @@ def save_tui_settings(settings: TuiSettings, paths: TauPaths | None = None) -> P
 
 def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
     """Parse TUI settings from JSON-compatible data."""
-    allowed_fields = {"auto_copy_selection", "keybindings", "theme"}
+    allowed_fields = {"auto_copy_selection", "keybindings", "sidebar_position", "theme"}
     unknown_fields = set(data) - allowed_fields
     if unknown_fields:
         raise TuiConfigError(f"Unknown TUI settings field: {sorted(unknown_fields)[0]}")
@@ -291,6 +293,9 @@ def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
     keybindings_data = data.get("keybindings", {})
     if not isinstance(keybindings_data, dict):
         raise TuiConfigError("TUI keybindings must be a JSON object")
+    raw_sidebar = data.get("sidebar_position", "left")
+    if not isinstance(raw_sidebar, str) or raw_sidebar not in {"left", "right", "off"}:
+        raise TuiConfigError("sidebar_position must be 'left', 'right', or 'off'")
     return TuiSettings(
         keybindings=_keybindings_from_json(keybindings_data),
         theme=_theme_name(data.get("theme", "tau-dark")),
@@ -298,6 +303,7 @@ def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
             data.get("auto_copy_selection", False),
             "auto_copy_selection",
         ),
+        sidebar_position=cast(Literal["left", "right", "off"], raw_sidebar),
     )
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1878,6 +1878,50 @@ async def test_tui_sidebar_visibility_updates_on_resize() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_sidebar_shows_on_right_when_configured() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="right"))
+
+    async with app.run_test(size=(120, 30)):
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is True
+        assert app.has_class("-sidebar-right")
+        assert not app.has_class("-sidebar-off")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_is_hidden_when_off() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="off"))
+
+    async with app.run_test(size=(120, 30)):
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is False
+        assert app.has_class("-hide-sidebar")
+        assert not app.has_class("-sidebar-right")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_right_still_hides_on_small_windows() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="right"))
+
+    async with app.run_test(size=(80, 30)):
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is False
+        assert app.has_class("-hide-sidebar")
+        assert app.has_class("-sidebar-right")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_off_ignores_responsive_toggle() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="off"))
+
+    async with app.run_test(size=(120, 30)):
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is False
+        assert app.has_class("-hide-sidebar")
+        assert not app.has_class("-sidebar-right")
+
+
+@pytest.mark.anyio
 async def test_tui_transcript_reflows_when_terminal_resizes() -> None:
     app = TauTuiApp(
         FakeSession(

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -164,3 +164,22 @@ def test_get_tui_theme_returns_builtin_theme() -> None:
     assert get_tui_theme("high-contrast").prompt_border == "#00ff66"
     assert get_tui_theme("tau-light").prompt_border == "#2563eb"
     assert get_tui_theme("tau-dark").screen_background == "#000000"
+
+
+def test_tui_sidebar_position_defaults_to_left() -> None:
+    assert TuiSettings().sidebar_position == "left"
+
+
+def test_tui_sidebar_position_roundtrips() -> None:
+    for value in ("left", "right", "off"):
+        settings = tui_settings_from_json({"sidebar_position": value})
+        assert settings.sidebar_position == value
+        assert settings.to_json()["sidebar_position"] == value
+
+
+def test_tui_sidebar_position_rejects_invalid() -> None:
+    with pytest.raises(TuiConfigError, match="sidebar_position"):
+        tui_settings_from_json({"sidebar_position": "top"})
+
+    with pytest.raises(TuiConfigError, match="sidebar_position"):
+        tui_settings_from_json({"sidebar_position": 123})

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -86,6 +86,10 @@ On wide-enough terminals Tau shows a sidebar with the active provider/model,
 thinking mode, loaded tools, skills, prompt templates, and context files such as
 `AGENTS.md`. It hides automatically when the terminal is small.
 
+The sidebar can be moved to the **right** or turned **off** entirely by setting
+`sidebar_position` in `~/.tau/tui.json` — see
+[Configuration]({{< relref "../reference/configuration.md#tui-settings" >}}).
+
 ## Next
 
 - [Sessions]({{< relref "./sessions.md" >}}) — resume, branch, rename, export.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -195,8 +195,13 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
 
 Built-in themes: `tau-dark` (default), `tau-light`, `high-contrast`. Set one with
 `/theme`. Keys use Textual syntax; omitted keys keep their defaults. Tau rejects
-unknown themes/keybinding names, empty keys, and duplicate assignments. Full list
-in [Keyboard shortcuts]({{< relref "./keybindings.md" >}}).
+unknown themes/keybinding names, empty keys, and duplicate assignments.
+
+- `sidebar_position`: `"left"` (default), `"right"`, or `"off"`. Controls
+  placement of the session metadata sidebar. `"off"` hides the sidebar entirely;
+  the compact session info row below the prompt still works.
+
+Full list in [Keyboard shortcuts]({{< relref "./keybindings.md" >}}).
 
 ## Sessions
 


### PR DESCRIPTION
## Summary

Currently, tau opens the sidebar on the left. I feel like this is a bit disorienting because most TUI tools tend to have the sidebar on the right. Besides, most of the information on the sidebar is kinda static (such as context files and skills used), so I really feel like it shouldn't take the center stage.

I'm not suggesting to change the default, I'm suggesting a small setting that allows the user to set the sidebar to the right, or even turn it off completely.

Tau doesn't seem to have a settings menu right now, so the setting is done by simply adding

```
{
  "sidebar_position": "right"
}
```

 to ~/.tau/tui.json

The possible options are: "off", "right" and "left". If this setting isn't added, or the file doesn't exist in the user's directory, the sidebar stays on the left.

The `"off"` option reuses the existing `-hide-sidebar` CSS class that already
hides the sidebar on narrow terminals, keeping the diff small.