### PR TITLE
fix: stop scanning .agents root directories for skills, ignore bare .md files in .agents/skills/

### DIFF
--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -60,17 +60,21 @@ class TauResourcePaths:
 
     @property
     def skills_dirs(self) -> tuple[Path, ...]:
-        """Return skill directories in increasing precedence order."""
+        """Return skill directories in increasing precedence order.
+
+        Only the ``skills`` subdirectory of an ``.agents`` root is scanned,
+        never the root ``.agents`` directory itself (which may contain
+        ``README.md``, ``AGENTS.md``, etc.).
+        """
         paths = self._paths()
         dirs = [self.skills_dir]
         if self.agents_root is not None:
-            dirs.extend([self.agents_root / "skills", self.agents_root])
+            dirs.append(self.agents_root / "skills")
         if self.cwd is not None:
             dirs.extend(
                 [
                     paths.project_skills_dir(self.cwd),
                     paths.project_agents_skills_dir(self.cwd),
-                    paths.project_agents_dir(self.cwd),
                 ]
             )
         return tuple(_dedupe_paths(dirs))

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -163,6 +163,12 @@ def _load_skills_from_dir_with_diagnostics(
     if not skills_dir.exists() or not skills_dir.is_dir():
         return [], []
 
+    # In .agents/skills/ directories, bare .md files are ignored — only
+    # SKILL.md files inside subdirectories are valid (Agent Skills standard).
+    # In .tau/skills/ directories, any .md file is treated as a skill
+    # (preserving the current behavior).
+    agents_mode = skills_dir.parent.name == ".agents"
+
     skills: list[Skill] = []
     diagnostics: list[ResourceDiagnostic] = []
     seen: set[str] = set()
@@ -174,7 +180,7 @@ def _load_skills_from_dir_with_diagnostics(
             name = path.name
             if not skill_path.exists():
                 continue
-        elif path.is_file() and path.suffix.lower() == ".md":
+        elif path.is_file() and path.suffix.lower() == ".md" and not agents_mode:
             if path.name.upper() == "AGENTS.MD":
                 continue
             skill_path = path

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -27,10 +27,8 @@ def test_resource_paths_include_agents_and_project_directories(tmp_path: Path) -
     assert paths.skills_dirs == (
         tau_home / "skills",
         agents_home / "skills",
-        agents_home,
         cwd / ".tau" / "skills",
         cwd / ".agents" / "skills",
-        cwd / ".agents",
     )
     assert paths.prompts_dirs == (
         tau_home / "prompts",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -36,15 +36,16 @@ def test_load_skills_from_directory_and_file(tmp_path: Path) -> None:
 
 
 def test_load_skills_includes_user_and_project_agents_directories(tmp_path: Path) -> None:
+    """Skills in .agents/skills/ must be subdirectories containing SKILL.md."""
     tau_home = tmp_path / "home" / ".tau"
     agents_home = tmp_path / "home" / ".agents"
     cwd = tmp_path / "project"
-    (agents_home / "skills").mkdir(parents=True)
-    (agents_home / "skills" / "user-skill.md").write_text(
+    (agents_home / "skills" / "user-skill").mkdir(parents=True)
+    (agents_home / "skills" / "user-skill" / "SKILL.md").write_text(
         "# User Skill\nFrom user agents.", encoding="utf-8"
     )
-    (cwd / ".agents" / "skills").mkdir(parents=True)
-    (cwd / ".agents" / "skills" / "project-skill.md").write_text(
+    (cwd / ".agents" / "skills" / "project-skill").mkdir(parents=True)
+    (cwd / ".agents" / "skills" / "project-skill" / "SKILL.md").write_text(
         "# Project Skill\nFrom project agents.", encoding="utf-8"
     )
 
@@ -54,18 +55,21 @@ def test_load_skills_includes_user_and_project_agents_directories(tmp_path: Path
 
 
 def test_project_agents_skill_overrides_user_agents_skill(tmp_path: Path) -> None:
+    """Project .agents/skills/ skills take precedence over user-level ones."""
     tau_home = tmp_path / "home" / ".tau"
     agents_home = tmp_path / "home" / ".agents"
     cwd = tmp_path / "project"
-    (agents_home / "skills").mkdir(parents=True)
-    (agents_home / "skills" / "review.md").write_text("# User Review", encoding="utf-8")
-    (cwd / ".agents" / "skills").mkdir(parents=True)
-    (cwd / ".agents" / "skills" / "review.md").write_text("# Project Review", encoding="utf-8")
+    (agents_home / "skills" / "review").mkdir(parents=True)
+    (agents_home / "skills" / "review" / "SKILL.md").write_text("# User Review", encoding="utf-8")
+    (cwd / ".agents" / "skills" / "review").mkdir(parents=True)
+    (cwd / ".agents" / "skills" / "review" / "SKILL.md").write_text(
+        "# Project Review", encoding="utf-8"
+    )
 
     skills = load_skills(TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd))
 
     assert len(skills) == 1
-    assert skills[0].path == cwd / ".agents" / "skills" / "review.md"
+    assert skills[0].path == cwd / ".agents" / "skills" / "review" / "SKILL.md"
     assert skills[0].description == "Project Review"
 
 
@@ -108,15 +112,55 @@ def test_load_skills_with_diagnostics_ignores_duplicate_within_directory(
     assert "Duplicate skill name" in diagnostics[0].message
 
 
-def test_agents_md_is_not_loaded_as_a_skill(tmp_path: Path) -> None:
+def test_agents_root_is_not_a_skills_directory(tmp_path: Path) -> None:
+    """The .agents root directory itself must not be scanned for skills.
+
+    Files like ``README.md`` or ``AGENTS.md`` in the root should be ignored.
+    Only ``.agents/skills/`` is a valid skill location.
+    """
     agents_home = tmp_path / ".agents"
     agents_home.mkdir()
     (agents_home / "AGENTS.md").write_text("# Instructions", encoding="utf-8")
+    (agents_home / "README.md").write_text("# Readme", encoding="utf-8")
     (agents_home / "review.md").write_text("# Review", encoding="utf-8")
 
     skills = load_skills(TauResourcePaths(root=tmp_path / ".tau", agents_root=agents_home))
 
-    assert [skill.name for skill in skills] == ["review"]
+    assert skills == []
+
+
+def test_agents_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
+    """Bare .md files in .agents/skills/ are not treated as skills.
+
+    Only subdirectories containing ``SKILL.md`` are valid. Files like
+    ``reference.md`` alongside a skill directory should be ignored.
+    """
+    agents_home = tmp_path / ".agents"
+    skills_dir = agents_home / "skills"
+    (skills_dir / "my-skill").mkdir(parents=True)
+    (skills_dir / "my-skill" / "SKILL.md").write_text("# Valid Skill", encoding="utf-8")
+    (skills_dir / "reference.md").write_text("# Reference doc", encoding="utf-8")
+
+    paths = TauResourcePaths(root=tmp_path / ".tau", agents_root=agents_home)
+    skills = load_skills(paths)
+
+    assert [s.name for s in skills] == ["my-skill"]
+
+
+def test_tau_skills_dir_loads_bare_md_files(tmp_path: Path) -> None:
+    """Bare .md files in .tau/skills/ are treated as individual skills.
+
+    This is pi mode: any ``.md`` file at the root is a skill.
+    """
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "my-skill").mkdir(parents=True)
+    (skills_dir / "my-skill" / "SKILL.md").write_text("# Subdir Skill", encoding="utf-8")
+    (skills_dir / "reference.md").write_text("# Reference doc", encoding="utf-8")
+
+    paths = TauResourcePaths(root=tmp_path, agents_root=None)
+    skills = load_skills(paths)
+
+    assert {s.name for s in skills} == {"my-skill", "reference"}
 
 
 def test_load_skills_rejects_duplicate_names(tmp_path: Path) -> None:


### PR DESCRIPTION
Currently Tau scans any `.md` file it finds in its configured skill directories as a skill — including the bare `.agents/` root directory itself. If the user has `README.md` in `~/.agents/`, it shows a README skill and allows running `/skill:README`.

That's not a big issue for Tau's own skills folder, but it's a problem for the system-wide `~/.agents` or project-specific `.agents` folders.

Per the [Agent Skills spec](https://agentskills.io/specification#directory-structure):

> A skill is a directory containing, at minimum, a SKILL.md file

This fix does two things:
1. Stops scanning the bare `.agents/` root directory as a skill location — only `.agents/skills/` is scanned.
2. In `.agents/skills/` directories, ignores bare `.md` files that are not `SKILL.md` (matching Pi's "agents" mode).

Now, Pi implements the same distinction (pi mode for its own skills folder, agents mode for `.agents/skills/`), but it also does recursive subdirectory search (while Tau only checks one level down). Useful if the user has nested skill folders (say they check out someone's skill repo into theirs), but I feel that's out of scope for this fix. Let me know, and I can prepare another PR.

Testing: I ran Tau with a README.md and an arbitrary .md file in my .agents/ folder — they no longer show up as skills. 686 tests pass, ruff and mypy are clean.
