### PR TITLE
Fix slash prompt optimistic TUI rendering

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2296,8 +2296,9 @@ class TauTuiApp(App[None]):
         """Add a prompt to the transcript and start the agent worker."""
         self._prompt_run_id += 1
         run_id = self._prompt_run_id
-        self._optimistic_user_messages.append((run_id, text))
-        await self._append_optimistic_user_message(text)
+        if _should_optimistically_render_prompt(text):
+            self._optimistic_user_messages.append((run_id, text))
+            await self._append_optimistic_user_message(text)
         self._prompt_worker = self.run_worker(self._run_prompt(text, run_id), exclusive=True)
 
     async def _append_optimistic_user_message(self, text: str) -> None:
@@ -2430,7 +2431,8 @@ class TauTuiApp(App[None]):
                     self._sync_text_selection_state()
                     self._refresh_chrome()
                     continue
-                self.adapter.apply(event)
+                if not (_is_user_message_end_event(event) and self.screen_stack):
+                    self.adapter.apply(event)
                 self._sync_text_selection_state()
                 if isinstance(event, ErrorEvent) and not event.recoverable:
                     _attach_diagnostic_log_path_to_error(self.state, self.session)
@@ -3427,6 +3429,17 @@ def _render_activity_indicator(theme: TuiTheme, *, frame: int, running: bool) ->
 def _is_terminal_command_prompt(text: str) -> bool:
     """Return whether the prompt is currently in terminal-command mode."""
     return _terminal_command_prefix_span(text) is not None
+
+
+def _should_optimistically_render_prompt(text: str) -> bool:
+    """Return whether submitted text can be safely shown before session expansion."""
+    stripped = text.strip()
+    return bool(stripped) and not stripped.startswith("/")
+
+
+def _is_user_message_end_event(event: AgentEvent) -> bool:
+    """Return whether an agent event closes a user message."""
+    return isinstance(event, MessageEndEvent) and isinstance(event.message, UserMessage)
 
 
 def _terminal_command_prefix_span(text: str) -> tuple[int, int] | None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1584,6 +1584,32 @@ async def test_tui_submit_prompt_optimistically_appends_user_message_without_ful
 
 
 @pytest.mark.anyio
+async def test_tui_submit_prompt_does_not_optimistically_append_slash_commands() -> None:
+    session = FakeSession(
+        events=[
+            AgentStartEvent(),
+            MessageEndEvent(message=UserMessage(content="Expanded prompt")),
+            AgentEndEvent(),
+        ],
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await app._submit_prompt("/review src/app.py")
+        await pilot.pause()
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        user_messages = [item.text for item in app.state.items if item.role == "user"]
+        transcript_lines = [line.text for line in transcript.lines]
+
+    assert session.prompt_texts == ["/review src/app.py"]
+    assert user_messages == ["Expanded prompt"]
+    assert "/review src/app.py" not in transcript_lines
+    assert transcript_lines.count("Expanded prompt") == 1
+
+
+@pytest.mark.anyio
 async def test_tui_app_mounts_sidebar_and_transcript() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
## Summary

- Fixes #278.
- Keeps optimistic TUI rendering for ordinary prompts.
- Skips optimistic rendering for slash-command prompts so custom prompt expansions render only the confirmed expanded user message.
- Avoids double-applying confirmed user message events to mounted transcripts.

## Testing

- `uv run pytest tests/test_tui_app.py -k 'optimistic or slash_commands'`
- `uv run pytest tests/test_tui_app.py`
- `uv run pytest`
- `uv run ruff check`
- `uv run mypy src`

Note: `uv run mypy src tests` still reports pre-existing typing issues in tests unrelated to this change.
