### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -1,5 +1,26 @@
 [
   {
+    "version": "0.1.3",
+    "date": "2026-07-07",
+    "sections": {
+      "New": [
+        "Add a config-driven Pi API provider catalog with user overlay support."
+      ],
+      "Changed": [
+        "Optimistically render ordinary TUI prompt submissions to reduce perceived latency.",
+        "Improve scoped provider/model switching performance and responsiveness.",
+        "Migrate the documentation site to Hugo."
+      ],
+      "Fixed": [
+        "Prevent custom prompt slash commands from appearing twice in the TUI transcript.",
+        "Persist interrupted tool repairs correctly when resuming sessions.",
+        "Show bad --model values as clean errors instead of tracebacks.",
+        "Fix provider/model selection and resume mismatch edge cases.",
+        "Hide code block scrollbars while assistant messages are streaming."
+      ]
+    }
+  },
+  {
     "version": "0.1.2",
     "date": "2026-07-03",
     "sections": {

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump `tau-ai` from `0.1.2` to `0.1.3`.
- Add 0.1.3 release notes covering the recent provider catalog, TUI responsiveness, docs, and bug-fix work.
- Refresh `uv.lock` with the new package version.

## Testing

- `uv run pytest`
- `uv run ruff check`
- `uv run mypy src`
