### PR TITLE
fix(google): strip unsupported JSON Schema keywords from tool params

### DIFF
--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -345,8 +345,24 @@ def _tool_to_google(tool: AgentTool) -> dict[str, JSONValue]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "parameters": dict(tool.input_schema),
+        "parameters": _sanitize_google_schema(dict(tool.input_schema)),
     }
+
+
+_UNSUPPORTED_GOOGLE_SCHEMA_KEYS = frozenset({"additionalProperties", "$schema"})
+
+
+def _sanitize_google_schema(value: JSONValue) -> JSONValue:
+    """Strip JSON Schema keywords Gemini's OpenAPI-subset parser rejects."""
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_google_schema(subvalue)
+            for key, subvalue in value.items()
+            if key not in _UNSUPPORTED_GOOGLE_SCHEMA_KEYS
+        }
+    if isinstance(value, list):
+        return [_sanitize_google_schema(item) for item in value]
+    return value
 
 
 def _parse_sse_line(line: str) -> str | None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -328,6 +328,66 @@ async def test_google_provider_sends_system_instruction_at_top_level() -> None:
 
 
 @pytest.mark.anyio
+async def test_google_provider_strips_unsupported_schema_keywords_from_tools() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},'
+                '"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async def executor(_arguments: dict[str, JSONValue]) -> AgentToolResult:
+        return AgentToolResult(tool_call_id="", ok=True, content="")
+
+    tool = AgentTool(
+        name="bash",
+        description="Run a shell command.",
+        input_schema={
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "command": {"type": "string"},
+                "env": {
+                    "type": "array",
+                    "items": {"type": "string", "additionalProperties": False},
+                },
+            },
+        },
+        executor=executor,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="List files")],
+                tools=[tool],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    parameters = payload["tools"][0]["functionDeclarations"][0]["parameters"]
+    assert "additionalProperties" not in parameters
+    assert "additionalProperties" not in parameters["properties"]["env"]["items"]
+    assert parameters["properties"]["command"] == {"type": "string"}
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_streams_reasoning_content() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary
- Gemini's function-calling API only supports an OpenAPI-3.0 subset of JSON Schema and rejects requests whose tool `parameters` include `additionalProperties` (or `$schema`) with a 400 error. Since tau always sends its built-in tool schemas, every Gemini request was failing.
- Added `_sanitize_google_schema` in `src/tau_ai/google.py`, which recursively strips these unsupported keys from tool `parameters` before building the Gemini request payload.

Fixes #287

## Test plan
- [x] Added `test_google_provider_strips_unsupported_schema_keywords_from_tools` in `tests/test_tau_ai.py`, asserting the sanitizer removes `additionalProperties` at nested depths while leaving supported schema fields intact.
- [x] `uv run pytest tests/test_tau_ai.py -q` — 40 passed.
- [x] `uv run ruff check src/tau_ai/google.py tests/test_tau_ai.py` — all checks passed.
- [x] `uv run mypy src/tau_ai/google.py` — no issues found.
- [x] Manually verified against the live Gemini API (`gemini-flash-latest`) with `GEMINI_API_KEY` set — request that previously failed with the `additionalProperties` 400 error now succeeds end-to-end.