### PR TITLE
fix(google): round-trip thoughtSignature on Gemini tool calls

### DIFF
--- a/src/tau_agent/tools.py
+++ b/src/tau_agent/tools.py
@@ -39,6 +39,9 @@ class ToolCall(BaseModel):
     id: str
     name: str
     arguments: dict[str, JSONValue] = Field(default_factory=dict)
+    # Opaque signature some providers (e.g. Gemini) require echoed back next
+    # turn; ignored by providers that don't use it.
+    thought_signature: str | None = None
 
 
 class AgentToolResult(BaseModel):

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -350,8 +350,24 @@ def _tool_to_google(tool: AgentTool) -> dict[str, JSONValue]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "parameters": dict(tool.input_schema),
+        "parameters": _sanitize_google_schema(dict(tool.input_schema)),
     }
+
+
+_UNSUPPORTED_GOOGLE_SCHEMA_KEYS = frozenset({"additionalProperties", "$schema"})
+
+
+def _sanitize_google_schema(value: JSONValue) -> JSONValue:
+    """Strip JSON Schema keywords Gemini's OpenAPI-subset parser rejects."""
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_google_schema(subvalue)
+            for key, subvalue in value.items()
+            if key not in _UNSUPPORTED_GOOGLE_SCHEMA_KEYS
+        }
+    if isinstance(value, list):
+        return [_sanitize_google_schema(item) for item in value]
+    return value
 
 
 def _parse_sse_line(line: str) -> str | None:

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -201,10 +201,14 @@ class _GoogleStreamParser:
             if isinstance(function_call, Mapping):
                 self.emitted_content = True
                 default_id = f"tool-call-{len(self._tool_calls)}"
+                thought_signature = part.get("thoughtSignature")
                 tool_call = ToolCall(
                     id=_string_or_default(function_call.get("id"), default_id),
                     name=_string_or_default(function_call.get("name"), ""),
                     arguments=_object_or_empty(function_call.get("args")),
+                    thought_signature=thought_signature
+                    if isinstance(thought_signature, str)
+                    else None,
                 )
                 self._tool_calls.append(tool_call)
                 events.append(ProviderToolCallEvent(tool_call=tool_call))
@@ -322,15 +326,16 @@ def _message_to_google(message: AgentMessage) -> dict[str, JSONValue]:
         if message.content:
             parts.append({"text": message.content})
         for tool_call in message.tool_calls:
-            parts.append(
-                {
-                    "functionCall": {
-                        "id": tool_call.id,
-                        "name": tool_call.name,
-                        "args": dict(tool_call.arguments),
-                    }
+            part: dict[str, JSONValue] = {
+                "functionCall": {
+                    "id": tool_call.id,
+                    "name": tool_call.name,
+                    "args": dict(tool_call.arguments),
                 }
-            )
+            }
+            if tool_call.thought_signature is not None:
+                part["thoughtSignature"] = tool_call.thought_signature
+            parts.append(part)
         return {"role": "model", "parts": parts or [{"text": ""}]}
     response: dict[str, JSONValue] = {
         "name": message.name,

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -383,6 +383,66 @@ async def test_google_provider_round_trips_thought_signature() -> None:
 
 
 @pytest.mark.anyio
+async def test_google_provider_strips_unsupported_schema_keywords_from_tools() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},'
+                '"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async def executor(_arguments: dict[str, JSONValue]) -> AgentToolResult:
+        return AgentToolResult(tool_call_id="", ok=True, content="")
+
+    tool = AgentTool(
+        name="bash",
+        description="Run a shell command.",
+        input_schema={
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "command": {"type": "string"},
+                "env": {
+                    "type": "array",
+                    "items": {"type": "string", "additionalProperties": False},
+                },
+            },
+        },
+        executor=executor,
+    )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="List files")],
+                tools=[tool],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    parameters = payload["tools"][0]["functionDeclarations"][0]["parameters"]
+    assert "additionalProperties" not in parameters
+    assert "additionalProperties" not in parameters["properties"]["env"]["items"]
+    assert parameters["properties"]["command"] == {"type": "string"}
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_streams_reasoning_content() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -328,6 +328,61 @@ async def test_google_provider_sends_system_instruction_at_top_level() -> None:
 
 
 @pytest.mark.anyio
+async def test_google_provider_round_trips_thought_signature() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"functionCall":'
+                '{"id":"call-1","name":"bash","args":{"command":"ls"}},'
+                '"thoughtSignature":"sig-123"}]},"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="List files")],
+                tools=[],
+            )
+        )
+
+        assistant_message = events[-1].message
+        assert assistant_message.tool_calls[0].thought_signature == "sig-123"
+
+        await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[
+                    UserMessage(content="List files"),
+                    assistant_message,
+                    ToolResultMessage(tool_call_id="call-1", name="bash", content="a.py"),
+                ],
+                tools=[],
+            )
+        )
+
+    second_payload = loads(requests[1].content)
+    tool_call_part = second_payload["contents"][1]["parts"][0]
+    assert tool_call_part["thoughtSignature"] == "sig-123"
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_streams_reasoning_content() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary
- Gemini 3 models attach a `thoughtSignature` to each `functionCall` part in the streamed response and require it echoed back on the next turn; without it, every subsequent request fails with `Function call is missing a thought_signature in functionCall parts.`
- tau captured tool calls but discarded this signature, so any multi-turn conversation using a tool broke right after the first tool call.
- Added an optional `thought_signature` field to the shared `ToolCall` model (harmless no-op for every other provider — only `.id`/`.name`/`.arguments` are read elsewhere).
- `_GoogleStreamParser.feed` now captures `thoughtSignature` off streamed `functionCall` parts.
- `_message_to_google` now replays it back as a sibling `thoughtSignature` key on the next request.

This complements #288 (Gemini `additionalProperties` schema fix reported in #287) — that issue's reporter hit this exact error as the *next* blocker after patching the schema issue locally.

## Test plan
- [x] Added `test_google_provider_round_trips_thought_signature` in `tests/test_tau_ai.py`: feeds a mocked streamed `functionCall` + `thoughtSignature`, asserts it lands on the resulting `ToolCall`, then asserts the follow-up request echoes it back as a sibling key on the `functionCall` part.
- [x] `uv run pytest tests/test_tau_ai.py -q` — 40 passed.
- [x] `uv run ruff check` / `uv run mypy` on changed files — clean.
- [x] Manually probed the raw Gemini `streamGenerateContent` response to confirm `thoughtSignature` is a sibling key of `functionCall` (not nested inside it), matching the request-side placement implemented here.
- [x] Verified live end-to-end against the real Gemini API with this fix applied together with #288's schema fix: `tau -p "List the files in the current directory using the bash tool."` against `gemini-flash-latest` completes the full tool-call round trip successfully.