### PR TITLE
fix(cli): force UTF-8 stdout/stderr to fix Windows crash on non-ASCII output

### DIFF
--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -61,14 +61,23 @@ from tau_coding.update_check import (
 )
 
 
+def _is_utf8_encoding(encoding: str | None) -> bool:
+    """Return whether a stream encoding name represents UTF-8."""
+    if encoding is None:
+        return False
+    return encoding.lower().replace("-", "").replace("_", "") == "utf8"
+
+
 def _force_utf8_streams() -> None:
-    """Reconfigure stdout/stderr to UTF-8.
+    """Reconfigure stdout/stderr to UTF-8 when they are not already UTF-8.
 
     Windows consoles default these streams to the system codepage (e.g.
     cp1252), which raises UnicodeEncodeError on model output containing
     characters outside that codepage.
     """
     for stream in (sys.stdout, sys.stderr):
+        if _is_utf8_encoding(getattr(stream, "encoding", None)):
+            continue
         with contextlib.suppress(AttributeError, ValueError):
             stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
 

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import sys
 from os import environ
 from pathlib import Path
 from typing import Annotated
@@ -57,6 +59,21 @@ from tau_coding.update_check import (
     startup_release_notes_notice,
     startup_update_notice,
 )
+
+
+def _force_utf8_streams() -> None:
+    """Reconfigure stdout/stderr to UTF-8.
+
+    Windows consoles default these streams to the system codepage (e.g.
+    cp1252), which raises UnicodeEncodeError on model output containing
+    characters outside that codepage.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        with contextlib.suppress(AttributeError, ValueError):
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+
+_force_utf8_streams()
 
 app = typer.Typer(
     name="tau",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,15 +58,19 @@ def _panel_text(value: str) -> str:
     return _collapse_ws(no_ansi.translate(borders))
 
 
-def test_force_utf8_streams_reconfigures_encodable_streams() -> None:
+def test_force_utf8_streams_reconfigures_non_utf8_streams() -> None:
     calls: list[tuple[str, str]] = []
 
     class FakeStream:
+        encoding = "cp1252"
+
         def reconfigure(self, *, encoding: str, errors: str) -> None:
             calls.append((encoding, errors))
 
     class UnreconfigurableStream:
         """Mimics streams (e.g. some test/CI capture streams) without reconfigure()."""
+
+        encoding = "cp437"
 
     fake_stdout = FakeStream()
     fake_stderr = UnreconfigurableStream()
@@ -77,6 +81,26 @@ def test_force_utf8_streams_reconfigures_encodable_streams() -> None:
         cli._force_utf8_streams()
 
     assert calls == [("utf-8", "replace")]
+
+
+def test_force_utf8_streams_leaves_utf8_streams_alone() -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeStream:
+        encoding = "UTF_8"
+
+        def reconfigure(self, *, encoding: str, errors: str) -> None:
+            calls.append((encoding, errors))
+
+    fake_stdout = FakeStream()
+    fake_stderr = FakeStream()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cli.sys, "stdout", fake_stdout)
+        mp.setattr(cli.sys, "stderr", fake_stderr)
+        cli._force_utf8_streams()
+
+    assert calls == []
 
 
 def test_version_command() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,27 @@ def _panel_text(value: str) -> str:
     return _collapse_ws(no_ansi.translate(borders))
 
 
+def test_force_utf8_streams_reconfigures_encodable_streams() -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeStream:
+        def reconfigure(self, *, encoding: str, errors: str) -> None:
+            calls.append((encoding, errors))
+
+    class UnreconfigurableStream:
+        """Mimics streams (e.g. some test/CI capture streams) without reconfigure()."""
+
+    fake_stdout = FakeStream()
+    fake_stderr = UnreconfigurableStream()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cli.sys, "stdout", fake_stdout)
+        mp.setattr(cli.sys, "stderr", fake_stderr)
+        cli._force_utf8_streams()
+
+    assert calls == [("utf-8", "replace")]
+
+
 def test_version_command() -> None:
     result = CliRunner().invoke(app, ["--version"])
 


### PR DESCRIPTION
## Summary
- On Windows, `sys.stdout`/`sys.stderr` inherit the console's codepage (commonly `cp1252`) unless explicitly reconfigured. Streamed model output containing any character outside that codepage (arrows, box-drawing, emoji, etc.) raised `UnicodeEncodeError`.
- This surfaced as a confusing double failure: a wrapped `typer.BadParameter` panel from the caught `UnicodeEncodeError`, plus an unrelated-looking `RuntimeError: athrow(): asynchronous generator is already running` from the abandoned provider stream's GC cleanup.
- Added `_force_utf8_streams()` in `src/tau_coding/cli.py`, called at import time (as early as possible, before any output), which reconfigures both streams to UTF-8 with `errors="replace"`, tolerating streams that don't support `.reconfigure()` (e.g. some test/CI capture streams).

Fixes #285

## Test plan
- [x] Added `test_force_utf8_streams_reconfigures_encodable_streams` in `tests/test_cli.py`, verifying the function calls `.reconfigure(encoding="utf-8", errors="replace")` on streams that support it and silently tolerates ones that don't.
- [x] `uv run pytest tests/test_cli.py -q` — 37 passed (2 pre-existing unrelated failures on this Windows machine, reproduced independently of this change on a clean checkout — provider-config lookup issues, not related to stdout/stderr).
- [x] `uv run ruff check` / `uv run mypy` on changed files — clean.
- [x] Reproduced the crash live on Windows (`chcp` 437/1252 console) with a prompt designed to elicit `→`/emoji output — confirmed `UnicodeEncodeError` before the fix, clean output after.