### PR TITLE
fix(skills): unify skill discovery on the Agent Skills spec

### DIFF
--- a/dev-notes/adr/0003-unify-skill-discovery-on-agent-skills-spec.md
+++ b/dev-notes/adr/0003-unify-skill-discovery-on-agent-skills-spec.md
@@ -1,0 +1,120 @@
+---
+title: "ADR 0003 — Unify skill discovery on the Agent Skills spec"
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+Tau discovers Markdown skills from four locations, in increasing precedence:
+
+```text
+~/.tau/skills/
+~/.agents/skills/
+<cwd>/.tau/skills/
+<cwd>/.agents/skills/
+```
+
+Historically Tau accepted **either** layout in any of these directories:
+
+- a `foo.md` file at the root (skill name = `foo`), or
+- a `foo/SKILL.md` subdirectory (skill name = `foo`).
+
+PR [#280](https://github.com/huggingface/tau/pull/280) tightened discovery for
+the `.agents/` locations to match the [Agent Skills
+spec](https://agentskills.io/specification#directory-structure), which requires
+the `subdir/SKILL.md` form. It intentionally left `.tau/skills/` on the
+permissive "any `.md`" rule.
+
+That left Tau with two different rules for two visually-identical locations:
+
+| Location | `foo.md` (bare file) | `foo/SKILL.md` (directory) |
+|---|---|---|
+| `.tau/skills/` | ✅ loaded | ✅ loaded |
+| `.agents/skills/` | ❌ ignored | ✅ loaded |
+
+## Decision
+
+Apply the Agent Skills spec uniformly to **every** skills location Tau
+scans. A skill is always `<skills-dir>/<name>/SKILL.md`. Bare `.md` files at
+the root of a skills directory are not loaded as skills; instead, Tau emits an
+informational `ResourceDiagnostic` telling the user how to migrate:
+
+```text
+mv foo.md foo/SKILL.md
+```
+
+The `agents_mode` branch introduced by #280 is removed from
+`_load_skills_from_dir_with_diagnostics`.
+
+## Why diverge from Pi here
+
+Pi maintains an explicit `SkillDiscoveryMode = "pi" | "agents"` split in
+`packages/coding-agent/src/core/package-manager.ts`:
+
+- `.pi/skills/` and `~/.pi/agent/skills/` use "pi mode" (bare `.md` allowed).
+- `.agents/skills/` uses "agents mode" (strict `SKILL.md` only).
+
+Reading Pi's own changelog makes clear that this split is **not a philosophical
+choice** — it is a **backward-compatibility carveout**:
+
+> **Pi skills now use `SKILL.md` convention**: Pi skills must now be named
+> `SKILL.md` inside a directory, matching Codex CLI format. Previously any
+> `*.md` file was treated as a skill. Migrate by renaming
+> `~/.pi/agent/skills/foo.md` to `~/.pi/agent/skills/foo/SKILL.md`.
+
+And the fix that mirrors #280:
+
+> Fixed skill discovery to stop recursing once a directory contains
+> `SKILL.md`, and to ignore root `*.md` files in `.agents/skills` while
+> keeping root markdown skill files supported in `~/.pi/agent/skills`,
+> `.pi/skills`, and package `skills/` directories (pi-mono#2603)
+
+Pi's direction of travel is clearly "`SKILL.md` everywhere." Pi cannot finish
+that migration cleanly because it has a large installed base of bare-`.md`
+skills that would break.
+
+Tau does not share that constraint. We are pre-1.0 (`0.1.3`), have no
+meaningful backward-compat contract for `.tau/skills/` layouts, and can ship
+the endgame directly instead of carrying a legacy path forward.
+
+## Consequences
+
+- One rule for every skills directory. The `agents_mode` heuristic
+  (`skills_dir.parent.name == ".agents"`) disappears.
+- User skills authored as bare `.md` files under `.tau/skills/` are no longer
+  loaded and must be migrated. Tau surfaces this via a diagnostic at load time
+  so the failure mode is visible rather than silent.
+- Skill loader behavior no longer depends on parent directory names, so it
+  stays correct when callers pass unusual `TauResourcePaths.agents_root`
+  values (for example a custom skills root during testing or embedding).
+- Documentation (`website/content/guides/skills-and-prompts.md`) now shows the
+  spec layout as the only supported form.
+
+## Migration
+
+For each bare `.md` skill under any Tau-scanned skills directory:
+
+```bash
+cd ~/.tau/skills          # or .tau/skills, .agents/skills, etc.
+for f in *.md; do
+  name="${f%.md}"
+  mkdir -p "$name"
+  mv "$f" "$name/SKILL.md"
+done
+```
+
+The load-time diagnostic points users at exactly the destination path they
+should rename each file to.
+
+## References
+
+- PR [#280](https://github.com/huggingface/tau/pull/280) — narrower fix for
+  `.agents/` only.
+- Issue [#292](https://github.com/huggingface/tau/issues/292) — this
+  unification.
+- Agent Skills spec: <https://agentskills.io/specification#directory-structure>
+- Pi's `SkillDiscoveryMode`: `packages/coding-agent/src/core/package-manager.ts`
+  in the pi-mono repo.

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -151,9 +151,13 @@ def build_skill_index(skills: Sequence[Skill]) -> str:
 
 def _load_skills_from_dir(skills_dir: Path) -> list[Skill]:
     skills, diagnostics = _load_skills_from_dir_with_diagnostics(skills_dir)
-    if diagnostics:
-        first = diagnostics[0]
-        raise ResourceError(first.message)
+    for diagnostic in diagnostics:
+        # Bare-.md migration hints are informational — the file is skipped,
+        # but that is not an error. Only fatal problems raise here; the full
+        # diagnostic stream is available through ``load_skills_with_diagnostics``.
+        if diagnostic.severity == "info":
+            continue
+        raise ResourceError(diagnostic.message)
     return skills
 
 
@@ -163,12 +167,13 @@ def _load_skills_from_dir_with_diagnostics(
     if not skills_dir.exists() or not skills_dir.is_dir():
         return [], []
 
-    # In .agents/skills/ directories, bare .md files are ignored — only
-    # SKILL.md files inside subdirectories are valid (Agent Skills standard).
-    # In .tau/skills/ directories, any .md file is treated as a skill
-    # (preserving the current behavior).
-    agents_mode = skills_dir.parent.name == ".agents"
-
+    # Tau follows the Agent Skills spec everywhere: a skill is a directory
+    # containing a ``SKILL.md`` file. Bare ``*.md`` files at the root of a
+    # skills directory are not skills and are surfaced as a diagnostic that
+    # tells the user how to migrate. This intentionally diverges from Pi,
+    # which keeps a permissive "any .md is a skill" path in its own
+    # ``.pi/skills/`` and ``~/.pi/agent/skills/`` folders purely for
+    # backward compatibility. See ADR 0003.
     skills: list[Skill] = []
     diagnostics: list[ResourceDiagnostic] = []
     seen: set[str] = set()
@@ -180,10 +185,22 @@ def _load_skills_from_dir_with_diagnostics(
             name = path.name
             if not skill_path.exists():
                 continue
-        elif path.is_file() and path.suffix.lower() == ".md" and not agents_mode:
+        elif path.is_file() and path.suffix.lower() == ".md":
             if path.name.upper() == "AGENTS.MD":
                 continue
-            skill_path = path
+            diagnostics.append(
+                ResourceDiagnostic(
+                    kind="skill",
+                    name=path.stem,
+                    path=path,
+                    message=(
+                        "bare .md files are no longer treated as skills; "
+                        f"move it to {(path.parent / path.stem / 'SKILL.md')}"
+                    ),
+                    severity="info",
+                )
+            )
+            continue
         else:
             continue
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -503,9 +503,9 @@ async def test_run_print_mode_expands_skill_commands(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
     resource_root = tmp_path / "resources"
-    skills_dir = resource_root / "skills"
+    skills_dir = resource_root / "skills" / "testing"
     skills_dir.mkdir(parents=True)
-    (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
+    (skills_dir / "SKILL.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
     provider = FakeProvider(
         [
             [

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1797,8 +1797,7 @@ async def test_session_loads_with_resource_diagnostics_instead_of_failing(
     assert [skill.name for skill in session.skills] == ["good"]
     assert len(session.resource_diagnostics) == 1
     assert (
-        "bare .md files are no longer treated as skills"
-        in session.resource_diagnostics[0].message
+        "bare .md files are no longer treated as skills" in session.resource_diagnostics[0].message
     )
     assert "Resource diagnostics: 1" in (session.handle_command("/session").message or "")
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1558,7 +1558,8 @@ async def test_session_builds_system_prompt_when_system_is_omitted(tmp_path: Pat
     skills_dir = resource_root / "skills"
     skills_dir.mkdir(parents=True)
     (tmp_path / "AGENTS.md").write_text("Follow project rules.", encoding="utf-8")
-    (skills_dir / "testing.md").write_text(
+    (skills_dir / "testing").mkdir()
+    (skills_dir / "testing" / "SKILL.md").write_text(
         "---\ndescription: Test code\n---\n# Testing",
         encoding="utf-8",
     )
@@ -1625,9 +1626,9 @@ async def test_session_touches_session_manager_after_persisting_messages(tmp_pat
 @pytest.mark.anyio
 async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
-    skills_dir = resource_root / "skills"
+    skills_dir = resource_root / "skills" / "testing"
     skills_dir.mkdir(parents=True)
-    (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
+    (skills_dir / "SKILL.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
         [
@@ -1723,9 +1724,9 @@ async def test_session_expands_prompt_templates_as_slash_commands(tmp_path: Path
 @pytest.mark.anyio
 async def test_session_skill_index_lets_agent_read_relevant_skill_file(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
-    skills_dir = resource_root / "skills"
+    skills_dir = resource_root / "skills" / "testing"
     skills_dir.mkdir(parents=True)
-    skill_path = skills_dir / "testing.md"
+    skill_path = skills_dir / "SKILL.md"
     skill_path.write_text(
         "---\ndescription: Use when writing tests\n---\n# Testing\nRun pytest.",
         encoding="utf-8",
@@ -1778,9 +1779,9 @@ async def test_session_loads_with_resource_diagnostics_instead_of_failing(
 ) -> None:
     resource_root = tmp_path / "resources"
     skills_dir = resource_root / "skills"
-    (skills_dir / "dup").mkdir(parents=True)
-    (skills_dir / "dup" / "SKILL.md").write_text("# Directory skill", encoding="utf-8")
-    (skills_dir / "dup.md").write_text("# File skill", encoding="utf-8")
+    (skills_dir / "good").mkdir(parents=True)
+    (skills_dir / "good" / "SKILL.md").write_text("# Directory skill", encoding="utf-8")
+    (skills_dir / "legacy.md").write_text("# Legacy bare-md skill", encoding="utf-8")
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     config = CodingSessionConfig(
         provider=FakeProvider([]),
@@ -1793,9 +1794,12 @@ async def test_session_loads_with_resource_diagnostics_instead_of_failing(
 
     session = await CodingSession.load(config)
 
-    assert [skill.name for skill in session.skills] == ["dup"]
+    assert [skill.name for skill in session.skills] == ["good"]
     assert len(session.resource_diagnostics) == 1
-    assert "Duplicate skill name" in session.resource_diagnostics[0].message
+    assert (
+        "bare .md files are no longer treated as skills"
+        in session.resource_diagnostics[0].message
+    )
     assert "Resource diagnostics: 1" in (session.handle_command("/session").message or "")
 
 
@@ -1823,9 +1827,9 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
     assert session.skills == ()
     assert session.context_files == ()
 
-    skills_dir = resource_root / "skills"
+    skills_dir = resource_root / "skills" / "testing"
     skills_dir.mkdir(parents=True)
-    (skills_dir / "testing.md").write_text(
+    (skills_dir / "SKILL.md").write_text(
         "---\ndescription: Test code\n---\n# Testing\nRun pytest.",
         encoding="utf-8",
     )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -82,9 +82,7 @@ def test_load_skills_with_diagnostics_reports_overrides(tmp_path: Path) -> None:
     agents_home = tmp_path / "home" / ".agents"
     cwd = tmp_path / "project"
     (tau_home / "skills" / "review").mkdir(parents=True)
-    (tau_home / "skills" / "review" / "SKILL.md").write_text(
-        "# User Tau Review", encoding="utf-8"
-    )
+    (tau_home / "skills" / "review" / "SKILL.md").write_text("# User Tau Review", encoding="utf-8")
     (cwd / ".tau" / "skills" / "review").mkdir(parents=True)
     (cwd / ".tau" / "skills" / "review" / "SKILL.md").write_text(
         "# Project Tau Review", encoding="utf-8"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -19,14 +19,18 @@ def test_load_skills_missing_directory_returns_empty(tmp_path: Path) -> None:
     assert load_skills(TauResourcePaths(root=tmp_path, agents_root=None)) == []
 
 
-def test_load_skills_from_directory_and_file(tmp_path: Path) -> None:
+def test_load_skills_from_directory(tmp_path: Path) -> None:
+    """Skills must live in ``<dir>/<name>/SKILL.md`` subdirectories."""
     skills_dir = tmp_path / "skills"
     (skills_dir / "python-testing").mkdir(parents=True)
     (skills_dir / "python-testing" / "SKILL.md").write_text(
         "---\ndescription: Test Python code\n---\n# Python Testing\nUse pytest.",
         encoding="utf-8",
     )
-    (skills_dir / "git-review.md").write_text("# Git Review\nReview diffs.", encoding="utf-8")
+    (skills_dir / "git-review").mkdir()
+    (skills_dir / "git-review" / "SKILL.md").write_text(
+        "# Git Review\nReview diffs.", encoding="utf-8"
+    )
 
     skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
@@ -77,39 +81,54 @@ def test_load_skills_with_diagnostics_reports_overrides(tmp_path: Path) -> None:
     tau_home = tmp_path / "home" / ".tau"
     agents_home = tmp_path / "home" / ".agents"
     cwd = tmp_path / "project"
-    (tau_home / "skills").mkdir(parents=True)
-    (tau_home / "skills" / "review.md").write_text("# User Tau Review", encoding="utf-8")
-    (cwd / ".tau" / "skills").mkdir(parents=True)
-    (cwd / ".tau" / "skills" / "review.md").write_text("# Project Tau Review", encoding="utf-8")
+    (tau_home / "skills" / "review").mkdir(parents=True)
+    (tau_home / "skills" / "review" / "SKILL.md").write_text(
+        "# User Tau Review", encoding="utf-8"
+    )
+    (cwd / ".tau" / "skills" / "review").mkdir(parents=True)
+    (cwd / ".tau" / "skills" / "review" / "SKILL.md").write_text(
+        "# Project Tau Review", encoding="utf-8"
+    )
 
     skills, diagnostics = load_skills_with_diagnostics(
         TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd)
     )
 
     assert [skill.name for skill in skills] == ["review"]
-    assert skills[0].path == cwd / ".tau" / "skills" / "review.md"
-    assert len(diagnostics) == 1
-    assert diagnostics[0].kind == "skill"
-    assert diagnostics[0].name == "review"
-    assert "overrides lower-precedence resource" in diagnostics[0].message
+    assert skills[0].path == cwd / ".tau" / "skills" / "review" / "SKILL.md"
+    override_diagnostics = [
+        d for d in diagnostics if "overrides lower-precedence resource" in d.message
+    ]
+    assert len(override_diagnostics) == 1
+    assert override_diagnostics[0].kind == "skill"
+    assert override_diagnostics[0].name == "review"
 
 
-def test_load_skills_with_diagnostics_ignores_duplicate_within_directory(
+def test_load_skills_with_diagnostics_reports_bare_md_migration_hint(
     tmp_path: Path,
 ) -> None:
+    """Bare ``.md`` files at a skills-dir root produce an info diagnostic.
+
+    They are silently skipped from the loaded skill set, but users are told
+    how to migrate: rename ``foo.md`` to ``foo/SKILL.md``.
+    """
     skills_dir = tmp_path / "skills"
-    (skills_dir / "dup").mkdir(parents=True)
-    (skills_dir / "dup" / "SKILL.md").write_text("# Directory skill", encoding="utf-8")
-    (skills_dir / "dup.md").write_text("# File skill", encoding="utf-8")
+    skills_dir.mkdir()
+    (skills_dir / "legacy.md").write_text("# Legacy Skill\nOld body.", encoding="utf-8")
+    (skills_dir / "good").mkdir()
+    (skills_dir / "good" / "SKILL.md").write_text("# Good Skill", encoding="utf-8")
 
     skills, diagnostics = load_skills_with_diagnostics(
         TauResourcePaths(root=tmp_path, agents_root=None)
     )
 
-    assert [skill.name for skill in skills] == ["dup"]
-    assert skills[0].path == skills_dir / "dup" / "SKILL.md"
-    assert len(diagnostics) == 1
-    assert "Duplicate skill name" in diagnostics[0].message
+    assert [skill.name for skill in skills] == ["good"]
+    migration_diagnostics = [d for d in diagnostics if d.severity == "info"]
+    assert len(migration_diagnostics) == 1
+    assert migration_diagnostics[0].name == "legacy"
+    assert migration_diagnostics[0].path == skills_dir / "legacy.md"
+    assert "bare .md files are no longer treated as skills" in migration_diagnostics[0].message
+    assert str(skills_dir / "legacy" / "SKILL.md") in migration_diagnostics[0].message
 
 
 def test_agents_root_is_not_a_skills_directory(tmp_path: Path) -> None:
@@ -147,10 +166,11 @@ def test_agents_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
     assert [s.name for s in skills] == ["my-skill"]
 
 
-def test_tau_skills_dir_loads_bare_md_files(tmp_path: Path) -> None:
-    """Bare .md files in .tau/skills/ are treated as individual skills.
+def test_tau_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
+    """Bare .md files in .tau/skills/ are also ignored (unified with .agents/).
 
-    This is pi mode: any ``.md`` file at the root is a skill.
+    Tau diverges from Pi here: Pi keeps a permissive ``.pi/skills`` for
+    backward compatibility, but Tau applies the Agent Skills spec uniformly.
     """
     skills_dir = tmp_path / "skills"
     (skills_dir / "my-skill").mkdir(parents=True)
@@ -160,23 +180,13 @@ def test_tau_skills_dir_loads_bare_md_files(tmp_path: Path) -> None:
     paths = TauResourcePaths(root=tmp_path, agents_root=None)
     skills = load_skills(paths)
 
-    assert {s.name for s in skills} == {"my-skill", "reference"}
-
-
-def test_load_skills_rejects_duplicate_names(tmp_path: Path) -> None:
-    skills_dir = tmp_path / "skills"
-    (skills_dir / "dup").mkdir(parents=True)
-    (skills_dir / "dup" / "SKILL.md").write_text("# Directory skill", encoding="utf-8")
-    (skills_dir / "dup.md").write_text("# File skill", encoding="utf-8")
-
-    with pytest.raises(ResourceError, match="Duplicate skill name"):
-        load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
+    assert [s.name for s in skills] == ["my-skill"]
 
 
 def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) -> None:
-    skills_dir = tmp_path / "skills"
-    skills_dir.mkdir()
-    (skills_dir / "testing.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
+    skills_dir = tmp_path / "skills" / "testing"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# Testing\nRun pytest.", encoding="utf-8")
     skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
     expanded = expand_skill_command("/skill:testing add parser tests", skills)
@@ -240,9 +250,9 @@ def test_expand_skill_command_rejects_unknown_skill() -> None:
 
 
 def test_build_skill_index(tmp_path: Path) -> None:
-    skills_dir = tmp_path / "skills"
-    skills_dir.mkdir()
-    (skills_dir / "testing.md").write_text(
+    skills_dir = tmp_path / "skills" / "testing"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text(
         "---\ndescription: Test things\n---\nBody",
         encoding="utf-8",
     )

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -36,8 +36,14 @@ fatal errors.
 
 ## Skills
 
-A skill is a Markdown file describing how to accomplish something. The filename
-is the skill name. Optional frontmatter gives it a description:
+A skill is a directory containing a `SKILL.md` file, following the
+[Agent Skills spec](https://agentskills.io/specification#directory-structure).
+The directory name is the skill name. Optional frontmatter gives it a
+description:
+
+```text
+~/.tau/skills/security-review/SKILL.md
+```
 
 ```md
 ---
@@ -46,6 +52,23 @@ description: Review a diff for security issues.
 
 Steps to review the current diff for security problems...
 ```
+
+Any supporting files (references, snippets) can live alongside `SKILL.md`
+inside the same directory.
+
+{{% tip %}}
+Bare `.md` files at the root of a skills directory (for example
+`~/.tau/skills/review.md`) are **not** loaded as skills. Tau will surface a
+diagnostic telling you to move them into their own directory:
+
+```bash
+cd ~/.tau/skills
+mkdir review && mv review.md review/SKILL.md
+```
+
+This matches the Agent Skills spec and applies uniformly across `.tau/` and
+`.agents/` locations.
+{{% /tip %}}
 
 Tau lists loaded skills in the system prompt so the model knows they exist and
 can read the full file (via the `read` tool) when relevant. Invoke one


### PR DESCRIPTION
Closes #292. Follow-up to #280.

## Summary

Apply the [Agent Skills spec](https://agentskills.io/specification#directory-structure) uniformly to **every** skills location Tau scans, not just `.agents/skills/`. A skill is always `<skills-dir>/<name>/SKILL.md`. Bare `*.md` files at the root of a skills directory are surfaced as an informational `ResourceDiagnostic` telling the user how to migrate, then skipped.

Before this PR, Tau had two different rules for two visually-identical directories:

| Location | `foo.md` (bare file) | `foo/SKILL.md` (directory) |
|---|---|---|
| `.tau/skills/` | ✅ loaded | ✅ loaded |
| `.agents/skills/` | ❌ ignored | ✅ loaded |

After this PR:

| Location | `foo.md` (bare file) | `foo/SKILL.md` (directory) |
|---|---|---|
| `.tau/skills/` | ❌ ignored (with migration hint) | ✅ loaded |
| `.agents/skills/` | ❌ ignored (with migration hint) | ✅ loaded |

## Why diverge from Pi

Pi maintains a `SkillDiscoveryMode = "pi" | "agents"` split in `packages/coding-agent/src/core/package-manager.ts`. #280 mirrored that design. However, reading Pi's own changelog makes clear that Pi's split is **not a philosophical choice** — it is a **backward-compatibility carveout**:

> **Pi skills now use `SKILL.md` convention**: Pi skills must now be named `SKILL.md` inside a directory, matching Codex CLI format. Previously any `*.md` file was treated as a skill. Migrate by renaming `~/.pi/agent/skills/foo.md` to `~/.pi/agent/skills/foo/SKILL.md`.

And the fix that mirrors #280:

> Fixed skill discovery to stop recursing once a directory contains `SKILL.md`, and to ignore root `*.md` files in `.agents/skills` while keeping root markdown skill files supported in `~/.pi/agent/skills`, `.pi/skills`, and package `skills/` directories (pi-mono#2603)

Pi's direction of travel is clearly "`SKILL.md` everywhere." Pi cannot finish that migration cleanly because it has a large installed base of bare-`.md` skills that would break.

Tau does not share that constraint. We are pre-1.0 (`0.1.3`), have no meaningful backward-compat contract for `.tau/skills/` layouts, and can ship the endgame directly. See `dev-notes/adr/0003` for the full rationale.

## Changes

- **`src/tau_coding/skills.py`** — Remove the `agents_mode` branch (`skills_dir.parent.name == ".agents"`). Bare `*.md` files everywhere emit an `info` diagnostic and are skipped. `_load_skills_from_dir` only raises on non-info diagnostics so callers using the strict `load_skills` API don't blow up on legacy files.
- **`tests/test_skills.py`** — Replace `test_tau_skills_dir_loads_bare_md_files` with `test_tau_skills_dir_ignores_bare_md_files`; add `test_load_skills_with_diagnostics_reports_bare_md_migration_hint`; update directory tests to the `SKILL.md` layout.
- **`tests/test_cli.py`, `tests/test_coding_session.py`** — Migrate fixtures that still created bare-`.md` skills. Rewrite `test_session_loads_with_resource_diagnostics_instead_of_failing` to assert the new migration diagnostic path.
- **`website/content/guides/skills-and-prompts.md`** — Rewrite the "Skills" section to show the spec layout as the only supported form, with a migration `mv` snippet.
- **`dev-notes/adr/0003-unify-skill-discovery-on-agent-skills-spec.md`** — New ADR documenting the decision, the Pi divergence, and user migration.

## Breaking change

Users with existing bare-`.md` skills under `.tau/skills/` (or `~/.tau/skills/`) will see them stop loading. The diagnostic emitted at load time points at exactly the destination each file should be renamed to:

```
bare .md files are no longer treated as skills; move it to /path/to/skills/foo/SKILL.md
```

Migration:

```bash
cd ~/.tau/skills          # or .tau/skills, .agents/skills, etc.
for f in *.md; do
  name="${f%.md}"
  mkdir -p "$name"
  mv "$f" "$name/SKILL.md"
done
```

## Validation

```text
uv run pytest -q            → 681 passed
uv run ruff check src tests → All checks passed!
uv run mypy src             → Success: no issues found in 63 source files
```

## References

- Issue #292 — this unification
- PR #280 — narrower fix for `.agents/` only that this builds on
- Agent Skills spec: https://agentskills.io/specification#directory-structure
- ADR 0003 (in this PR): `dev-notes/adr/0003-unify-skill-discovery-on-agent-skills-spec.md`
