### PR TITLE
fix(cli): read version from package metadata

### DIFF
--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -149,8 +149,9 @@ from tau_coding.tools import (
     create_write_tool,
     create_write_tool_definition,
 )
+from tau_coding.version import current_version
 
-__version__ = "0.1.2"
+__version__ = current_version()
 
 __all__ = [
     "__version__",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -19,7 +19,6 @@ from tau_ai import (
     ModelProvider,
 )
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
-from tau_coding import __version__
 from tau_coding.catalog_loader import user_catalog_path
 from tau_coding.credentials import FileCredentialStore
 from tau_coding.provider_config import (
@@ -59,6 +58,7 @@ from tau_coding.update_check import (
     startup_release_notes_notice,
     startup_update_notice,
 )
+from tau_coding.version import current_version as _current_version
 
 
 def _is_utf8_encoding(encoding: str | None) -> bool:
@@ -207,8 +207,9 @@ def main(
     ] = False,
 ) -> None:
     """Run the Tau CLI."""
+    current_version = _current_version()
     if version:
-        typer.echo(f"tau {__version__}")
+        typer.echo(f"tau {current_version}")
         raise typer.Exit()
 
     if ctx.invoked_subcommand is not None:
@@ -304,7 +305,7 @@ async def run_openai_tui(
     update_notice: UpdateNotice | None = None,
 ) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
-    release_notes_notice = startup_release_notes_notice(__version__)
+    release_notes_notice = startup_release_notes_notice(_current_version())
     startup_notices = [
         notice
         for notice in (
@@ -326,7 +327,7 @@ async def run_openai_tui(
 
 
 def _startup_update_notice() -> UpdateNotice | None:
-    return startup_update_notice(__version__)
+    return startup_update_notice(_current_version())
 
 
 def render_session_list(records: list[CodingSessionRecord]) -> None:

--- a/src/tau_coding/version.py
+++ b/src/tau_coding/version.py
@@ -1,0 +1,16 @@
+"""Package version helpers."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+_DISTRIBUTION_NAME = "tau-ai"
+_UNKNOWN_VERSION = "0+unknown"
+
+
+def current_version() -> str:
+    """Return Tau's installed package version from package metadata."""
+    try:
+        return version(_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        return _UNKNOWN_VERSION

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,14 +103,17 @@ def test_force_utf8_streams_leaves_utf8_streams_alone() -> None:
     assert calls == []
 
 
-def test_version_command() -> None:
+def test_version_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_current_version", lambda: "1.2.3")
+
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.2"
+    assert result.stdout.strip() == "tau 1.2.3"
 
 
 def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_current_version", lambda: "1.2.3")
     monkeypatch.setattr(
         cli,
         "_startup_update_notice",
@@ -120,7 +123,7 @@ def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPa
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "tau 0.1.2"
+    assert result.stdout.strip() == "tau 1.2.3"
 
 
 def test_print_mode_writes_update_notice_to_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -271,6 +274,7 @@ async def test_run_openai_tui_combines_release_notes_and_update_notice(
         calls.append(kwargs["startup_notices"])  # type: ignore[arg-type]
 
     monkeypatch.setattr(cli, "run_tui_app", fake_run_tui_app)
+    monkeypatch.setattr(cli, "_current_version", lambda: "0.1.2")
     monkeypatch.setattr(
         cli,
         "startup_release_notes_notice",


### PR DESCRIPTION
## Summary

- Stop hardcoding Tau's CLI version string in `tau_coding.__init__`.
- Add a small `tau_coding.version.current_version()` helper that reads the installed package metadata via `importlib.metadata.version("tau-ai")`.
- Use that helper for `tau --version`, startup update checks, and startup release-note checks.

## Test plan

- `uv run pytest tests/test_cli.py tests/test_package_metadata.py -q`
- `uv run ruff check src/tau_coding/cli.py src/tau_coding/__init__.py src/tau_coding/version.py tests/test_cli.py`
- `uv run mypy src/tau_coding/cli.py src/tau_coding/__init__.py src/tau_coding/version.py`
- `uv run tau --version` → `tau 0.1.3`
