### PR TITLE
fix(tui): keep completion height stable while typing

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2106,7 +2106,6 @@ class TauTuiApp(App[None]):
         if event.text_area.id != "prompt":
             return
         self._sync_prompt_shell_mode(event.text_area.text)
-        self._completion_visible_line_budget = None
         self._completion_state = self._build_completion_state(event.text_area.text)
         self._refresh_completions()
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3139,7 +3139,10 @@ async def test_tui_app_uses_terminal_space_for_initial_completion_window() -> No
 
 
 @pytest.mark.anyio
-async def test_tui_app_keeps_completion_window_height_stable_while_navigating() -> None:
+@pytest.mark.parametrize("edit_key", ["down", "r"])
+async def test_tui_app_keeps_completion_window_height_stable_after_edit(
+    edit_key: str,
+) -> None:
     session = FakeSession()
     session.prompt_templates = tuple(
         PromptTemplate(
@@ -3155,13 +3158,11 @@ async def test_tui_app_keeps_completion_window_height_stable_while_navigating() 
         prompt = app.query_one("#prompt")
         prompt.focus()
         prompt.value = "/"
-        app._completion_state = app._build_completion_state(prompt.value)
-        app._refresh_completions()
         await pilot.pause()
         autocomplete = app.query_one("#autocomplete", Static)
         initial_line_budget = app._completion_window_line_budget(autocomplete)
 
-        app.action_completion_next()
+        await pilot.press(edit_key)
         await pilot.pause()
 
         assert autocomplete.size.height < initial_line_budget


### PR DESCRIPTION
## Summary

- Keep the autocomplete line budget stable when the prompt text changes
- Extend the completion-height regression test to cover typing/filtering as well as navigation

## Test

```bash
uv run pytest tests/test_tui_app.py -k 'completion_window_height_stable_after_edit or uses_terminal_space_for_initial_completion_window or scrolls_completion_selection_into_view'
```
