### PR TITLE
fix(tui): compact large pasted prompts

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -196,6 +196,9 @@ class SessionCompletionRecord(Protocol):
     updated_at: float
 
 
+PASTE_DISPLAY_THRESHOLD = 2_000
+
+
 class PromptInput(TextArea):
     """Multiline prompt input with completion key bindings."""
 
@@ -213,6 +216,8 @@ class PromptInput(TextArea):
         self.tui_keybindings = tui_keybindings or TuiKeybindings()
         self._base_bindings = self._bindings.copy()
         self._footer_mode: Literal["normal", "completion", "running"] = "normal"
+        self._pending_paste_content: str | None = None
+        self._pending_paste_placeholder: str | None = None
         self._apply_prompt_bindings()
 
     def set_footer_mode(self, mode: Literal["normal", "completion", "running"]) -> None:
@@ -309,6 +314,7 @@ class PromptInput(TextArea):
         if self.text:
             self.text = ""
             self.move_cursor((0, 0))
+            self._clear_pending_paste()
 
     def get_line(self, line_index: int) -> Text:
         """Retrieve one prompt line with shell prefixes highlighted."""
@@ -345,6 +351,53 @@ class PromptInput(TextArea):
     def action_scroll_up(self) -> None:
         """Use up arrow for completion selection while focused."""
         self.action_completion_previous()
+
+    def on_paste(self, event: events.Paste) -> None:
+        """Show a compact placeholder instead of rendering very large pasted text."""
+        if len(event.text) <= PASTE_DISPLAY_THRESHOLD:
+            return
+        event.stop()
+        event.prevent_default()
+        self._show_large_paste_placeholder(event.text)
+
+    def _show_large_paste_placeholder(self, content: str) -> None:
+        """Store large pasted text and render a compact placeholder."""
+        placeholder = self._large_paste_placeholder(content)
+        self._pending_paste_content = content
+        self._pending_paste_placeholder = placeholder
+        self.insert(placeholder)
+
+    def _large_paste_placeholder(self, content: str) -> str:
+        """Build the display text for a large paste."""
+        char_count = len(content)
+        line_count = content.count("\n") + 1
+        kb = char_count / 1024
+        parts: list[str] = [f"{char_count:,} characters"]
+        if line_count > 1:
+            parts.append(f"{line_count} lines")
+        if kb >= 1:
+            parts.append(f"{kb:.1f} KB")
+        return f"[Pasted content: {', '.join(parts)}]"
+
+    def _clear_pending_paste(self) -> None:
+        """Forget any stored large paste content."""
+        self._pending_paste_content = None
+        self._pending_paste_placeholder = None
+
+    def sync_pending_paste(self) -> None:
+        """Invalidate stored paste content when the placeholder is edited away."""
+        placeholder = self._pending_paste_placeholder
+        if placeholder is not None and placeholder not in self.text:
+            self._clear_pending_paste()
+
+    def text_for_submission(self) -> str:
+        """Return the prompt text, expanding an intact large-paste placeholder."""
+        self.sync_pending_paste()
+        placeholder = self._pending_paste_placeholder
+        content = self._pending_paste_content
+        if placeholder is None or content is None:
+            return self.text
+        return self.text.replace(placeholder, content, 1)
 
     async def on_key(self, event: Key) -> None:
         """Route completion and submission keys before default input handling."""
@@ -2105,6 +2158,8 @@ class TauTuiApp(App[None]):
         """Update prompt autocomplete when the prompt text changes."""
         if event.text_area.id != "prompt":
             return
+        prompt = self.query_one("#prompt", PromptInput)
+        prompt.sync_pending_paste()
         self._sync_prompt_shell_mode(event.text_area.text)
         self._completion_state = self._build_completion_state(event.text_area.text)
         self._refresh_completions()
@@ -2123,10 +2178,11 @@ class TauTuiApp(App[None]):
         streaming_behavior: Literal["steer", "follow_up"],
     ) -> None:
         prompt = self.query_one("#prompt", PromptInput)
-        raw_text = prompt.text
+        raw_text = prompt.text_for_submission()
         applied_completion = self._apply_selected_completion(raw_text)
         if applied_completion is not None and applied_completion != raw_text:
             prompt.text = applied_completion
+            prompt._clear_pending_paste()
             prompt.move_cursor(_text_end_location(applied_completion))
             self._completion_state = self._build_completion_state(applied_completion)
             self._refresh_completions()
@@ -2135,6 +2191,7 @@ class TauTuiApp(App[None]):
         text = raw_text.strip()
         if not text:
             prompt.text = ""
+            prompt._clear_pending_paste()
             self._completion_state = CompletionState()
             self._refresh_completions()
             return
@@ -2152,6 +2209,7 @@ class TauTuiApp(App[None]):
             return
 
         prompt.text = ""
+        prompt._clear_pending_paste()
         self._completion_state = CompletionState()
         self._refresh_completions()
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -216,8 +216,8 @@ class PromptInput(TextArea):
         self.tui_keybindings = tui_keybindings or TuiKeybindings()
         self._base_bindings = self._bindings.copy()
         self._footer_mode: Literal["normal", "completion", "running"] = "normal"
-        self._pending_paste_content: str | None = None
-        self._pending_paste_placeholder: str | None = None
+        self._pending_pastes: list[tuple[str, str]] = []
+        self._paste_placeholder_counter = 0
         self._apply_prompt_bindings()
 
     def set_footer_mode(self, mode: Literal["normal", "completion", "running"]) -> None:
@@ -362,12 +362,12 @@ class PromptInput(TextArea):
 
     def _show_large_paste_placeholder(self, content: str) -> None:
         """Store large pasted text and render a compact placeholder."""
-        placeholder = self._large_paste_placeholder(content)
-        self._pending_paste_content = content
-        self._pending_paste_placeholder = placeholder
+        self._paste_placeholder_counter += 1
+        placeholder = self._large_paste_placeholder(content, self._paste_placeholder_counter)
+        self._pending_pastes.append((placeholder, content))
         self.insert(placeholder)
 
-    def _large_paste_placeholder(self, content: str) -> str:
+    def _large_paste_placeholder(self, content: str, paste_number: int) -> str:
         """Build the display text for a large paste."""
         char_count = len(content)
         line_count = content.count("\n") + 1
@@ -377,27 +377,27 @@ class PromptInput(TextArea):
             parts.append(f"{line_count} lines")
         if kb >= 1:
             parts.append(f"{kb:.1f} KB")
-        return f"[Pasted content: {', '.join(parts)}]"
+        return f"[Pasted content #{paste_number}: {', '.join(parts)}]"
 
     def _clear_pending_paste(self) -> None:
         """Forget any stored large paste content."""
-        self._pending_paste_content = None
-        self._pending_paste_placeholder = None
+        self._pending_pastes.clear()
 
     def sync_pending_paste(self) -> None:
-        """Invalidate stored paste content when the placeholder is edited away."""
-        placeholder = self._pending_paste_placeholder
-        if placeholder is not None and placeholder not in self.text:
-            self._clear_pending_paste()
+        """Invalidate stored paste content when its placeholder is edited away."""
+        self._pending_pastes = [
+            (placeholder, content)
+            for placeholder, content in self._pending_pastes
+            if placeholder in self.text
+        ]
 
     def text_for_submission(self) -> str:
-        """Return the prompt text, expanding an intact large-paste placeholder."""
+        """Return the prompt text, expanding intact large-paste placeholders."""
         self.sync_pending_paste()
-        placeholder = self._pending_paste_placeholder
-        content = self._pending_paste_content
-        if placeholder is None or content is None:
-            return self.text
-        return self.text.replace(placeholder, content, 1)
+        text = self.text
+        for placeholder, content in self._pending_pastes:
+            text = text.replace(placeholder, content, 1)
+        return text
 
     async def on_key(self, event: Key) -> None:
         """Route completion and submission keys before default input handling."""

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from rich.console import Console
 from rich.panel import Panel
+from textual import events
 from textual.color import Color
 from textual.containers import VerticalScroll
 from textual.geometry import Offset
@@ -58,6 +59,7 @@ from tau_coding.tools import create_coding_tools
 from tau_coding.tui import app as tui_app
 from tau_coding.tui.app import (
     COMPLETION_MAX_VISIBLE_LINES,
+    PASTE_DISPLAY_THRESHOLD,
     CommandOutputScreen,
     CustomProviderLoginResult,
     CustomProviderLoginScreen,
@@ -1607,6 +1609,81 @@ async def test_tui_submit_prompt_does_not_optimistically_append_slash_commands()
     assert user_messages == ["Expanded prompt"]
     assert "/review src/app.py" not in transcript_lines
     assert transcript_lines.count("Expanded prompt") == 1
+
+
+def test_prompt_input_shows_placeholder_for_large_paste() -> None:
+    prompt = PromptInput()
+    pasted = ("line\n" * 500) + "end"
+
+    prompt.on_paste(events.Paste(pasted))
+
+    assert prompt.text.startswith("[Pasted content:")
+    assert f"{len(pasted):,} characters" in prompt.text
+    assert "501 lines" in prompt.text
+    assert prompt.text_for_submission() == pasted
+
+
+def test_prompt_input_keeps_small_paste_default_behavior() -> None:
+    prompt = PromptInput()
+    event = events.Paste("x" * PASTE_DISPLAY_THRESHOLD)
+
+    prompt.on_paste(event)
+
+    assert prompt.text == ""
+    assert prompt.text_for_submission() == ""
+
+
+def test_prompt_input_preserves_edits_around_large_paste() -> None:
+    prompt = PromptInput()
+    pasted = "x" * (PASTE_DISPLAY_THRESHOLD + 1)
+    prompt.text = "before "
+    prompt.move_cursor((0, len(prompt.text)))
+
+    prompt.on_paste(events.Paste(pasted))
+    prompt.text = f"{prompt.text}\nafter"
+
+    assert prompt.text_for_submission() == f"before {pasted}\nafter"
+
+
+def test_prompt_input_does_not_submit_deleted_large_paste() -> None:
+    prompt = PromptInput()
+    pasted = "x" * (PASTE_DISPLAY_THRESHOLD + 1)
+    prompt.on_paste(events.Paste(pasted))
+
+    prompt.text = "replacement prompt"
+
+    assert prompt.text_for_submission() == "replacement prompt"
+
+
+@pytest.mark.anyio
+async def test_tui_submit_large_paste_sends_full_content() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    pasted = "x" * (PASTE_DISPLAY_THRESHOLD + 1)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.on_paste(events.Paste(pasted))
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.prompt_texts == [pasted]
+
+
+@pytest.mark.anyio
+async def test_tui_submit_replaced_large_paste_does_not_send_stale_content() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    pasted = "x" * (PASTE_DISPLAY_THRESHOLD + 1)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.on_paste(events.Paste(pasted))
+        prompt.text = "replacement prompt"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.prompt_texts == ["replacement prompt"]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1617,7 +1617,7 @@ def test_prompt_input_shows_placeholder_for_large_paste() -> None:
 
     prompt.on_paste(events.Paste(pasted))
 
-    assert prompt.text.startswith("[Pasted content:")
+    assert prompt.text.startswith("[Pasted content #1:")
     assert f"{len(pasted):,} characters" in prompt.text
     assert "501 lines" in prompt.text
     assert prompt.text_for_submission() == pasted
@@ -1655,6 +1655,34 @@ def test_prompt_input_does_not_submit_deleted_large_paste() -> None:
     assert prompt.text_for_submission() == "replacement prompt"
 
 
+def test_prompt_input_expands_multiple_large_pastes() -> None:
+    prompt = PromptInput()
+    first = "a" * (PASTE_DISPLAY_THRESHOLD + 1)
+    second = "b" * (PASTE_DISPLAY_THRESHOLD + 2)
+
+    prompt.on_paste(events.Paste(first))
+    prompt.insert("\nbetween\n")
+    prompt.on_paste(events.Paste(second))
+
+    assert "[Pasted content #1:" in prompt.text
+    assert "[Pasted content #2:" in prompt.text
+    assert prompt.text_for_submission() == f"{first}\nbetween\n{second}"
+
+
+def test_prompt_input_drops_only_deleted_large_paste_placeholder() -> None:
+    prompt = PromptInput()
+    first = "a" * (PASTE_DISPLAY_THRESHOLD + 1)
+    second = "b" * (PASTE_DISPLAY_THRESHOLD + 2)
+
+    prompt.on_paste(events.Paste(first))
+    first_placeholder = prompt.text
+    prompt.insert("\n")
+    prompt.on_paste(events.Paste(second))
+    prompt.text = prompt.text.replace(first_placeholder, "removed", 1)
+
+    assert prompt.text_for_submission() == f"removed\n{second}"
+
+
 @pytest.mark.anyio
 async def test_tui_submit_large_paste_sends_full_content() -> None:
     session = FakeSession()
@@ -1684,6 +1712,24 @@ async def test_tui_submit_replaced_large_paste_does_not_send_stale_content() -> 
         await pilot.pause()
 
     assert session.prompt_texts == ["replacement prompt"]
+
+
+@pytest.mark.anyio
+async def test_tui_submit_multiple_large_pastes_sends_all_full_content() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+    first = "a" * (PASTE_DISPLAY_THRESHOLD + 1)
+    second = "b" * (PASTE_DISPLAY_THRESHOLD + 2)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.on_paste(events.Paste(first))
+        prompt.insert("\nthen\n")
+        prompt.on_paste(events.Paste(second))
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert session.prompt_texts == [f"{first}\nthen\n{second}"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Show a compact placeholder when a large bracketed paste lands in the TUI prompt
- Preserve the full pasted content for submission while the placeholder remains present
- Invalidate stored pasted content when the placeholder is deleted, so stale content is not sent
- Add focused tests for large paste display, submit restoration, edits around the placeholder, and stale-content prevention

## Validation

- `uv run pytest tests/test_tui_app.py tests/test_tui_adapter.py`
- `uv run ruff check src/tau_coding/tui/app.py tests/test_tui_app.py`
- `uv run mypy src/tau_coding/tui/app.py`
