### PR TITLE
Add Claude Fable 5 and Sonnet 5 to Anthropic catalog

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -437,7 +437,7 @@ kind = "anthropic"
 base_url = "https://api.anthropic.com"
 api_key_env = "ANTHROPIC_API_KEY"
 credential_name = "anthropic"
-models = ["claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6"]
+models = ["claude-fable-5", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6", "claude-sonnet-5"]
 default_model = "claude-sonnet-4-6"
 docs_url = "https://docs.anthropic.com"
 api = "anthropic-messages"
@@ -446,6 +446,7 @@ thinking_default = "medium"
 thinking_parameter = "anthropic.thinking"
 
 [providers.context_windows]
+claude-fable-5 = 1000000
 claude-haiku-4-5 = 200000
 claude-haiku-4-5-20251001 = 200000
 claude-opus-4-1 = 200000
@@ -457,6 +458,17 @@ claude-opus-4-7 = 1000000
 claude-sonnet-4-5 = 200000
 claude-sonnet-4-5-20250929 = 200000
 claude-sonnet-4-6 = 1000000
+claude-sonnet-5 = 1000000
+
+[providers.model_metadata.claude-fable-5]
+name = "Claude Fable 5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 10, output = 50, cacheRead = 1, cacheWrite = 12.5 }
+unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.claude-haiku-4-5]
 name = "Claude Haiku 4.5 (latest)"
@@ -550,6 +562,16 @@ reasoning = true
 input = ["text", "image"]
 context_window = 1000000
 max_tokens = 64000
+compat = { forceAdaptiveThinking = true }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata.claude-sonnet-5]
+name = "Claude Sonnet 5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
 cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
 unsupported_thinking_levels = ["minimal"]

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -83,6 +83,7 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
     assert entry.api_key_env == "ANTHROPIC_API_KEY"
     assert entry.credential_name == "anthropic"
     assert entry.models == (
+        "claude-fable-5",
         "claude-haiku-4-5",
         "claude-haiku-4-5-20251001",
         "claude-opus-4-1",
@@ -94,10 +95,12 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
         "claude-sonnet-4-5",
         "claude-sonnet-4-5-20250929",
         "claude-sonnet-4-6",
+        "claude-sonnet-5",
     )
     assert entry.default_model == "claude-sonnet-4-6"
     assert entry.docs_url == "https://docs.anthropic.com"
     assert entry.context_windows == {
+        "claude-fable-5": 1_000_000,
         "claude-haiku-4-5": 200_000,
         "claude-haiku-4-5-20251001": 200_000,
         "claude-opus-4-1": 200_000,
@@ -109,6 +112,7 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
         "claude-sonnet-4-5": 200_000,
         "claude-sonnet-4-5-20250929": 200_000,
         "claude-sonnet-4-6": 1_000_000,
+        "claude-sonnet-5": 1_000_000,
     }
     assert entry.thinking_levels == ("off", "minimal", "low", "medium", "high", "xhigh")
     assert entry.thinking_models == ()


### PR DESCRIPTION
## Summary

- add Claude Fable 5 (`claude-fable-5`) to the built-in Anthropic catalog
- add Claude Sonnet 5 (`claude-sonnet-5`) to the built-in Anthropic catalog
- include context windows, max output tokens, pricing metadata, adaptive-thinking compatibility, and catalog tests

## Sources

Official Anthropic model docs list these Claude API IDs:

- Claude Fable 5: `claude-fable-5`
- Claude Sonnet 5: `claude-sonnet-5`

Source: https://platform.claude.com/docs/en/about-claude/models/overview

## Tests

- `uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py tests/test_cli.py -q`
- `uv run ruff format --check src/tau_coding/data/catalog.toml tests/test_provider_catalog.py`
- `uv run ruff check src/tau_coding/data/catalog.toml tests/test_provider_catalog.py`
