### PR TITLE
fix: support socks proxy environment URLs

### DIFF
--- a/dev-notes/architecture/socks-proxy-support.md
+++ b/dev-notes/architecture/socks-proxy-support.md
@@ -1,0 +1,46 @@
+# SOCKS proxy support
+
+Tau uses `httpx` for provider requests, OAuth token refreshes, and startup update checks. `httpx` reads standard proxy environment variables such as `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
+## What changed
+
+Issue #221 reported failures when the environment contained a generic SOCKS proxy URL such as:
+
+```bash
+ALL_PROXY=socks://127.0.0.1:1080
+```
+
+`httpx` does not accept the generic `socks://` scheme. It accepts explicit SOCKS schemes such as `socks5://` and `socks5h://`, and those require the optional SOCKS dependency.
+
+Tau now:
+
+- installs `httpx[socks]` in the base package so `socksio` is available;
+- normalizes `socks://...` to `socks5://...` before constructing Tau-owned HTTP clients;
+- routes provider clients, OAuth token refresh clients, and update-check fetches through shared helpers in `tau_ai.http`.
+
+## Why `socks://` maps to `socks5://`
+
+The generic scheme does not specify whether DNS lookup should happen locally or through the proxy. Tau treats it as SOCKS5 with local DNS resolution because that is the closest explicit `httpx` scheme and avoids silently changing DNS behavior beyond making the previously invalid URL usable.
+
+Users who need proxy-side DNS resolution should set an explicit `socks5h://` URL.
+
+## Future improvement: avoid temporary environment mutation
+
+The current helper temporarily normalizes proxy environment variables while constructing Tau-owned `httpx` clients. For the synchronous update-check helper, the normalization currently wraps the full `httpx.get(...)` call because `httpx.get` constructs and uses a short-lived client internally.
+
+This is acceptable for the current low-concurrency startup update-check path, but environment variables are process-global state. If Tau later performs more concurrent networking around this helper, another thread or task could observe the normalized proxy value while the request is in progress.
+
+If this becomes a concern, prefer avoiding process environment mutation for request execution:
+
+1. normalize proxy values into local data;
+2. construct an explicit `httpx.Client` or `httpx.AsyncClient` with equivalent proxy configuration;
+3. perform requests through that client without changing `os.environ` during request execution.
+
+When implementing that, preserve `NO_PROXY` semantics. `httpx` currently handles environment proxy discovery and no-proxy matching internally, so replacing it with explicit mounts/proxy configuration should include tests for:
+
+- `ALL_PROXY=socks://...` normalization;
+- `HTTP_PROXY` and `HTTPS_PROXY` handling;
+- lowercase proxy env vars;
+- `NO_PROXY=*` bypass;
+- host/domain/IP `NO_PROXY` entries;
+- explicit `socks5://` and `socks5h://` values staying unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.0",
-    "httpx>=0.27",
+    "httpx[socks]>=0.27",
     "packaging>=24.0",
     "pydantic>=2.0",
     "rich>=13.0",

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -21,6 +21,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
@@ -236,7 +237,7 @@ class AnthropicProvider:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+            self._client = create_async_client(timeout=self._config.timeout_seconds)
         return self._client
 
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -20,6 +20,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
@@ -148,7 +149,7 @@ class GoogleGenerativeAIProvider:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+            self._client = create_async_client(timeout=self._config.timeout_seconds)
         return self._client
 
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:

--- a/src/tau_ai/http.py
+++ b/src/tau_ai/http.py
@@ -1,0 +1,81 @@
+"""HTTP client helpers shared by Tau network integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+
+
+def normalize_proxy_url(proxy_url: str) -> str:
+    """Return an httpx-compatible proxy URL.
+
+    Some environments use ``socks://`` as a generic SOCKS proxy scheme. httpx
+    accepts explicit SOCKS versions (for example ``socks5://`` and
+    ``socks5h://``), but rejects the generic scheme before it can make a
+    request. Treat the generic form as SOCKS5 so Tau can honor these proxy
+    environment variables.
+    """
+
+    if proxy_url.lower().startswith("socks://"):
+        return f"socks5://{proxy_url[len('socks://') :]}"
+    return proxy_url
+
+
+@contextmanager
+def normalized_proxy_environment() -> Iterator[None]:
+    """Temporarily normalize proxy environment variables for httpx construction."""
+
+    original: dict[str, str | None] = {}
+    changed = False
+    for name in _PROXY_ENV_VARS:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        normalized = normalize_proxy_url(value)
+        if normalized == value:
+            continue
+        original[name] = value
+        os.environ[name] = normalized
+        changed = True
+
+    try:
+        yield
+    finally:
+        if changed:
+            for name, value in original.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+
+def create_async_client(**kwargs: Any) -> httpx.AsyncClient:
+    """Create an ``httpx.AsyncClient`` with Tau's proxy normalization applied."""
+
+    with normalized_proxy_environment():
+        return httpx.AsyncClient(**kwargs)
+
+
+def get_json(url: str, *, timeout: float, follow_redirects: bool = False) -> dict[str, object]:
+    """Fetch a JSON object with Tau's proxy normalization applied."""
+
+    with normalized_proxy_environment():
+        response = httpx.get(url, timeout=timeout, follow_redirects=follow_redirects)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("HTTP response must be a JSON object")
+    return data

--- a/src/tau_ai/mistral.py
+++ b/src/tau_ai/mistral.py
@@ -21,6 +21,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
@@ -160,7 +161,7 @@ class MistralConversationsProvider:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+            self._client = create_async_client(timeout=self._config.timeout_seconds)
         return self._client
 
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -27,6 +27,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
@@ -203,7 +204,7 @@ class OpenAICodexProvider:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+            self._client = create_async_client(timeout=self._config.timeout_seconds)
         return self._client
 
     def _should_retry(

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -29,6 +29,7 @@ from tau_ai.events import (
     ProviderThinkingDeltaEvent,
     ProviderToolCallEvent,
 )
+from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
@@ -269,7 +270,7 @@ class OpenAICompatibleProvider:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+            self._client = create_async_client(timeout=self._config.timeout_seconds)
         return self._client
 
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:

--- a/src/tau_coding/oauth.py
+++ b/src/tau_coding/oauth.py
@@ -19,6 +19,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 
+from tau_ai.http import create_async_client
 from tau_coding.credentials import OAuthCredential
 
 OPENAI_CODEX_OAUTH_PROVIDER = "openai-codex"
@@ -334,7 +335,7 @@ async def _post_openai_codex_token(
     action: str,
 ) -> dict[str, Any]:
     owns_client = client is None
-    active_client = client or httpx.AsyncClient(timeout=60)
+    active_client = client or create_async_client(timeout=60)
     try:
         response = await active_client.post(
             OPENAI_CODEX_TOKEN_URL,

--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -10,9 +10,9 @@ from os import environ
 from pathlib import Path
 from typing import Any
 
-import httpx
 from packaging.version import InvalidVersion, Version
 
+from tau_ai.http import get_json
 from tau_coding.paths import TauPaths
 
 PYPI_PACKAGE_NAME = "tau-ai"
@@ -285,9 +285,7 @@ def _stable_release_versions(releases: dict[Any, Any]) -> list[Version]:
 
 
 def _httpx_fetch_json(url: str, timeout_seconds: float) -> dict[str, Any]:
-    response = httpx.get(url, timeout=timeout_seconds, follow_redirects=True)
-    response.raise_for_status()
-    data = response.json()
+    data = get_json(url, timeout=timeout_seconds, follow_redirects=True)
     if not isinstance(data, dict):
         raise ValueError("PyPI response must be a JSON object")
     return data

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,45 @@
+import os
+
+import httpx
+import pytest
+
+from tau_ai.http import create_async_client, normalize_proxy_url, normalized_proxy_environment
+
+
+def test_normalize_proxy_url_converts_generic_socks_scheme() -> None:
+    assert normalize_proxy_url("socks://127.0.0.1:1080") == "socks5://127.0.0.1:1080"
+    assert normalize_proxy_url("SOCKS://user:pass@proxy.local:1080") == (
+        "socks5://user:pass@proxy.local:1080"
+    )
+
+
+def test_normalize_proxy_url_leaves_explicit_schemes_unchanged() -> None:
+    assert normalize_proxy_url("socks5://127.0.0.1:1080") == "socks5://127.0.0.1:1080"
+    assert normalize_proxy_url("socks5h://127.0.0.1:1080") == "socks5h://127.0.0.1:1080"
+    assert normalize_proxy_url("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
+
+
+def test_normalized_proxy_environment_restores_original_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+
+    with normalized_proxy_environment():
+        assert os.environ["ALL_PROXY"] == "socks5://127.0.0.1:1080"
+
+    assert os.environ["ALL_PROXY"] == "socks://127.0.0.1:1080"
+
+
+@pytest.mark.anyio
+async def test_create_async_client_accepts_generic_socks_proxy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+
+    client = create_async_client(timeout=1)
+    try:
+        assert isinstance(client, httpx.AsyncClient)
+    finally:
+        await client.aclose()
+
+    assert os.environ["ALL_PROXY"] == "socks://127.0.0.1:1080"

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "idna"
 version = "3.18"
@@ -512,12 +517,21 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "tau-ai"
 version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "rich" },
@@ -535,7 +549,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -30,6 +30,31 @@ Startup update checks cache their latest PyPI result in
 `~/.tau/cache/update-check.json` and refresh at most once per day. Set
 `TAU_NO_UPDATE_CHECK=1` to disable the check; Tau also skips it when `CI` is set.
 
+## Network proxies
+
+Tau uses `httpx` for provider requests, OAuth token refreshes, and startup update
+checks, so it honors standard proxy environment variables such as `HTTP_PROXY`,
+`HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
+SOCKS proxies are supported by the base installation. Use explicit schemes when
+you can:
+
+```bash
+export ALL_PROXY=socks5://127.0.0.1:1080
+# or, when proxy-side DNS resolution is required:
+export ALL_PROXY=socks5h://127.0.0.1:1080
+```
+
+Tau also accepts the generic `socks://` form that some systems and tools set in
+the environment. Before creating its own HTTP clients, Tau normalizes
+`socks://...` to `socks5://...` because `httpx` does not recognize the generic
+scheme directly.
+
+This matters for users behind corporate proxies, VPNs, local tunnels, or
+privacy/network-routing setups: without SOCKS support and normalization, Tau can
+fail before making a model API request with an error like
+`Unknown scheme for proxy URL URL('socks://...')`.
+
 ## Providers
 
 Tau separates provider metadata from runtime preferences:


### PR DESCRIPTION
## Summary

This PR fixes Tau's handling of SOCKS proxy environments.

### What changed

- Adds `httpx[socks]` to Tau's base dependencies, which installs SOCKS proxy support via `socksio`.
- Adds shared HTTP helpers in `src/tau_ai/http.py`.
- Normalizes proxy URLs like `socks://127.0.0.1:1080` to `socks5://127.0.0.1:1080` before Tau creates its own `httpx` clients.
- Applies that proxy-aware client creation to provider calls, OAuth token refreshes, and update checks.
- Documents proxy behavior in `website/content/reference/configuration.md`.
- Adds tests for proxy URL normalization and client creation behavior.

### Why this matters

Users behind SOCKS proxies could see errors such as:

```text
Unknown scheme for proxy URL URL('socks://...')
```

`httpx` does not understand the generic `socks://` scheme, and without the optional SOCKS dependency it also cannot use `socks5://` or `socks5h://`. Many systems and tools expose SOCKS proxies through environment variables like `ALL_PROXY=socks://...`, so Tau could fail before making any model API request.

This makes Tau work correctly in proxy-restricted networks, corporate/VPN environments, local tunnel setups, and privacy/network-routing configurations.

Fixes #221.

## Tests

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest`
- `uv run pytest tests/test_http.py tests/test_update_check.py`
