### PR TITLE
feat(tui): reflect session state in terminal tab title

### DIFF
--- a/dev-notes/architecture/tui-terminal-tab-title.md
+++ b/dev-notes/architecture/tui-terminal-tab-title.md
@@ -44,7 +44,9 @@ activity timer drives both the in-app prompt animation and the tab-title spinner
 Title writing is enabled only when stdout is a TTY, `TERM` is not `dumb`, and CI
 is not detected. Users can opt out with `TAU_TERMINAL_TITLE=0`; CI/no-TTY cases
 can opt in explicitly with `TAU_TERMINAL_TITLE=1` only where supported by the
-helper's rules.
+helper's rules. Title writes are best-effort: if the terminal stream raises while
+Tau is writing an OSC sequence, Tau disables further title writes for that TUI
+process instead of interrupting the session.
 
 Session names are sanitized before they enter an OSC payload: C0/C1 control
 characters, including BEL and ESC, are stripped and the title is capped to 120

--- a/dev-notes/architecture/tui-terminal-tab-title.md
+++ b/dev-notes/architecture/tui-terminal-tab-title.md
@@ -7,11 +7,11 @@ Issue: #260
 The Textual TUI now updates the terminal emulator's window/tab title with the
 active Tau session name and running state:
 
-- idle unnamed session: `Tau`
-- idle named session: `<session name> — Tau`
+- idle unnamed session: `τ`
+- idle named session: `τ | <session name>`
 - running session: an animated Braille spinner prefix plus the idle title
 
-On TUI shutdown Tau writes a neutral `Tau` title so the terminal is not left with
+On TUI shutdown Tau writes a neutral `τ` title so the terminal is not left with
 a stale running frame.
 
 ## Why it lives in `tau_coding`
@@ -60,10 +60,10 @@ deduplicated writes, and TUI running/name/idle transitions.
 Manual verification:
 
 1. Open `tau` in a real terminal tab.
-2. Confirm an unnamed idle TUI shows `Tau` in the tab title.
-3. Run `/name build notes` and confirm the tab changes to `build notes — Tau`.
+2. Confirm an unnamed idle TUI shows `τ` in the tab title.
+3. Run `/name build notes` and confirm the tab changes to `τ | build notes`.
 4. Submit a prompt that runs long enough to observe the animated spinner prefix.
 5. Cancel or let the run finish; confirm the spinner stops.
-6. Quit the TUI and confirm the tab is reset to `Tau`.
+6. Quit the TUI and confirm the tab is reset to `τ`.
 7. Repeat once with `TAU_TERMINAL_TITLE=0 tau` and confirm Tau does not manage
    the tab title.

--- a/dev-notes/architecture/tui-terminal-tab-title.md
+++ b/dev-notes/architecture/tui-terminal-tab-title.md
@@ -1,0 +1,67 @@
+# TUI terminal tab titles
+
+Issue: #260
+
+## What changed
+
+The Textual TUI now updates the terminal emulator's window/tab title with the
+active Tau session name and running state:
+
+- idle unnamed session: `Tau`
+- idle named session: `<session name> — Tau`
+- running session: an animated Braille spinner prefix plus the idle title
+
+On TUI shutdown Tau writes a neutral `Tau` title so the terminal is not left with
+a stale running frame.
+
+## Why it lives in `tau_coding`
+
+Terminal title updates are a frontend concern. The implementation uses state the
+TUI already owns:
+
+- `TuiState.running`, populated from `AgentStartEvent`, `AgentEndEvent`, and
+  non-recoverable `ErrorEvent` by the adapter;
+- `CodingSession.session_title`, which is updated by `/name` and automatic
+  session naming.
+
+No terminal or Textual dependencies were added to `tau_agent` or `tau_ai`.
+
+## Mechanism
+
+`src/tau_coding/tui/terminal_title.py` emits OSC 0 sequences:
+
+```text
+ESC ] 0 ; <title> BEL
+```
+
+OSC 0 is broadly supported by common terminal emulators and sets the terminal
+window/tab title. The `TerminalTitleController` writes only when the computed
+title changes, so idle refreshes do not spam stdout. While running, the existing
+activity timer drives both the in-app prompt animation and the tab-title spinner.
+
+## Capability detection and safety
+
+Title writing is enabled only when stdout is a TTY, `TERM` is not `dumb`, and CI
+is not detected. Users can opt out with `TAU_TERMINAL_TITLE=0`; CI/no-TTY cases
+can opt in explicitly with `TAU_TERMINAL_TITLE=1` only where supported by the
+helper's rules.
+
+Session names are sanitized before they enter an OSC payload: C0/C1 control
+characters, including BEL and ESC, are stripped and the title is capped to 120
+characters.
+
+## Testing and manual verification
+
+Automated tests cover title construction, sanitization, capability detection,
+deduplicated writes, and TUI running/name/idle transitions.
+
+Manual verification:
+
+1. Open `tau` in a real terminal tab.
+2. Confirm an unnamed idle TUI shows `Tau` in the tab title.
+3. Run `/name build notes` and confirm the tab changes to `build notes — Tau`.
+4. Submit a prompt that runs long enough to observe the animated spinner prefix.
+5. Cancel or let the run finish; confirm the spinner stops.
+6. Quit the TUI and confirm the tab is reset to `Tau`.
+7. Repeat once with `TAU_TERMINAL_TITLE=0 tau` and confirm Tau does not manage
+   the tab title.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2563,6 +2563,7 @@ class TauTuiApp(App[None]):
         if isinstance(event, MessageEndEvent):
             if event.message.role == "user":
                 await self._append_confirmed_user_message(event.message)
+                self._sync_header_title()
                 return
             if event.message.role == "assistant":
                 await transcript.finish_assistant_message(event.message.content)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -106,6 +106,7 @@ from tau_coding.tui.config import (
     save_tui_settings,
 )
 from tau_coding.tui.state import TuiState, format_terminal_command_result_block
+from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
     SessionSidebar,
@@ -2044,6 +2045,7 @@ class TauTuiApp(App[None]):
         self._completion_visible_line_budget: int | None = None
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
+        self._terminal_title = TerminalTitleController()
         self._active_notification_keys: set[tuple[str, str]] = set()
         self._supports_pyperclip: bool | None = None
         self._sync_header_title()
@@ -2052,6 +2054,15 @@ class TauTuiApp(App[None]):
         """Reflect the active session name in Textual's header state."""
         self.title = "Tau"
         self.sub_title = _session_header_sub_title(self.session)
+        self._sync_terminal_title()
+
+    def _sync_terminal_title(self) -> None:
+        """Reflect the active session name and running state in the terminal tab title."""
+        self._terminal_title.update(
+            getattr(self.session, "session_title", None),
+            running=self.state.running,
+            frame=self._activity_frame,
+        )
 
     def _sync_text_selection_state(self) -> None:
         """Disable native text selection while the transcript is mutating."""
@@ -2123,10 +2134,11 @@ class TauTuiApp(App[None]):
             await self._submit_prompt(self.initial_prompt.strip())
 
     def on_unmount(self) -> None:
-        """Stop the activity timer when the app is torn down."""
+        """Stop activity animations when the app is torn down."""
         if self._activity_timer is not None:
             self._activity_timer.stop()
             self._activity_timer = None
+        self._terminal_title.restore()
 
     def on_resize(self, event: Resize) -> None:
         """Update responsive chrome when the terminal changes size."""
@@ -3293,6 +3305,7 @@ class TauTuiApp(App[None]):
         self.adapter.apply(queue_event())
 
     def _sync_activity_indicator(self) -> None:
+        self._sync_terminal_title()
         if self.state.running:
             if self._activity_timer is None:
                 self._activity_timer = self.set_interval(
@@ -3314,6 +3327,7 @@ class TauTuiApp(App[None]):
             return
         self._activity_frame += 1
         self._apply_activity_indicator()
+        self._sync_terminal_title()
 
     def _apply_activity_indicator(self) -> None:
         theme = self.tui_settings.resolved_theme

--- a/src/tau_coding/tui/terminal_title.py
+++ b/src/tau_coding/tui/terminal_title.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from collections.abc import Callable, Mapping
+from contextlib import suppress
 from typing import TextIO, cast
 
 MAX_TERMINAL_TITLE_LENGTH = 120
@@ -22,8 +23,6 @@ def terminal_title_supported(
     """Return whether Tau should emit OSC title sequences in this process."""
     env = os.environ if environ is None else environ
     if env.get("TAU_TERMINAL_TITLE", "").lower() in {"0", "false", "no", "off"}:
-        return False
-    if env.get("NO_COLOR", "") and env.get("TAU_TERMINAL_TITLE", "").lower() != "1":
         return False
     target = sys.__stdout__ if stream is None else stream
     if not getattr(target, "isatty", lambda: False)():
@@ -90,6 +89,14 @@ class TerminalTitleController:
         self._last_title: str | None = None
         self._exit_title = exit_title
 
+    def _write(self, sequence: str) -> bool:
+        """Best-effort title write; disable future writes if the stream fails."""
+        with suppress(OSError, ValueError):
+            self._writer(sequence)
+            return True
+        self.enabled = False
+        return False
+
     def update(self, session_title: str | None, *, running: bool, frame: int = 0) -> None:
         """Write the current Tau title if it differs from the last emitted title."""
         if not self.enabled:
@@ -97,15 +104,15 @@ class TerminalTitleController:
         title = build_terminal_title(session_title, running=running, frame=frame)
         if title == self._last_title:
             return
-        self._writer(osc_terminal_title_sequence(title))
-        self._last_title = title
+        if self._write(osc_terminal_title_sequence(title)):
+            self._last_title = title
 
     def restore(self) -> None:
         """Leave the terminal title in a neutral idle Tau state on shutdown."""
         if not self.enabled:
             return
-        self._writer(osc_terminal_title_sequence(self._exit_title))
-        self._last_title = self._exit_title
+        if self._write(osc_terminal_title_sequence(self._exit_title)):
+            self._last_title = self._exit_title
 
     def _default_write(self, sequence: str) -> None:
         self._stream.write(sequence)

--- a/src/tau_coding/tui/terminal_title.py
+++ b/src/tau_coding/tui/terminal_title.py
@@ -1,0 +1,112 @@
+"""Helpers for updating the terminal window/tab title from Tau's TUI."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping
+from typing import TextIO, cast
+
+MAX_TERMINAL_TITLE_LENGTH = 120
+OSC_TERMINATOR = "\a"
+RUNNING_TITLE_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def terminal_title_supported(
+    *,
+    environ: Mapping[str, str] | None = None,
+    stream: TextIO | None = None,
+) -> bool:
+    """Return whether Tau should emit OSC title sequences in this process."""
+    env = os.environ if environ is None else environ
+    if env.get("TAU_TERMINAL_TITLE", "").lower() in {"0", "false", "no", "off"}:
+        return False
+    if env.get("NO_COLOR", "") and env.get("TAU_TERMINAL_TITLE", "").lower() != "1":
+        return False
+    target = sys.__stdout__ if stream is None else stream
+    if not getattr(target, "isatty", lambda: False)():
+        return False
+    if env.get("TERM", "") == "dumb":
+        return False
+    return not (env.get("CI", "") and env.get("TAU_TERMINAL_TITLE", "").lower() != "1")
+
+
+def sanitize_terminal_title(
+    value: str | None,
+    *,
+    max_length: int = MAX_TERMINAL_TITLE_LENGTH,
+) -> str:
+    """Strip OSC-breaking control bytes and cap terminal-title text."""
+    if value is None:
+        return ""
+    sanitized = _CONTROL_CHARS_RE.sub("", value).strip()
+    if len(sanitized) <= max_length:
+        return sanitized
+    if max_length <= 1:
+        return sanitized[:max_length]
+    return sanitized[: max_length - 1].rstrip() + "…"
+
+
+def build_terminal_title(
+    session_title: str | None,
+    *,
+    running: bool,
+    frame: int = 0,
+) -> str:
+    """Return Tau's terminal tab title for the current session/running state."""
+    title = sanitize_terminal_title(session_title)
+    title = "Tau" if not title or title.lower() == "untitled session" else f"{title} — Tau"
+    if not running:
+        return title
+    return f"{RUNNING_TITLE_FRAMES[frame % len(RUNNING_TITLE_FRAMES)]} {title}"
+
+
+def osc_terminal_title_sequence(title: str) -> str:
+    """Return an OSC 0 sequence that sets the terminal window/tab title."""
+    return f"\x1b]0;{sanitize_terminal_title(title)}{OSC_TERMINATOR}"
+
+
+class TerminalTitleController:
+    """Small stateful writer that avoids duplicate OSC title writes."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool | None = None,
+        writer: Callable[[str], object] | None = None,
+        stream: TextIO | None = None,
+        environ: Mapping[str, str] | None = None,
+        exit_title: str = "Tau",
+    ) -> None:
+        self._stream = cast(TextIO, sys.__stdout__) if stream is None else stream
+        self.enabled = (
+            terminal_title_supported(environ=environ, stream=self._stream)
+            if enabled is None
+            else enabled
+        )
+        self._writer = writer or self._default_write
+        self._last_title: str | None = None
+        self._exit_title = exit_title
+
+    def update(self, session_title: str | None, *, running: bool, frame: int = 0) -> None:
+        """Write the current Tau title if it differs from the last emitted title."""
+        if not self.enabled:
+            return
+        title = build_terminal_title(session_title, running=running, frame=frame)
+        if title == self._last_title:
+            return
+        self._writer(osc_terminal_title_sequence(title))
+        self._last_title = title
+
+    def restore(self) -> None:
+        """Leave the terminal title in a neutral idle Tau state on shutdown."""
+        if not self.enabled:
+            return
+        self._writer(osc_terminal_title_sequence(self._exit_title))
+        self._last_title = self._exit_title
+
+    def _default_write(self, sequence: str) -> None:
+        self._stream.write(sequence)
+        self._stream.flush()

--- a/src/tau_coding/tui/terminal_title.py
+++ b/src/tau_coding/tui/terminal_title.py
@@ -11,6 +11,7 @@ from typing import TextIO, cast
 
 MAX_TERMINAL_TITLE_LENGTH = 120
 OSC_TERMINATOR = "\a"
+TAU_TITLE_MARK = "τ"
 RUNNING_TITLE_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
@@ -56,7 +57,11 @@ def build_terminal_title(
 ) -> str:
     """Return Tau's terminal tab title for the current session/running state."""
     title = sanitize_terminal_title(session_title)
-    title = "Tau" if not title or title.lower() == "untitled session" else f"{title} — Tau"
+    title = (
+        TAU_TITLE_MARK
+        if not title or title.lower() == "untitled session"
+        else f"{TAU_TITLE_MARK} | {title}"
+    )
     if not running:
         return title
     return f"{RUNNING_TITLE_FRAMES[frame % len(RUNNING_TITLE_FRAMES)]} {title}"
@@ -77,7 +82,7 @@ class TerminalTitleController:
         writer: Callable[[str], object] | None = None,
         stream: TextIO | None = None,
         environ: Mapping[str, str] | None = None,
-        exit_title: str = "Tau",
+        exit_title: str = TAU_TITLE_MARK,
     ) -> None:
         self._stream = cast(TextIO, sys.__stdout__) if stream is None else stream
         self.enabled = (

--- a/tests/test_terminal_title.py
+++ b/tests/test_terminal_title.py
@@ -50,6 +50,10 @@ def test_osc_terminal_title_sequence_sanitizes_payload() -> None:
 
 def test_terminal_title_supported_requires_tty_and_allows_opt_out() -> None:
     assert terminal_title_supported(environ={"TERM": "xterm-256color"}, stream=TtyStringIO())
+    assert terminal_title_supported(
+        environ={"TERM": "xterm-256color", "NO_COLOR": "1"},
+        stream=TtyStringIO(),
+    )
     assert not terminal_title_supported(environ={"TERM": "xterm-256color"}, stream=PipeStringIO())
     assert not terminal_title_supported(
         environ={"TERM": "xterm-256color", "TAU_TERMINAL_TITLE": "0"},
@@ -82,3 +86,20 @@ def test_terminal_title_controller_noops_when_disabled() -> None:
     controller.restore()
 
     assert writes == []
+
+
+def test_terminal_title_controller_disables_itself_after_write_failure() -> None:
+    calls = 0
+
+    def failing_writer(sequence: str) -> None:
+        nonlocal calls
+        calls += 1
+        raise OSError("terminal is gone")
+
+    controller = TerminalTitleController(enabled=True, writer=failing_writer)
+
+    controller.update("build notes", running=False)
+    controller.update("other", running=False)
+
+    assert calls == 1
+    assert controller.enabled is False

--- a/tests/test_terminal_title.py
+++ b/tests/test_terminal_title.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from tau_coding.tui.terminal_title import (
+    MAX_TERMINAL_TITLE_LENGTH,
+    TerminalTitleController,
+    build_terminal_title,
+    osc_terminal_title_sequence,
+    sanitize_terminal_title,
+    terminal_title_supported,
+)
+
+
+class TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class PipeStringIO(StringIO):
+    def isatty(self) -> bool:
+        return False
+
+
+def test_build_terminal_title_uses_session_name_and_running_frame() -> None:
+    assert build_terminal_title("build notes", running=False) == "build notes — Tau"
+    assert build_terminal_title("build notes", running=True, frame=1) == "⠙ build notes — Tau"
+
+
+def test_build_terminal_title_falls_back_for_unnamed_sessions() -> None:
+    assert build_terminal_title(None, running=False) == "Tau"
+    assert build_terminal_title(" Untitled session ", running=True) == "⠋ Tau"
+
+
+def test_sanitize_terminal_title_strips_control_bytes_and_caps_length() -> None:
+    malicious = "\x1b]0;bad\x07\n" + ("x" * MAX_TERMINAL_TITLE_LENGTH)
+
+    sanitized = sanitize_terminal_title(malicious)
+
+    assert "\x1b" not in sanitized
+    assert "\x07" not in sanitized
+    assert "\n" not in sanitized
+    assert len(sanitized) == MAX_TERMINAL_TITLE_LENGTH
+    assert sanitized.endswith("…")
+
+
+def test_osc_terminal_title_sequence_sanitizes_payload() -> None:
+    assert osc_terminal_title_sequence("hello\x07") == "\x1b]0;hello\x07"
+
+
+def test_terminal_title_supported_requires_tty_and_allows_opt_out() -> None:
+    assert terminal_title_supported(environ={"TERM": "xterm-256color"}, stream=TtyStringIO())
+    assert not terminal_title_supported(environ={"TERM": "xterm-256color"}, stream=PipeStringIO())
+    assert not terminal_title_supported(
+        environ={"TERM": "xterm-256color", "TAU_TERMINAL_TITLE": "0"},
+        stream=TtyStringIO(),
+    )
+    assert not terminal_title_supported(environ={"TERM": "dumb"}, stream=TtyStringIO())
+
+
+def test_terminal_title_controller_writes_running_idle_and_restore_titles() -> None:
+    writes: list[str] = []
+    controller = TerminalTitleController(enabled=True, writer=writes.append)
+
+    controller.update("build notes", running=False)
+    controller.update("build notes", running=False)
+    controller.update("build notes", running=True, frame=2)
+    controller.restore()
+
+    assert writes == [
+        "\x1b]0;build notes — Tau\x07",
+        "\x1b]0;⠹ build notes — Tau\x07",
+        "\x1b]0;Tau\x07",
+    ]
+
+
+def test_terminal_title_controller_noops_when_disabled() -> None:
+    writes: list[str] = []
+    controller = TerminalTitleController(enabled=False, writer=writes.append)
+
+    controller.update("build notes", running=True)
+    controller.restore()
+
+    assert writes == []

--- a/tests/test_terminal_title.py
+++ b/tests/test_terminal_title.py
@@ -23,13 +23,13 @@ class PipeStringIO(StringIO):
 
 
 def test_build_terminal_title_uses_session_name_and_running_frame() -> None:
-    assert build_terminal_title("build notes", running=False) == "build notes — Tau"
-    assert build_terminal_title("build notes", running=True, frame=1) == "⠙ build notes — Tau"
+    assert build_terminal_title("build notes", running=False) == "τ | build notes"
+    assert build_terminal_title("build notes", running=True, frame=1) == "⠙ τ | build notes"
 
 
 def test_build_terminal_title_falls_back_for_unnamed_sessions() -> None:
-    assert build_terminal_title(None, running=False) == "Tau"
-    assert build_terminal_title(" Untitled session ", running=True) == "⠋ Tau"
+    assert build_terminal_title(None, running=False) == "τ"
+    assert build_terminal_title(" Untitled session ", running=True) == "⠋ τ"
 
 
 def test_sanitize_terminal_title_strips_control_bytes_and_caps_length() -> None:
@@ -72,9 +72,9 @@ def test_terminal_title_controller_writes_running_idle_and_restore_titles() -> N
     controller.restore()
 
     assert writes == [
-        "\x1b]0;build notes — Tau\x07",
-        "\x1b]0;⠹ build notes — Tau\x07",
-        "\x1b]0;Tau\x07",
+        "\x1b]0;τ | build notes\x07",
+        "\x1b]0;⠹ τ | build notes\x07",
+        "\x1b]0;τ\x07",
     ]
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -89,6 +89,7 @@ from tau_coding.tui.config import (
     tui_settings_path,
 )
 from tau_coding.tui.state import ChatItem
+from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
     LeftAlignedMarkdownHeading,
     StreamingTranscriptMessageWidget,
@@ -2245,6 +2246,35 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
         assert not app.query("#status")
         assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
         assert indicator.render().plain == "τ"
+
+
+@pytest.mark.anyio
+async def test_tui_app_updates_terminal_title_for_running_and_named_session() -> None:
+    session = FakeSession()
+    session._session_title = "build notes"
+    app = TauTuiApp(session)
+    writes: list[str] = []
+    app._terminal_title = TerminalTitleController(enabled=True, writer=writes.append)
+
+    async with app.run_test():
+        assert writes[-1] == "\x1b]0;build notes — Tau\x07"
+
+        app.adapter.apply(AgentStartEvent())
+        app._refresh()
+        assert writes[-1] == "\x1b]0;⠋ build notes — Tau\x07"
+
+        app._tick_activity()
+        assert writes[-1] == "\x1b]0;⠙ build notes — Tau\x07"
+
+        session._session_title = "ship notes"
+        app._refresh_chrome()
+        assert writes[-1] == "\x1b]0;⠙ ship notes — Tau\x07"
+
+        app.adapter.apply(AgentEndEvent())
+        app._refresh()
+        assert writes[-1] == "\x1b]0;ship notes — Tau\x07"
+
+    assert writes[-1] == "\x1b]0;Tau\x07"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2257,24 +2257,24 @@ async def test_tui_app_updates_terminal_title_for_running_and_named_session() ->
     app._terminal_title = TerminalTitleController(enabled=True, writer=writes.append)
 
     async with app.run_test():
-        assert writes[-1] == "\x1b]0;build notes — Tau\x07"
+        assert writes[-1] == "\x1b]0;τ | build notes\x07"
 
         app.adapter.apply(AgentStartEvent())
         app._refresh()
-        assert writes[-1] == "\x1b]0;⠋ build notes — Tau\x07"
+        assert writes[-1] == "\x1b]0;⠋ τ | build notes\x07"
 
         app._tick_activity()
-        assert writes[-1] == "\x1b]0;⠙ build notes — Tau\x07"
+        assert writes[-1] == "\x1b]0;⠙ τ | build notes\x07"
 
         session._session_title = "ship notes"
         app._refresh_chrome()
-        assert writes[-1] == "\x1b]0;⠙ ship notes — Tau\x07"
+        assert writes[-1] == "\x1b]0;⠙ τ | ship notes\x07"
 
         app.adapter.apply(AgentEndEvent())
         app._refresh()
-        assert writes[-1] == "\x1b]0;ship notes — Tau\x07"
+        assert writes[-1] == "\x1b]0;τ | ship notes\x07"
 
-    assert writes[-1] == "\x1b]0;Tau\x07"
+    assert writes[-1] == "\x1b]0;τ\x07"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2278,6 +2278,36 @@ async def test_tui_app_updates_terminal_title_for_running_and_named_session() ->
 
 
 @pytest.mark.anyio
+async def test_tui_app_updates_terminal_title_after_auto_session_naming() -> None:
+    class AutoNamingSession(FakeSession):
+        async def prompt(
+            self,
+            text: str,
+            *,
+            streaming_behavior: str | None = None,
+        ) -> AsyncIterator[AgentEvent]:
+            del streaming_behavior
+            self.prompt_texts.append(text)
+            yield AgentStartEvent()
+            self._session_title = "Debug login"
+            yield MessageEndEvent(message=UserMessage(content=text))
+            yield AgentEndEvent()
+
+    app = TauTuiApp(AutoNamingSession())
+    writes: list[str] = []
+    app._terminal_title = TerminalTitleController(enabled=True, writer=writes.append)
+
+    async with app.run_test():
+        assert writes[-1] == "\x1b]0;τ\x07"
+
+        await app._run_prompt("debug the login flow")
+
+        assert "\x1b]0;τ | Debug login\x07" in writes
+        assert app.sub_title == "Debug login"
+        assert writes[-1] == "\x1b]0;τ | Debug login\x07"
+
+
+@pytest.mark.anyio
 async def test_tui_app_clears_activity_status_on_error() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -13,7 +13,7 @@ Type into the prompt box at the bottom and press **Enter** to submit.
 **Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
 assistant's reply above the prompt, showing tool calls as they run. In supported
 terminal emulators, Tau also updates the tab title: named sessions show as
-`<name> — Tau`, and active runs add an animated running indicator so you can see
+`τ | <name>`, and active runs add an animated running indicator so you can see
 work continuing from another tab.
 
 Clicking anywhere in the window returns focus to the prompt, so you can scroll

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -11,7 +11,10 @@ see [Keyboard shortcuts]({{< relref "../reference/keybindings.md" >}}).
 
 Type into the prompt box at the bottom and press **Enter** to submit.
 **Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
-assistant's reply above the prompt, showing tool calls as they run.
+assistant's reply above the prompt, showing tool calls as they run. In supported
+terminal emulators, Tau also updates the tab title: named sessions show as
+`<name> — Tau`, and active runs add an animated running indicator so you can see
+work continuing from another tab.
 
 Clicking anywhere in the window returns focus to the prompt, so you can scroll
 the transcript and keep typing without tabbing back.

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -16,7 +16,7 @@ command palette with **Ctrl+K**.
 | `/export [--format html\|jsonl] [dest]` | Export the current session |
 | `/resume [session-id]` | Resume a previous session, or open the picker |
 | `/tree` | Branch from an earlier point in the session tree |
-| `/name <new name>` | Rename the current session |
+| `/name <new name>` | Rename the current session and, in supported terminals, the terminal tab title |
 | `/model` | Open the model picker |
 | `/scoped-models` | Choose favorite models for the Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |


### PR DESCRIPTION
## Summary

- add a `tau_coding` terminal-title helper that emits sanitized OSC 0 title updates when supported
- wire the Textual TUI activity/session-name refresh paths to animate running tab titles and restore a neutral title on exit
- document the behavior in dev notes and user docs

Closes #260.

## Tests

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest`
