### PR TITLE
fix: recall queued steering messages

### DIFF
--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -167,6 +167,12 @@ class AgentHarness:
             return None
         return self._follow_up_queue.pop()
 
+    def pop_latest_steering(self) -> AgentMessage | None:
+        """Remove and return the most recently queued steering message."""
+        if not self._steering_queue:
+            return None
+        return self._steering_queue.pop()
+
     def queue_update_event(self) -> QueueUpdateEvent:
         """Return the current queue state as a portable agent event."""
         return QueueUpdateEvent(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -668,6 +668,11 @@ class CodingSession:
         message = self._harness.pop_latest_follow_up()
         return None if message is None else message.content
 
+    def pop_latest_steering_message(self) -> str | None:
+        """Remove and return the most recently queued steering message."""
+        message = self._harness.pop_latest_steering()
+        return None if message is None else message.content
+
     def set_model(self, model: str) -> None:
         """Switch the active model for future turns and make it the default."""
         provider = self._active_provider_config()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -179,7 +179,7 @@ class CompletionActionTarget(Protocol):
 
     def action_toggle_thinking(self) -> None: ...
 
-    def action_edit_queued_follow_up(self) -> bool: ...
+    def action_edit_queued_message(self) -> bool: ...
 
     async def action_submit_prompt(self) -> None: ...
 
@@ -274,7 +274,7 @@ class PromptInput(TextArea):
         """Select the previous app-level completion or move up in the prompt."""
         if self._has_completion_options():
             self._completion_target().action_completion_previous()
-        elif self._completion_target().action_edit_queued_follow_up():
+        elif self._completion_target().action_edit_queued_message():
             return
         else:
             self.action_cursor_up()
@@ -2692,7 +2692,7 @@ class TauTuiApp(App[None]):
             self.screen.action_cursor_up()
             return
         if not self._completion_state.items:
-            if self.action_edit_queued_follow_up():
+            if self.action_edit_queued_message():
                 return
             if self.action_recall_previous_prompt():
                 return
@@ -2715,17 +2715,15 @@ class TauTuiApp(App[None]):
         self._refresh_completions()
         return True
 
-    def action_edit_queued_follow_up(self) -> bool:
-        """Move the latest queued follow-up back into the prompt for editing."""
+    def action_edit_queued_message(self) -> bool:
+        """Move the latest queued message back into the prompt for editing."""
         if not self.state.running:
             return False
         prompt = self.query_one("#prompt", PromptInput)
         if prompt.text.strip():
             return False
-        pop_follow_up = getattr(self.session, "pop_latest_follow_up_message", None)
-        if not callable(pop_follow_up):
-            return False
-        message = pop_follow_up()
+
+        message = self._pop_latest_queued_message()
         if not message:
             return False
         prompt.text = message
@@ -2734,6 +2732,26 @@ class TauTuiApp(App[None]):
         self._completion_state = self._build_completion_state(prompt.text)
         self._refresh()
         return True
+
+    def action_edit_queued_follow_up(self) -> bool:
+        """Move the latest queued message back into the prompt for editing."""
+        return self.action_edit_queued_message()
+
+    def _pop_latest_queued_message(self) -> str | None:
+        """Pop the latest queued follow-up or steering message from the session."""
+        pop_follow_up = getattr(self.session, "pop_latest_follow_up_message", None)
+        if callable(pop_follow_up):
+            message = pop_follow_up()
+            if isinstance(message, str) and message:
+                return message
+
+        pop_steering = getattr(self.session, "pop_latest_steering_message", None)
+        if callable(pop_steering):
+            message = pop_steering()
+            if isinstance(message, str) and message:
+                return message
+
+        return None
 
     def action_open_command_palette(self) -> None:
         """Open the slash-command palette in the prompt."""

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -122,6 +122,21 @@ def test_harness_can_pop_latest_follow_up_message() -> None:
     assert harness.pop_latest_follow_up() is None
 
 
+def test_harness_can_pop_latest_steering_message() -> None:
+    harness = AgentHarness(
+        AgentHarnessConfig(provider=FakeProvider([]), model="fake", system="You are Tau.")
+    )
+
+    harness.steer("First")
+    harness.steer("Second")
+    popped = harness.pop_latest_steering()
+
+    assert popped == UserMessage(content="Second")
+    assert harness.queue_update_event().steering == ("First",)
+    assert harness.pop_latest_steering() == UserMessage(content="First")
+    assert harness.pop_latest_steering() is None
+
+
 @pytest.mark.anyio
 async def test_subscribed_listeners_receive_events_and_can_unsubscribe() -> None:
     assistant = AssistantMessage(content="Hello")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -371,6 +371,13 @@ class FakeSession:
         self.queued_follow_up_messages = self.queued_follow_up_messages[:-1]
         return message
 
+    def pop_latest_steering_message(self) -> str | None:
+        if not self.queued_steering_messages:
+            return None
+        message = self.queued_steering_messages[-1]
+        self.queued_steering_messages = self.queued_steering_messages[:-1]
+        return message
+
     async def prompt(
         self,
         text: str,
@@ -4535,6 +4542,53 @@ async def test_tui_app_up_arrow_edits_latest_queued_follow_up() -> None:
         assert app.state.queued_follow_up == ("first follow-up",)
         queued_messages = app.query_one("#queued-messages")
         assert queued_messages.display is True
+
+
+@pytest.mark.anyio
+async def test_tui_app_up_arrow_edits_latest_queued_steering_message() -> None:
+    session = FakeSession(messages=[UserMessage(content="remembered prompt")])
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        session.queued_steering_messages = ("first steering", "latest steering")
+        app._refresh()
+
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.focus()
+        prompt.text = ""
+        await pilot.press("up")
+        await pilot.pause()
+
+        assert prompt.text == "latest steering"
+        assert session.queued_steering_messages == ("first steering",)
+        assert app.state.queued_steering == ("first steering",)
+        queued_messages = app.query_one("#queued-messages")
+        assert queued_messages.display is True
+
+
+@pytest.mark.anyio
+async def test_tui_app_up_arrow_prefers_queued_follow_up_before_steering() -> None:
+    session = FakeSession(messages=[UserMessage(content="remembered prompt")])
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        app.state.running = True
+        session.queued_steering_messages = ("queued steering",)
+        session.queued_follow_up_messages = ("queued follow-up",)
+        app._refresh()
+
+        prompt = app.query_one("#prompt", TextArea)
+        prompt.focus()
+        prompt.text = ""
+        await pilot.press("up")
+        await pilot.pause()
+
+        assert prompt.text == "queued follow-up"
+        assert session.queued_steering_messages == ("queued steering",)
+        assert session.queued_follow_up_messages == ()
+        assert app.state.queued_steering == ("queued steering",)
+        assert app.state.queued_follow_up == ()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Add steering-queue pop support to the agent harness and coding session
- Update Up Arrow queued-message recall to restore queued steering messages when no follow-up is queued
- Add regression coverage for queued steering recall and existing follow-up priority

Fixes #305.

## Tests

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
