### PR TITLE
Decouple session persistence from automatic naming

### DIFF
--- a/dev-notes/architecture/auto-session-naming.md
+++ b/dev-notes/architecture/auto-session-naming.md
@@ -28,6 +28,8 @@ Tau uses the session's currently selected provider/model for the naming request.
 
 Naming happens only after the first user message has been persisted. This preserves deferred indexing for newly prepared sessions: a session that is cancelled before its first durable message should not appear in the resume index just because naming started.
 
+Persistence is intentionally independent from naming. The first durable message indexes the session before Tau attempts to write title metadata. If the provider naming call fails, returns unusable text, or even the title metadata update raises an error, Tau logs the metadata failure and keeps the transcript/session record resumable. Automatic names are helpful metadata, not a prerequisite for durability.
+
 ## How to test
 
 ```bash

--- a/dev-notes/architecture/auto-session-naming.md
+++ b/dev-notes/architecture/auto-session-naming.md
@@ -28,7 +28,7 @@ Tau uses the session's currently selected provider/model for the naming request.
 
 Naming happens only after the first user message has been persisted. This preserves deferred indexing for newly prepared sessions: a session that is cancelled before its first durable message should not appear in the resume index just because naming started.
 
-Persistence is intentionally independent from naming. The first durable message indexes the session before Tau attempts to write title metadata. If the provider naming call fails, returns unusable text, or even the title metadata update raises an error, Tau logs the metadata failure and keeps the transcript/session record resumable. Automatic names are helpful metadata, not a prerequisite for durability.
+Persistence is intentionally independent from naming. The first durable message indexes the session before Tau attempts to write title metadata. Tau starts the naming request in the background so the first assistant response can stream without waiting for title generation. Before the prompt run fully finishes, Tau awaits the background naming task so best-effort title metadata is settled. If the provider naming call fails, returns unusable text, or even the title metadata update raises an error, Tau logs the metadata failure and keeps the transcript/session record resumable. Automatic names are helpful metadata, not a prerequisite for durability.
 
 ## How to test
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import string
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
@@ -1241,7 +1242,7 @@ class CodingSession:
 
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
         persisted_count = len(self._harness.messages)
-        auto_name_attempted = False
+        auto_name_task: asyncio.Task[None] | None = None
         overflow_event: ErrorEvent | None = None
         try:
             events = self._harness.prompt(expanded_content)
@@ -1249,9 +1250,11 @@ class CodingSession:
             async for event in events:
                 if isinstance(event, MessageEndEvent):
                     persisted_count = await self._persist_messages_since(persisted_count)
-                    if not auto_name_attempted and isinstance(event.message, UserMessage):
-                        auto_name_attempted = True
-                        await self._try_auto_name_session(event.message.content, context=context)
+                    if auto_name_task is None and isinstance(event.message, UserMessage):
+                        auto_name_task = asyncio.create_task(
+                            self._try_auto_name_session(event.message.content, context=context)
+                        )
+                        await asyncio.sleep(0)
                 if isinstance(event, ToolExecutionEndEvent):
                     self._invalidate_context_usage_cache()
                 if isinstance(event, ErrorEvent) and not event.recoverable:
@@ -1265,6 +1268,7 @@ class CodingSession:
                 yield event
             persisted_count = await self._persist_messages_since(persisted_count)
             if overflow_event is not None:
+                await _wait_for_auto_name_task(auto_name_task)
                 compacted = await self._try_overflow_compact(context=context)
                 if compacted:
                     retry_persisted_count = len(self._harness.messages)
@@ -1288,8 +1292,12 @@ class CodingSession:
                         yield retry_event
                     await self._persist_messages_since(retry_persisted_count)
                 return
+            await _wait_for_auto_name_task(auto_name_task)
             await self._try_auto_compact(context=context, phase="auto_compact_after_prompt")
         except Exception as exc:
+            if auto_name_task is not None and not auto_name_task.done():
+                auto_name_task.cancel()
+            await _wait_for_auto_name_task(auto_name_task)
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
                 context=context,
                 phase="agent_loop",
@@ -1703,6 +1711,16 @@ class CodingSession:
         self._harness.replace_messages(self._state.messages)
         self._invalidate_context_usage_cache()
         return compaction
+
+
+async def _wait_for_auto_name_task(task: asyncio.Task[None] | None) -> None:
+    """Wait for background session naming without surfacing optional metadata failures."""
+    if task is None:
+        return
+    try:
+        await task
+    except asyncio.CancelledError:
+        return
 
 
 def _first_recent_context_index(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1401,12 +1401,7 @@ class CodingSession:
     async def _refresh_persisted_state(self, *, leaf_id: str | None) -> None:
         entries = await self._read_session_entries()
         self._state = SessionState.from_entries(entries, leaf_id=leaf_id)
-        if self._config.session_id is not None and self._config.session_manager is not None:
-            self._config.session_manager.touch_session(
-                self._config.session_id,
-                model=self.model,
-                provider_name=self.provider_name,
-            )
+        self._touch_or_index_session()
 
     async def _read_session_entries(self) -> list[SessionEntry]:
         """Read stored entries, detaching roots imported from external history."""
@@ -1437,17 +1432,27 @@ class CodingSession:
         self._pending_initial_entries = ()
 
     def _index_current_session(self) -> None:
+        self._touch_or_index_session(update_timestamp=False)
+        self._config = replace(self._config, index_on_first_persist=False)
+
+    def _touch_or_index_session(self, *, update_timestamp: bool = True) -> None:
         if self._config.session_id is None or self._config.session_manager is None:
             return
         existing = self._config.session_manager.get_session(self._config.session_id)
-        if existing is not None:
+        if existing is None:
+            self._config.session_manager.create_session(
+                cwd=self.cwd,
+                model=self.model,
+                provider_name=self.provider_name,
+                session_id=self._config.session_id,
+            )
             return
-        self._config.session_manager.create_session(
-            cwd=self.cwd,
-            model=self.model,
-            provider_name=self.provider_name,
-            session_id=self._config.session_id,
-        )
+        if update_timestamp:
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+            )
 
     async def _try_auto_compact(
         self,
@@ -1491,22 +1496,32 @@ class CodingSession:
         *,
         context: AgentCallDiagnosticContext,
     ) -> None:
-        if not self._should_auto_name_session():
-            return
         try:
+            if not self._should_auto_name_session():
+                return
             title = await self._generate_session_name(first_message)
+            if title is None:
+                title = _fallback_session_name(first_message)
+            if title is None:
+                return
+            self._set_auto_session_title(title)
         except Exception as exc:  # noqa: BLE001 - naming must not interrupt the agent turn
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
                 context=context,
                 phase="auto_name_session",
                 exc=exc,
             )
-            title = _fallback_session_name(first_message)
-        if title is None:
-            title = _fallback_session_name(first_message)
-        if title is None:
-            return
-        self._set_auto_session_title(title)
+            fallback_title = _fallback_session_name(first_message)
+            if fallback_title is None:
+                return
+            try:
+                self._set_auto_session_title(fallback_title)
+            except Exception as fallback_exc:  # noqa: BLE001 - title metadata is optional
+                self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
+                    context=context,
+                    phase="auto_name_session_fallback",
+                    exc=fallback_exc,
+                )
 
     def _should_auto_name_session(self) -> bool:
         if self._config.session_id is None or self._config.session_manager is None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2526,6 +2526,7 @@ class TauTuiApp(App[None]):
         finally:
             self._clear_optimistic_user_messages(run_id=active_run_id)
             if active_run_id == self._prompt_run_id:
+                self._sync_header_title()
                 self._prompt_worker = None
 
     async def _apply_streaming_transcript_event(self, event: AgentEvent) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1717,6 +1717,100 @@ async def test_session_auto_name_falls_back_when_provider_fails(tmp_path: Path) 
 
 
 @pytest.mark.anyio
+async def test_session_persists_prepared_session_when_auto_naming_fails(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.prepare_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderErrorEvent(message="naming failed"),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=record.cwd,
+            session_id=record.id,
+            session_manager=manager,
+            index_on_first_persist=True,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Keep this resumable even if naming fails"))
+
+    indexed = manager.get_session(record.id)
+    assert indexed is not None
+    assert indexed.title == "Keep this resumable even"
+    assert indexed.path == record.path
+    assert session.messages == (
+        UserMessage(content="Keep this resumable even if naming fails"),
+        AssistantMessage(content="Done"),
+    )
+    assert await storage.read_all()
+
+
+@pytest.mark.anyio
+async def test_session_persists_when_auto_name_touch_fails(tmp_path: Path) -> None:
+    class FailingTitleSessionManager(SessionManager):
+        def touch_session(self, session_id: str, **kwargs: object):  # type: ignore[no-untyped-def]
+            if kwargs.get("title") is not None:
+                raise RuntimeError("title index update failed")
+            return super().touch_session(session_id, **kwargs)  # type: ignore[arg-type]
+
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = FailingTitleSessionManager(
+        TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    )
+    record = manager.prepare_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Generated title")),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=record.cwd,
+            session_id=record.id,
+            session_manager=manager,
+            index_on_first_persist=True,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Do not lose this session"))
+
+    indexed = manager.get_session(record.id)
+    assert indexed is not None
+    assert indexed.title is None
+    assert session.messages == (
+        UserMessage(content="Do not lose this session"),
+        AssistantMessage(content="Done"),
+    )
+    assert await storage.read_all()
+
+
+@pytest.mark.anyio
 async def test_session_auto_name_falls_back_when_provider_returns_unusable_title(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -9,6 +9,7 @@ from tau_agent import (
     AgentMessage,
     AgentTool,
     AssistantMessage,
+    MessageEndEvent,
     QueueUpdateEvent,
     ToolCall,
     ToolResultMessage,
@@ -1808,6 +1809,83 @@ async def test_session_persists_when_auto_name_touch_fails(tmp_path: Path) -> No
         AssistantMessage(content="Done"),
     )
     assert await storage.read_all()
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_runs_while_assistant_responds(tmp_path: Path) -> None:
+    class SlowNamingProvider:
+        def __init__(self) -> None:
+            self.naming_started = asyncio.Event()
+            self.release_naming = asyncio.Event()
+
+        def stream_response(
+            self,
+            *,
+            model: str,
+            system: str,
+            messages: list[AgentMessage],
+            tools: list[AgentTool],
+            signal: CancellationToken | None = None,
+        ) -> AsyncIterator[ProviderEvent]:
+            is_naming = system.startswith("You write concise coding-agent session names")
+            del model, messages, signal
+
+            async def iterator() -> AsyncIterator[ProviderEvent]:
+                if is_naming:
+                    self.naming_started.set()
+                    await self.release_naming.wait()
+                    yield ProviderResponseEndEvent(
+                        message=AssistantMessage(content="Generated title")
+                    )
+                    return
+                yield ProviderResponseStartEvent(model="fake")
+                yield ProviderResponseEndEvent(message=AssistantMessage(content="Done"))
+
+            return iterator()
+
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = SlowNamingProvider()
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    stream = session.prompt("Name this session in the background")
+    seen_assistant = False
+    try:
+        async for event in stream:
+            if (
+                provider.naming_started.is_set()
+                and isinstance(event, MessageEndEvent)
+                and isinstance(event.message, AssistantMessage)
+            ):
+                seen_assistant = True
+                break
+        assert seen_assistant
+        assert provider.naming_started.is_set()
+        assert manager.get_session(record.id).title is None
+        assert session.messages == (
+            UserMessage(content="Name this session in the background"),
+            AssistantMessage(content="Done"),
+        )
+        provider.release_naming.set()
+        await _collect_session_events(stream)
+    finally:
+        provider.release_naming.set()
+        await stream.aclose()
+
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Generated title"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2315,6 +2315,36 @@ async def test_tui_app_updates_terminal_title_after_auto_session_naming() -> Non
 
 
 @pytest.mark.anyio
+async def test_tui_app_updates_terminal_title_after_background_auto_session_naming() -> None:
+    class BackgroundAutoNamingSession(FakeSession):
+        async def prompt(
+            self,
+            text: str,
+            *,
+            streaming_behavior: str | None = None,
+        ) -> AsyncIterator[AgentEvent]:
+            del streaming_behavior
+            self.prompt_texts.append(text)
+            yield AgentStartEvent()
+            yield MessageEndEvent(message=UserMessage(content=text))
+            yield MessageEndEvent(message=AssistantMessage(content="Done"))
+            self._session_title = "Debug login"
+            yield AgentEndEvent()
+
+    app = TauTuiApp(BackgroundAutoNamingSession())
+    writes: list[str] = []
+    app._terminal_title = TerminalTitleController(enabled=True, writer=writes.append)
+
+    async with app.run_test():
+        assert writes[-1] == "\x1b]0;τ\x07"
+
+        await app._run_prompt("debug the login flow")
+
+        assert app.sub_title == "Debug login"
+        assert writes[-1] == "\x1b]0;τ | Debug login\x07"
+
+
+@pytest.mark.anyio
 async def test_tui_app_clears_activity_status_on_error() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -52,7 +52,8 @@ If a summary request fails, Tau falls back to a deterministic summary.
 New sessions are automatically given a short name from the first message when
 Tau can generate one. The name appears anywhere session names are already shown,
 including the `/resume` picker and id completions. If naming fails, the session
-continues normally and Tau falls back to a short local name when possible.
+continues normally, is still saved for resume, and Tau falls back to a short
+local name when possible.
 
 ```text
 /name My refactor session


### PR DESCRIPTION
## Summary

- Decouple first-message session indexing/touching from automatic session title generation
- Treat auto-naming/title metadata failures as non-fatal after the durable transcript has been saved
- Add regression tests for prepared sessions when provider naming fails and when title metadata updates fail
- Update session naming docs to clarify that resume persistence does not depend on naming

Fixes #306.

## Tests

- `uv run pytest tests/test_coding_session.py -q`
- `uv run ruff check src/tau_coding/session.py tests/test_coding_session.py website/content/guides/sessions.md`
- `uv run pytest -q`
- `uv run ruff check`
