### PR TITLE
Prepare 0.1.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "0.1.4",
+    "date": "2026-07-08",
+    "sections": {
+      "New": [
+        "Add automatic session naming for new conversations.",
+        "Add terminal tab titles with the Tau mark and active session name.",
+        "Add Claude Fable 5 and Claude Sonnet 5 model catalog entries.",
+        "Add a TUI sidebar_position setting for left or right sidebar placement."
+      ],
+      "Changed": [
+        "Unify skill discovery around the Agent Skills specification.",
+        "Read tau --version from installed package metadata.",
+        "Compact large pasted prompts in the TUI while preserving pasted content."
+      ],
+      "Fixed": [
+        "Fix Windows crashes caused by non-ASCII CLI output on non-UTF-8 streams.",
+        "Fix Gemini tool-call compatibility by preserving thought signatures and stripping unsupported JSON Schema keywords.",
+        "Fix skill discovery edge cases by ignoring .agents root directories and bare Markdown files under .agents/skills.",
+        "Fix SOCKS proxy environment URL handling.",
+        "Fix queued steering recall, TUI completion height stability, pasted placeholder expansion, auto-naming indexing, and terminal-title refreshes."
+      ]
+    }
+  },
+  {
     "version": "0.1.3",
     "date": "2026-07-07",
     "sections": {

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the `0.1.4` patch release.

## Changes

- Bump package metadata from `0.1.3` to `0.1.4`.
- Sync the editable package version in `uv.lock`.
- Add structured release notes for `0.1.4`.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy`
