### PR TITLE
fix: make session auto-naming failures non-fatal to the agent turn

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import string
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
@@ -112,6 +113,8 @@ SESSION_NAME_SYSTEM_PROMPT = (
     "You write concise coding-agent session names. Reply with only a short title, "
     "maximum four words, no quotes, no punctuation-only output."
 )
+# Auto-naming is optional metadata; a slow provider must not stall the first turn.
+SESSION_NAME_TIMEOUT_SECONDS = 10.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -1491,22 +1494,39 @@ class CodingSession:
         *,
         context: AgentCallDiagnosticContext,
     ) -> None:
-        if not self._should_auto_name_session():
-            return
         try:
-            title = await self._generate_session_name(first_message)
+            should_name = self._should_auto_name_session()
         except Exception as exc:  # noqa: BLE001 - naming must not interrupt the agent turn
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
                 context=context,
                 phase="auto_name_session",
                 exc=exc,
             )
-            title = _fallback_session_name(first_message)
+            return
+        if not should_name:
+            return
+        title: str | None = None
+        try:
+            async with asyncio.timeout(SESSION_NAME_TIMEOUT_SECONDS):
+                title = await self._generate_session_name(first_message)
+        except Exception as exc:  # noqa: BLE001 - naming must not interrupt the agent turn
+            self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
+                context=context,
+                phase="auto_name_session",
+                exc=exc,
+            )
         if title is None:
             title = _fallback_session_name(first_message)
         if title is None:
             return
-        self._set_auto_session_title(title)
+        try:
+            self._set_auto_session_title(title)
+        except Exception as exc:  # noqa: BLE001 - the title is optional session metadata
+            self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
+                context=context,
+                phase="auto_name_session",
+                exc=exc,
+            )
 
     def _should_auto_name_session(self) -> bool:
         if self._config.session_id is None or self._config.session_manager is None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1755,6 +1755,146 @@ async def test_session_auto_name_falls_back_when_provider_returns_unusable_title
 
 
 @pytest.mark.anyio
+async def test_session_auto_name_index_write_failure_does_not_break_turn(
+    tmp_path: Path,
+) -> None:
+    # Regression test for issue #306: an index failure while writing the
+    # generated title must not abort the turn or lose the assistant reply.
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content='"Generated title"')),
+            ],
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+    original_touch = manager.touch_session
+
+    def failing_touch(session_id: str, **kwargs: object) -> object:
+        if kwargs.get("title") is not None:
+            raise OSError("index file is locked")
+        return original_touch(session_id, **kwargs)  # type: ignore[arg-type]
+
+    manager.touch_session = failing_touch  # type: ignore[method-assign]
+
+    await _collect_session_events(session.prompt("First message"))
+
+    assert session.messages == (
+        UserMessage(content="First message"),
+        AssistantMessage(content="Done"),
+    )
+    persisted = manager.get_session(record.id)
+    assert persisted is not None
+    assert persisted.title is None
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_index_read_failure_does_not_break_turn(
+    tmp_path: Path,
+) -> None:
+    # Regression test for issue #306: an index failure while checking whether
+    # the session needs a name must not abort the turn.
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    provider = FakeProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+    def failing_get(session_id: str) -> object:
+        raise OSError("index file is unreadable")
+
+    manager.get_session = failing_get  # type: ignore[method-assign]
+
+    await session._try_auto_name_session(  # noqa: SLF001 - guard under test
+        "First message",
+        context=session._diagnostic_context(),  # noqa: SLF001
+    )
+
+
+@pytest.mark.anyio
+async def test_session_auto_name_times_out_and_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression test for issue #306: a hung naming request must not stall the
+    # turn; the session falls back to a title derived from the first message.
+    monkeypatch.setattr(coding_session_module, "SESSION_NAME_TIMEOUT_SECONDS", 0.05)
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+
+    class HangingNamingProvider(FakeProvider):
+        def stream_response(self, **kwargs: object) -> AsyncIterator[ProviderEvent]:
+            if kwargs["system"] == coding_session_module.SESSION_NAME_SYSTEM_PROMPT:
+
+                async def hang() -> AsyncIterator[ProviderEvent]:
+                    await asyncio.Event().wait()
+                    yield ProviderResponseStartEvent(model="fake")
+
+                return hang()
+            return super().stream_response(**kwargs)  # type: ignore[arg-type]
+
+    provider = HangingNamingProvider(
+        [
+            [
+                ProviderResponseStartEvent(model="fake"),
+                ProviderResponseEndEvent(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+        )
+    )
+
+    await _collect_session_events(session.prompt("Investigate flaky session restore tests"))
+
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Investigate flaky session restore"
+
+
+@pytest.mark.anyio
 async def test_session_auto_name_does_not_overwrite_manual_name(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))


### PR DESCRIPTION
@-