### PR TITLE
feat: add todo_write and todo_read tools to the default coding tool set

### DIFF
--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -139,6 +139,7 @@ from tau_coding.thinking import (
 )
 from tau_coding.tools import (
     ToolDefinition,
+    ToolInputError,
     create_bash_tool,
     create_bash_tool_definition,
     create_coding_tools,
@@ -146,6 +147,7 @@ from tau_coding.tools import (
     create_edit_tool_definition,
     create_read_tool,
     create_read_tool_definition,
+    create_todo_tools,
     create_write_tool,
     create_write_tool_definition,
 )
@@ -195,6 +197,7 @@ __all__ = [
     "TauPaths",
     "TauResourcePaths",
     "ToolDefinition",
+    "ToolInputError",
     "TranscriptRenderer",
     "ThinkingLevel",
     "ThinkingParameter",
@@ -216,6 +219,7 @@ __all__ = [
     "create_event_renderer",
     "create_read_tool",
     "create_read_tool_definition",
+    "create_todo_tools",
     "create_write_tool",
     "create_write_tool_definition",
     "credentials_path",

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -92,6 +92,172 @@ class ToolDefinition:
 
 _file_locks: dict[Path, asyncio.Lock] = {}
 
+_TODO_VALID_STATUSES: frozenset[str] = frozenset({"pending", "in_progress", "completed"})
+_TODO_VALID_PRIORITIES: frozenset[str] = frozenset({"high", "medium", "low"})
+
+
+def create_todo_tools() -> tuple[AgentTool, AgentTool]:
+    """Create the ``todo_write`` and ``todo_read`` tools with shared in-memory state.
+
+    Both tools share the same todo list for the lifetime of the returned
+    objects. Calling ``create_todo_tools`` a second time produces a new pair
+    with a fresh list; the two pairs do not share state.
+    """
+    state: list[dict[str, JSONValue]] = []
+    return (
+        _create_todo_write_definition(state).to_agent_tool(),
+        _create_todo_read_definition(state).to_agent_tool(),
+    )
+
+
+def _create_todo_write_definition(
+    state: list[dict[str, JSONValue]],
+) -> ToolDefinition:
+    """Create the ``todo_write`` tool definition backed by *state*."""
+
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del signal
+        raw: JSONValue = arguments.get("todos")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                raw = None
+        if not isinstance(raw, list):
+            raise ToolInputError("todos must be an array of todo objects")
+
+        validated: list[dict[str, JSONValue]] = []
+        for index, item in enumerate(raw):
+            if not isinstance(item, dict):
+                raise ToolInputError(f"todos[{index}] must be an object")
+            todo_id = item.get("id")
+            content = item.get("content")
+            status = item.get("status")
+            priority = item.get("priority")
+            if not isinstance(todo_id, str):
+                raise ToolInputError(f"todos[{index}].id must be a string")
+            if not isinstance(content, str):
+                raise ToolInputError(f"todos[{index}].content must be a string")
+            if not isinstance(status, str) or status not in _TODO_VALID_STATUSES:
+                raise ToolInputError(
+                    f"todos[{index}].status must be one of: "
+                    + ", ".join(sorted(_TODO_VALID_STATUSES))
+                )
+            if not isinstance(priority, str) or priority not in _TODO_VALID_PRIORITIES:
+                raise ToolInputError(
+                    f"todos[{index}].priority must be one of: "
+                    + ", ".join(sorted(_TODO_VALID_PRIORITIES))
+                )
+            validated.append(
+                {
+                    "id": todo_id,
+                    "content": content,
+                    "status": status,
+                    "priority": priority,
+                }
+            )
+
+        state.clear()
+        state.extend(validated)
+        count = len(validated)
+        noun = "item" if count == 1 else "items"
+        return AgentToolResult(
+            tool_call_id="",
+            name="todo_write",
+            ok=True,
+            content=f"Todo list updated. {count} {noun} saved.",
+            data={"count": count},
+        )
+
+    return ToolDefinition(
+        name="todo_write",
+        description=(
+            "Replace the session todo list with a new list of tasks. "
+            "Use this to track what you plan to do and mark tasks as you progress. "
+            "Each todo requires: id (string), content (string), "
+            "status (pending|in_progress|completed), priority (high|medium|low)."
+        ),
+        prompt_snippet="Write or update the todo list",
+        prompt_guidelines=(
+            "Use todo_write to track multi-step tasks: create todos before starting, "
+            "update status as you work (pending → in_progress → completed).",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "todos": {
+                    "type": "array",
+                    "description": "The complete new todo list, replacing any existing items",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Unique task identifier",
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "Task description",
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed"],
+                                "description": "Current task status",
+                            },
+                            "priority": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                                "description": "Task priority",
+                            },
+                        },
+                        "required": ["id", "content", "status", "priority"],
+                    },
+                }
+            },
+            "required": ["todos"],
+        },
+        executor=execute,
+    )
+
+
+def _create_todo_read_definition(
+    state: list[dict[str, JSONValue]],
+) -> ToolDefinition:
+    """Create the ``todo_read`` tool definition backed by *state*."""
+
+    async def execute(
+        arguments: Mapping[str, JSONValue],
+        signal: ToolCancellationToken | None = None,
+    ) -> AgentToolResult:
+        del arguments, signal
+        content = json.dumps(state, indent=2) if state else "[]"
+        return AgentToolResult(
+            tool_call_id="",
+            name="todo_read",
+            ok=True,
+            content=content,
+            data={"count": len(state)},
+        )
+
+    return ToolDefinition(
+        name="todo_read",
+        description=(
+            "Read the current session todo list. "
+            "Returns all tasks with their id, content, status, and priority."
+        ),
+        prompt_snippet="Read the current todo list",
+        prompt_guidelines=("Use todo_read to check outstanding tasks before starting work.",),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        executor=execute,
+    )
+
 
 def create_coding_tools(
     *,
@@ -100,12 +266,14 @@ def create_coding_tools(
 ) -> list[AgentTool]:
     """Create the default coding-tool set for a local project.
 
-    The returned tools are ordered as `read`, `write`, `edit`, and `bash`.
-    Relative paths used with those tools are resolved against `cwd`; when `cwd`
-    is omitted, the process current working directory at factory-call time is
-    used. The tools share per-path write/edit locks within this process so
-    concurrent mutations of the same file do not interleave. When configured,
-    `shell_command_prefix` is prepended to every bash tool command.
+    The returned tools are ordered as ``read``, ``write``, ``edit``, ``bash``,
+    ``todo_write``, and ``todo_read``. Relative paths used with those tools are
+    resolved against `cwd`; when `cwd` is omitted, the process current working
+    directory at factory-call time is used. The tools share per-path write/edit
+    locks within this process so concurrent mutations of the same file do not
+    interleave. When configured, `shell_command_prefix` is prepended to every
+    bash tool command. The ``todo_write`` and ``todo_read`` tools share a
+    single in-memory list that lives for the lifetime of the returned list.
     """
     root = Path.cwd() if cwd is None else Path(cwd)
     return [
@@ -113,6 +281,7 @@ def create_coding_tools(
         create_write_tool(cwd=root),
         create_edit_tool(cwd=root),
         create_bash_tool(cwd=root, shell_command_prefix=shell_command_prefix),
+        *create_todo_tools(),
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,7 +336,14 @@ async def test_run_print_mode_prints_final_assistant_text(
     assert provider.calls[0][1] == build_system_prompt(
         BuildSystemPromptOptions(cwd=tmp_path, tools=create_coding_tools(cwd=tmp_path))
     )
-    assert [tool.name for tool in provider.calls[0][3]] == ["read", "write", "edit", "bash"]
+    assert [tool.name for tool in provider.calls[0][3]] == [
+        "read",
+        "write",
+        "edit",
+        "bash",
+        "todo_write",
+        "todo_read",
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -184,7 +184,14 @@ async def test_load_empty_session_defers_transcript_file(tmp_path: Path) -> None
     assert session.available_thinking_levels == ("off", "minimal", "low", "medium", "high", "xhigh")
     assert session.cwd == tmp_path
     assert session.model == "fake"
-    assert [tool.name for tool in session.tools] == ["read", "write", "edit", "bash"]
+    assert [tool.name for tool in session.tools] == [
+        "read",
+        "write",
+        "edit",
+        "bash",
+        "todo_write",
+        "todo_read",
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import shlex
 from pathlib import Path
 from time import monotonic
@@ -12,8 +13,10 @@ from tau_coding import (
     create_edit_tool_definition,
     create_read_tool,
     create_read_tool_definition,
+    create_todo_tools,
     create_write_tool,
 )
+from tau_coding.tools import ToolInputError
 
 
 class FakeCancellationToken:
@@ -31,7 +34,14 @@ class FakeCancellationToken:
 async def test_create_coding_tools_returns_initial_tool_set(tmp_path: Path) -> None:
     tools = create_coding_tools(cwd=tmp_path)
 
-    assert [tool.name for tool in tools] == ["read", "write", "edit", "bash"]
+    assert [tool.name for tool in tools] == [
+        "read",
+        "write",
+        "edit",
+        "bash",
+        "todo_write",
+        "todo_read",
+    ]
     edit_tool = tools[2]
     assert edit_tool.prompt_snippet is not None
     assert "Use edit for precise changes" in edit_tool.prompt_guidelines[0]
@@ -244,3 +254,169 @@ async def test_bash_tool_cancellation_kills_shell_children(tmp_path: Path) -> No
     assert result.data["cancelled"] is True
     assert "cancelled" in result.content
     assert duration < 0.5
+
+
+# ---------------------------------------------------------------------------
+# todo_write / todo_read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_todo_read_returns_empty_list_initially() -> None:
+    _write_tool, read_tool = create_todo_tools()
+
+    result = await read_tool.execute({})
+
+    assert result.ok is True
+    assert result.name == "todo_read"
+    assert result.content == "[]"
+    assert result.data == {"count": 0}
+
+
+@pytest.mark.anyio
+async def test_todo_write_saves_todos_and_read_returns_them() -> None:
+    write_tool, read_tool = create_todo_tools()
+    todos = [
+        {"id": "1", "content": "Write tests", "status": "pending", "priority": "high"},
+        {"id": "2", "content": "Run linter", "status": "in_progress", "priority": "medium"},
+    ]
+
+    write_result = await write_tool.execute({"todos": todos})
+
+    assert write_result.ok is True
+    assert write_result.name == "todo_write"
+    assert "2 items saved" in write_result.content
+    assert write_result.data == {"count": 2}
+
+    read_result = await read_tool.execute({})
+    parsed = json.loads(read_result.content)
+    assert len(parsed) == 2
+    assert parsed[0] == {
+        "id": "1",
+        "content": "Write tests",
+        "status": "pending",
+        "priority": "high",
+    }
+    assert parsed[1]["status"] == "in_progress"
+
+
+@pytest.mark.anyio
+async def test_todo_write_singular_item_message() -> None:
+    write_tool, _read_tool = create_todo_tools()
+    todos = [{"id": "1", "content": "Only task", "status": "pending", "priority": "low"}]
+
+    result = await write_tool.execute({"todos": todos})
+
+    assert "1 item saved" in result.content
+
+
+@pytest.mark.anyio
+async def test_todo_write_replaces_list_on_second_call() -> None:
+    write_tool, read_tool = create_todo_tools()
+    first = [{"id": "1", "content": "First", "status": "pending", "priority": "low"}]
+    second = [{"id": "2", "content": "Second", "status": "completed", "priority": "high"}]
+
+    await write_tool.execute({"todos": first})
+    await write_tool.execute({"todos": second})
+
+    parsed = json.loads((await read_tool.execute({})).content)
+    assert len(parsed) == 1
+    assert parsed[0]["content"] == "Second"
+
+
+@pytest.mark.anyio
+async def test_todo_write_clears_list_when_given_empty_array() -> None:
+    write_tool, read_tool = create_todo_tools()
+    initial = [{"id": "1", "content": "Task", "status": "pending", "priority": "low"}]
+    await write_tool.execute({"todos": initial})
+
+    await write_tool.execute({"todos": []})
+
+    read_result = await read_tool.execute({})
+    assert read_result.content == "[]"
+    assert read_result.data == {"count": 0}
+
+
+@pytest.mark.anyio
+async def test_todo_write_rejects_invalid_status() -> None:
+    write_tool, _read_tool = create_todo_tools()
+
+    with pytest.raises(ToolInputError, match="status must be one of"):
+        await write_tool.execute(
+            {"todos": [{"id": "1", "content": "Task", "status": "done", "priority": "high"}]}
+        )
+
+
+@pytest.mark.anyio
+async def test_todo_write_rejects_invalid_priority() -> None:
+    write_tool, _read_tool = create_todo_tools()
+
+    with pytest.raises(ToolInputError, match="priority must be one of"):
+        await write_tool.execute(
+            {"todos": [{"id": "1", "content": "Task", "status": "pending", "priority": "urgent"}]}
+        )
+
+
+@pytest.mark.anyio
+async def test_todo_write_rejects_missing_required_field() -> None:
+    write_tool, _read_tool = create_todo_tools()
+
+    with pytest.raises(ToolInputError, match="id must be a string"):
+        await write_tool.execute(
+            {"todos": [{"content": "No id", "status": "pending", "priority": "low"}]}
+        )
+
+
+@pytest.mark.anyio
+async def test_todo_write_rejects_non_list_todos() -> None:
+    write_tool, _read_tool = create_todo_tools()
+
+    with pytest.raises(ToolInputError, match="todos must be an array"):
+        await write_tool.execute({"todos": "not a list"})
+
+
+@pytest.mark.anyio
+async def test_todo_write_accepts_json_string_todos() -> None:
+    write_tool, read_tool = create_todo_tools()
+    expected = {"id": "1", "content": "From JSON string", "status": "pending", "priority": "low"}
+    todos_json = json.dumps([expected])
+
+    result = await write_tool.execute({"todos": todos_json})
+    assert result.ok is True
+
+    read_result = await read_tool.execute({})
+    parsed = json.loads(read_result.content)
+    assert parsed == [expected]
+
+
+@pytest.mark.anyio
+async def test_todo_tools_from_different_create_calls_do_not_share_state() -> None:
+    write_a, read_a = create_todo_tools()
+    _write_b, read_b = create_todo_tools()
+
+    await write_a.execute(
+        {
+            "todos": [
+                {"id": "1", "content": "Session A task", "status": "pending", "priority": "high"}
+            ]
+        }
+    )
+
+    result_b = await read_b.execute({})
+    assert result_b.content == "[]"
+
+
+def test_todo_write_tool_has_expected_prompt_metadata() -> None:
+    write_tool, _read_tool = create_todo_tools()
+
+    assert write_tool.prompt_snippet == "Write or update the todo list"
+    assert len(write_tool.prompt_guidelines) == 1
+    assert "todo_write" in write_tool.prompt_guidelines[0]
+
+
+def test_todo_read_tool_has_expected_prompt_metadata() -> None:
+    _write_tool, read_tool = create_todo_tools()
+
+    assert read_tool.prompt_snippet == "Read the current todo list"
+    assert len(read_tool.prompt_guidelines) == 1
+    assert "todo_read" in read_tool.prompt_guidelines[0]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -198,7 +198,7 @@ def test_session_command_includes_session_details(tmp_path: Path) -> None:
     assert result.message is not None
     assert "Model: fake-model" in result.message
     assert f"CWD: {tmp_path}" in result.message
-    assert "Tools: 4" in result.message
+    assert "Tools: 6" in result.message
     assert "Skills: 1" in result.message
     assert "Context files: 1" in result.message
     assert "Estimated context tokens: 123" in result.message

--- a/website/content/concepts.md
+++ b/website/content/concepts.md
@@ -25,8 +25,9 @@ You pick a provider + model; you can switch either mid-session.
 
 ## Tools
 
-**Tools** are the actions the agent can take in your project. Tau ships four:
-`read`, `write`, `edit`, and `bash`. The model decides when to call them; Tau
+**Tools** are the actions the agent can take in your project. Tau ships six:
+`read`, `write`, `edit`, `bash`, `todo_write`, and `todo_read`. The model
+decides when to call them; Tau
 executes them in your working directory and streams the results.
 → [Tools reference]({{< relref "./reference/tools.md" >}})
 

--- a/website/content/reference/tools.md
+++ b/website/content/reference/tools.md
@@ -1,11 +1,12 @@
 ---
 title: Built-in tools
-description: The read, write, edit, and bash tools the agent uses to work in your project.
+description: The read, write, edit, bash, and todo tools the agent uses to work in your project.
 ---
 
 Tools are the actions the agent can take in your working directory. The model
 decides when to call them; Tau executes them and streams the results back. Tau
-ships four built-in coding tools: `read`, `write`, `edit`, and `bash`.
+ships six built-in coding tools: `read`, `write`, `edit`, `bash`, `todo_write`,
+and `todo_read`.
 
 All paths are resolved against the session's working directory (`--cwd`, or the
 directory you launched Tau from).
@@ -98,9 +99,40 @@ of large output (truncated to 2,000 lines / 50 KB; the full output is written to
 a temp `.log` file whose path is included in the result). On POSIX, a timeout
 kills the whole process group.
 
+## `todo_write`
+
+Replaces the session's in-memory todo list with a new list of tasks. The agent
+uses it to plan multi-step work and mark tasks as it progresses.
+
+```json
+{
+  "todos": [
+    { "id": "1", "content": "Write tests", "status": "in_progress", "priority": "high" }
+  ]
+}
+```
+
+| Argument | Required | Type | Description |
+| --- | --- | --- | --- |
+| `todos` | yes | array | The complete new todo list, replacing any existing items. |
+
+Each todo requires an `id` (string), `content` (string), `status`
+(`pending`, `in_progress`, or `completed`), and `priority` (`high`, `medium`,
+or `low`). The list lives in memory for the lifetime of the tool set — it is
+not persisted to disk. Passing an empty array clears the list.
+
+## `todo_read`
+
+Returns the current session todo list as JSON. Takes no arguments.
+
+```json
+{}
+```
+
 ## Choosing the right tool
 
 - **`read`** — inspect files (instead of `cat`/`sed`).
 - **`write`** — new files or complete rewrites.
 - **`edit`** — precise changes to an existing file.
 - **`bash`** — tests, linters, searches, project inspection.
+- **`todo_write` / `todo_read`** — plan and track multi-step tasks.


### PR DESCRIPTION
## Motivation

Tau's agent currently has no way to plan and track multi-step work. This adds a lightweight session todo list — the pattern used by most production coding agents — as two ordinary typed tools in `tau_coding`, keeping `tau_agent` untouched per the layer boundaries in CONTRIBUTING.md.

## Behavior changes

- New `create_todo_tools()` factory in `tau_coding.tools` returning a `todo_write`/`todo_read` pair that shares an in-memory list; separate factory calls get isolated state, so sessions don't leak into each other.
- `todo_write` replaces the whole list (empty array clears it) and validates each item's `id`, `content`, `status` (`pending|in_progress|completed`), and `priority` (`high|medium|low`), raising `ToolInputError` with pointed messages. It also tolerates a JSON-string `todos` argument, since models sometimes double-encode.
- `create_coding_tools()` now returns six tools: `read`, `write`, `edit`, `bash`, `todo_write`, `todo_read`.
- `create_todo_tools` and `ToolInputError` are exported from `tau_coding`.
- The list is in-memory only (not persisted to session files), so session durability/resume behavior is unchanged.

## Docs

Updated `website/content/reference/tools.md` and `website/content/concepts.md` to document the new tools.

## Tests / checks run

- `uv run pytest` — 735 passed (13 new todo-tool tests; 4 existing tests updated for the 6-tool list)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run mypy` — no issues in 67 source files

## Compatibility

No config, migration, or provider-specific changes. Callers that asserted a 4-tool list will see 6 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)