### PR TITLE
fix: unify TUI theme selection

### DIFF
--- a/dev-notes/architecture/phase-23-tui-polish.md
+++ b/dev-notes/architecture/phase-23-tui-polish.md
@@ -143,7 +143,10 @@ back to plain code rendering instead of producing a broken transcript block.
 The built-in theme set now includes `tau-light` alongside `tau-dark` and
 `high-contrast`. Theme choice stays in `tau_coding.tui` configuration and feeds
 Textual CSS variables plus Rich renderers without leaking UI policy into the
-portable harness.
+portable harness. Textual's native theme registry is constrained to these same
+Tau themes, so Textual's menu/command-palette theme entry changes Tau's durable
+`~/.tau/tui.json` setting instead of becoming a second, non-persistent theme
+system.
 
 Sessions can now be renamed from the TUI with `/name <new name>`. The command
 updates the indexed session metadata used by `/resume`, resume completions, and

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -21,6 +21,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
+from textual.theme import Theme
 from textual.timer import Timer
 from textual.widgets import (
     Button,
@@ -2029,6 +2030,8 @@ class TauTuiApp(App[None]):
         self.startup_notices = tuple((*startup_notices, *legacy_notices))
         self.initial_prompt = initial_prompt
         super().__init__()
+        self._register_tau_textual_themes()
+        self.theme = self.tui_settings.theme
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
         self.state = TuiState(skills=session.skills)
@@ -2086,6 +2089,28 @@ class TauTuiApp(App[None]):
             with suppress(Exception):
                 pyperclip.copy(text)
         super().copy_to_clipboard(text)
+
+    def _register_tau_textual_themes(self) -> None:
+        """Register Tau themes with Textual's theme system.
+
+        Textual exposes its own theme menu and command palette entries. Registering
+        Tau's built-in themes there makes those controls update the same theme as
+        `/theme` instead of changing only Textual's chrome.
+        """
+        self._registered_themes.clear()
+        for theme_name in BUILTIN_TUI_THEME_NAMES:
+            self.register_theme(_textual_theme_for_tau_theme(theme_name))
+
+    def _watch_theme(self, theme_name: str) -> None:
+        """Keep Textual theme changes synchronized with Tau's durable TUI theme."""
+        super()._watch_theme(theme_name)
+        if theme_name not in BUILTIN_TUI_THEME_NAMES:
+            return
+        tau_theme: TuiThemeName = theme_name
+        if self.tui_settings.theme == tau_theme:
+            return
+        self._replace_tui_settings(theme=tau_theme)
+        save_tui_settings(self.tui_settings)
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Return Tau-specific CSS variables for the selected TUI theme."""
@@ -2471,15 +2496,19 @@ class TauTuiApp(App[None]):
         self._follow_transcript_output()
         self._refresh()
 
-    def _set_tui_theme(self, theme: TuiThemeName) -> None:
+    def _replace_tui_settings(self, *, theme: TuiThemeName) -> None:
+        """Replace the current immutable TUI settings with a new theme."""
         self.tui_settings = TuiSettings(
             keybindings=self.tui_settings.keybindings,
             theme=theme,
             auto_copy_selection=self.tui_settings.auto_copy_selection,
             sidebar_position=self.tui_settings.sidebar_position,
         )
+
+    def _set_tui_theme(self, theme: TuiThemeName) -> None:
+        self._replace_tui_settings(theme=theme)
         save_tui_settings(self.tui_settings)
-        self.refresh_css(animate=False)
+        self.theme = theme
         self._refresh()
 
     async def _queue_prompt(
@@ -3888,7 +3917,28 @@ def _is_thinking_cycle_key(key: str, configured_key: str) -> bool:
     return configured_key == "shift+tab" and key == "backtab"
 
 
+def _textual_theme_for_tau_theme(theme_name: TuiThemeName) -> Theme:
+    """Map a Tau theme to Textual's native theme type."""
+    theme = TuiSettings(theme=theme_name).resolved_theme
+    return Theme(
+        name=theme.name,
+        primary=theme.accent,
+        secondary=theme.prompt_border,
+        warning=theme.markdown_bullet,
+        error=theme.role_styles["error"].border,
+        success=theme.role_styles["assistant"].border,
+        accent=theme.accent,
+        foreground=theme.screen_text,
+        background=theme.screen_background,
+        surface=theme.chrome_background,
+        panel=theme.sidebar_background,
+        dark=theme.name != "tau-light",
+        variables=_theme_css_variables(theme),
+    )
+
+
 def _theme_css_variables(theme: TuiTheme) -> dict[str, str]:
+    """Return Textual CSS variables for a resolved Tau theme."""
     return {
         "tau-screen-background": theme.screen_background,
         "tau-screen-text": theme.screen_text,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -76,6 +76,7 @@ from tau_coding.tui.app import (
     _activity_prompt_border_color,
     _completion_selected_render_line,
     _terminal_command_prefix_span,
+    _textual_theme_for_tau_theme,
     _theme_css_variables,
     _visible_completion_state,
 )
@@ -2139,6 +2140,8 @@ def test_tui_app_uses_configured_theme_css_variables() -> None:
     assert variables["tau-screen-background"] == "#000000"
     assert variables["tau-prompt-background"] == "#1a1a1a"
     assert variables["tau-prompt-border"] == "#00ff66"
+    assert app.theme == "high-contrast"
+    assert app.current_theme.name == "high-contrast"
 
 
 def test_tui_app_uses_light_theme_css_variables() -> None:
@@ -2155,6 +2158,22 @@ def test_tui_app_uses_light_theme_css_variables() -> None:
     assert variables["footer-foreground"] == "#111827"
     assert variables["footer-description-foreground"] == "#111827"
     assert variables["footer-key-foreground"] == "#0f766e"
+    assert app.current_theme.dark is False
+
+
+def test_tui_app_registers_only_tau_themes_with_textual() -> None:
+    app = TauTuiApp(FakeSession())
+
+    assert tuple(app.available_themes) == ("tau-dark", "tau-light", "high-contrast")
+
+
+def test_textual_theme_mapping_uses_tau_theme_values() -> None:
+    textual_theme = _textual_theme_for_tau_theme("tau-light")
+
+    assert textual_theme.name == "tau-light"
+    assert textual_theme.primary == TAU_LIGHT_THEME.accent
+    assert textual_theme.dark is False
+    assert textual_theme.variables["tau-screen-background"] == TAU_LIGHT_THEME.screen_background
 
 
 def test_tau_dark_theme_uses_black_chat_backgrounds() -> None:
@@ -2333,6 +2352,21 @@ async def test_tui_app_clears_activity_status_on_error() -> None:
 
 
 @pytest.mark.anyio
+async def test_textual_theme_change_persists_tau_theme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        app.theme = "tau-light"
+        await pilot.pause()
+
+    assert app.tui_settings.theme == "tau-light"
+    assert tui_settings_path().read_text(encoding="utf-8").find('"theme": "tau-light"') != -1
+
+
+@pytest.mark.anyio
 async def test_tui_app_theme_command_opens_picker_and_persists_selection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2365,6 +2399,7 @@ async def test_tui_app_theme_command_opens_picker_and_persists_selection(
         await pilot.pause()
 
         assert app.tui_settings.theme == "tau-light"
+        assert app.theme == "tau-light"
         assert tui_settings_path().read_text(encoding="utf-8").find('"theme": "tau-light"') != -1
         assert app.get_theme_variable_defaults()["tau-screen-background"] == "#ffffff"
 
@@ -2382,6 +2417,7 @@ async def test_tui_app_theme_command_argument_updates_theme_and_persists(
         await pilot.press("enter")
 
         assert app.tui_settings.theme == "tau-light"
+        assert app.theme == "tau-light"
         assert tui_settings_path().read_text(encoding="utf-8").find('"theme": "tau-light"') != -1
         assert app.get_theme_variable_defaults()["tau-screen-background"] == "#ffffff"
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -219,8 +219,10 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
 ```
 
 Built-in themes: `tau-dark` (default), `tau-light`, `high-contrast`. Set one with
-`/theme`. Keys use Textual syntax; omitted keys keep their defaults. Tau rejects
-unknown themes/keybinding names, empty keys, and duplicate assignments.
+`/theme`. Textual's native theme picker is mapped to the same Tau themes and
+persists the same `theme` setting. Keys use Textual syntax; omitted keys keep
+their defaults. Tau rejects unknown themes/keybinding names, empty keys, and
+duplicate assignments.
 
 - `sidebar_position`: `"left"` (default), `"right"`, or `"off"`. Controls
   placement of the session metadata sidebar. `"off"` hides the sidebar entirely;


### PR DESCRIPTION
## Summary

- Register Tau's built-in themes with Textual and remove Textual's unrelated default theme list from the app-level theme picker.
- Keep Textual theme changes synchronized with Tau's `TuiSettings` and persist them to `~/.tau/tui.json`.
- Keep `/theme` changes reflected in Textual's active theme and document the unified behavior.

Fixes #281.

## Tests

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`
