### PR TITLE
ci: pin GitHub Actions to commit SHAs for supply-chain hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: .python-version
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -55,10 +55,10 @@ jobs:
         working-directory: website
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: "0.152.2"
           extended: true
@@ -67,4 +67,4 @@ jobs:
         run: hugo --minify
 
       - name: Build search index
-        run: npx --yes pagefind@latest --site public
+        run: npx --yes pagefind@1.5.2 --site public

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: "0.152.2"
           extended: true
@@ -36,10 +36,10 @@ jobs:
         run: hugo --minify
 
       - name: Build search index
-        run: npx --yes pagefind@latest --site public
+        run: npx --yes pagefind@1.5.2 --site public
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/public
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     environment: pypi
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Build package
         run: uv build


### PR DESCRIPTION
## Motivation

Closes #199.

Follow-up hardening pass after #189 (Dependabot weekly actions updates): pin every third-party GitHub Action to a full commit SHA so workflow dependencies are reproducible and resistant to tag-move attacks, per the acceptance criteria in the issue.

## Changes

All third-party actions in `.github/workflows/` are now pinned to full commit SHAs, each with a human-readable version comment:

| Action | Pinned SHA | Version |
|---|---|---|
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | v7.0.0 |
| `actions/setup-python` | `ece7cb06caefa5fff74198d8649806c4678c61a1` | v6.3.0 |
| `astral-sh/setup-uv` | `fac544c07dec837d0ccb6301d7b5580bf5edae39` | v8.2.0 |
| `peaceiris/actions-hugo` | `2752ce1d29631191ea3f27c23495fa06139a5b78` | v3.2.1 |
| `actions/upload-pages-artifact` | `fc324d3547104276b827a68afc52ff2a11cc49c9` | v5.0.0 |
| `actions/deploy-pages` | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | v5.0.0 |

Each SHA was resolved from the action's own repository via the GitHub API (`repos/<action>/commits/<tag>`) and cross-checked against the exact release tag pointing at that commit.

Runtime-version notes:

- The issue mentions `oven-sh/setup-bun@v2` / `bun-version: latest`, but the workflows have since moved to Hugo + Pagefind, so there is no Bun reference left to pin. The remaining floating runtime was `npx --yes pagefind@latest` in the CI and docs workflows — replaced with `pagefind@1.5.2` (current release) in both.
- `hugo-version` was already pinned to `0.152.2`; Python resolves from `.python-version`; both left as-is.

Dependabot (from #189) already groups weekly `github-actions` updates and understands SHA + version-comment pinning, so these stay current automatically.

## Scope

Per the automation-pass note on the issue, this first pass only pins existing actions and runtime versions. It does not add an enforcement check — happy to follow up with `pinact` (or a lightweight CI grep) in a separate PR if you want the policy enforced going forward.

## Checks

- Workflow YAML parses (files are structurally unchanged apart from `uses:`/`run:` version strings).
- `uv run pytest`, `ruff check`, `ruff format --check` unaffected (no Python changes); CI on this PR exercises the pinned actions directly.

---

🤖 Disclosure: analysis and edits by Claude Code (Claude Fable 5), working as my pair-programming agent — SHA resolution done against each action's own repo via the GitHub API, not copied from docs. Reviewed and submitted by me (@Rishi943).
