### PR TITLE
docs: fix stale docs paths left over from the pre-Hugo site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,5 +77,5 @@ Each substantial phase should leave behind beginner-friendly notes under `dev-no
 - how to test or use it
 
 When a phase adds or changes user-facing behavior, also update the published docs
-under `website/src/content/docs/` (the "Use Tau" guides and reference).
+under `website/content/` (the guides and reference).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ For substantial architectural or phase-oriented work, add beginner-friendly note
 For user-facing behavior, update the published docs under:
 
 ```text
-website/src/content/docs/
+website/content/
 ```
 
 ## Release process

--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -4,8 +4,8 @@ These are the internal, phase-by-phase build journals and design records for Tau
 They are **not** published on the docs site — they live here for contributors who
 want to trace how the system was assembled.
 
-User-facing documentation lives in `website/src/content/docs/` and is published at
-<https://alejandro-ao.github.io/tau/>.
+User-facing documentation lives in `website/content/` and is published at
+<https://twotimespi.dev/>.
 
 ## Contents
 

--- a/website/content/contributing.md
+++ b/website/content/contributing.md
@@ -64,4 +64,4 @@ templates in `website/layouts/`.
 Each substantial phase should leave beginner-friendly notes in `dev-notes/`
 explaining what was added, why it exists, how it maps to [Pi](https://pi.dev)'s
 design, and how to test or use it. When a feature is user-facing, also update or
-add the relevant page under `website/src/content/docs/`.
+add the relevant page under `website/content/`.


### PR DESCRIPTION
## Motivation

The contributor docs still point at documentation paths from two site migrations ago. The docs tree moved MkDocs → Astro Starlight (`website/src/content/docs/`, fcd0d39) → Hugo (`website/content/`), but four references were never updated, so CONTRIBUTING.md, AGENTS.md, and the published contributing page all tell contributors (and coding agents following AGENTS.md) to put docs in a directory that doesn't exist.

## Changes

- `CONTRIBUTING.md` — published-docs path `website/src/content/docs/` → `website/content/`
- `AGENTS.md` — same path fix (this one actively misroutes coding agents that follow it)
- `website/content/contributing.md` — same path fix; the page already states the correct `website/content/` location three paragraphs earlier, so this also removes a self-contradiction on the published site
- `dev-notes/README.md` — same path fix, plus the published-site URL `alejandro-ao.github.io/tau` → `twotimespi.dev` (matches `baseURL` in `website/hugo.toml`)

## Checks

- `Test-Path website/src` → false (confirmed the referenced tree is gone)
- Remaining `website/content/` references verified against the actual tree
- Docs-only change; no code touched

---

🤖 Disclosure: found and drafted with Claude Code (Claude Fable 5) as my pair-programming agent; reviewed and submitted by me (@Rishi943).
