### PR TITLE
Prepare 0.1.5 release

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -10,7 +10,7 @@ kind = "openai-compatible"
 base_url = "https://api.openai.com/v1"
 api_key_env = "OPENAI_API_KEY"
 credential_name = "openai"
-models = ["gpt-4", "gpt-4-turbo", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20", "gpt-4o-mini", "gpt-5", "gpt-5-chat-latest", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.1", "gpt-5.1-chat-latest", "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-chat-latest", "gpt-5.2-codex", "gpt-5.2-pro", "gpt-5.3-chat-latest", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "o1", "o1-pro", "o3", "o3-mini", "o3-pro", "o4-mini"]
+models = ["gpt-4", "gpt-4-turbo", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20", "gpt-4o-mini", "gpt-5", "gpt-5-chat-latest", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.1", "gpt-5.1-chat-latest", "gpt-5.1-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-chat-latest", "gpt-5.2-codex", "gpt-5.2-pro", "gpt-5.3-chat-latest", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "o1", "o1-pro", "o3", "o3-mini", "o3-pro", "o4-mini"]
 default_model = "gpt-5.4"
 docs_url = "https://platform.openai.com/docs"
 api = "openai-responses"
@@ -52,6 +52,10 @@ gpt-5-pro = 400000
 "gpt-5.4-pro" = 1050000
 "gpt-5.5" = 272000
 "gpt-5.5-pro" = 1050000
+"gpt-5.6" = 1050000
+"gpt-5.6-sol" = 1050000
+"gpt-5.6-terra" = 1050000
+"gpt-5.6-luna" = 1050000
 o1 = 200000
 o1-pro = 200000
 o3 = 200000
@@ -359,6 +363,46 @@ cost = { input = 30, output = 180, cacheRead = 0, cacheWrite = 0 }
 thinking_level_map = { xhigh = "xhigh" }
 unsupported_thinking_levels = ["off", "minimal", "low"]
 
+[providers.model_metadata."gpt-5.6"]
+name = "GPT-5.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-sol"]
+name = "GPT-5.6 Sol"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-terra"]
+name = "GPT-5.6 Terra"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 3.125 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-luna"]
+name = "GPT-5.6 Luna"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 1, output = 6, cacheRead = 0.1, cacheWrite = 1.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
 [providers.model_metadata.o1]
 reasoning = true
 input = ["text", "image"]
@@ -414,21 +458,65 @@ kind = "openai-codex"
 base_url = "https://chatgpt.com/backend-api"
 api_key_env = "OPENAI_CODEX_ACCESS_TOKEN"
 credential_name = "openai-codex"
-models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
+models = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 default_model = "gpt-5.5"
 docs_url = "https://chatgpt.com/codex"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
-thinking_models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
+thinking_models = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 thinking_default = "medium"
 thinking_parameter = "reasoning.effort"
 
 [providers.context_windows]
+"gpt-5.6" = 1050000
+"gpt-5.6-sol" = 1050000
+"gpt-5.6-terra" = 1050000
+"gpt-5.6-luna" = 1050000
 "gpt-5.5" = 272000
 "gpt-5.4" = 272000
 "gpt-5.4-mini" = 400000
 "gpt-5.3-codex" = 400000
 "gpt-5.3-codex-spark" = 400000
 "gpt-5.2" = 400000
+
+[providers.model_metadata."gpt-5.6"]
+name = "GPT-5.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-sol"]
+name = "GPT-5.6 Sol"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-terra"]
+name = "GPT-5.6 Terra"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 3.125 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
+
+[providers.model_metadata."gpt-5.6-luna"]
+name = "GPT-5.6 Luna"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 1, output = 6, cacheRead = 0.1, cacheWrite = 1.25 }
+thinking_level_map = { off = "none", xhigh = "xhigh" }
+unsupported_thinking_levels = ["minimal"]
 
 [[providers]]
 name = "anthropic"

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -830,6 +830,10 @@ def test_load_provider_settings_does_not_restore_stale_codex_builtin_models(
     provider = settings.get_provider("openai-codex")
 
     assert provider.models == (
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",


### PR DESCRIPTION
## Summary

- Add the new OpenAI GPT-5.6 model IDs to the built-in OpenAI and OpenAI Codex provider catalogs:
  - `gpt-5.6`
  - `gpt-5.6-sol`
  - `gpt-5.6-terra`
  - `gpt-5.6-luna`
- Include context window, max output, reasoning, multimodal input, and pricing/cache metadata from the OpenAI API model docs.
- Keep the existing OpenAI and OpenAI Codex default models unchanged to avoid changing default behavior.
- Prepare the `0.1.5` patch release with release notes and lockfile version bump.

## Validation

Ran the release checks locally before pushing:

```bash
uv run pytest
uv run ruff check .
uv run ruff format --check .
uv run mypy
uv build
```

All passed locally.

Also confirmed `tau-ai==0.1.5` is not currently published on PyPI.
