### PR TITLE
Prepare 0.1.5 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.1.5",
+    "date": "2026-07-09",
+    "sections": {
+      "New": [
+        "Add OpenAI GPT-5.6, GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna model catalog entries for OpenAI and OpenAI Codex.",
+        "Add NVIDIA NIM as a built-in provider.",
+        "Redesign session HTML export with a cleaner, icon-based interface."
+      ],
+      "Changed": [
+        "Improve the documentation website with a roadmap page, clearer Pi links, and refreshed navigation and homepage polish."
+      ],
+      "Fixed": [
+        "Fix release-note packaging so installed wheels include the bundled release notes file.",
+        "Fix Windows test isolation by avoiding accidental writes to a real ~/.tau directory.",
+        "Fix TUI theme selection edge cases."
+      ]
+    }
+  },
+  {
     "version": "0.1.4",
     "date": "2026-07-08",
     "sections": {

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump `tau-ai` to `0.1.5`.
- Add `0.1.5` release notes.
- Update `uv.lock` for the package version bump.

## Validation

Release checks already passed locally before pushing:

```bash
uv run pytest
uv run ruff check .
uv run ruff format --check .
uv run mypy
uv build
```

Also confirmed `tau-ai==0.1.5` is not currently published on PyPI.
