### PR TITLE
fix(anthropic): retry 5xx above 504 and 425 like other providers

### DIFF
--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -243,7 +243,7 @@ class AnthropicProvider:
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:
         if attempt >= self._config.max_retries:
             return False
-        return status_code is None or status_code in {408, 409, 429, 500, 502, 503, 504}
+        return status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
 
 
 class _AnthropicToolBuilder:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1343,6 +1343,56 @@ async def test_anthropic_provider_retries_transient_status_with_event() -> None:
 
 
 @pytest.mark.anyio
+async def test_anthropic_provider_retries_overloaded_529() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(529, text="overloaded")
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert isinstance(events[0], ProviderRetryEvent)
+    assert events[0].data == {"status_code": 529, "body": "overloaded"}
+    assert [event.type for event in events] == [
+        "retry",
+        "response_start",
+        "text_delta",
+        "response_end",
+    ]
+
+
+@pytest.mark.anyio
 async def test_anthropic_provider_includes_http_error_detail_in_message() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary

`AnthropicProvider._should_retry` used a fixed status set that stops at 504, so 529 (`overloaded_error`) and gateway statuses like 520-524 were treated as fatal instead of retried. This aligns it with the rule the other four providers already use.

Fixes #333.

## Change

`src/tau_ai/anthropic.py`: `_should_retry` now returns

```python
status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
```

matching `google.py`, `mistral.py`, `openai_compatible.py`, and `openai_codex.py`.

## Test

Added `test_anthropic_provider_retries_overloaded_529`, mirroring the existing 503 retry test: a 529 followed by a valid stream now makes two requests and emits a `ProviderRetryEvent`. It fails before the change (one request, fatal `ProviderErrorEvent`).

`pytest`, `ruff check`, `ruff format --check`, and `mypy` pass. Two provider-config tests fail on my machine but also fail on clean `main`, so they are unrelated.
