### PR TITLE
Fix TUI layout jump when clicking header

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1654,6 +1654,10 @@ class TauTuiApp(App[None]):
         dock: top;
     }
 
+    Header.-tall {
+        height: 1;
+    }
+
     Footer {
         background: $tau-chrome-background;
         color: $tau-chrome-text;
@@ -2120,7 +2124,7 @@ class TauTuiApp(App[None]):
 
     def compose(self) -> ComposeResult:
         """Compose the TUI widgets."""
-        yield Header()
+        yield Header(id="header")
         with Horizontal(id="workspace"):
             yield SessionSidebar(id="sidebar")
             with Vertical(id="main-pane"):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3543,6 +3543,27 @@ async def test_tui_app_notifications_render_literal_markup_text() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_clicking_header_does_not_resize_workspace() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        header = app.query_one("#header")
+        workspace = app.query_one("#workspace")
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is True
+        initial_header_height = header.region.height
+        initial_workspace_region = workspace.region
+        initial_sidebar_region = sidebar.region
+
+        await pilot.click("#header")
+        await pilot.pause()
+
+        assert header.region.height == initial_header_height == 1
+        assert workspace.region == initial_workspace_region
+        assert sidebar.region == initial_sidebar_region
+
+
+@pytest.mark.anyio
 async def test_tui_app_clicking_transcript_refocuses_prompt() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
Currently if you click on the "Tau — Untitled session" at the top (or actually click anywhere on that very thin strip at the top) it causes the sidebar to jump down and then it jumps back up when clicked again.

Textual's built-in `Header` toggles its `-tall` class when clicked. Its default styling changes the header from one row to three rows, which shifts Tau's workspace and sidebar down. Tau uses the header only as a single-line title, so this overrides the tall state to remain one row.