### PR TITLE
fix(tui): require textual>=8.2.8 so CJK IME input works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic>=2.0",
     "pygments>=2.18",
     "rich>=13.0",
-    "textual>=1.0",
+    "textual>=8.2.8",
     "typer>=0.12",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygments", specifier = ">=2.18" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "textual", specifier = ">=1.0" },
+    { name = "textual", specifier = ">=8.2.8" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
@@ -568,7 +568,7 @@ dev = [
 
 [[package]]
 name = "textual"
-version = "8.2.7"
+version = "8.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -578,9 +578,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #337

## Motivation

CJK IME input is unusable in the TUI on kitty-keyboard-protocol terminals (Ghostty, kitty, recent WezTerm): committing 你好 from a Pinyin IME inserts `[49;;20320:22909u` into the input box instead of the text. Full root-cause analysis is in #337 — in short, Textual 8.2.7 requests the kitty protocol's associated-text reporting (`KITTY_REPORT_ASSOCIATED_TEXT`) but its parser cannot handle multi-codepoint text fields, so the sequence is reissued as literal keystrokes. Textual 8.2.8 fixes the parser ([Textualize/textual#6592](https://github.com/Textualize/textual/pull/6592)).

## Change

- Raise the dependency floor in `pyproject.toml` from `textual>=1.0` to `textual>=8.2.8` so no install resolves to a version with the broken parser.
- Refresh `uv.lock` (only textual moves: 8.2.7 → 8.2.8).

No code changes — the fix lives entirely in the dependency, which keeps Textual-specific behavior behind the TUI layer.

## Why no regression test

The bug is in Textual's input parser; Tau has no input-parsing code of its own to exercise. A test would assert Textual's internal behavior, and the version floor itself is the regression guard.

## Verification

- Fed the exact byte stream Ghostty sends for an IME commit (`"\x1b[49;;20320:22909u"`) through `XTermParser.feed()`: with 8.2.7 the sequence fails to parse and is reissued as garbage; with 8.2.8 it emits key events for 你 and 好.
- Manually verified in the TUI (Ghostty 1.3.1, macOS Pinyin IME): Chinese input now works. Before/after screenshots in #337.

## Checks

- `uv run pytest` — 736 passed
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy` — clean

## Compatibility notes

Textual 8.2.7 → 8.2.8 also ships two small behavior changes (see upstream changelog): a crash fix when clicking the Screen's padding, and `super+backspace` / `alt+backspace` bindings in Input/TextArea. No API changes affecting Tau; the full test suite passes unchanged.
