### PR TITLE
fix: never let a missing or malformed releases.json crash startup

### DIFF
--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -172,10 +172,16 @@ def startup_release_notes_notice(
     except InvalidVersion:
         return None
 
+    if release_notes is None:
+        try:
+            release_notes = load_release_notes()
+        except Exception:  # noqa: BLE001 - a broken bundled file must not block startup
+            release_notes = ()
+
     entries = release_notes_between(
         previous_version,
         current_version,
-        release_notes if release_notes is not None else load_release_notes(),
+        release_notes,
     )
     return ReleaseNotesNotice(
         current_version=current_version,

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -219,6 +219,42 @@ def test_startup_release_notes_notice_reports_upgrade_once(tmp_path) -> None:
     assert second_notice is None
 
 
+def test_startup_release_notes_notice_survives_missing_release_notes_file(
+    tmp_path, monkeypatch
+) -> None:
+    # Regression test for issue #313: a wheel missing releases.json crashed
+    # startup with FileNotFoundError instead of skipping the notice.
+    import tau_coding.update_check as update_check_module
+
+    monkeypatch.setattr(
+        update_check_module, "RELEASE_NOTES_PATH", tmp_path / "missing" / "releases.json"
+    )
+    state_path = tmp_path / "release-notes-state.json"
+    state_path.write_text('{"last_seen_version":"0.1.1"}\n', encoding="utf-8")
+
+    notice = startup_release_notes_notice("0.1.2", state_path=state_path)
+
+    assert notice is not None
+    assert notice.entries == ()
+
+
+def test_startup_release_notes_notice_survives_malformed_release_notes_file(
+    tmp_path, monkeypatch
+) -> None:
+    import tau_coding.update_check as update_check_module
+
+    broken_path = tmp_path / "releases.json"
+    broken_path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(update_check_module, "RELEASE_NOTES_PATH", broken_path)
+    state_path = tmp_path / "release-notes-state.json"
+    state_path.write_text('{"last_seen_version":"0.1.1"}\n', encoding="utf-8")
+
+    notice = startup_release_notes_notice("0.1.2", state_path=state_path)
+
+    assert notice is not None
+    assert notice.entries == ()
+
+
 def test_startup_release_notes_notice_combines_skipped_versions(tmp_path) -> None:
     state_path = tmp_path / "release-notes-state.json"
     state_path.write_text('{"last_seen_version":"0.1.0"}\n', encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes #313.

Opening this after claiming the issue two days ago with no objection; happy to adjust or close if a different fix is already planned.

## Root cause

The immediate packaging problem from the report (the 0.1.4 wheel not shipping `releases.json`) was already fixed in 0290c55, which bundles the file inside the package. But the crash half is still live on `main`: `startup_release_notes_notice` calls `load_release_notes()` unguarded, so any install with a missing or malformed `data/release-notes/releases.json` (broken wheel, corrupted file, overzealous antivirus) still dies at startup with `FileNotFoundError` - exactly what the reporter hit, and contradicting the function's own docstring ("Read/write failures are quiet no-ops so startup can continue").

## Fix

Treat a failed release-notes load as empty notes: startup proceeds normally and simply skips the what's-new banner. Release notes are optional metadata and must never sit on the startup critical path.

```python
if release_notes is None:
    try:
        release_notes = load_release_notes()
    except Exception:  # a broken bundled file must not block startup
        release_notes = ()
```

## Tests

Two regression tests in `tests/test_update_check.py`:
- `test_startup_release_notes_notice_survives_missing_release_notes_file` - file absent (the reporter's scenario) -> notice returned with empty entries, no crash.
- `test_startup_release_notes_notice_survives_malformed_release_notes_file` - file contains invalid JSON -> same.

Full `tests/test_update_check.py`: 19 passed. `ruff` and `mypy` clean. Rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
