### PR TITLE
fix: keep @ file references available in /skill argument text

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -114,6 +114,9 @@ def build_completion_state(
     has_argument_text = token_end < len(text)
     if token.startswith("/skill:"):
         if has_argument_text and _matches_skill_command(token, skills):
+            # Skill arguments are prompt text, so @ file references stay available.
+            if cwd is not None:
+                return CompletionState(_file_reference_completions(text=text, cwd=cwd))
             return CompletionState()
         return CompletionState(_skill_completions(token=token, token_end=token_end, skills=skills))
 

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -188,6 +188,32 @@ def test_skill_name_completion_hides_after_completed_skill_command_space() -> No
     assert request_state.items == ()
 
 
+def test_file_reference_completion_works_in_skill_command_arguments(tmp_path: Path) -> None:
+    # Regression test for issue #316: @ file references stopped working in the
+    # argument text of a /skill invocation.
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "/skill:review fix @app",
+        command_registry=create_default_command_registry(),
+        skills=(
+            Skill(
+                name="review",
+                path=Path("review.md"),
+                content="Review code",
+                description="Review code",
+            ),
+        ),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["@src/app.py"]
+    assert state.selected is not None
+    assert state.selected.apply("/skill:review fix @app") == "/skill:review fix @src/app.py"
+
+
 def test_custom_prompt_completion_hides_after_completed_prompt_command_space() -> None:
     trailing_space_state = build_completion_state(
         "/example ",


### PR DESCRIPTION
## Summary

Fixes #316.

Opening this after claiming the issue two days ago; the reporter confirmed the exact reproduction in the meantime (`/skill:foo @` on the same line shows no completions). Happy to adjust or close if a different fix is planned.

## Root cause

Not stale state - a routing gap in `build_completion_state` (`src/tau_coding/tui/autocomplete.py`). Any text starting with `/` never reaches the `@` file completer, and a matched `/skill:` command with argument text returned an **empty** completion state. So `@` references, which work in normal prompt text, offered nothing inside a skill invocation.

## Fix

Skill arguments are prompt text, so that branch now falls through to the file-reference completer (the TUI already passes `cwd`, so it works end to end):

```python
if token.startswith("/skill:"):
    if has_argument_text and _matches_skill_command(token, skills):
        # Skill arguments are prompt text, so @ file references stay available.
        if cwd is not None:
            return CompletionState(_file_reference_completions(text=text, cwd=cwd))
        return CompletionState()
```

`/skill:review fix @app` now suggests `@src/app.py`. Generic slash commands like `/help @read` keep completions off - that behavior is deliberate and its existing test (`test_file_reference_completion_stays_off_for_slash_commands`) is untouched.

## Scope note

The reporter also raised skill chaining (`/skill:foo /skill:bar` in one line). That is new command-parsing semantics rather than a completion-routing bug, so it is deliberately out of scope here (noted on the issue).

## Tests

- New regression test `test_file_reference_completion_works_in_skill_command_arguments`, written first and confirmed failing before the fix.
- Full `tests/test_tui_autocomplete.py`: 30 passed. `ruff` and `mypy` clean. Rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
