### PR TITLE
docs: fix stale docs URL and path in dev-notes README

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -4,8 +4,8 @@ These are the internal, phase-by-phase build journals and design records for Tau
 They are **not** published on the docs site — they live here for contributors who
 want to trace how the system was assembled.
 
-User-facing documentation lives in `website/src/content/docs/` and is published at
-<https://alejandro-ao.github.io/tau/>.
+User-facing documentation lives in `website/content/` and is published at
+<https://twotimespi.dev/>.
 
 ## Contents
 


### PR DESCRIPTION
The docs link in `dev-notes/README.md` still points to the old `alejandro-ao.github.io/tau/` (404 now) and an Astro-style path. Looks like it just didn't get updated after the move to Hugo + custom domain.

Fixed both to match the current setup: `website/content/` and https://twotimespi.dev/.