### PR TITLE
fix(tau_ai): retry HTTP 529 and 5xx above 504 in Anthropic provider

### DIFF
--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -243,7 +243,7 @@ class AnthropicProvider:
     def _should_retry(self, attempt: int, *, status_code: int | None = None) -> bool:
         if attempt >= self._config.max_retries:
             return False
-        return status_code is None or status_code in {408, 409, 429, 500, 502, 503, 504}
+        return status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
 
 
 class _AnthropicToolBuilder:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1343,6 +1343,57 @@ async def test_anthropic_provider_retries_transient_status_with_event() -> None:
 
 
 @pytest.mark.anyio
+async def test_anthropic_provider_retries_529_and_5xx_above_504() -> None:
+    """Regression for #333: Anthropic must retry HTTP 529 (overloaded) and 520-524."""
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(529, text="overloaded")
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert isinstance(events[0], ProviderRetryEvent)
+    assert events[0].data == {"status_code": 529, "body": "overloaded"}
+    assert [event.type for event in events] == [
+        "retry",
+        "response_start",
+        "text_delta",
+        "response_end",
+    ]
+
+
+@pytest.mark.anyio
 async def test_anthropic_provider_includes_http_error_detail_in_message() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
**Motivation**

Anthropic's `_should_retry` used a hardcoded status set that stopped at 504, while every other provider (OpenAI-compatible, Mistral, Google) retries any `status_code >= 500`. This caused HTTP 529 (`overloaded_error`) and gateway codes 520–524 to be treated as fatal instead of retried with backoff.

**What changed**

- `src/tau_ai/anthropic.py`: `_should_retry` now uses the same rule as other providers: `status_code in {408, 409, 425, 429} or status_code >= 500`
- `tests/test_tau_ai.py`: Added regression test `test_anthropic_provider_retries_529_and_5xx_above_504`

**Tests**

`uv run pytest tests/test_tau_ai.py -q`

42 passed

**Compatibility**

No breaking changes. Only expands the set of retried status codes; previously fatal codes now get the same backoff retry behavior as the rest of the provider adapters.

Fixes #333