### PR TITLE
fix: filepaths at start of message treated as slash commands

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -185,6 +185,13 @@ class CommandRegistry:
         if not name:
             return CommandResult(handled=False)
 
+        # A name containing a slash is a file path, not a command.
+        # On *nix, absolute paths like /Users/me/file.png start with / and
+        # would be misparsed as a slash command. Return unhandled so the
+        # message flows through as a normal prompt.
+        if "/" in name:
+            return CommandResult(handled=False)
+
         command = self.get(name)
         if command is None and name == "scoped" and args.lower() == "models":
             command = self.get("scoped-models")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,6 +103,17 @@ def test_registry_ignores_ordinary_prompts_and_skill_expansion(tmp_path: Path) -
     assert registry.execute(session, "/skill:review fix this").handled is False
 
 
+def test_registry_ignores_file_paths_starting_with_slash(tmp_path: Path) -> None:
+    """Absolute file paths starting with / must not be treated as slash commands."""
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    assert registry.execute(session, "/Users/me/screenshot.png").handled is False
+    assert registry.execute(session, "/docs/design.md").handled is False
+    assert registry.execute(session, "/tmp/foo/bar.txt").handled is False
+    assert registry.execute(session, "/home/user/file with spaces.md").handled is False
+
+
 def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
     commands = create_default_command_registry().list_commands()
 


### PR DESCRIPTION
On *nix, messages starting with / like /Users/me/screenshot.png get caught by the slash command parser. The parser sees the leading /, extracts Users/me/screenshot.png as the command name, doesn't find a matching command, returns handled=True — and the user's message is completely discarded.

So the fix is this: after parsing the command name, check if it contains a /. Real commands are a single word (/quit, /model); a slash inside the name means it's a file path, not a command. Return handled=False so the message proceeds as a normal prompt.