### PR TITLE
fix: pass unknown slash input through as prompts

### DIFF
--- a/dev-notes/architecture/phase-15-slash-command-registry.md
+++ b/dev-notes/architecture/phase-15-slash-command-registry.md
@@ -127,6 +127,11 @@ The registry intentionally returns `handled=False` for skill and prompt-template
 expansion directives so `CodingSession.prompt()` can replace them before sending
 the prompt to the model.
 
+Like Pi, Tau also returns `handled=False` for every unregistered slash-prefixed
+input. Only recognized commands are consumed locally; unknown command-like text
+and absolute paths such as `/tmp` or `/Users/me/file.png` continue as normal
+prompts.
+
 There is no plain `/skill` slash command in the Pi-aligned registry.
 
 ## Future use

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -191,7 +191,7 @@ class CommandRegistry:
             name = "scoped-models"
             args = ""
         if command is None:
-            return CommandResult(handled=True, message=f"Unknown command: /{name}")
+            return CommandResult(handled=False)
 
         return command.handler(
             CommandContext(session=session, registry=self, text=stripped, name=name, args=args)

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3576,7 +3576,7 @@ def test_minimal_commands_are_handled(tmp_path: Path) -> None:
 
     assert session.handle_command("hello").handled is False
     assert session.handle_command("/new").new_session_requested is True
-    assert session.handle_command("/clear").message == "Unknown command: /clear"
+    assert session.handle_command("/clear").handled is False
     assert session.handle_command("/quit").exit_requested is True
     assert session.handle_command("/exit").exit_requested is True
-    assert session.handle_command("/unknown").message == "Unknown command: /unknown"
+    assert session.handle_command("/unknown").handled is False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,6 +103,16 @@ def test_registry_ignores_ordinary_prompts_and_skill_expansion(tmp_path: Path) -
     assert registry.execute(session, "/skill:review fix this").handled is False
 
 
+def test_registry_ignores_unregistered_slash_prompts(tmp_path: Path) -> None:
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    for prompt in ("/missing", "/README.md", "/tmp", "/Users/me/screenshot.png"):
+        result = registry.execute(session, prompt)
+        assert result.handled is False
+        assert result.message is None
+
+
 def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
     commands = create_default_command_registry().list_commands()
 
@@ -144,9 +154,9 @@ def test_quit_and_new_return_control_flags(tmp_path: Path) -> None:
 
     assert registry.execute(session, "/quit").exit_requested is True
     assert registry.execute(session, "/exit").exit_requested is True
-    assert registry.execute(session, "/q").message == "Unknown command: /q"
+    assert registry.execute(session, "/q").handled is False
     assert registry.execute(session, "/new").new_session_requested is True
-    assert registry.execute(session, "/clear").message == "Unknown command: /clear"
+    assert registry.execute(session, "/clear").handled is False
 
 
 def test_compact_command_accepts_optional_instructions(tmp_path: Path) -> None:
@@ -209,8 +219,7 @@ def test_session_command_includes_session_details(tmp_path: Path) -> None:
     assert "Session: session-1" in result.message
     assert "Session name:" not in result.message
     assert (
-        create_default_command_registry().execute(FakeSession(tmp_path), "/status").message
-        == "Unknown command: /status"
+        create_default_command_registry().execute(FakeSession(tmp_path), "/status").handled is False
     )
 
 
@@ -314,8 +323,8 @@ def test_non_pi_commands_are_not_registered(tmp_path: Path) -> None:
 
     for command in ("/provider", "/skills", "/resources", "/context", "/help"):
         result = registry.execute(session, command)
-        assert result.handled is True
-        assert result.message == f"Unknown command: {command}"
+        assert result.handled is False
+        assert result.message is None
 
 
 def test_login_command_requests_provider_picker(tmp_path: Path) -> None:
@@ -387,9 +396,7 @@ def test_resume_without_argument_requests_picker(tmp_path: Path) -> None:
 
     assert result.resume_picker_requested is True
     assert result.message is None
-    assert create_default_command_registry().execute(session, "/sessions").message == (
-        "Unknown command: /sessions"
-    )
+    assert create_default_command_registry().execute(session, "/sessions").handled is False
 
 
 def test_resume_command_requests_indexed_session(tmp_path: Path) -> None:
@@ -469,13 +476,6 @@ def test_name_command_rejects_multiline_name(tmp_path: Path) -> None:
 
     assert result.message == "Session name must be a single line."
     assert manager.get_session(record.id) == record
-
-
-def test_unknown_command_returns_message(tmp_path: Path) -> None:
-    result = create_default_command_registry().execute(FakeSession(tmp_path), "/missing")
-
-    assert result.handled is True
-    assert result.message == "Unknown command: /missing"
 
 
 def test_registry_rejects_duplicate_commands_and_aliases() -> None:

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -32,6 +32,10 @@ the named skill into your prompt and runs it as a turn. See
 [Skills & prompt templates]({{< relref "../guides/skills-and-prompts.md" >}}).
 {{% /note %}}
 
+Only registered commands are consumed locally. Other slash-prefixed input, including
+absolute paths such as `/tmp` or `/Users/me/file.png`, is sent to the model as a normal
+prompt.
+
 Related:
 
 - **Thinking mode** is keyboard-driven, not a slash command — see


### PR DESCRIPTION
## Summary

- consume only registered slash commands, matching Pi's dispatch behavior
- pass unknown slash-prefixed input and absolute paths through as normal prompts
- update regression tests and slash-command documentation

Resolves the filepath/slash-command bug reported in #350 and supersedes that PR with a simpler Pi-aligned approach. No separate GitHub issue is linked from #350.

## Validation

- `uv run pytest` (739 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
