### PR TITLE
fix: ignore orphaned provider preferences

### DIFF
--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1094,7 +1094,11 @@ def _providers_with_preferences(
         if provider_name in seen:
             raise ProviderConfigError("Provider preference names must be unique")
         if provider_name not in catalog_configs:
-            raise ProviderConfigError(f"Unknown provider preference: {provider_name}")
+            # Preferences contain runtime overrides, not provider definitions. A
+            # catalog entry may be removed independently, leaving an orphaned
+            # preference behind. Ignore it so one stale entry cannot prevent Tau
+            # from starting or running `tau setup` to register it again.
+            continue
         providers.append(
             _apply_provider_preference(
                 catalog_configs[provider_name],

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -196,6 +196,30 @@ docs_url = "http://localhost:11434/v1"
     assert settings.scoped_models == (ScopedModelConfig(provider="local", model="qwen"),)
 
 
+def test_load_provider_settings_ignores_preference_without_catalog_entry(
+    tmp_path: Path,
+) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        json.dumps(
+            {
+                "default_provider": "openai",
+                "provider_preferences": {
+                    "openai": {"default_model": "gpt-5-mini"},
+                    "llama-cpp": {"default_model": "local"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+
+    assert settings.get_provider("openai").default_model == "gpt-5-mini"
+    assert "llama-cpp" not in {provider.name for provider in settings.providers}
+
+
 def test_save_provider_settings_writes_backup_when_replacing(tmp_path: Path) -> None:
     paths = TauPaths(home=tmp_path / ".tau")
     initial = ProviderSettings(


### PR DESCRIPTION
## Summary

- ignore provider preferences whose provider definition is no longer present in the effective catalog
- prevent one stale preference from blocking all Tau startup paths, including `tau setup`
- add regression coverage for loading valid preferences alongside an orphaned `llama-cpp` preference

## Motivation

`providers.json` stores runtime overrides, while provider definitions live separately in the built-in or user `catalog.toml`. Those files can legitimately drift across Tau upgrades, catalog changes, migrations, or manual configuration updates.

Previously, if a provider definition disappeared while its preference remained, every settings load failed with an error such as:

```text
Invalid value: Unknown provider preference: llama-cpp
```

That made Tau unusable even when the orphaned provider was not selected, and it also prevented users from running `tau setup` to register the provider again. Since preferences are overrides rather than provider definitions, this PR treats unknown entries as orphaned state and skips them. A later settings save naturally rewrites only effective providers.

## Testing

- `uv run pytest` — 740 passed
- `uv run ruff check src/tau_coding/provider_config.py tests/test_provider_config.py`
- `uv run ruff format --check src/tau_coding/provider_config.py tests/test_provider_config.py`
