### PR TITLE
fix: don't split session JSONL on Unicode line separators

### DIFF
--- a/src/tau_agent/session/storage.py
+++ b/src/tau_agent/session/storage.py
@@ -37,4 +37,6 @@ class JsonlSessionStorage:
         """Read all entries in file order. Missing files are empty sessions."""
         if not self.path.exists():
             return []
-        return entries_from_json_lines(self.path.read_text(encoding="utf-8").splitlines())
+        # Split on newlines only: str.splitlines() would also split on characters
+        # like U+2028 that appear unescaped inside JSON string values.
+        return entries_from_json_lines(self.path.read_text(encoding="utf-8").split("\n"))

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -212,7 +212,9 @@ class SessionManager:
             return []
 
         records: list[CodingSessionRecord] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        # Split on newlines only: str.splitlines() would also split on characters
+        # like U+2028 that appear unescaped inside JSON string values.
+        for line in path.read_text(encoding="utf-8").split("\n"):
             stripped = line.strip()
             if not stripped:
                 continue

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -238,6 +238,31 @@ async def test_jsonl_storage_appends_and_reads_entries(tmp_path: Path) -> None:
     assert await storage.read_all() == [first, second]
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("separator", ["\u2028", "\u2029", "\u0085"])
+async def test_jsonl_storage_round_trips_unicode_line_separators(
+    tmp_path: Path, separator: str
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    entry = MessageEntry(id="one", message=UserMessage(content=f"before{separator}after"))
+
+    await storage.append(entry)
+
+    assert await storage.read_all() == [entry]
+
+
+@pytest.mark.anyio
+async def test_jsonl_storage_reads_existing_file_with_unicode_line_separator(
+    tmp_path: Path,
+) -> None:
+    entry = MessageEntry(id="one", message=UserMessage(content="a\u2028b"))
+    path = tmp_path / "session.jsonl"
+    path.write_text(entry_to_json_line(entry), encoding="utf-8")
+    storage = JsonlSessionStorage(path)
+
+    assert await storage.read_all() == [entry]
+
+
 def test_session_state_replays_linear_entries() -> None:
     user = UserMessage(content="Hi", timestamp=1)
     assistant = AssistantMessage(content="Hello", timestamp=2)

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from tau_coding.paths import TauPaths
 from tau_coding.session_manager import SessionManager
 
@@ -26,6 +28,20 @@ def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
     assert record.path.name == f"{record.id}.jsonl"
     assert manager.get_session(record.id) == record
     assert manager.list_sessions() == [record]
+    assert manager.list_sessions(cwd) == [record]
+
+
+@pytest.mark.parametrize("separator", ["\u2028", "\u2029", "\u0085"])
+def test_session_manager_round_trips_unicode_line_separator_in_title(
+    tmp_path: Path, separator: str
+) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+
+    record = manager.create_session(cwd=cwd, model="fake", title=f"line one{separator}line two")
+
+    assert manager.get_session(record.id) == record
     assert manager.list_sessions(cwd) == [record]
 
 


### PR DESCRIPTION
Session files are JSONL, but the reader split them with str.splitlines(), which also breaks on U+2028/U+2029/U+0085. These are characters pydantic writes unescaped into JSON strings. One message containing such a character (e.g. from a file read into a tool result) splits a valid line into two malformed fragments, so every subsequent session load/resume raises SessionJsonlError — the session is permanently bricked. Fix: split on \n only, which also retroactively repairs already-broken files; same bug fixed in the session index reader.

To reproduce, run this snippet on main (fails with `SessionJsonlError`) and on this branch (prints one entry). Note the append succeeds either way — the corruption is only visible on the next read, and typing/pasting the character into the TUI won't trigger it because the input path sanitizes it; the script drives the storage API directly, as a tool result would:

```bash
uv run python - <<'EOF'
import asyncio, tempfile
from pathlib import Path
from tau_agent.messages import UserMessage
from tau_agent.session.entries import MessageEntry
from tau_agent.session.storage import JsonlSessionStorage

content = "Here is the error:" + chr(0x2028) + "TypeError: cannot read properties of undefined"

async def main():
    with tempfile.TemporaryDirectory() as tmp:
        storage = JsonlSessionStorage(Path(tmp) / "session.jsonl")
        await storage.append(MessageEntry(message=UserMessage(content=content)))
        print("append: OK (write never fails)")
        entries = await storage.read_all()  # raises SessionJsonlError before this fix
        print(f"read_all: OK, {len(entries)} entry")

asyncio.run(main())
EOF
```