### PR TITLE
feat(catalog): add StepFun providers

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6213,6 +6213,47 @@ context_window = 262144
 cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
 
 [[providers]]
+name = "stepfun-cn"
+display_name = "StepFun (China)"
+kind = "openai-compatible"
+base_url = "https://api.stepfun.com/v1"
+api_key_env = "STEPFUN_CN_API_KEY"
+credential_name = "stepfun-cn"
+models = ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"]
+default_model = "step-3.7-flash"
+docs_url = "https://platform.stepfun.com/docs"
+api = "openai-completions"
+thinking_levels = ["low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"step-3.7-flash" = 262144
+"step-3.5-flash" = 262144
+"step-3.5-flash-2603" = 262144
+
+[providers.model_metadata."step-3.7-flash"]
+name = "Step 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash"]
+name = "Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash-2603"]
+name = "Step 3.5 Flash (2603)"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[[providers]]
 name = "stepfun-step-plan"
 display_name = "StepFun Step Plan"
 kind = "openai-compatible"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6172,6 +6172,47 @@ compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = 
 cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
 
 [[providers]]
+name = "stepfun-step-plan"
+display_name = "StepFun Step Plan"
+kind = "openai-compatible"
+base_url = "https://api.stepfun.ai/step_plan/v1"
+api_key_env = "STEPFUN_STEP_PLAN_API_KEY"
+credential_name = "stepfun-step-plan"
+models = ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"]
+default_model = "step-3.7-flash"
+docs_url = "https://platform.stepfun.ai/docs/en/step-plan/overview"
+api = "openai-completions"
+thinking_levels = ["low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"step-3.7-flash" = 262144
+"step-3.5-flash" = 262144
+"step-3.5-flash-2603" = 262144
+
+[providers.model_metadata."step-3.7-flash"]
+name = "Step 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+cost = { input = 0.2, output = 1.15, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash"]
+name = "Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash-2603"]
+name = "Step 3.5 Flash (2603)"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[[providers]]
 name = "stepfun-step-plan-cn"
 display_name = "StepFun Step Plan (China)"
 kind = "openai-compatible"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6237,21 +6237,21 @@ name = "Step 3.7 Flash"
 reasoning = true
 input = ["text", "image"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.2, output = 1.15, cacheRead = 0.04, cacheWrite = 0 }
 
 [providers.model_metadata."step-3.5-flash"]
 name = "Step 3.5 Flash"
 reasoning = true
 input = ["text"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
 
 [providers.model_metadata."step-3.5-flash-2603"]
 name = "Step 3.5 Flash (2603)"
 reasoning = true
 input = ["text"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
 
 [[providers]]
 name = "stepfun-step-plan"
@@ -6319,18 +6319,18 @@ name = "Step 3.7 Flash"
 reasoning = true
 input = ["text", "image"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.2, output = 1.15, cacheRead = 0.04, cacheWrite = 0 }
 
 [providers.model_metadata."step-3.5-flash"]
 name = "Step 3.5 Flash"
 reasoning = true
 input = ["text"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
 
 [providers.model_metadata."step-3.5-flash-2603"]
 name = "Step 3.5 Flash (2603)"
 reasoning = true
 input = ["text"]
 context_window = 262144
-cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6170,3 +6170,44 @@ context_window = 1048576
 max_tokens = 131072
 compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
 cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "stepfun-step-plan-cn"
+display_name = "StepFun Step Plan (China)"
+kind = "openai-compatible"
+base_url = "https://api.stepfun.com/step_plan/v1"
+api_key_env = "STEPFUN_STEP_PLAN_CN_API_KEY"
+credential_name = "stepfun-step-plan-cn"
+models = ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"]
+default_model = "step-3.7-flash"
+docs_url = "https://platform.stepfun.com/docs/zh/step-plan/overview"
+api = "openai-completions"
+thinking_levels = ["low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"step-3.7-flash" = 262144
+"step-3.5-flash" = 262144
+"step-3.5-flash-2603" = 262144
+
+[providers.model_metadata."step-3.7-flash"]
+name = "Step 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash"]
+name = "Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash-2603"]
+name = "Step 3.5 Flash (2603)"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6172,6 +6172,47 @@ compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = 
 cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
 
 [[providers]]
+name = "stepfun"
+display_name = "StepFun"
+kind = "openai-compatible"
+base_url = "https://api.stepfun.ai/v1"
+api_key_env = "STEPFUN_API_KEY"
+credential_name = "stepfun"
+models = ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"]
+default_model = "step-3.7-flash"
+docs_url = "https://platform.stepfun.ai/docs"
+api = "openai-completions"
+thinking_levels = ["low", "medium", "high"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"step-3.7-flash" = 262144
+"step-3.5-flash" = 262144
+"step-3.5-flash-2603" = 262144
+
+[providers.model_metadata."step-3.7-flash"]
+name = "Step 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+cost = { input = 0.2, output = 1.15, cacheRead = 0.04, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash"]
+name = "Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[providers.model_metadata."step-3.5-flash-2603"]
+name = "Step 3.5 Flash (2603)"
+reasoning = true
+input = ["text"]
+context_window = 262144
+cost = { input = 0.1, output = 0.3, cacheRead = 0.02, cacheWrite = 0 }
+
+[[providers]]
 name = "stepfun-step-plan"
 display_name = "StepFun Step Plan"
 kind = "openai-compatible"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -73,6 +73,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
         "stepfun",
+        "stepfun-cn",
         "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -72,6 +72,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -72,6 +72,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun-step-plan-cn",
     ]
 
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -72,6 +72,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun",
         "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -58,6 +58,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]
     assert settings.providers[0].default_model == DEFAULT_MODEL

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -59,6 +59,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
         "stepfun",
+        "stepfun-cn",
         "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -58,6 +58,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun-step-plan-cn",
     ]
     assert settings.providers[0].default_model == DEFAULT_MODEL
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -58,6 +58,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "stepfun",
         "stepfun-step-plan",
         "stepfun-step-plan-cn",
     ]


### PR DESCRIPTION
## Motivation

Add StepFun (阶跃星辰) Step-series reasoning models to the provider catalog, following the domestic/international split used by `minimax`, `moonshot`, and `xiaomi`.

## What's added

Four `openai-compatible` providers, all serving `step-3.7-flash`, `step-3.5-flash`, and `step-3.5-flash-2603`:

| Provider | Base URL | Region / plan |
|---|---|---|
| `stepfun` | `https://api.stepfun.ai/v1` | International, standard API |
| `stepfun-cn` | `https://api.stepfun.com/v1` | China, standard API |
| `stepfun-step-plan` | `https://api.stepfun.ai/step_plan/v1` | International, Step Plan |
| `stepfun-step-plan-cn` | `https://api.stepfun.com/step_plan/v1` | China, Step Plan |

- `step-3.7-flash` is multimodal (text + image); the `step-3.5-flash` variants are text-only.
- Reasoning via `reasoning_effort` (`low` / `medium` / `high` only — StepFun exposes no `off`/`minimal`).
- 256k context window for all models.

## Pricing

Per-million-token USD prices, same for all four providers:

| Model | Input | Cached input | Output |
|---|---|---|---|
| `step-3.7-flash` | 0.20 | 0.04 | 1.15 |
| `step-3.5-flash` | 0.10 | 0.02 | 0.30 |
| `step-3.5-flash-2603` | 0.10 | 0.02 | 0.30 |

## Checks

- `uv run pytest` — 739 passed
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run mypy` — clean

Catalog-only change; no Python or architectural changes.
