### PR TITLE
Fix extension reload lifecycle ordering

### DIFF
--- a/dev-notes/architecture/phase-21-extensions.md
+++ b/dev-notes/architecture/phase-21-extensions.md
@@ -619,21 +619,23 @@ subscription dropped, new one added) and emit
 `setup` therefore runs once per process per extension, not once per session
 swap. `aclose` emits `session_shutdown(reason="quit")`.
 
-`CodingSession.reload` (sync, from `/reload`) re-runs discovery: it purges
-`tau_extension_*` modules from `sys.modules`, re-imports, re-runs `setup`
-on a fresh runtime registration set, rebuilds the wrapped tool list in
-place (`harness.config.tools` is mutable by design), rebuilds the session
-command registry, and re-subscribes the fan-out listener. The summary gains
-an `extensions` category in `CodingReloadSummary`. Reload emits no
-`session_shutdown`/`session_start` pair (it runs on the sync command path,
-so async handlers could not be awaited); extension state is simply rebuilt,
-and background work started before the reload is orphaned. The `"reload"`
-lifecycle reason is reserved for when the command path becomes async.
+`CodingSession.reload` is async. The synchronous command registry returns a
+`reload_requested` action, and each frontend awaits the session operation.
+Reload first awaits `session_shutdown(reason="reload")` while the outgoing
+extension generation is still active, clears its host UI, invalidates the old
+generation, purges `tau_extension_*` modules from `sys.modules`, re-imports,
+and re-runs `setup` on a fresh registration set. It then rebuilds the wrapped
+tool list in place (`harness.config.tools` is mutable by design), rebuilds the
+session command registry, re-subscribes the fan-out listener, and awaits
+`session_start(reason="reload")` on the new generation. This lets shutdown
+handlers clean up through their live API and start handlers remount UI before
+reload reports completion. The summary includes an `extensions` category in
+`CodingReloadSummary`.
 
 **Ruling:** reload invalidates prior extension instances (Pi's
 `assertActive`/`invalidate` parity). Each load generation shares an
-`ExtensionGeneration` token; `reset_for_reload` marks it stale and mints a
-fresh one, and every `ExtensionAPI` method/property and every
+`ExtensionGeneration` token; `reset_for_reload` clears outgoing UI first, then marks the generation stale
+and mints a fresh one, and every `ExtensionAPI` method/property and every
 `ExtensionContext`/`ExtensionUi` read — trivial reads like `has_ui`
 included, matching Pi's assert-on-everything — checks the token first and
 raises `ExtensionError`. An orphaned background task holding a pre-reload

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -20,6 +20,7 @@ from tau_ai import (
 )
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
 from tau_coding.catalog_loader import user_catalog_path
+from tau_coding.commands import format_reload_summary
 from tau_coding.credentials import FileCredentialStore
 from tau_coding.extensions import StderrUiBridge
 from tau_coding.provider_config import (
@@ -621,8 +622,16 @@ async def run_print_mode(
             return result.ok
         command = session.handle_command(prompt)
         if command.handled:
-            if command.message:
-                typer.echo(command.message)
+            message = command.message
+            if command.reload_requested:
+                try:
+                    summary = await session.reload()
+                except ValueError as exc:
+                    message = f"Could not reload: {exc}"
+                else:
+                    message = format_reload_summary(summary)
+            if message:
+                typer.echo(message)
             return True
         async for event in session.prompt(prompt):
             renderer.render(event)

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -84,8 +84,6 @@ class CommandSession(Protocol):
 
     def set_model(self, model: str) -> None: ...
 
-    def reload(self) -> CodingReloadSummary: ...
-
     def reload_provider_settings(self) -> None: ...
 
 
@@ -96,6 +94,7 @@ class CommandResult:
     handled: bool
     exit_requested: bool = False
     clear_requested: bool = False
+    reload_requested: bool = False
     new_session_requested: bool = False
     compact_summary: str | None = None
     export_requested: bool = False
@@ -476,15 +475,9 @@ def _resources_command(context: CommandContext) -> CommandResult:
 
 
 def _reload_command(context: CommandContext) -> CommandResult:
-    try:
-        summary = context.session.reload()
-    except ValueError as exc:
-        return CommandResult(handled=True, message=f"Could not reload: {exc}")
-
-    return CommandResult(
-        handled=True,
-        message=_format_reload_summary(summary),
-    )
+    # Reload owns async extension lifecycle hooks, so frontends execute it from
+    # their async command path rather than inside this synchronous registry.
+    return CommandResult(handled=True, reload_requested=True)
 
 
 def _context_command(context: CommandContext) -> CommandResult:
@@ -742,7 +735,7 @@ def _refresh_provider_settings(session: CommandSession) -> CommandResult | None:
     return None
 
 
-def _format_reload_summary(summary: CodingReloadSummary) -> str:
+def format_reload_summary(summary: CodingReloadSummary) -> str:
     lines = [
         "Reloaded local coding resources and project context.",
         "Resources:",

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -192,12 +192,13 @@ class ExtensionRuntime:
         against the fresh registration set. Session rebinding does not come
         through here and never invalidates.
         """
+        # Host-side extension UI (slot widgets, main views, key interceptors)
+        # belongs to the outgoing generation. Tear it down while that generation
+        # is still active so host cleanup triggered by component disposal can
+        # safely use its API; only then make every captured API/context stale.
+        self.clear_ui_components()
         self._generation.invalidate()
         self._generation = ExtensionGeneration()
-        # Host-side extension UI (slot widgets, main views, key interceptors)
-        # belongs to the invalidated generation: tear it down with the
-        # registrations, or interceptors accumulate one copy per reload.
-        self.clear_ui_components()
         if self._harness_unsubscribe is not None:
             self._harness_unsubscribe()
             self._harness_unsubscribe = None

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1015,8 +1015,16 @@ class CodingSession:
         self._harness.config.provider = provider
         self._runtime_provider_config = provider_config
 
-    def reload(self) -> CodingReloadSummary:
-        """Reload local resources, project context, and extensions."""
+    async def reload(self) -> CodingReloadSummary:
+        """Reload resources and extensions with an awaited lifecycle boundary.
+
+        Outgoing handlers finish ``session_shutdown(reason="reload")`` while
+        their API generation is still active. The runtime then clears UI,
+        invalidates/reloads registrations, and awaits the new generation's
+        ``session_start(reason="reload")`` so startup-mounted UI is restored
+        before the command reports completion.
+        """
+        await self._extension_runtime.emit_session_shutdown("reload")
         before_skills = _skill_signatures(self._skills)
         before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
         before_context_files = _context_file_signatures(self._context_files)
@@ -1075,6 +1083,8 @@ class CodingSession:
         if rebuilt_system_prompt is not None:
             self._harness.config.system = rebuilt_system_prompt
             self._invalidate_context_usage_cache()
+
+        await self._extension_runtime.emit_session_start("reload")
 
         return CodingReloadSummary(
             skills=_category_summary(before_skills, after_skills),

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6,7 +6,7 @@ import asyncio
 import traceback
 from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from inspect import isawaitable
 from io import StringIO
@@ -59,7 +59,11 @@ from tau_agent.types import JSONValue
 from tau_ai import ProviderErrorEvent, ProviderEvent
 from tau_ai.provider import CancellationToken
 from tau_coding.catalog_loader import save_user_catalog_entries
-from tau_coding.commands import CommandRegistry, create_default_command_registry
+from tau_coding.commands import (
+    CommandRegistry,
+    create_default_command_registry,
+    format_reload_summary,
+)
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.extensions.api import (
     KeyInterceptor,
@@ -2853,6 +2857,13 @@ class TauTuiApp(App[None]):
         if command.handled:
             if command.clear_requested:
                 self.state.clear()
+            if command.reload_requested:
+                try:
+                    summary = await self.session.reload()
+                except ValueError as exc:
+                    command = replace(command, message=f"Could not reload: {exc}")
+                else:
+                    command = replace(command, message=format_reload_summary(summary))
             if command.new_session_requested:
                 await self._new_session()
             if command.compact_summary is not None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1999,7 +1999,7 @@ async def test_session_reload_preserves_disabled_skills(tmp_path: Path) -> None:
 
     assert session.skills == ()
 
-    session.reload()
+    await session.reload()
 
     assert session.skills == ()
     assert "<available_skills>" not in session.system_prompt
@@ -2183,16 +2183,15 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
     (tmp_path / "AGENTS.md").write_text("Reloaded project rules.", encoding="utf-8")
 
     entries_before = await storage.read_all()
-    result = session.handle_command("/reload")
+    command = session.handle_command("/reload")
+    assert command.reload_requested is True
+    summary = await session.reload()
     entries_after = await storage.read_all()
     _events = await _collect_session_events(session.prompt("Hello"))
 
-    assert result.message is not None
-    assert "Reloaded local coding resources and project context." in result.message
-    assert "Skills: 1 total (changed, +1)" in result.message
-    assert "Project context files: 1 total (changed, +1)" in result.message
-    assert "Next-turn system prompt: rebuilt" in result.message
-    assert "Not refreshed by /reload" in result.message
+    assert summary.skills.after == 1
+    assert summary.context_files.after == 1
+    assert summary.system_prompt_rebuilt is True
     assert entries_after == entries_before
     assert [skill.name for skill in session.skills] == ["testing"]
     assert [Path(context_file.path).name for context_file in session.context_files] == ["AGENTS.md"]
@@ -2226,11 +2225,9 @@ async def test_session_reload_skips_provider_settings_refresh(
         )
     )
 
-    result = session.handle_command("/reload")
-
-    assert result.message is not None
-    assert "Provider config:" in result.message
-    assert "Not refreshed by /reload" in result.message
+    command = session.handle_command("/reload")
+    assert command.reload_requested is True
+    await session.reload()
 
 
 @pytest.mark.anyio
@@ -2258,10 +2255,11 @@ async def test_session_reload_leaves_system_prompt_when_inputs_are_unchanged(
         fail_build_system_prompt,
     )
 
-    result = session.handle_command("/reload")
+    command = session.handle_command("/reload")
+    assert command.reload_requested is True
+    summary = await session.reload()
 
-    assert result.message is not None
-    assert "Next-turn system prompt: unchanged" in result.message
+    assert summary.system_prompt_rebuilt is False
 
 
 @pytest.mark.anyio

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -371,21 +371,15 @@ def test_logout_command_rejects_unknown_provider(tmp_path: Path) -> None:
     assert "Unknown logout provider: local" in result.message
 
 
-def test_reload_command_refreshes_session_resources(tmp_path: Path) -> None:
+def test_reload_command_requests_async_session_reload(tmp_path: Path) -> None:
     session = FakeSession(tmp_path)
 
     result = create_default_command_registry().execute(session, "/reload")
 
-    assert result.message is not None
-    assert "Reloaded local coding resources and project context." in result.message
-    assert "Resources:" in result.message
-    assert "Skills: 1 total (changed, +1)" in result.message
-    assert "Prompt templates: 0 total (unchanged)" in result.message
-    assert "Project context files: 1 total (changed, +1)" in result.message
-    assert "Next-turn system prompt: rebuilt" in result.message
-    assert "Provider config:" in result.message
-    assert "Not refreshed by /reload" in result.message
-    assert session.reload_called is True
+    assert result.handled is True
+    assert result.reload_requested is True
+    assert result.message is None
+    assert session.reload_called is False
     assert session.provider_reload_called is False
 
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1422,7 +1422,7 @@ async def test_reload_picks_up_guideline_changes(tmp_path: Path) -> None:
         "def setup(tau):\n    tau.add_prompt_guideline('Prefer uv over pip')\n",
     )
 
-    summary = session.reload()
+    summary = await session.reload()
 
     assert summary.system_prompt_rebuilt is True
     assert "Prefer uv over pip" in session.system_prompt
@@ -1683,7 +1683,7 @@ async def test_reload_picks_up_new_extension(tmp_path: Path) -> None:
     paths = _paths(tmp_path)
     _write_extension(_user_extensions_dir(paths), "late_arrival", HELLO_TOOL_EXTENSION)
 
-    summary = session.reload()
+    summary = await session.reload()
 
     assert summary.extensions.after == 1
     assert "hello" in [tool.name for tool in session.tools]
@@ -1838,7 +1838,7 @@ async def test_reload_invalidates_old_instance_and_new_instance_works(
     old_api = cast(ExtensionAPI, old_module.APIS[-1])  # type: ignore[attr-defined]
     assert old_api.context.cwd == session.cwd
 
-    session.reload()
+    await session.reload()
 
     with pytest.raises(ExtensionError, match="stale after reload"):
         old_api.send_user_message("zombie")
@@ -1850,6 +1850,42 @@ async def test_reload_invalidates_old_instance_and_new_instance_works(
     assert new_api is not old_api
     assert new_api.context.cwd == session.cwd
     new_api.send_user_message("fresh")  # the reloaded instance works normally
+
+
+async def test_reload_awaits_shutdown_before_invalidation_and_starts_new_generation(
+    tmp_path: Path,
+) -> None:
+    body = (
+        "EVENTS = []\n\n"
+        "def setup(tau):\n"
+        "    @tau.on('session_shutdown')\n"
+        "    async def stop(event):\n"
+        "        EVENTS.append(('stop', event.reason, tau.name))\n"
+        "    @tau.on('session_start')\n"
+        "    async def start(event):\n"
+        "        EVENTS.append(('start', event.reason, tau.name))\n"
+        "        tau.context.ui.components.set_slot_widget('status', [event.reason])\n"
+    )
+    session = await CodingSession.load(
+        _session_config(tmp_path, FakeProvider([]), extension_body=body)
+    )
+    ui = RecordingUiBridge()
+    session.extension_runtime.set_ui_bridge(ui)
+    old_module = _loaded_extension_module("integration")
+
+    await session.emit_pending_session_start()
+    assert old_module.EVENTS == [("start", "startup", "integration")]  # type: ignore[attr-defined]
+
+    await session.reload()
+
+    # The outgoing async shutdown completed while its API was active.
+    assert old_module.EVENTS[-1] == ("stop", "reload", "integration")  # type: ignore[attr-defined]
+    new_module = _loaded_extension_module("integration")
+    assert new_module.EVENTS == [("start", "reload", "integration")]  # type: ignore[attr-defined]
+    assert ui.calls[-2:] == [
+        ("clear_components", (), {}),
+        ("set_slot_widget", ("status",), {"placement": "above_prompt"}),
+    ]
 
 
 async def test_session_rebinding_does_not_invalidate_extension_instances(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1758,6 +1758,25 @@ def test_reset_for_reload_clears_host_extension_components() -> None:
     assert ("clear_components", (), {}) in ui.calls
 
 
+def test_reset_for_reload_invalidates_only_after_component_cleanup() -> None:
+    runtime = ExtensionRuntime()
+    api = cast(ExtensionAPI, _register_inline_extension(runtime, "old"))
+    observed_active: list[bool] = []
+
+    class CleanupBridge(RecordingUiBridge):
+        def clear_components(self) -> None:
+            observed_active.append(api.name == "old")
+            super().clear_components()
+
+    runtime.set_ui_bridge(CleanupBridge())
+
+    runtime.reset_for_reload()
+
+    assert observed_active == [True]
+    with pytest.raises(ExtensionError, match="stale after reload"):
+        _ = api.name
+
+
 # -- reload staleness guard (Pi's assertActive/invalidate) ---------------------
 
 

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -79,9 +79,10 @@ repo root when a manifest declares the entry.
 Extensions load project-first; on name conflicts (extension names, tool
 names, command names) the first registration wins. `--no-extensions`
 disables directory discovery entirely (explicit `-x` paths still load).
-`/reload` re-imports all extensions and re-runs `setup`; it does not emit
-`session_shutdown`, so background work an extension started before the
-reload is orphaned — treat `/reload` as a restart of extension state.
+`/reload` awaits `session_shutdown(reason="reload")` on the outgoing
+extension generation, clears its UI, re-imports every extension and re-runs
+`setup`, then awaits `session_start(reason="reload")` on the new generation.
+Use those lifecycle hooks to stop and restart background work and to remount UI.
 
 > **Security.** Extensions execute arbitrary Python inside your session.
 > Project extensions are therefore off by default — enable them with


### PR DESCRIPTION
## Summary

- await `session_shutdown(reason="reload")` while the outgoing extension generation is still active
- clear extension-owned UI before invalidating stale API/context objects
- reload registrations, then await `session_start(reason="reload")` so extension UI can remount
- move `/reload` execution into the async frontend paths and document the lifecycle contract

## Validation

- `uv run pytest` — 945 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
