### PR TITLE
feat: support tiered model pricing metadata

### DIFF
--- a/dev-notes/tiered-model-pricing.md
+++ b/dev-notes/tiered-model-pricing.md
@@ -1,0 +1,15 @@
+# Tiered model pricing
+
+Tau's catalog originally stored one flat `cost` mapping per model. That works for most providers, but MiniMax-M3 doubles its standard rates when input grows beyond 512,000 tokens while supporting a one-million-token context window.
+
+Issue #364 adds optional ordered `cost_tiers` to `ModelCatalogMetadata`. Each tier contains the same per-million-token rate fields as `cost` and may set an inclusive `max_input_tokens`. Limits must increase, and the final tier is unbounded. The existing flat `cost` remains the base rate for backward compatibility.
+
+`model_cost_for_input_tokens()` resolves the first tier that includes a given input-token count. Catalog loading, user overlays, TOML serialization, and runtime provider metadata preserve the tiers. MiniMax-M3 now records both its `<=512k` and `>512k` standard rates.
+
+Validate with:
+
+```bash
+uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py
+uv run ruff check .
+uv run mypy
+```

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -26,6 +26,7 @@ from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
     ModelCatalogMetadata,
+    ModelCostTier,
     ModelInput,
     ProviderApi,
     ProviderCatalogEntry,
@@ -53,6 +54,16 @@ class CatalogError(ValueError):
     """Raised when a Tau catalog file is invalid."""
 
 
+class _CatalogCostTier(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    max_input_tokens: _PositiveInt | None = None
+    input: _NonNegativeFloat
+    output: _NonNegativeFloat
+    cacheRead: _NonNegativeFloat
+    cacheWrite: _NonNegativeFloat
+
+
 class _CatalogModelMetadata(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -62,6 +73,7 @@ class _CatalogModelMetadata(BaseModel):
     reasoning: StrictBool | None = None
     input: tuple[ModelInput, ...] = ()
     cost: dict[_NonEmptyString, _NonNegativeFloat] | None = None
+    cost_tiers: tuple[_CatalogCostTier, ...] = ()
     context_window: _PositiveInt | None = None
     max_tokens: _PositiveInt | None = None
     headers: dict[_NonEmptyString, _NonEmptyString] = {}
@@ -296,6 +308,12 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
             f"{prefix}.thinking_default: {provider.thinking_default!r} is not in thinking_levels"
         )
 
+    for model, catalog_metadata in provider.model_metadata.items():
+        _validate_cost_tiers(
+            catalog_metadata.cost_tiers,
+            field_name=f"{prefix}.model_metadata.{model}",
+        )
+
     model_metadata = {
         model: _model_metadata_from_provider(metadata)
         for model, metadata in provider.model_metadata.items()
@@ -327,6 +345,26 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
     )
 
 
+def _validate_cost_tiers(
+    tiers: tuple[_CatalogCostTier, ...],
+    *,
+    field_name: str,
+) -> None:
+    if not tiers:
+        return
+    if tiers[-1].max_input_tokens is not None:
+        raise CatalogError(f"{field_name}.cost_tiers: final tier must omit max_input_tokens")
+    previous_limit = 0
+    for index, tier in enumerate(tiers[:-1]):
+        limit = tier.max_input_tokens
+        if limit is None or limit <= previous_limit:
+            raise CatalogError(
+                f"{field_name}.cost_tiers.{index}.max_input_tokens: "
+                "limits must be strictly increasing"
+            )
+        previous_limit = limit
+
+
 def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatalogMetadata:
     thinking_level_map: dict[ThinkingLevel, str | None] = dict(metadata.thinking_level_map)
     for level in metadata.unsupported_thinking_levels:
@@ -338,6 +376,18 @@ def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatal
         reasoning=metadata.reasoning,
         input=metadata.input,
         cost=dict(metadata.cost) if metadata.cost else None,
+        cost_tiers=tuple(
+            ModelCostTier(
+                max_input_tokens=tier.max_input_tokens,
+                cost={
+                    "input": tier.input,
+                    "output": tier.output,
+                    "cacheRead": tier.cacheRead,
+                    "cacheWrite": tier.cacheWrite,
+                },
+            )
+            for tier in metadata.cost_tiers
+        ),
         context_window=metadata.context_window,
         max_tokens=metadata.max_tokens,
         headers=dict(metadata.headers),
@@ -440,6 +490,18 @@ def _raw_model_metadata_from_entry(metadata: ModelCatalogMetadata) -> dict[str, 
         raw["input"] = list(metadata.input)
     if metadata.cost:
         raw["cost"] = dict(metadata.cost)
+    if metadata.cost_tiers:
+        raw["cost_tiers"] = [
+            {
+                **(
+                    {"max_input_tokens": tier.max_input_tokens}
+                    if tier.max_input_tokens is not None
+                    else {}
+                ),
+                **tier.cost,
+            }
+            for tier in metadata.cost_tiers
+        ]
     if metadata.context_window is not None:
         raw["context_window"] = metadata.context_window
     if metadata.max_tokens is not None:

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3700,8 +3700,11 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 131072
 compat = { forceAdaptiveThinking = true }
-# Standard-tier rates for requests with <=512k input tokens. MiniMax charges 2x above 512k.
 cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+cost_tiers = [
+  { max_input_tokens = 512000, input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 },
+  { input = 0.6, output = 2.4, cacheRead = 0.12, cacheWrite = 0 },
+]
 
 [[providers]]
 name = "minimax-cn"
@@ -3743,8 +3746,11 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 131072
 compat = { forceAdaptiveThinking = true }
-# Standard-tier rates for requests with <=512k input tokens. MiniMax charges 2x above 512k.
 cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+cost_tiers = [
+  { max_input_tokens = 512000, input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 },
+  { input = 0.6, output = 2.4, cacheRead = 0.12, cacheWrite = 0 },
+]
 
 [[providers]]
 name = "moonshotai"

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -28,6 +28,14 @@ ThinkingLevelMap = dict[ThinkingLevel, str | None]
 
 
 @dataclass(frozen=True, slots=True)
+class ModelCostTier:
+    """Model rates that apply up to an optional input-token limit."""
+
+    cost: dict[str, float]
+    max_input_tokens: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ModelCatalogMetadata:
     """Provider-catalog metadata for a single model."""
 
@@ -37,11 +45,25 @@ class ModelCatalogMetadata:
     reasoning: bool | None = None
     input: tuple[ModelInput, ...] = ()
     cost: dict[str, float] | None = None
+    cost_tiers: tuple[ModelCostTier, ...] = ()
     context_window: int | None = None
     max_tokens: int | None = None
     headers: dict[str, str] = field(default_factory=dict)
     compat: dict[str, JSONValue] = field(default_factory=dict)
     thinking_level_map: ThinkingLevelMap = field(default_factory=dict)
+
+
+def model_cost_for_input_tokens(
+    metadata: ModelCatalogMetadata,
+    input_tokens: int,
+) -> dict[str, float] | None:
+    """Return model rates for an input size, falling back to the flat base cost."""
+    if not isinstance(input_tokens, int) or isinstance(input_tokens, bool) or input_tokens < 0:
+        raise ValueError("input_tokens must be a non-negative integer")
+    for tier in metadata.cost_tiers:
+        if tier.max_input_tokens is None or input_tokens <= tier.max_input_tokens:
+            return dict(tier.cost)
+    return dict(metadata.cost) if metadata.cost is not None else None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -27,6 +27,7 @@ from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ModelCatalogMetadata,
+    ModelCostTier,
     ProviderApi,
     ProviderCatalogEntry,
     ProviderKind,
@@ -65,6 +66,7 @@ class ProviderModelMetadata:
     reasoning: bool | None = None
     input: tuple[str, ...] = ()
     cost: dict[str, float] = field(default_factory=dict)
+    cost_tiers: tuple[ModelCostTier, ...] = ()
     context_window: int | None = None
     max_tokens: int | None = None
     headers: dict[str, str] = field(default_factory=dict)
@@ -80,6 +82,17 @@ class ProviderModelMetadata:
             "reasoning": self.reasoning,
             "input": list(self.input),
             "cost": dict(self.cost),
+            "cost_tiers": [
+                {
+                    **(
+                        {"max_input_tokens": tier.max_input_tokens}
+                        if tier.max_input_tokens is not None
+                        else {}
+                    ),
+                    **tier.cost,
+                }
+                for tier in self.cost_tiers
+            ],
             "context_window": self.context_window,
             "max_tokens": self.max_tokens,
             "headers": dict(self.headers),
@@ -448,6 +461,7 @@ def _provider_model_metadata_from_catalog(
             reasoning=metadata.reasoning,
             input=tuple(metadata.input),
             cost=dict(metadata.cost or {}),
+            cost_tiers=metadata.cost_tiers,
             context_window=metadata.context_window,
             max_tokens=metadata.max_tokens,
             headers=dict(metadata.headers),
@@ -883,6 +897,7 @@ def _merge_provider_model_metadata(
             reasoning=metadata.reasoning if metadata.reasoning is not None else base.reasoning,
             input=metadata.input or base.input,
             cost={**base.cost, **metadata.cost},
+            cost_tiers=metadata.cost_tiers or base.cost_tiers,
             context_window=metadata.context_window or base.context_window,
             max_tokens=metadata.max_tokens or base.max_tokens,
             headers={**base.headers, **metadata.headers},
@@ -1026,6 +1041,7 @@ def _catalog_model_metadata_from_provider(
             reasoning=metadata.reasoning,
             input=tuple(item for item in metadata.input if item in {"text", "image"}),
             cost=dict(metadata.cost) or None,
+            cost_tiers=metadata.cost_tiers,
             context_window=metadata.context_window,
             max_tokens=metadata.max_tokens,
             headers=dict(metadata.headers),
@@ -1856,6 +1872,7 @@ def _validate_model_metadata(
             raise ProviderConfigError("Provider model_metadata input must contain text or image")
         if any(value < 0 for value in metadata.cost.values()):
             raise ProviderConfigError("Provider model_metadata cost values must be non-negative")
+        _validate_runtime_cost_tiers(metadata.cost_tiers)
         _validate_json_object(metadata.compat, "Provider model_metadata compat")
         _validate_string_dict(metadata.headers, "Provider model_metadata headers")
         for level, value in metadata.thinking_level_map.items():
@@ -1864,6 +1881,24 @@ def _validate_model_metadata(
                 raise ProviderConfigError(
                     "Provider model_metadata thinking_level_map values must be strings or null"
                 )
+
+
+def _validate_runtime_cost_tiers(tiers: tuple[ModelCostTier, ...]) -> None:
+    if tiers and tiers[-1].max_input_tokens is not None:
+        raise ProviderConfigError("Provider model_metadata final cost tier must be unbounded")
+    previous_limit = 0
+    for tier in tiers:
+        if any(value < 0 for value in tier.cost.values()):
+            raise ProviderConfigError(
+                "Provider model_metadata cost tier values must be non-negative"
+            )
+        if tier.max_input_tokens is None:
+            continue
+        if tier.max_input_tokens <= previous_limit:
+            raise ProviderConfigError(
+                "Provider model_metadata cost tier limits must be strictly increasing"
+            )
+        previous_limit = tier.max_input_tokens
 
 
 def _validate_string_dict(value: dict[str, str], field_name: str) -> None:
@@ -2100,6 +2135,9 @@ def _model_metadata_dict(
             reasoning=_optional_bool(item.get("reasoning"), f"{field_name}.{model}.reasoning"),
             input=_optional_string_tuple(item.get("input"), f"{field_name}.{model}.input"),
             cost=_float_dict(item.get("cost", {}), f"{field_name}.{model}.cost"),
+            cost_tiers=_cost_tiers(
+                item.get("cost_tiers", []), f"{field_name}.{model}.cost_tiers"
+            ),
             context_window=_optional_positive_int(
                 item.get("context_window"), f"{field_name}.{model}.context_window"
             ),
@@ -2114,6 +2152,34 @@ def _model_metadata_dict(
             ),
         )
     return items
+
+
+def _cost_tiers(value: object, field_name: str) -> tuple[ModelCostTier, ...]:
+    if not isinstance(value, list):
+        raise ProviderConfigError(f"Provider field must be an array: {field_name}")
+    tiers: list[ModelCostTier] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ProviderConfigError(f"Provider cost tiers must be objects: {field_name}")
+        tier_field = f"{field_name}.{index}"
+        allowed = {"max_input_tokens", "input", "output", "cacheRead", "cacheWrite"}
+        if set(item) - allowed:
+            raise ProviderConfigError(f"Provider cost tier has unknown fields: {tier_field}")
+        cost = {
+            key: _non_negative_float(item.get(key), f"{tier_field}.{key}")
+            for key in ("input", "output", "cacheRead", "cacheWrite")
+        }
+        tiers.append(
+            ModelCostTier(
+                max_input_tokens=_optional_positive_int(
+                    item.get("max_input_tokens"), f"{tier_field}.max_input_tokens"
+                ),
+                cost=cost,
+            )
+        )
+    result = tuple(tiers)
+    _validate_runtime_cost_tiers(result)
+    return result
 
 
 def _thinking_level_map_dict(

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1885,7 +1885,9 @@ def _validate_model_metadata(
 
 def _validate_runtime_cost_tiers(tiers: tuple[ModelCostTier, ...]) -> None:
     if tiers and tiers[-1].max_input_tokens is not None:
-        raise ProviderConfigError("Provider model_metadata final cost tier must be unbounded")
+        raise ProviderConfigError(
+            "Provider model_metadata final cost tier must omit max_input_tokens"
+        )
     previous_limit = 0
     for tier in tiers:
         if any(value < 0 for value in tier.cost.values()):
@@ -2135,9 +2137,7 @@ def _model_metadata_dict(
             reasoning=_optional_bool(item.get("reasoning"), f"{field_name}.{model}.reasoning"),
             input=_optional_string_tuple(item.get("input"), f"{field_name}.{model}.input"),
             cost=_float_dict(item.get("cost", {}), f"{field_name}.{model}.cost"),
-            cost_tiers=_cost_tiers(
-                item.get("cost_tiers", []), f"{field_name}.{model}.cost_tiers"
-            ),
+            cost_tiers=_cost_tiers(item.get("cost_tiers", []), f"{field_name}.{model}.cost_tiers"),
             context_window=_optional_positive_int(
                 item.get("context_window"), f"{field_name}.{model}.context_window"
             ),

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -11,10 +11,15 @@ from tau_coding.catalog_loader import (
     builtin_catalog,
     builtin_catalog_resource_text,
     effective_catalog,
+    save_user_catalog_entries,
     user_catalog_path,
 )
 from tau_coding.paths import TauPaths
-from tau_coding.provider_catalog import BUILTIN_PROVIDER_CATALOG, builtin_provider_entry
+from tau_coding.provider_catalog import (
+    BUILTIN_PROVIDER_CATALOG,
+    builtin_provider_entry,
+    model_cost_for_input_tokens,
+)
 from tau_coding.provider_config import load_provider_settings
 
 VALID_PROVIDER = """
@@ -216,6 +221,34 @@ def test_builtin_catalog_golden_kimi_entries() -> None:
     assert latest.context_window == 262_144
 
 
+def test_builtin_minimax_m3_has_tiered_pricing() -> None:
+    base_cost = {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0}
+    long_context_cost = {
+        "input": 0.6,
+        "output": 2.4,
+        "cacheRead": 0.12,
+        "cacheWrite": 0,
+    }
+
+    for provider_name in ("minimax", "minimax-cn"):
+        entry = builtin_provider_entry(provider_name)
+        assert entry is not None
+        metadata = entry.model_metadata["MiniMax-M3"]
+        assert metadata.input == ("text", "image")
+        assert metadata.cost == base_cost
+        assert model_cost_for_input_tokens(metadata, 512_000) == base_cost
+        assert model_cost_for_input_tokens(metadata, 512_001) == long_context_cost
+
+
+def test_model_cost_for_input_tokens_rejects_invalid_count() -> None:
+    entry = builtin_provider_entry("minimax")
+    assert entry is not None
+    metadata = entry.model_metadata["MiniMax-M3"]
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        model_cost_for_input_tokens(metadata, -1)
+
+
 def test_builtin_catalog_entries_are_internally_consistent() -> None:
     for entry in builtin_catalog():
         assert entry.default_model in entry.models
@@ -286,6 +319,60 @@ thinking_default = "high"
     assert entry.thinking_default == "high"
     assert entry.thinking_models == ()
     assert entry.thinking_parameter is None
+
+
+def test_user_catalog_overlays_and_serializes_cost_tiers(tmp_path: Path) -> None:
+    paths = _write_user_catalog(
+        tmp_path / ".tau",
+        """
+[[providers]]
+name = "minimax"
+
+[providers.model_metadata."MiniMax-M3"]
+cost_tiers = [
+  { max_input_tokens = 400000, input = 0.2, output = 1.0, cacheRead = 0.04, cacheWrite = 0 },
+  { input = 0.5, output = 2.0, cacheRead = 0.1, cacheWrite = 0 },
+]
+""",
+    )
+    entry = next(e for e in effective_catalog(paths) if e.name == "minimax")
+    metadata = entry.model_metadata["MiniMax-M3"]
+    assert model_cost_for_input_tokens(metadata, 400_000) == {
+        "input": 0.2,
+        "output": 1.0,
+        "cacheRead": 0.04,
+        "cacheWrite": 0,
+    }
+    long_context_cost = {
+        "input": 0.5,
+        "output": 2.0,
+        "cacheRead": 0.1,
+        "cacheWrite": 0,
+    }
+    assert model_cost_for_input_tokens(metadata, 400_001) == long_context_cost
+
+    save_user_catalog_entries([entry], paths)
+    reloaded = next(e for e in effective_catalog(paths) if e.name == "minimax")
+    assert model_cost_for_input_tokens(
+        reloaded.model_metadata["MiniMax-M3"], 400_001
+    ) == long_context_cost
+
+
+def test_user_catalog_rejects_bounded_final_cost_tier(tmp_path: Path) -> None:
+    paths = _write_user_catalog(
+        tmp_path / ".tau",
+        """
+[[providers]]
+name = "minimax"
+
+[providers.model_metadata."MiniMax-M3"]
+cost_tiers = [
+  { max_input_tokens = 512000, input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 },
+]
+""",
+    )
+    with pytest.raises(CatalogError, match="final tier must omit max_input_tokens"):
+        effective_catalog(paths)
 
 
 def test_user_catalog_rejects_unknown_keys(tmp_path: Path) -> None:

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -240,13 +240,14 @@ def test_builtin_minimax_m3_has_tiered_pricing() -> None:
         assert model_cost_for_input_tokens(metadata, 512_001) == long_context_cost
 
 
-def test_model_cost_for_input_tokens_rejects_invalid_count() -> None:
+@pytest.mark.parametrize("input_tokens", [-1, True])
+def test_model_cost_for_input_tokens_rejects_invalid_count(input_tokens: int) -> None:
     entry = builtin_provider_entry("minimax")
     assert entry is not None
     metadata = entry.model_metadata["MiniMax-M3"]
 
     with pytest.raises(ValueError, match="non-negative integer"):
-        model_cost_for_input_tokens(metadata, -1)
+        model_cost_for_input_tokens(metadata, input_tokens)
 
 
 def test_builtin_catalog_entries_are_internally_consistent() -> None:
@@ -353,9 +354,10 @@ cost_tiers = [
 
     save_user_catalog_entries([entry], paths)
     reloaded = next(e for e in effective_catalog(paths) if e.name == "minimax")
-    assert model_cost_for_input_tokens(
-        reloaded.model_metadata["MiniMax-M3"], 400_001
-    ) == long_context_cost
+    assert (
+        model_cost_for_input_tokens(reloaded.model_metadata["MiniMax-M3"], 400_001)
+        == long_context_cost
+    )
 
 
 def test_user_catalog_rejects_bounded_final_cost_tier(tmp_path: Path) -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -5,12 +5,14 @@ import pytest
 
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.paths import TauPaths
+from tau_coding.provider_catalog import ModelCostTier
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     AnthropicProviderConfig,
     OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfigError,
+    ProviderModelMetadata,
     ProviderSettings,
     ScopedModelConfig,
     anthropic_config_from_provider,
@@ -282,6 +284,167 @@ def test_save_and_load_provider_settings_round_trip(tmp_path: Path) -> None:
 
     assert path == tmp_path / ".tau" / "providers.json"
     assert loaded == settings
+
+
+def test_legacy_provider_model_cost_tiers_round_trip() -> None:
+    raw = {
+        "default_provider": "local",
+        "providers": [
+            {
+                "type": "openai-compatible",
+                "name": "local",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "LOCAL_API_KEY",
+                "models": ["qwen"],
+                "default_model": "qwen",
+                "model_metadata": {
+                    "qwen": {
+                        "cost": {
+                            "input": 0.3,
+                            "output": 1.2,
+                            "cacheRead": 0.06,
+                            "cacheWrite": 0,
+                        },
+                        "cost_tiers": [
+                            {
+                                "max_input_tokens": 512000,
+                                "input": 0.3,
+                                "output": 1.2,
+                                "cacheRead": 0.06,
+                                "cacheWrite": 0,
+                            },
+                            {
+                                "input": 0.6,
+                                "output": 2.4,
+                                "cacheRead": 0.12,
+                                "cacheWrite": 0,
+                            },
+                        ],
+                    }
+                },
+            }
+        ],
+        "scoped_models": [],
+    }
+
+    settings = provider_settings_from_json(raw)
+    provider = settings.get_provider("local")
+    assert isinstance(provider, OpenAICompatibleProviderConfig)
+    assert (
+        provider.model_metadata["qwen"].to_json()["cost_tiers"]
+        == raw["providers"][0]["model_metadata"]["qwen"]["cost_tiers"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("cost_tiers", "match"),
+    [
+        (
+            [
+                {
+                    "max_input_tokens": 512000,
+                    "input": 0.3,
+                    "output": 1.2,
+                    "cacheRead": 0.06,
+                    "cacheWrite": 0,
+                }
+            ],
+            "final cost tier must omit max_input_tokens",
+        ),
+        (
+            [
+                {
+                    "max_input_tokens": 512000,
+                    "input": 0.3,
+                    "output": 1.2,
+                    "cacheRead": 0.06,
+                    "cacheWrite": 0,
+                },
+                {
+                    "max_input_tokens": 400000,
+                    "input": 0.4,
+                    "output": 1.6,
+                    "cacheRead": 0.08,
+                    "cacheWrite": 0,
+                },
+                {
+                    "input": 0.6,
+                    "output": 2.4,
+                    "cacheRead": 0.12,
+                    "cacheWrite": 0,
+                },
+            ],
+            "limits must be strictly increasing",
+        ),
+        (
+            [
+                {
+                    "unexpected": 1,
+                    "input": 0.3,
+                    "output": 1.2,
+                    "cacheRead": 0.06,
+                    "cacheWrite": 0,
+                }
+            ],
+            "unknown fields",
+        ),
+        (
+            [
+                {
+                    "input": -0.3,
+                    "output": 1.2,
+                    "cacheRead": 0.06,
+                    "cacheWrite": 0,
+                }
+            ],
+            "0 or greater",
+        ),
+    ],
+)
+def test_legacy_provider_rejects_invalid_cost_tiers(
+    cost_tiers: list[dict[str, object]],
+    match: str,
+) -> None:
+    raw = {
+        "default_provider": "local",
+        "providers": [
+            {
+                "type": "openai-compatible",
+                "name": "local",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "LOCAL_API_KEY",
+                "models": ["qwen"],
+                "default_model": "qwen",
+                "model_metadata": {"qwen": {"cost_tiers": cost_tiers}},
+            }
+        ],
+    }
+
+    with pytest.raises(ProviderConfigError, match=match):
+        provider_settings_from_json(raw)
+
+
+def test_runtime_metadata_rejects_invalid_cost_tier_values() -> None:
+    with pytest.raises(ProviderConfigError, match="cost tier values must be non-negative"):
+        OpenAICompatibleProviderConfig(
+            name="local",
+            models=("qwen",),
+            default_model="qwen",
+            model_metadata={
+                "qwen": ProviderModelMetadata(
+                    cost_tiers=(
+                        ModelCostTier(
+                            cost={
+                                "input": -0.3,
+                                "output": 1.2,
+                                "cacheRead": 0.06,
+                                "cacheWrite": 0,
+                            }
+                        ),
+                    )
+                )
+            },
+        )
 
 
 def test_provider_settings_parses_scoped_models() -> None:

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -96,9 +96,12 @@ Catalog entries support `kind` values of `openai-compatible`, `anthropic`, and
 
 User catalog overlays can be partial when they use the same `name` as a built-in
 provider. Scalar fields replace built-in values, `models` are merged with user
-models first, `context_windows` are merged, and the thinking fields
-(`thinking_levels`, `thinking_models`, `thinking_default`, `thinking_parameter`)
-replace as a group when `thinking_levels` is present.
+models first, and `context_windows` are merged. Model metadata is merged by model;
+its `headers`, `compat`, and `thinking_level_map` mappings are merged, while other
+metadata fields—including the complete `cost_tiers` array—replace the built-in
+value. The thinking fields (`thinking_levels`, `thinking_models`,
+`thinking_default`, `thinking_parameter`) replace as a group when
+`thinking_levels` is present.
 
 `catalog.toml` does not store runtime request options such as custom HTTP
 headers, timeouts, or retry settings. Put those in `~/.tau/providers.json` on the

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -109,6 +109,23 @@ strings, empty model names, unsupported provider kinds, default models that are
 not listed in `models`, `thinking_models` or `context_windows` entries for
 unknown models, and non-positive or non-integer context-window values.
 
+Model metadata can retain a backward-compatible flat `cost` and optionally
+provide ordered `cost_tiers` for rates that depend on input size:
+
+```toml
+[providers.model_metadata."long-context-model"]
+cost = { input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 }
+cost_tiers = [
+  { max_input_tokens = 512000, input = 0.3, output = 1.2, cacheRead = 0.06, cacheWrite = 0 },
+  { input = 0.6, output = 2.4, cacheRead = 0.12, cacheWrite = 0 },
+]
+```
+
+Limits are inclusive, must increase strictly, and the final tier must omit
+`max_input_tokens` so every valid input size has a rate. Callers that understand
+tiers should select the first tier whose limit includes the input-token count;
+older callers continue to see `cost` as the base rate.
+
 ### Provider preferences
 
 Provider preferences live in `~/.tau/providers.json`:


### PR DESCRIPTION
## Summary

- add typed, ordered input-token pricing tiers while preserving the existing flat base cost
- carry tier metadata through catalog loading, user overlays, TOML serialization, and runtime provider metadata
- add inclusive threshold resolution and validation for increasing limits plus an unbounded final tier
- represent MiniMax-M3's standard `<=512k` and `>512k` rates for both MiniMax providers
- document the catalog format and add parsing, overlay, serialization, validation, and boundary tests

## Validation

- `uv run pytest -q` — 744 passed
- `uv run ruff check .` — passed
- `uv run mypy` — passed

## Dependency

This PR is stacked on #363, which adds MiniMax-M3 to the catalog. The overlapping catalog diff will disappear once #363 merges.

Closes #364
