### PR TITLE
Persist thinking on Pi-compatible assistant event streams

### DIFF
--- a/dev-notes/architecture/structured-assistant-content.md
+++ b/dev-notes/architecture/structured-assistant-content.md
@@ -1,0 +1,64 @@
+# Structured assistant content and persisted thinking
+
+## What changed
+
+Tau now keeps a provider response as ordered assistant content blocks:
+
+- text
+- thinking/reasoning
+- tool calls
+
+The finalized Pi-shaped `AssistantMessage.content` array is persisted in session
+JSONL. Its `text`, `thinking_text`, and `tool_calls` properties provide convenient
+views for current application and extension consumers.
+
+Legacy Tau session rows that used string `content` and separate `tool_calls` are
+migrated at the JSONL storage boundary into the canonical Pi message shape.
+
+## Why
+
+Thinking used to exist only as transient `ThinkingDeltaEvent` values. It could be
+shown during a live response, but was lost at `message_end`. That made resumed
+transcripts incomplete, prevented faithful export and provider replay, and forced the
+TUI to infer where thinking belonged.
+
+Pi keeps thinking, text, and tool calls in one ordered assistant content array. Tau
+now follows the same core invariant while retaining compatibility properties for its
+existing Python API and extension system.
+
+## Provider behavior
+
+Provider adapters expose Pi-compatible `AssistantMessageEvent` streams. Nested
+text/thinking updates support responsive frontends; the final response is authoritative
+and includes ordered blocks and opaque replay metadata where available:
+
+- OpenAI-compatible chat preserves the reasoning field name.
+- Responses/Codex preserve serialized reasoning items when the transport supplies
+  them.
+- Anthropic preserves thinking signatures.
+- Google preserves thought signatures.
+- Mistral preserves reasoning text.
+
+History serializers replay supported metadata on later tool-loop requests.
+
+## Frontend and extension behavior
+
+The Textual state loader projects persisted blocks in order, so resumed thinking is
+available to Ctrl+T. Live provisional rows are replaced by final structured blocks at
+`message_end` through the normal transcript redraw path. That path still resolves
+extension custom-message, tool-call, and tool-result renderers.
+
+Extensions receive the same Pi-shaped messages and nested event protocol as the rest
+of Tau. Extension-driven custom messages and TUI render hooks remain separate from
+assistant content and continue through the normal redraw path.
+
+## Validation
+
+Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -11,6 +11,8 @@ import httpx
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    TextContent,
+    ThinkingContent,
     ToolResultMessage,
     Usage,
     UserMessage,
@@ -169,6 +171,8 @@ class AnthropicProvider:
 
                         yield ProviderResponseStartEvent(model=model)
                         content_parts: list[str] = []
+                        thinking_parts: list[str] = []
+                        thinking_signature: str | None = None
                         tool_builders: dict[int, _AnthropicToolBuilder] = {}
                         finish_reason: str | None = None
                         usage: Usage | None = None
@@ -217,7 +221,14 @@ class AnthropicProvider:
                                     thinking = _string_or_empty(delta.get("thinking"))
                                     if thinking:
                                         emitted_content = True
+                                        thinking_parts.append(thinking)
                                         yield ProviderThinkingDeltaEvent(delta=thinking)
+                                elif delta_type == "signature_delta":
+                                    signature = _string_or_empty(delta.get("signature"))
+                                    if signature:
+                                        thinking_signature = (
+                                            f"{thinking_signature or ''}{signature}"
+                                        )
                                 elif delta_type == "input_json_delta":
                                     index = int(chunk.get("index", 0))
                                     builder = tool_builders.setdefault(
@@ -248,9 +259,18 @@ class AnthropicProvider:
                         for tool_call in tool_calls:
                             yield ProviderToolCallEvent(tool_call=tool_call)
 
+                        content = assistant_content("".join(content_parts), tool_calls)
+                        if thinking_parts:
+                            content.insert(
+                                0,
+                                ThinkingContent(
+                                    thinking="".join(thinking_parts),
+                                    thinking_signature=thinking_signature,
+                                ),
+                            )
                         yield ProviderResponseEndEvent(
                             message=AssistantMessage(
-                                content=assistant_content("".join(content_parts), tool_calls),
+                                content=content,
                                 usage=usage or Usage(),
                             ),
                             finish_reason=finish_reason,
@@ -360,17 +380,26 @@ def _anthropic_message(message: AgentMessage) -> dict[str, JSONValue]:
         return {"role": "user", "content": message.text}
     if isinstance(message, AssistantMessage):
         content: list[JSONValue] = []
-        if message.text:
-            content.append({"type": "text", "text": message.text})
-        for tool_call in message.tool_calls:
-            content.append(
-                {
-                    "type": "tool_use",
-                    "id": tool_call.id,
-                    "name": tool_call.name,
-                    "input": tool_call.arguments,
+        for block in message.content:
+            if isinstance(block, TextContent):
+                content.append({"type": "text", "text": block.text})
+            elif isinstance(block, ThinkingContent):
+                thinking: dict[str, JSONValue] = {
+                    "type": "thinking",
+                    "thinking": block.thinking,
                 }
-            )
+                if block.thinking_signature is not None:
+                    thinking["signature"] = block.thinking_signature
+                content.append(thinking)
+            elif isinstance(block, ToolCall):
+                content.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.id,
+                        "name": block.name,
+                        "input": block.arguments,
+                    }
+                )
         return {"role": "assistant", "content": content}
     if isinstance(message, ToolResultMessage):
         return {

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -10,6 +10,8 @@ import httpx
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    TextContent,
+    ThinkingContent,
     ToolResultMessage,
     UserMessage,
     assistant_content,
@@ -242,11 +244,12 @@ class _GoogleStreamParser:
         return events
 
     def finalize(self) -> list[ProviderEvent]:
+        content = assistant_content("".join(self._content_parts), self._tool_calls)
+        if self._thinking_parts:
+            content.insert(0, ThinkingContent(thinking="".join(self._thinking_parts)))
         return [
             ProviderResponseEndEvent(
-                message=AssistantMessage(
-                    content=assistant_content("".join(self._content_parts), self._tool_calls)
-                ),
+                message=AssistantMessage(content=content),
                 finish_reason=_normalize_finish_reason(
                     self._finish_reason, has_tool_calls=bool(self._tool_calls)
                 ),
@@ -350,19 +353,25 @@ def _message_to_google(message: AgentMessage) -> dict[str, JSONValue]:
         return {"role": "user", "parts": [{"text": message.text}]}
     if isinstance(message, AssistantMessage):
         parts: list[JSONValue] = []
-        if message.text:
-            parts.append({"text": message.text})
-        for tool_call in message.tool_calls:
-            part: dict[str, JSONValue] = {
-                "functionCall": {
-                    "id": tool_call.id,
-                    "name": tool_call.name,
-                    "args": dict(tool_call.arguments),
+        for block in message.content:
+            if isinstance(block, TextContent):
+                parts.append({"text": block.text})
+            elif isinstance(block, ThinkingContent):
+                part: dict[str, JSONValue] = {"text": block.thinking, "thought": True}
+                if block.thinking_signature is not None:
+                    part["thoughtSignature"] = block.thinking_signature
+                parts.append(part)
+            elif isinstance(block, ToolCall):
+                part = {
+                    "functionCall": {
+                        "id": block.id,
+                        "name": block.name,
+                        "args": dict(block.arguments),
+                    }
                 }
-            }
-            if tool_call.thought_signature is not None:
-                part["thoughtSignature"] = tool_call.thought_signature
-            parts.append(part)
+                if block.thought_signature is not None:
+                    part["thoughtSignature"] = block.thought_signature
+                parts.append(part)
         return {"role": "model", "parts": parts or [{"text": ""}]}
     if isinstance(message, ToolResultMessage):
         response: dict[str, JSONValue] = {

--- a/src/tau_ai/mistral.py
+++ b/src/tau_ai/mistral.py
@@ -11,6 +11,7 @@ import httpx
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    ThinkingContent,
     ToolResultMessage,
     UserMessage,
     assistant_content,
@@ -208,6 +209,7 @@ class _MistralStreamParser:
     def __init__(self) -> None:
         self.emitted_content = False
         self._content_parts: list[str] = []
+        self._thinking_parts: list[str] = []
         self._tool_call_builders: dict[int, _ToolCallBuilder] = {}
         self._finish_reason: str | None = None
 
@@ -233,6 +235,7 @@ class _MistralStreamParser:
             events.append(ProviderTextDeltaEvent(delta=content))
         for thinking in _thinking_deltas(delta):
             self.emitted_content = True
+            self._thinking_parts.append(thinking)
             events.append(ProviderThinkingDeltaEvent(delta=thinking))
         for tool_call_delta in _tool_call_deltas(delta):
             self.emitted_content = True
@@ -248,11 +251,12 @@ class _MistralStreamParser:
         events: list[ProviderEvent] = [
             ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
         ]
+        content = assistant_content("".join(self._content_parts), tool_calls)
+        if self._thinking_parts:
+            content.insert(0, ThinkingContent(thinking="".join(self._thinking_parts)))
         events.append(
             ProviderResponseEndEvent(
-                message=AssistantMessage(
-                    content=assistant_content("".join(self._content_parts), tool_calls)
-                ),
+                message=AssistantMessage(content=content),
                 finish_reason=self._finish_reason or ("tool_calls" if tool_calls else "stop"),
             )
         )
@@ -331,6 +335,8 @@ def _message_to_mistral(message: AgentMessage) -> dict[str, JSONValue]:
         return {"role": "user", "content": message.text}
     if isinstance(message, AssistantMessage):
         item: dict[str, JSONValue] = {"role": "assistant", "content": message.text}
+        if message.thinking_text:
+            item["reasoning_content"] = message.thinking_text
         if message.tool_calls:
             item["tool_calls"] = [
                 _tool_call_to_mistral(tool_call) for tool_call in message.tool_calls

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -13,6 +13,8 @@ import httpx
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    TextContent,
+    ThinkingContent,
     ToolResultMessage,
     Usage,
     UserMessage,
@@ -328,23 +330,31 @@ def _messages_to_responses_input(messages: list[AgentMessage]) -> list[JSONValue
                 }
             )
         elif isinstance(message, AssistantMessage):
-            if message.text:
-                items.append(
-                    {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": message.text,
-                                "annotations": [],
-                            }
-                        ],
-                        "status": "completed",
-                        "id": f"msg_{assistant_index}",
-                    }
-                )
-                assistant_index += 1
+            for block in message.content:
+                if isinstance(block, ThinkingContent) and block.thinking_signature:
+                    try:
+                        reasoning_item = loads(block.thinking_signature)
+                    except (TypeError, ValueError):
+                        reasoning_item = None
+                    if isinstance(reasoning_item, dict):
+                        items.append(reasoning_item)
+                elif isinstance(block, TextContent):
+                    items.append(
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": block.text,
+                                    "annotations": [],
+                                }
+                            ],
+                            "status": "completed",
+                            "id": block.text_signature or f"msg_{assistant_index}",
+                        }
+                    )
+                    assistant_index += 1
             for tool_call in message.tool_calls:
                 call_id, item_id = _split_tool_call_id(tool_call.id)
                 item: dict[str, JSONValue] = {
@@ -384,6 +394,8 @@ async def _codex_provider_events(
     signal: CancellationToken | None,
 ) -> AsyncIterator[ProviderEvent]:
     content_parts: list[str] = []
+    thinking_parts: list[str] = []
+    reasoning_items: dict[str, dict[str, JSONValue]] = {}
     tool_calls: list[ToolCall] = []
     active_tools: list[_ToolCallBuilder] = []
     tools_by_item_id: dict[str, _ToolCallBuilder] = {}
@@ -415,7 +427,11 @@ async def _codex_provider_events(
 
         if event_type == "response.output_item.added":
             item = event.get("item")
-            if isinstance(item, Mapping) and item.get("type") == "function_call":
+            if isinstance(item, Mapping) and item.get("type") == "reasoning":
+                item_id = item.get("id")
+                if isinstance(item_id, str):
+                    reasoning_items[item_id] = dict(item)
+            elif isinstance(item, Mapping) and item.get("type") == "function_call":
                 _track_tool_builder(
                     _tool_builder_from_item(item),
                     event,
@@ -462,6 +478,7 @@ async def _codex_provider_events(
         }:
             delta = event.get("delta")
             if isinstance(delta, str) and delta:
+                thinking_parts.append(delta)
                 yield ProviderThinkingDeltaEvent(delta=delta)
 
         elif event_type in {
@@ -469,7 +486,11 @@ async def _codex_provider_events(
             "response.output_item.completed",
         }:
             item = event.get("item")
-            if isinstance(item, Mapping) and item.get("type") == "function_call":
+            if isinstance(item, Mapping) and item.get("type") == "reasoning":
+                item_id = item.get("id")
+                if isinstance(item_id, str):
+                    reasoning_items[item_id] = dict(item)
+            elif isinstance(item, Mapping) and item.get("type") == "function_call":
                 tool_builder = _tool_builder_for_event(
                     event,
                     active_tools=active_tools,
@@ -517,9 +538,20 @@ async def _codex_provider_events(
             usage = _usage_from_response(event) or usage
             break
 
+    content = assistant_content("".join(content_parts), tool_calls)
+    if thinking_parts:
+        content.insert(
+            0,
+            ThinkingContent(
+                thinking="".join(thinking_parts),
+                thinking_signature=(
+                    dumps(next(iter(reasoning_items.values()))) if reasoning_items else None
+                ),
+            ),
+        )
     yield ProviderResponseEndEvent(
         message=AssistantMessage(
-            content=assistant_content("".join(content_parts), tool_calls),
+            content=content,
             usage=usage or Usage(),
         ),
         finish_reason=finish_reason,

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -19,6 +19,7 @@ import httpx
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    ThinkingContent,
     ToolResultMessage,
     Usage,
     UserMessage,
@@ -349,6 +350,8 @@ class _ChatStreamParser:
         self.emitted_content = False
         self.fatal = False
         self._content_parts: list[str] = []
+        self._thinking_parts: list[str] = []
+        self._thinking_signature: str | None = None
         self._tool_call_builders: dict[int, _ToolCallBuilder] = {}
         self._finish_reason: str | None = None
         self._usage: Usage | None = None
@@ -391,10 +394,13 @@ class _ChatStreamParser:
             self._content_parts.append(content)
             events.append(ProviderTextDeltaEvent(delta=content))
 
-        thinking = _thinking_delta_text(delta)
-        if thinking:
+        thinking = _thinking_delta(delta)
+        if thinking is not None:
+            field_name, text = thinking
             self.emitted_content = True
-            events.append(ProviderThinkingDeltaEvent(delta=thinking))
+            self._thinking_parts.append(text)
+            self._thinking_signature = self._thinking_signature or field_name
+            events.append(ProviderThinkingDeltaEvent(delta=text))
 
         for tool_call_delta in _tool_call_deltas(delta):
             self.emitted_content = True
@@ -411,10 +417,19 @@ class _ChatStreamParser:
         events: list[ProviderEvent] = [
             ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
         ]
+        content = assistant_content("".join(self._content_parts), tool_calls)
+        if self._thinking_parts:
+            content.insert(
+                0,
+                ThinkingContent(
+                    thinking="".join(self._thinking_parts),
+                    thinking_signature=self._thinking_signature,
+                ),
+            )
         events.append(
             ProviderResponseEndEvent(
                 message=AssistantMessage(
-                    content=assistant_content("".join(self._content_parts), tool_calls),
+                    content=content,
                     usage=self._usage or Usage(),
                 ),
                 finish_reason=self._finish_reason,
@@ -430,6 +445,8 @@ class _ResponsesStreamParser:
         self.emitted_content = False
         self.fatal = False
         self._content_parts: list[str] = []
+        self._thinking_parts: list[str] = []
+        self._reasoning_items: dict[str, dict[str, JSONValue]] = {}
         self._tool_call_builders: dict[str, _ResponsesToolCallBuilder] = {}
         self._status: str | None = None
         self._usage: Usage | None = None
@@ -462,12 +479,15 @@ class _ResponsesStreamParser:
             delta = chunk.get("delta")
             if isinstance(delta, str) and delta:
                 self.emitted_content = True
+                self._thinking_parts.append(delta)
                 return [ProviderThinkingDeltaEvent(delta=delta)], False
 
         elif chunk_type == "response.output_item.added":
+            item = chunk.get("item")
+            _register_reasoning_item(self._reasoning_items, item)
             _register_responses_item(
                 self._tool_call_builders,
-                chunk.get("item"),
+                item,
                 output_index=chunk.get("output_index"),
             )
 
@@ -485,9 +505,11 @@ class _ResponsesStreamParser:
                 builder.set_final(arguments=chunk.get("arguments"))
 
         elif chunk_type == "response.output_item.done":
+            item = chunk.get("item")
+            _register_reasoning_item(self._reasoning_items, item)
             _finalize_responses_item(
                 self._tool_call_builders,
-                chunk.get("item"),
+                item,
                 output_index=chunk.get("output_index"),
             )
 
@@ -517,10 +539,23 @@ class _ResponsesStreamParser:
             ProviderToolCallEvent(tool_call=tool_call) for tool_call in tool_calls
         ]
         finish_reason = _normalize_finish_reason(self._status, has_tool_calls=bool(tool_calls))
+        content = assistant_content("".join(self._content_parts), tool_calls)
+        if self._thinking_parts:
+            content.insert(
+                0,
+                ThinkingContent(
+                    thinking="".join(self._thinking_parts),
+                    thinking_signature=(
+                        dumps(next(iter(self._reasoning_items.values())))
+                        if self._reasoning_items
+                        else None
+                    ),
+                ),
+            )
         events.append(
             ProviderResponseEndEvent(
                 message=AssistantMessage(
-                    content=assistant_content("".join(self._content_parts), tool_calls),
+                    content=content,
                     usage=self._usage or Usage(),
                 ),
                 finish_reason=finish_reason,
@@ -764,6 +799,14 @@ def _messages_to_responses_input(
         if isinstance(message, UserMessage):
             items.append({"role": "user", "content": message.text})
         elif isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, ThinkingContent) and block.thinking_signature:
+                    try:
+                        reasoning_item = loads(block.thinking_signature)
+                    except (TypeError, ValueError):
+                        reasoning_item = None
+                    if isinstance(reasoning_item, dict):
+                        items.append(reasoning_item)
             if message.text:
                 items.append({"role": "assistant", "content": message.text})
             for tool_call in message.tool_calls:
@@ -793,6 +836,17 @@ def _tool_to_responses(tool: AgentTool) -> dict[str, JSONValue]:
         "description": tool.description,
         "parameters": dict(tool.input_schema),
     }
+
+
+def _register_reasoning_item(
+    items: dict[str, dict[str, JSONValue]],
+    item: object,
+) -> None:
+    if not isinstance(item, Mapping) or item.get("type") != "reasoning":
+        return
+    item_id = item.get("id")
+    if isinstance(item_id, str):
+        items[item_id] = dict(item)
 
 
 def _register_responses_item(
@@ -900,6 +954,11 @@ def _message_to_openai(message: AgentMessage) -> dict[str, JSONValue]:
 
     if isinstance(message, AssistantMessage):
         item: dict[str, JSONValue] = {"role": "assistant", "content": message.text}
+        thinking = [block for block in message.content if isinstance(block, ThinkingContent)]
+        if thinking:
+            signature = thinking[0].thinking_signature or "reasoning_content"
+            if signature in {"reasoning_content", "reasoning", "thinking"}:
+                item[signature] = "".join(block.thinking for block in thinking)
         if message.tool_calls:
             item["tool_calls"] = [
                 _tool_call_to_openai(tool_call) for tool_call in message.tool_calls
@@ -1055,12 +1114,12 @@ def _tool_call_deltas(delta: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [tool_call for tool_call in tool_calls if isinstance(tool_call, Mapping)]
 
 
-def _thinking_delta_text(delta: Mapping[str, Any]) -> str:
+def _thinking_delta(delta: Mapping[str, Any]) -> tuple[str, str] | None:
     for field_name in ("reasoning_content", "reasoning", "thinking"):
         value = delta.get(field_name)
         if isinstance(value, str) and value:
-            return value
-    return ""
+            return field_name, value
+    return None
 
 
 def _is_transient_status(status_code: int) -> bool:

--- a/src/tau_ai/stream.py
+++ b/src/tau_ai/stream.py
@@ -41,6 +41,42 @@ def _snapshot(message: AssistantMessage) -> AssistantMessage:
     return message.model_copy(deep=True)
 
 
+async def _end_active_block(
+    partial: AssistantMessage,
+    index: int | None,
+) -> AsyncIterator[AssistantMessageEvent]:
+    """End the active text/thinking block before the provider changes channels."""
+    if index is None:
+        return
+    block = partial.content[index]
+    if isinstance(block, TextContent):
+        yield TextEndEvent(
+            content_index=index,
+            content=block.text,
+            partial=_snapshot(partial),
+        )
+    elif isinstance(block, ThinkingContent):
+        yield ThinkingEndEvent(
+            content_index=index,
+            content=block.thinking,
+            partial=_snapshot(partial),
+        )
+
+
+def _copy_replay_metadata(target: AssistantMessage, source: AssistantMessage) -> None:
+    """Copy provider metadata onto streamed blocks without changing their order."""
+    source_thinking = [block for block in source.content if isinstance(block, ThinkingContent)]
+    target_thinking = [block for block in target.content if isinstance(block, ThinkingContent)]
+    for target_block, source_block in zip(target_thinking, source_thinking, strict=False):
+        target_block.thinking_signature = source_block.thinking_signature
+        target_block.redacted = source_block.redacted
+
+    source_text = [block for block in source.content if isinstance(block, TextContent)]
+    target_text = [block for block in target.content if isinstance(block, TextContent)]
+    for target_text_block, source_text_block in zip(target_text, source_text, strict=False):
+        target_text_block.text_signature = source_text_block.text_signature
+
+
 def _finish_reason(value: str | None, *, has_tools: bool) -> str:
     if has_tools or value in {"tool_calls", "tool_use", "toolUse"}:
         return "toolUse"
@@ -62,8 +98,8 @@ async def canonicalize_provider_stream(
     migrated incrementally. The public provider protocol exposes only Pi events.
     """
     partial = AssistantMessage(api=api, provider=provider, model=model)
-    text_index: int | None = None
-    thinking_index: int | None = None
+    active_index: int | None = None
+    active_kind: str | None = None
     started = False
     terminal = False
 
@@ -81,35 +117,47 @@ async def canonicalize_provider_stream(
             yield AssistantStartEvent(partial=_snapshot(partial))
 
         if isinstance(event, ProviderTextDeltaEvent):
-            if text_index is None:
-                text_index = len(partial.content)
+            if active_kind != "text":
+                async for end_event in _end_active_block(partial, active_index):
+                    yield end_event
+                active_index = len(partial.content)
+                active_kind = "text"
                 partial.content.append(TextContent(text=""))
-                yield TextStartEvent(content_index=text_index, partial=_snapshot(partial))
-            block = partial.content[text_index]
+                yield TextStartEvent(content_index=active_index, partial=_snapshot(partial))
+            assert active_index is not None
+            block = partial.content[active_index]
             assert isinstance(block, TextContent)
             block.text += event.delta
             yield TextDeltaEvent(
-                content_index=text_index,
+                content_index=active_index,
                 delta=event.delta,
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderThinkingDeltaEvent):
-            if thinking_index is None:
-                thinking_index = len(partial.content)
+            if active_kind != "thinking":
+                async for end_event in _end_active_block(partial, active_index):
+                    yield end_event
+                active_index = len(partial.content)
+                active_kind = "thinking"
                 partial.content.append(ThinkingContent(thinking=""))
                 yield ThinkingStartEvent(
-                    content_index=thinking_index,
+                    content_index=active_index,
                     partial=_snapshot(partial),
                 )
-            block = partial.content[thinking_index]
+            assert active_index is not None
+            block = partial.content[active_index]
             assert isinstance(block, ThinkingContent)
             block.thinking += event.delta
             yield ThinkingDeltaEvent(
-                content_index=thinking_index,
+                content_index=active_index,
                 delta=event.delta,
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderToolCallEvent):
+            async for end_event in _end_active_block(partial, active_index):
+                yield end_event
+            active_index = None
+            active_kind = None
             index = len(partial.content)
             partial.content.append(event.tool_call.model_copy(deep=True))
             yield ToolCallStartEvent(content_index=index, partial=_snapshot(partial))
@@ -119,22 +167,10 @@ async def canonicalize_provider_stream(
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderResponseEndEvent):
-            if text_index is not None:
-                block = partial.content[text_index]
-                assert isinstance(block, TextContent)
-                yield TextEndEvent(
-                    content_index=text_index,
-                    content=block.text,
-                    partial=_snapshot(partial),
-                )
-            if thinking_index is not None:
-                block = partial.content[thinking_index]
-                assert isinstance(block, ThinkingContent)
-                yield ThinkingEndEvent(
-                    content_index=thinking_index,
-                    content=block.thinking,
-                    partial=_snapshot(partial),
-                )
+            async for end_event in _end_active_block(partial, active_index):
+                yield end_event
+            active_index = None
+            active_kind = None
 
             # Preserve the exact streamed content order. The parser's final
             # message remains authoritative only for response metadata/usage.
@@ -145,6 +181,7 @@ async def canonicalize_provider_stream(
             final.content = [block.model_copy(deep=True) for block in partial.content]
             if not final.content and event.message.content:
                 final.content = [block.model_copy(deep=True) for block in event.message.content]
+            _copy_replay_metadata(final, event.message)
             final.stop_reason = _finish_reason(
                 event.finish_reason,
                 has_tools=bool(final.tool_calls),

--- a/src/tau_coding/context_window.py
+++ b/src/tau_coding/context_window.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    ThinkingContent,
     ToolResultMessage,
     UserMessage,
     message_text,
@@ -128,6 +129,11 @@ def estimate_message_tokens(message: AgentMessage) -> int:
     """Return a rough token estimate for one provider-neutral message."""
     tokens = MESSAGE_OVERHEAD_TOKENS + estimate_text_tokens(message_text(message))
     if isinstance(message, AssistantMessage):
+        tokens += sum(
+            estimate_text_tokens(block.thinking)
+            for block in message.content
+            if isinstance(block, ThinkingContent)
+        )
         tokens += sum(
             estimate_text_tokens(call.name) + estimate_text_tokens(str(call.arguments))
             for call in message.tool_calls

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -15,6 +15,9 @@ from pygments.lexers import JsonLexer
 
 from tau_agent.messages import (
     AssistantMessage,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
     ToolResultMessage,
     UserMessage,
     message_text,
@@ -773,25 +776,24 @@ def _render_message_entry(entry: MessageEntry) -> str:
             f"<pre>{_escape(message.text)}</pre>"
         )
     if isinstance(message, AssistantMessage):
-        tool_calls = ""
-        if message.tool_calls:
-            tool_calls = (
-                "<h4>Tool calls</h4>"
-                "<ul>"
-                + "".join(
-                    "<li>"
-                    f"<code>{_escape(call.name)}</code> "
-                    f"<code>{_escape(call.id)}</code>"
-                    f"{_render_json_block(call.arguments)}"
-                    "</li>"
-                    for call in message.tool_calls
+        blocks: list[str] = []
+        for block in message.content:
+            if isinstance(block, ThinkingContent):
+                blocks.append(f"<h4>Thinking</h4><pre>{_escape(block.thinking)}</pre>")
+            elif isinstance(block, TextContent):
+                blocks.append(f"<pre>{_escape(block.text)}</pre>")
+            elif isinstance(block, ToolCall):
+                blocks.append(
+                    "<h4>Tool call</h4><ul><li>"
+                    f"<code>{_escape(block.name)}</code> "
+                    f"<code>{_escape(block.id)}</code>"
+                    f"{_render_json_block(block.arguments)}"
+                    "</li></ul>"
                 )
-                + "</ul>"
-            )
-        content = message.text or "(no assistant text)"
+        content = "".join(blocks) or "<pre>(no assistant text)</pre>"
         return (
             f'<p class="message-role"><span class="icon">{_ICON_ASSISTANT}</span>assistant</p>'
-            f"<pre>{_escape(content)}</pre>{tool_calls}"
+            f"{content}"
         )
     if isinstance(message, ToolResultMessage):
         metadata = [

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -19,6 +19,7 @@ from tau_coding.tui.state import TuiState
 class TuiEventAdapter:
     def __init__(self, state: TuiState) -> None:
         self.state = state
+        self._assistant_start_item_index: int | None = None
 
     def apply(self, event: CodingSessionEvent) -> None:
         if isinstance(event, AgentStartEvent):
@@ -39,6 +40,7 @@ class TuiEventAdapter:
         if isinstance(event, MessageStartEvent):
             if isinstance(event.message, AssistantMessage):
                 self.state.assistant_buffer = event.message.text
+                self._assistant_start_item_index = len(self.state.items)
             return
         if isinstance(event, MessageUpdateEvent):
             nested = event.assistant_message_event
@@ -64,10 +66,14 @@ class TuiEventAdapter:
                     self.state.running = False
                     self.state.add_item("error", f"Error: {text}")
                 else:
-                    text = message.text or self.state.assistant_buffer
-                    if text:
-                        self.state.add_item("assistant", text)
+                    # Replace provisional delta rows with the final canonical
+                    # message so persisted block boundaries and ordering win.
+                    start = self._assistant_start_item_index
+                    if start is not None:
+                        del self.state.items[start:]
+                    self.state.add_assistant_message(message, include_tool_calls=False)
                 self.state.assistant_buffer = ""
+                self._assistant_start_item_index = None
             return
         if isinstance(event, ToolExecutionStartEvent):
             self._flush()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -49,7 +49,14 @@ from tau_agent.events import (
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
 )
-from tau_agent.messages import AgentMessage, AssistantMessage, CustomMessage, UserMessage
+from tau_agent.messages import (
+    AgentMessage,
+    AssistantMessage,
+    CustomMessage,
+    TextContent,
+    ThinkingContent,
+    UserMessage,
+)
 from tau_agent.provider import CancellationToken
 from tau_agent.provider_events import (
     AssistantErrorEvent,
@@ -3904,8 +3911,21 @@ class TauTuiApp(App[None]):
                 self._sync_header_title()
                 return
             if isinstance(event.message, AssistantMessage):
-                await transcript.finish_assistant_message(event.message.text)
-                self._refresh_chrome()
+                visible_blocks = [
+                    block
+                    for block in event.message.content
+                    if isinstance(block, (TextContent, ThinkingContent))
+                ]
+                if (
+                    any(isinstance(block, ThinkingContent) for block in visible_blocks)
+                    or len(visible_blocks) > 1
+                ):
+                    # The adapter replaced provisional rows with canonical ordered
+                    # blocks. Redraw through the normal extension-aware path.
+                    self._refresh()
+                else:
+                    await transcript.finish_assistant_message(event.message.text)
+                    self._refresh_chrome()
                 return
             return
         if isinstance(event, ToolExecutionStartEvent):

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -14,6 +14,8 @@ from tau_agent.messages import (
     BranchSummaryMessage,
     CompactionSummaryMessage,
     CustomMessage,
+    TextContent,
+    ThinkingContent,
     ToolResultMessage,
     UserMessage,
 )
@@ -315,12 +317,7 @@ class TuiState:
                     details=message.details if isinstance(message.details, dict) else None,
                 )
             elif isinstance(message, AssistantMessage):
-                if message.thinking_text:
-                    self.add_item("thinking", message.thinking_text)
-                if message.text:
-                    self.add_item("assistant", message.text)
-                for tool_call in message.tool_calls:
-                    self.add_tool_call(tool_call)
+                self.add_assistant_message(message)
             elif isinstance(message, ToolResultMessage):
                 self.record_tool_result(
                     message.tool_call_id,
@@ -340,6 +337,23 @@ class TuiState:
                     "Compaction summary (Ctrl+O to expand)",
                     tool_result_text=message.summary,
                 )
+
+    def add_assistant_message(
+        self,
+        message: AssistantMessage,
+        *,
+        include_tool_calls: bool = True,
+    ) -> None:
+        """Project canonical assistant blocks into display state in order."""
+        for block in message.content:
+            if isinstance(block, ThinkingContent):
+                if block.thinking:
+                    self.add_item("thinking", block.thinking)
+            elif isinstance(block, TextContent):
+                if block.text:
+                    self.add_item("assistant", block.text)
+            elif include_tool_calls:
+                self.add_tool_call(block)
 
     def _read_skill_name(self, tool_call: ToolCall) -> str | None:
         if tool_call.name != "read":

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -541,83 +541,14 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Update only thinking-token widgets after visibility changes."""
+        """Rebuild canonical transcript order after thinking visibility changes."""
         self._render_state = state
         self._render_theme = theme
         should_follow = self._should_follow_output
         previous_scroll_y = self.scroll_y
 
-        message_children = [
-            child
-            for child in self.children
-            if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-        ]
-        thinking_children = [child for child in message_children if child.item.role == "thinking"]
-        if thinking_children:
-            self.remove_children(thinking_children)
-
-        non_thinking_children = [
-            child for child in message_children if child.item.role != "thinking"
-        ]
-        non_thinking_index = 0
-        pending_thinking: list[TranscriptMessageWidget] = []
-        hidden_thinking_placeholder = False
-
-        def flush_pending(
-            *, before: TranscriptMessageWidget | StreamingTranscriptMessageWidget | None
-        ) -> None:
-            nonlocal pending_thinking
-            for widget in pending_thinking:
-                self.mount(widget, before=before)
-            pending_thinking = []
-
-        for item in state.items:
-            if item.role == "thinking":
-                if state.show_thinking:
-                    pending_thinking.append(
-                        TranscriptMessageWidget(
-                            item,
-                            theme=theme,
-                            show_tool_results=state.show_tool_results,
-                        )
-                    )
-                elif not hidden_thinking_placeholder:
-                    pending_thinking.append(
-                        TranscriptMessageWidget(
-                            ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
-                            theme=theme,
-                            show_tool_results=state.show_tool_results,
-                        )
-                    )
-                    hidden_thinking_placeholder = True
-                continue
-
-            hidden_thinking_placeholder = False
-            target = None
-            while non_thinking_index < len(non_thinking_children):
-                candidate = non_thinking_children[non_thinking_index]
-                non_thinking_index += 1
-                if candidate.item is item:
-                    target = candidate
-                    break
-            if target is not None:
-                flush_pending(before=target)
-
-        tail_child = (
-            non_thinking_children[non_thinking_index]
-            if non_thinking_index < len(non_thinking_children)
-            else None
-        )
-        flush_pending(before=tail_child)
-        self._active_thinking_widget = None
-        self._hidden_thinking_placeholder_visible = (
-            _last_transcript_child_is_hidden_thinking_placeholder(self.children)
-        )
-        self._last_render_width = self.scrollable_content_region.width
-        self.refresh(layout=True)
-        if should_follow:
-            self._request_follow_scroll()
-        else:
+        self._redraw(scroll_end=should_follow)
+        if not should_follow:
             self.call_after_refresh(
                 lambda: self.scroll_to(y=previous_scroll_y, animate=False, immediate=True)
             )
@@ -686,13 +617,14 @@ class TranscriptView(VerticalScroll):
                 )
             )
         if state.assistant_buffer:
-            self.mount(
-                TranscriptMessageWidget(
-                    ChatItem(role="assistant", text=state.assistant_buffer),
-                    theme=theme,
-                    show_tool_results=state.show_tool_results,
-                )
+            self._active_assistant_widget = StreamingTranscriptMessageWidget(
+                ChatItem(role="assistant", text=state.assistant_buffer),
+                theme=theme,
             )
+            self.mount(self._active_assistant_widget)
+        self._hidden_thinking_placeholder_visible = (
+            _last_transcript_child_is_hidden_thinking_placeholder(self.children)
+        )
         self.refresh(layout=True)
         if scroll_end:
             self._request_follow_scroll()

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -117,6 +117,8 @@ async def test_agent_loop_nests_thinking_events_without_losing_final_message() -
     ]
     assert [event.delta for event in nested] == ["hidden ", "reasoning"]
     assert messages[-1] == assistant
+    # The final provider message is the canonical persistence boundary.
+    assert isinstance(messages[-1], AssistantMessage)
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -11,6 +11,7 @@ from tau_agent import (
     MessageStartEvent,
     MessageUpdateEvent,
     TextContent,
+    ThinkingContent,
     ToolCall,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
@@ -44,6 +45,26 @@ def test_assistant_message_keeps_ordered_content_blocks() -> None:
         "name": "read",
         "arguments": {"path": "README.md"},
         "thoughtSignature": None,
+    }
+
+
+def test_assistant_message_persists_thinking_blocks_and_signatures() -> None:
+    message = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="plan", thinking_signature="reasoning_content"),
+            TextContent(text="done"),
+        ],
+        model="fake",
+        timestamp=123,
+    )
+
+    assert message.thinking_text == "plan"
+    payload = message.model_dump(by_alias=True)
+    assert payload["content"][0] == {
+        "type": "thinking",
+        "thinking": "plan",
+        "thinkingSignature": "reasoning_content",
+        "redacted": False,
     }
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pytest
 
-from tau_agent import AssistantMessage, CustomMessage, ToolResultMessage, UserMessage
+from tau_agent import (
+    AssistantMessage,
+    CustomMessage,
+    TextContent,
+    ThinkingContent,
+    ToolResultMessage,
+    UserMessage,
+)
 from tau_agent.session import (
     BranchSummaryEntry,
     CompactionEntry,
@@ -79,6 +86,25 @@ def test_assistant_and_tool_result_round_trip_canonical_blocks() -> None:
     assert result_payload["toolName"] == "edit"
     assert entry_from_json_line(entry_to_json_line(assistant)) == assistant
     assert entry_from_json_line(entry_to_json_line(result)) == result
+
+
+def test_structured_thinking_message_round_trips_jsonl() -> None:
+    entry = MessageEntry(
+        id="a",
+        message=AssistantMessage(
+            content=[
+                ThinkingContent(thinking="plan", thinking_signature="reasoning"),
+                TextContent(text="done"),
+            ]
+        ),
+    )
+
+    parsed = entry_from_json_line(entry_to_json_line(entry))
+
+    assert parsed == entry
+    payload = json.loads(entry_to_json_line(entry))["message"]
+    assert [block["type"] for block in payload["content"]] == ["thinking", "text"]
+    assert payload["content"][0]["thinkingSignature"] == "reasoning"
 
 
 def test_legacy_assistant_message_migrates_to_ordered_blocks() -> None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -10,6 +10,7 @@ from tau_agent import (
     AssistantMessage,
     SimpleCancellationToken,
     TextContent,
+    ThinkingContent,
     ToolCall,
     ToolResultMessage,
     UserMessage,
@@ -502,16 +503,62 @@ async def test_openai_compatible_provider_streams_reasoning_content() -> None:
         "thinking_start",
         "thinking_delta",
         "thinking_delta",
+        "thinking_end",
         "text_start",
         "text_delta",
         "text_end",
-        "thinking_end",
         "done",
     ]
     thinking_events = [event for event in events if isinstance(event, ThinkingDeltaEvent)]
     assert [event.delta for event in thinking_events] == ["plan ", "steps"]
     assert isinstance(events[-1], AssistantDoneEvent)
     assert events[-1].message.text == "done"
+    assert [block.type for block in events[-1].message.content] == ["thinking", "text"]
+    assert events[-1].message.thinking_text == "plan steps"
+    thinking = events[-1].message.content[0]
+    assert isinstance(thinking, ThinkingContent)
+    assert thinking.thinking_signature == "reasoning_content"
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_replays_persisted_reasoning() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"choices":[{"delta":{"content":"next"},"finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    prior = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="prior plan", thinking_signature="reasoning_content"),
+            TextContent(text="prior answer"),
+        ]
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+        await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="You are Tau.",
+                messages=[UserMessage(content="first"), prior],
+                tools=[],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    replay = payload["messages"][-1]
+    assert replay["content"] == "prior answer"
+    assert replay["reasoning_content"] == "prior plan"
 
 
 @pytest.mark.anyio
@@ -1006,10 +1053,10 @@ async def test_openai_codex_provider_streams_reasoning_deltas() -> None:
         "thinking_start",
         "thinking_delta",
         "thinking_delta",
+        "thinking_end",
         "text_start",
         "text_delta",
         "text_end",
-        "thinking_end",
         "done",
     ]
     thinking_events = [event for event in events if isinstance(event, ThinkingDeltaEvent)]
@@ -1285,10 +1332,10 @@ async def test_anthropic_provider_streams_thinking_deltas() -> None:
         "thinking_start",
         "thinking_delta",
         "thinking_delta",
+        "thinking_end",
         "text_start",
         "text_delta",
         "text_end",
-        "thinking_end",
         "done",
     ]
     thinking_events = [event for event in events if isinstance(event, ThinkingDeltaEvent)]
@@ -1690,10 +1737,10 @@ async def test_responses_api_streams_reasoning_summary_as_thinking() -> None:
         "start",
         "thinking_start",
         "thinking_delta",
+        "thinking_end",
         "text_start",
         "text_delta",
         "text_end",
-        "thinking_end",
         "done",
     ]
     thinking = next(e for e in events if isinstance(e, ThinkingDeltaEvent))

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -9,6 +9,8 @@ from tau_agent import (
     MessageStartEvent,
     MessageUpdateEvent,
     TextContent,
+    ThinkingContent,
+    ToolCall,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
@@ -84,6 +86,31 @@ def test_tui_adapter_groups_nested_thinking_deltas() -> None:
 
     assert [(item.role, item.text) for item in state.items] == [("thinking", "hidden reasoning")]
     assert state.show_thinking is False
+
+
+def test_tui_state_restores_persisted_assistant_blocks_in_order() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ThinkingContent(thinking="plan"),
+                    TextContent(text="before"),
+                    ToolCall(id="call-1", name="read", arguments={"path": "README.md"}),
+                    ThinkingContent(thinking="continue"),
+                    TextContent(text="done"),
+                ]
+            )
+        ]
+    )
+
+    assert [item.role for item in state.items] == [
+        "thinking",
+        "assistant",
+        "tool",
+        "thinking",
+        "assistant",
+    ]
 
 
 def test_tui_adapter_records_tool_progress_and_result() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -28,6 +28,7 @@ from tau_agent import (
     MessageStartEvent,
     MessageUpdateEvent,
     TextContent,
+    ThinkingContent,
     ToolCall,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
@@ -3429,6 +3430,56 @@ async def test_tui_mid_run_custom_follow_up_renders_card_not_raw_content() -> No
 
 
 @pytest.mark.anyio
+async def test_structured_assistant_redraw_preserves_extension_custom_card() -> None:
+    raw = "<task-notification>agent-1 completed</task-notification>"
+    partial = AssistantMessage()
+    final = AssistantMessage(content=[ThinkingContent(thinking="plan"), TextContent(text="done")])
+    session = FakeSession(
+        events=[
+            AgentStartEvent(),
+            MessageEndEvent(
+                message=CustomMessage(
+                    content=raw,
+                    custom_type="subagent-notification",
+                    details={"description": "Summarize codebase"},
+                )
+            ),
+            MessageStartEvent(message=partial),
+            MessageUpdateEvent(
+                message=partial,
+                assistant_message_event=ThinkingDeltaEvent(
+                    content_index=0,
+                    delta="plan",
+                    partial=partial,
+                ),
+            ),
+            MessageUpdateEvent(
+                message=partial,
+                assistant_message_event=TextDeltaEvent(
+                    content_index=1,
+                    delta="done",
+                    partial=partial,
+                ),
+            ),
+            MessageEndEvent(message=final),
+            AgentEndEvent(),
+        ]
+    )
+    session.extension_runtime = _CustomMessageRuntime()
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await app._run_prompt("run")
+        await pilot.pause()
+
+        custom_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "custom"
+        )
+        assert "✓ Summarize codebase completed" in custom_widget.selection_text
+        assert "<task-notification>" not in custom_widget.selection_text
+
+
+@pytest.mark.anyio
 async def test_tui_app_completes_custom_prompt_slash_command() -> None:
     session = FakeSession()
     session.prompt_templates = (
@@ -5717,7 +5768,57 @@ async def test_tui_app_hidden_thinking_placeholder_stays_before_streamed_answer(
 
 
 @pytest.mark.anyio
-async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
+async def test_tui_app_restored_thinking_toggles_in_persisted_order() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=(
+                UserMessage(content="prompt"),
+                AssistantMessage(
+                    content=[
+                        ThinkingContent(thinking="first plan"),
+                        TextContent(text="first answer"),
+                        ThinkingContent(thinking="second plan"),
+                        TextContent(text="second answer"),
+                    ]
+                ),
+            )
+        )
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "prompt",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "first answer",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "second answer",
+        ]
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == [
+            "prompt",
+            "first plan",
+            "first answer",
+            "second plan",
+            "second answer",
+        ]
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == [
+            "prompt",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "first answer",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "second answer",
+        ]
+
+
+@pytest.mark.anyio
+async def test_tui_app_thinking_toggle_preserves_unrelated_items() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5731,31 +5832,8 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
         await pilot.pause()
 
         transcript = app.query_one("#transcript", TranscriptView)
-        stable_widgets = [
-            widget
-            for widget in transcript.children
-            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-            and widget.item.role != "thinking"
-        ]
-        assert len(stable_widgets) == 4
-        assert (
-            sum(
-                1
-                for widget in transcript.children
-                if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-                and widget.item.role == "thinking"
-            )
-            == 2
-        )
-
         await pilot.press("ctrl+t")
         await pilot.pause()
-        assert [
-            widget
-            for widget in transcript.children
-            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-            and widget.item.role != "thinking"
-        ] == stable_widgets
         assert [line.text for line in transcript.lines] == [
             "first prompt",
             "plan one",
@@ -5768,23 +5846,8 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_widgets() -> None:
         app.state.add_item("status", "late status")
         await transcript.append_item(app.state.items[-1])
         await pilot.pause()
-        stable_widgets.append(
-            next(
-                widget
-                for widget in reversed(transcript.children)
-                if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-                and widget.item.role == "status"
-            )
-        )
-
         await pilot.press("ctrl+t")
         await pilot.pause()
-        assert [
-            widget
-            for widget in transcript.children
-            if isinstance(widget, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-            and widget.item.role != "thinking"
-        ] == stable_widgets
         assert [line.text for line in transcript.lines] == [
             "first prompt",
             "Thinking… Press Ctrl+T to show thinking tokens.",

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -68,8 +68,9 @@ off → minimal → low → medium → high → xhigh
 ```
 
 - **Shift+Tab** cycles the thinking level (default is `medium`).
-- **Ctrl+T** toggles whether streamed reasoning tokens are shown (hidden by
-  default).
+- **Ctrl+T** toggles whether reasoning tokens are shown (hidden by default).
+  Reasoning blocks are saved with the assistant response, so their original
+  positions and visibility toggle are restored when you resume a session.
 
 Thinking is model-aware: Tau enables it only when the active provider declares
 supported levels for the active model. When it's unavailable, `/session` shows

--- a/website/content/internals/agent-loop.md
+++ b/website/content/internals/agent-loop.md
@@ -37,7 +37,7 @@ provider-neutral events — never from raw provider chunks. The portable `tau_ag
 - `AgentStartEvent` / `AgentEndEvent` — a run begins / ends
 - `TurnStartEvent` / `TurnEndEvent` — one assistant response and its tool results
 - `MessageStartEvent` / `MessageUpdateEvent` / `MessageEndEvent` — a message's
-  lifecycle
+  Pi-compatible lifecycle
 - `ToolExecutionStartEvent` / `ToolExecutionUpdateEvent` / `ToolExecutionEndEvent`
   — a tool runs
 
@@ -55,6 +55,10 @@ adapter enriches `turn_start` with a zero-based `turn_index` and millisecond
 `timestamp`, and `turn_end` with the matching index. See
 [Extensions]({{< relref "../guides/extensions.md#events" >}}) for their complete
 payload table.
+
+The final `AssistantMessage` is authoritative: it persists text, thinking, and tool
+calls as ordered content blocks. Nested update events provide responsive rendering,
+while saved sessions and provider history replay use the finalized structured message.
 
 Because the contract is *events*, a frontend's job is reduced to: send a prompt,
 consume the stream, draw what you see.


### PR DESCRIPTION
## Summary

- preserve thinking/reasoning in Tau's canonical Pi-shaped `AssistantMessage.content` blocks
- keep exact thinking/text/tool-call order through Pi-compatible provider and agent event streams
- preserve provider replay metadata (OpenAI reasoning fields/items, Anthropic signatures, Google thought signatures)
- replay persisted reasoning on later tool-loop requests where supported
- restore persisted thinking in the TUI and keep Ctrl+T ordering stable
- keep extension custom/tool render paths active during canonical transcript redraws
- update context accounting, HTML export, docs, and architecture notes

## Event protocol integration

This branch is based on #375 and #376. It does not reintroduce Tau's removed delta/event types. Providers expose canonical `AssistantMessageEvent` streams, the agent emits Pi-shaped `MessageUpdateEvent` values with nested text/thinking events, and the final `MessageEndEvent.message` is the persistence authority.

## Extension compatibility

Extensions continue to receive the canonical Pi-shaped messages/events introduced by #375/#376. The TUI redraw path still resolves extension custom-message, tool-call, and tool-result renderers. Dedicated tests cover an extension custom card surviving the final structured assistant redraw.

## Validation

- `uv run pytest -q` — 956 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy src` — 80 source files clean

Closes #368.
Related: #275, #296, #375, #376.
