### PR TITLE
feat: add OAuth provider parity and OpenCode login options

### DIFF
--- a/dev-notes/architecture/oauth-provider-parity.md
+++ b/dev-notes/architecture/oauth-provider-parity.md
@@ -1,0 +1,144 @@
+# OAuth provider parity and login production journal
+
+Issue: [#370](https://github.com/huggingface/tau/issues/370)
+
+## What this phase adds
+
+Tau's original OAuth code was tied directly to OpenAI Codex. This phase adds a
+small provider-neutral registry in `tau_coding`, ports the two broadly useful Pi
+subscription providers that Tau was missing, and adds the current OpenCode
+products using their supported API-key mechanism:
+
+- Anthropic Claude Pro/Max OAuth (authorization code + PKCE)
+- GitHub Copilot OAuth (device authorization, including GitHub Enterprise
+  domain input)
+- existing OpenAI Codex OAuth through the same registry
+- OpenCode Go and OpenCode Zen catalog entries (`OPENCODE_API_KEY`, not OAuth)
+
+The registry can also be extended by application extensions without adding
+provider policy to `tau_agent`.
+
+## Audited upstream snapshot
+
+The parity audit is pinned to Pi commit
+[`dcfe36c79702ec240b146c45f167ab75ecddd205`](https://github.com/earendil-works/pi/commit/dcfe36c79702ec240b146c45f167ab75ecddd205),
+committed 2026-07-14. The relevant source is under
+`packages/ai/src/utils/oauth/`, while Pi's provider guide is
+[`packages/coding-agent/docs/providers.md`](https://github.com/earendil-works/pi/blob/dcfe36c79702ec240b146c45f167ab75ecddd205/packages/coding-agent/docs/providers.md).
+
+| Provider/product | Upstream auth | Tau decision | Notes |
+| --- | --- | --- | --- |
+| OpenAI Codex | OAuth browser callback; Pi also has device code | Ship existing browser flow through registry | Existing Tau credentials remain compatible. Device code remains a follow-up. |
+| Anthropic Claude Pro/Max | OAuth authorization code + PKCE | Ship | OAuth requests use Bearer auth, Claude Code identity headers/betas, and the required identity system block. Anthropic currently describes third-party harness use as extra usage billed per token. |
+| GitHub Copilot | GitHub device authorization followed by Copilot token exchange | Ship | Supports github.com and a prompted GitHub Enterprise Server domain. Model availability is account policy dependent. |
+| Radius | Gateway-discovered browser/device OAuth | Exclude from Tau core | Radius is Pi's first-party `pi-messages` gateway, not a general provider. Tau should not bind a reusable harness to another product's gateway. |
+| OpenCode Go | API key | Ship as API-key provider | Official setup asks users to subscribe in the OpenCode console and copy an API key. |
+| OpenCode Zen | API key | Ship as API-key provider | This is pay-as-you-go gateway access; it is not OAuth login. |
+| Google Gemini API | API key | Keep existing API-key provider | Gemini CLI's consumer OAuth is a first-party-client login. This phase does not reuse undocumented consumer credentials in a third-party harness. Vertex ADC remains a possible separate ambient-auth feature. |
+
+The OpenCode decisions were checked against the OpenCode `dev` documentation:
+[`go.mdx`](https://github.com/sst/opencode/blob/dev/packages/web/src/content/docs/go.mdx)
+and
+[`zen.mdx`](https://github.com/sst/opencode/blob/dev/packages/web/src/content/docs/zen.mdx).
+OpenCode's newer console account OAuth dynamically returns workspace provider
+configuration, but OpenCode Go/Zen's documented portable provider credential is
+still an API key. Tau therefore does not mislabel either product as OAuth.
+
+## Architecture
+
+```text
+Textual OAuthLoginScreen
+        │ OAuthLoginCallbacks (URL, device code, prompts, progress)
+        ▼
+tau_coding.oauth_registry
+        │ OAuthProvider protocol
+        ├── OpenAI Codex
+        ├── Anthropic
+        └── GitHub Copilot
+        │
+        ▼
+FileCredentialStore ── OAuthRuntimeCredentialResolver ── tau_ai adapter
+```
+
+Responsibilities remain aligned with Tau's package boundaries:
+
+- `tau_coding` owns login UX contracts, provider registry, token refresh, local
+  credential storage, and provider setup policy.
+- `tau_ai` only knows request-time auth material and protocol-specific header or
+  payload behavior.
+- `tau_agent` is unchanged and knows nothing about providers, OAuth, Textual, or
+  local paths.
+
+`OAuthCredential` now allows an optional `account_id` and JSON-compatible
+provider metadata. Existing Codex JSON objects load unchanged. GitHub Enterprise
+stores only its normalized domain. Writes use a private temporary file and an
+atomic replace, avoiding partially written JSON.
+
+Request-time resolvers refresh expired credentials and save replacements before
+the request. This also allows Copilot to derive a per-account API base URL from
+the short-lived token.
+
+## Security choices and limitations
+
+- PKCE and state validation are retained for browser callbacks.
+- Device verification URLs are accepted only with `http` or `https` schemes.
+- Device polling follows RFC 8628 defaults, `slow_down`, expiry, and
+  cancellation.
+- Provider HTTP failures do not include token response bodies, tokens, or
+  authorization codes in user-facing exceptions.
+- Credentials remain in `~/.tau/credentials.json` with mode `0600`. OS keyring
+  or encrypted-at-rest storage is intentionally deferred; users with a stronger
+  local threat model should prefer environment variables or protect their Tau
+  home directory.
+- `/logout` removes local credentials but does not remotely revoke a provider
+  grant. Users can revoke Tau/CLI access in their provider account settings.
+- Copilot model support varies by plan, organization policy, and model opt-in.
+  The bundled catalog is a candidate list; provider errors should be interpreted
+  with those account restrictions in mind.
+
+## Validation and release process
+
+Deterministic tests use `httpx.MockTransport` and fake credentials. They cover:
+
+- Anthropic refresh success and error redaction
+- Copilot device login, token exchange, Enterprise routing, untrusted URL
+  rejection, and refresh metadata
+- RFC 8628 `slow_down` and cancellation
+- registry replacement/restoration
+- legacy Codex credential loading, extensible metadata, permissions, and atomic
+  writes
+- login picker separation between OAuth and API-key methods
+
+Run the production checks with:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+Live OAuth smoke tests are deliberately not automated because they require paid
+personal subscriptions and external browsers. Before a release, maintainers
+should manually verify each enabled flow using test accounts, including one
+headless Copilot device flow and one pasted browser callback. Sanitized results
+belong in the release PR; no token, code, callback query, JWT, or credential
+file content should be copied into GitHub.
+
+## Rollback
+
+The registry and provider catalog additions can be reverted without changing
+session files. Existing API-key credentials and old Codex OAuth objects retain
+their previous format. If a provider changes an endpoint or terms, remove it
+from `auth_methods`/the built-in registry while retaining credential parsing so
+users can update or delete old local entries safely.
+
+## Follow-ups
+
+- Add OpenAI Codex device-code login and an explicit browser/device selector.
+- Add a frontend-neutral non-TUI login command for SSH-only use.
+- Consider process-level refresh locking if Tau introduces concurrent processes
+  sharing one credentials file; atomic replacement protects file integrity but
+  does not serialize competing read-modify-write operations across processes.
+- Evaluate OS keyring integration and remote revocation links.
+- Consider live Copilot model discovery/filtering after login.

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -10,6 +10,7 @@ from tau_ai.env import (
     DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
     AnthropicConfig,
     OpenAICompatibleConfig,
+    RuntimeProviderAuth,
     openai_compatible_config_from_env,
 )
 from tau_ai.events import (
@@ -52,6 +53,7 @@ __all__ = [
     "OpenAICodexProvider",
     "OpenAICompatibleConfig",
     "OpenAICompatibleProvider",
+    "RuntimeProviderAuth",
     "ProviderErrorEvent",
     "ProviderEvent",
     "ProviderResponseEndEvent",

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -68,9 +68,21 @@ class AnthropicProvider:
 
         async def iterator() -> AsyncIterator[ProviderEvent]:
             client = self._get_client()
+            api_key = self._config.api_key
+            base_url = self._config.base_url
+            auth_headers: dict[str, str] = {}
+            if self._config.credential_resolver is not None:
+                auth = await self._config.credential_resolver()
+                api_key = auth.api_key
+                if auth.base_url is not None:
+                    base_url = auth.base_url.rstrip("/")
+                    if not base_url.endswith("/v1"):
+                        base_url = f"{base_url}/v1"
+                auth_headers.update(auth.headers or {})
             payload = _build_messages_payload(
                 model=model,
                 system=system,
+                oauth_system_prompt=self._config.oauth_system_prompt,
                 messages=messages,
                 tools=tools,
                 max_tokens=self._config.max_tokens,
@@ -79,12 +91,16 @@ class AnthropicProvider:
                 thinking_mode=self._config.thinking_mode,
             )
             headers = {
-                **(dict(self._config.headers or {})),
                 "anthropic-version": ANTHROPIC_VERSION,
                 "content-type": "application/json",
-                "x-api-key": self._config.api_key,
+                **(dict(self._config.headers or {})),
+                **auth_headers,
             }
-            url = f"{self._config.base_url.rstrip('/')}/messages"
+            if self._config.bearer_auth:
+                headers.setdefault("Authorization", f"Bearer {api_key}")
+            else:
+                headers["x-api-key"] = api_key
+            url = f"{base_url.rstrip('/')}/messages"
 
             attempt = 0
             while True:
@@ -282,6 +298,7 @@ def _build_messages_payload(
     model: str,
     system: str,
     messages: list[AgentMessage],
+    oauth_system_prompt: str | None = None,
     tools: list[AgentTool],
     max_tokens: int | None = None,
     thinking_budget_tokens: int | None = None,
@@ -295,7 +312,14 @@ def _build_messages_payload(
         "model": model,
         "max_tokens": resolved_max_tokens,
         "stream": True,
-        "system": system,
+        "system": (
+            [
+                {"type": "text", "text": oauth_system_prompt},
+                {"type": "text", "text": system},
+            ]
+            if oauth_system_prompt
+            else system
+        ),
         "messages": [_anthropic_message(message) for message in messages],
     }
     if thinking_mode == "adaptive" and thinking_effort is not None:

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from os import environ
 
@@ -13,6 +13,18 @@ DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
 DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS = 60.0
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES = 2
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProviderAuth:
+    """Request auth resolved immediately before a provider call."""
+
+    api_key: str
+    base_url: str | None = None
+    headers: Mapping[str, str] | None = None
+
+
+type RuntimeProviderAuthResolver = Callable[[], Awaitable[RuntimeProviderAuth]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,6 +45,8 @@ class OpenAICompatibleConfig:
     compat: Mapping[str, JSONValue] = field(default_factory=dict)
     include_reasoning_effort_none: bool = False
     provider_name: str = "OpenAI-compatible provider"
+    omit_authorization_header: bool = False
+    credential_resolver: RuntimeProviderAuthResolver | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,6 +54,7 @@ class AnthropicConfig:
     """Configuration for Anthropic's Messages API."""
 
     api_key: str
+    bearer_auth: bool = False
     base_url: str = DEFAULT_ANTHROPIC_BASE_URL
     headers: Mapping[str, str] | None = None
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
@@ -50,6 +65,8 @@ class AnthropicConfig:
     thinking_effort: str | None = None
     thinking_mode: str = "budget"
     provider_name: str = "Anthropic"
+    oauth_system_prompt: str | None = None
+    credential_resolver: RuntimeProviderAuthResolver | None = None
 
 
 def openai_compatible_config_from_env(

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -176,17 +176,31 @@ class OpenAICompatibleProvider:
 
         async def iterator() -> AsyncIterator[ProviderEvent]:
             client = self._get_client()
-            headers = {
-                **(dict(self._config.headers or {})),
-                "Authorization": f"Bearer {self._config.api_key}",
-            }
+            api_key = self._config.api_key
+            request_url = url
+            headers = dict(self._config.headers or {})
+            if self._config.credential_resolver is not None:
+                auth = await self._config.credential_resolver()
+                api_key = auth.api_key
+                headers.update(auth.headers or {})
+                if auth.base_url is not None:
+                    endpoint = (
+                        "/responses"
+                        if url.rstrip("/").endswith("/responses")
+                        else "/chat/completions"
+                    )
+                    request_url = f"{auth.base_url.rstrip('/')}{endpoint}"
+            if not self._config.omit_authorization_header:
+                has_authorization = any(key.casefold() == "authorization" for key in headers)
+                if not has_authorization:
+                    headers["Authorization"] = f"Bearer {api_key}"
 
             attempt = 0
             while True:
                 parser = parser_factory()
                 try:
                     async with client.stream(
-                        "POST", url, json=payload, headers=headers
+                        "POST", request_url, json=payload, headers=headers
                     ) as response:
                         if response.status_code >= 400:
                             body = await response.aread()

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -32,6 +32,21 @@ from tau_coding.credentials import (
     OAuthCredential,
     credentials_path,
 )
+from tau_coding.oauth_registry import (
+    get_oauth_provider,
+    get_oauth_providers,
+    register_oauth_provider,
+    reset_oauth_providers,
+    unregister_oauth_provider,
+)
+from tau_coding.oauth_types import (
+    OAuthAuthInfo,
+    OAuthDeviceCodeInfo,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthProvider,
+    OAuthRuntimeAuth,
+)
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import (
     PromptTemplate,
@@ -174,7 +189,13 @@ __all__ = [
     "AnthropicProviderConfig",
     "OpenAICompatibleProviderConfig",
     "OpenAICodexProviderConfig",
+    "OAuthAuthInfo",
     "OAuthCredential",
+    "OAuthDeviceCodeInfo",
+    "OAuthLoginCallbacks",
+    "OAuthPrompt",
+    "OAuthProvider",
+    "OAuthRuntimeAuth",
     "PrintOutputMode",
     "ProjectContextFile",
     "PromptTemplate",
@@ -245,6 +266,8 @@ __all__ = [
     "format_project_context",
     "format_skills_for_prompt",
     "FileCredentialStore",
+    "get_oauth_provider",
+    "get_oauth_providers",
     "jsonl_session_storage",
     "load_provider_settings",
     "load_shell_settings",
@@ -262,7 +285,9 @@ __all__ = [
     "provider_thinking_unavailable_reason",
     "normalize_thinking_levels",
     "reasoning_effort_for_level",
+    "register_oauth_provider",
     "render_prompt_template",
+    "reset_oauth_providers",
     "render_session_html",
     "resolve_provider_selection",
     "save_default_provider_model",
@@ -274,5 +299,6 @@ __all__ = [
     "upsert_provider",
     "upsert_openai_compatible_provider",
     "upsert_saved_provider",
+    "unregister_oauth_provider",
     "validate_provider_model",
 ]

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -25,6 +25,7 @@ from pydantic import (
 from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
+    AuthMethod,
     ModelCatalogMetadata,
     ModelCostTier,
     ModelInput,
@@ -103,6 +104,7 @@ class _CatalogProvider(BaseModel):
     thinking_models: tuple[_NonEmptyString, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    auth_methods: tuple[AuthMethod, ...] = ("api_key",)
 
 
 class _CatalogFile(BaseModel):
@@ -342,6 +344,7 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
         thinking_models=provider.thinking_models,
         thinking_default=provider.thinking_default,
         thinking_parameter=provider.thinking_parameter,
+        auth_methods=provider.auth_methods,
     )
 
 
@@ -473,6 +476,8 @@ def _raw_provider_from_entry(entry: ProviderCatalogEntry) -> dict[str, Any]:
         raw["thinking_default"] = entry.thinking_default
     if entry.thinking_parameter is not None:
         raw["thinking_parameter"] = entry.thinking_parameter
+    if entry.auth_methods != ("api_key",):
+        raw["auth_methods"] = list(entry.auth_methods)
     return raw
 
 
@@ -542,6 +547,7 @@ def _catalog_to_toml(raw: dict[str, Any]) -> str:
             "thinking_models",
             "thinking_default",
             "thinking_parameter",
+            "auth_methods",
         ):
             if key in provider:
                 lines.append(f"{key} = {_toml_value(provider[key])}")

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -335,7 +335,7 @@ def create_default_command_registry() -> CommandRegistry:
         SlashCommand(
             name="login",
             usage="/login [provider]",
-            description="Save an API key for a built-in provider.",
+            description="Connect a provider with OAuth or an API key.",
             handler=_login_command,
         )
     )

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -18,6 +18,10 @@ from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.thinking import normalize_thinking_level
 
 BUILTIN_TUI_THEME_NAMES = ("tau-dark", "tau-light", "high-contrast")
+LOGIN_PROVIDER_ALIASES = {
+    "anthropic-api": ("anthropic", "api-key"),
+    "anthropic-subscription": ("anthropic", "subscription"),
+}
 
 
 class CommandSession(Protocol):
@@ -106,6 +110,7 @@ class CommandResult:
     login_picker_requested: bool = False
     custom_provider_login_requested: bool = False
     login_provider: str | None = None
+    login_method: str | None = None
     logout_picker_requested: bool = False
     logout_provider: str | None = None
     model_picker_requested: bool = False
@@ -677,16 +682,30 @@ def _login_command(context: CommandContext) -> CommandResult:
     if provider_name in {"custom", "new", "add"}:
         return CommandResult(handled=True, custom_provider_login_requested=True)
     if provider_name:
+        aliased_provider = LOGIN_PROVIDER_ALIASES.get(provider_name)
+        if aliased_provider is not None:
+            provider_name, login_method = aliased_provider
+        else:
+            login_method = None
         entry = builtin_provider_entry(provider_name)
         if entry is None:
-            providers = ", ".join(entry.name for entry in BUILTIN_PROVIDER_CATALOG)
+            providers = ", ".join(
+                [
+                    *(entry.name for entry in BUILTIN_PROVIDER_CATALOG),
+                    *LOGIN_PROVIDER_ALIASES,
+                ]
+            )
             return CommandResult(
                 handled=True,
                 message=(
                     f"Unknown login provider: {provider_name}\nAvailable providers: {providers}"
                 ),
             )
-        return CommandResult(handled=True, login_provider=entry.name)
+        return CommandResult(
+            handled=True,
+            login_provider=entry.name,
+            login_method=login_method,
+        )
 
     return CommandResult(handled=True, login_picker_requested=True)
 

--- a/src/tau_coding/credentials.py
+++ b/src/tau_coding/credentials.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from json import dumps, loads
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any, Literal
 
+from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
 
 
@@ -16,22 +18,32 @@ class CredentialStoreError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class OAuthCredential:
-    """Refreshable OAuth credential persisted under Tau home."""
+    """Refreshable OAuth credential persisted under Tau home.
+
+    ``account_id`` remains optional so legacy OpenAI Codex credentials load
+    unchanged while device-code providers can persist only the metadata they
+    actually receive. Provider-specific, non-secret values live in ``metadata``.
+    """
 
     access: str
     refresh: str
     expires: int
-    account_id: str
+    account_id: str | None = None
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self) -> dict[str, JSONValue]:
         """Serialize this OAuth credential to JSON-compatible data."""
-        return {
+        result: dict[str, JSONValue] = {
             "type": "oauth",
             "access": self.access,
             "refresh": self.refresh,
             "expires": self.expires,
-            "account_id": self.account_id,
         }
+        if self.account_id is not None:
+            result["account_id"] = self.account_id
+        if self.metadata:
+            result["metadata"] = dict(self.metadata)
+        return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,7 +52,7 @@ class ApiKeyCredential:
 
     key: str
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self) -> dict[str, JSONValue]:
         """Serialize this API key credential to JSON-compatible data."""
         return {"type": "api_key", "key": self.key}
 
@@ -115,8 +127,25 @@ class FileCredentialStore:
     def _save(self, data: dict[str, StoredCredential]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         raw = {key: _credential_to_json(value) for key, value in data.items()}
-        self.path.write_text(dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        self.path.chmod(0o600)
+        content = dumps(raw, indent=2, sort_keys=True) + "\n"
+        temporary_path: Path | None = None
+        try:
+            with NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                delete=False,
+            ) as handle:
+                temporary_path = Path(handle.name)
+                temporary_path.chmod(0o600)
+                handle.write(content)
+                handle.flush()
+            temporary_path.replace(self.path)
+            self.path.chmod(0o600)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
 
 
 def credentials_path(paths: TauPaths | None = None) -> Path:
@@ -136,10 +165,11 @@ def _validate_oauth_credential(credential: OAuthCredential) -> None:
         raise CredentialStoreError("OAuth access token must not be empty")
     if not credential.refresh.strip():
         raise CredentialStoreError("OAuth refresh token must not be empty")
-    if not credential.account_id.strip():
+    if credential.account_id is not None and not credential.account_id.strip():
         raise CredentialStoreError("OAuth account id must not be empty")
     if credential.expires <= 0:
         raise CredentialStoreError("OAuth expiry must be greater than 0")
+    _validate_oauth_metadata(credential.metadata)
 
 
 def _credential_from_json(value: object) -> StoredCredential:
@@ -158,18 +188,44 @@ def _credential_from_json(value: object) -> StoredCredential:
     expires = value.get("expires")
     if not isinstance(expires, int) or isinstance(expires, bool) or expires <= 0:
         raise CredentialStoreError("Tau oauth credential expires must be a positive integer")
+    account_id = value.get("account_id")
+    if account_id is not None and (not isinstance(account_id, str) or not account_id.strip()):
+        raise CredentialStoreError("Tau oauth credential account_id must be a non-empty string")
+    metadata = value.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise CredentialStoreError("Tau oauth credential metadata must be an object")
+    _validate_oauth_metadata(metadata)
     return OAuthCredential(
         access=_string_field(value, "access", credential_type),
         refresh=_string_field(value, "refresh", credential_type),
         expires=expires,
-        account_id=_string_field(value, "account_id", credential_type),
+        account_id=account_id,
+        metadata=dict(metadata),
     )
 
 
-def _credential_to_json(value: StoredCredential) -> str | dict[str, str | int]:
+def _credential_to_json(value: StoredCredential) -> str | dict[str, JSONValue]:
     if isinstance(value, str):
         return value
     return value.to_json()
+
+
+def _validate_oauth_metadata(metadata: dict[Any, Any]) -> None:
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise CredentialStoreError("Tau oauth credential metadata keys must be strings")
+        if not _is_json_value(value):
+            raise CredentialStoreError("Tau oauth credential metadata values must be JSON values")
+
+
+def _is_json_value(value: object) -> bool:
+    if value is None or isinstance(value, str | bool | int | float):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_json_value(item) for key, item in value.items())
+    return False
 
 
 def _string_field(

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3756,7 +3756,7 @@ cost_tiers = [
 
 [[providers]]
 name = "moonshotai"
-display_name = "Moonshot AI"
+display_name = "Moonshot AI (Kimi)"
 kind = "openai-compatible"
 base_url = "https://api.moonshot.ai/v1"
 api_key_env = "MOONSHOT_API_KEY"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -458,6 +458,7 @@ kind = "openai-codex"
 base_url = "https://chatgpt.com/backend-api"
 api_key_env = "OPENAI_CODEX_ACCESS_TOKEN"
 credential_name = "openai-codex"
+auth_methods = ["oauth"]
 models = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 default_model = "gpt-5.5"
 docs_url = "https://chatgpt.com/codex"
@@ -525,6 +526,7 @@ kind = "anthropic"
 base_url = "https://api.anthropic.com"
 api_key_env = "ANTHROPIC_API_KEY"
 credential_name = "anthropic"
+auth_methods = ["api_key", "oauth"]
 models = ["claude-fable-5", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-opus-4-1", "claude-opus-4-1-20250805", "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-5-20250929", "claude-sonnet-4-6", "claude-sonnet-5"]
 default_model = "claude-sonnet-4-6"
 docs_url = "https://docs.anthropic.com"
@@ -6245,3 +6247,134 @@ context_window = 1048576
 max_tokens = 131072
 compat = { requiresReasoningContentOnAssistantMessages = true, thinkingFormat = "deepseek" }
 cost = { input = 1, output = 3, cacheRead = 0.2, cacheWrite = 0 }
+
+[[providers]]
+name = "opencode-go"
+display_name = "OpenCode Go"
+kind = "openai-compatible"
+base_url = "https://opencode.ai/zen/go/v1"
+api_key_env = "OPENCODE_API_KEY"
+credential_name = "opencode-go"
+models = ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.1", "glm-5.2", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.7", "minimax-m3", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"]
+default_model = "kimi-k2.7-code"
+docs_url = "https://opencode.ai/docs/go"
+api = "openai-completions"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"deepseek-v4-flash" = 1000000
+"deepseek-v4-pro" = 1000000
+"glm-5.1" = 202752
+"glm-5.2" = 202752
+"kimi-k2.6" = 262144
+"kimi-k2.7-code" = 262144
+"mimo-v2.5" = 262144
+"mimo-v2.5-pro" = 262144
+"minimax-m2.7" = 204800
+"minimax-m3" = 204800
+"qwen3.6-plus" = 1000000
+"qwen3.7-max" = 1000000
+"qwen3.7-plus" = 1000000
+
+[[providers]]
+name = "opencode"
+display_name = "OpenCode Zen"
+kind = "openai-compatible"
+base_url = "https://opencode.ai/zen/v1"
+api_key_env = "OPENCODE_API_KEY"
+credential_name = "opencode"
+models = ["big-pickle", "deepseek-v4-flash", "deepseek-v4-flash-free", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.5-pro", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "grok-4.5", "grok-build-0.1", "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5-free", "minimax-m2.5", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-free", "north-mini-code-free", "qwen3.5-plus", "qwen3.6-plus"]
+default_model = "kimi-k2.7-code"
+docs_url = "https://opencode.ai/docs/zen"
+api = "openai-completions"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.model_metadata."gpt-5.4"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.4-mini"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.5"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.5-pro"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.6-luna"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.6-sol"]
+api = "openai-responses"
+
+[providers.model_metadata."gpt-5.6-terra"]
+api = "openai-responses"
+
+[[providers]]
+name = "github-copilot"
+display_name = "GitHub Copilot"
+kind = "openai-compatible"
+base_url = "https://api.individual.githubcopilot.com"
+api_key_env = "COPILOT_GITHUB_TOKEN"
+credential_name = "github-copilot"
+auth_methods = ["oauth"]
+models = ["claude-fable-5", "claude-haiku-4.5", "claude-opus-4.5", "claude-opus-4.6", "claude-opus-4.7", "claude-opus-4.8", "claude-sonnet-4", "claude-sonnet-4.5", "claude-sonnet-4.6", "claude-sonnet-5", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-3.5-flash", "gpt-4.1", "gpt-5-mini", "gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "kimi-k2.7-code", "mai-code-1-flash-picker"]
+default_model = "gpt-5.4"
+docs_url = "https://docs.github.com/en/copilot"
+api = "openai-responses"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+headers = { User-Agent = "GitHubCopilotChat/0.35.0", Editor-Version = "vscode/1.107.0", Editor-Plugin-Version = "copilot-chat/0.35.0", Copilot-Integration-Id = "vscode-chat" }
+
+[providers.model_metadata."claude-fable-5"]
+api = "openai-completions"
+
+[providers.model_metadata."claude-haiku-4.5"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-opus-4.5"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-opus-4.6"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-opus-4.7"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-opus-4.8"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-sonnet-4"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-sonnet-4.5"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-sonnet-4.6"]
+api = "anthropic-messages"
+
+[providers.model_metadata."claude-sonnet-5"]
+api = "anthropic-messages"
+
+[providers.model_metadata."gemini-2.5-pro"]
+api = "openai-completions"
+
+[providers.model_metadata."gemini-3-flash-preview"]
+api = "openai-completions"
+
+[providers.model_metadata."gemini-3.1-pro-preview"]
+api = "openai-completions"
+
+[providers.model_metadata."gemini-3.5-flash"]
+api = "openai-completions"
+
+[providers.model_metadata."gpt-4.1"]
+api = "openai-completions"
+
+[providers.model_metadata."kimi-k2.7-code"]
+api = "openai-completions"

--- a/src/tau_coding/oauth.py
+++ b/src/tau_coding/oauth.py
@@ -21,6 +21,13 @@ import httpx
 
 from tau_ai.http import create_async_client
 from tau_coding.credentials import OAuthCredential
+from tau_coding.oauth_types import (
+    OAuthAuthInfo,
+    OAuthFlowKind,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthRuntimeAuth,
+)
 
 OPENAI_CODEX_OAUTH_PROVIDER = "openai-codex"
 OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -36,22 +43,6 @@ type AuthCallback = Callable[["OAuthAuthInfo"], None]
 type PromptCallback = Callable[["OAuthPrompt"], Awaitable[str]]
 type ManualCodeCallback = Callable[[], Awaitable[str]]
 type ProgressCallback = Callable[[str], None]
-
-
-@dataclass(frozen=True, slots=True)
-class OAuthAuthInfo:
-    """Authorization URL and optional user instructions."""
-
-    url: str
-    instructions: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class OAuthPrompt:
-    """Text prompt used for manual OAuth fallback input."""
-
-    message: str
-    placeholder: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +73,32 @@ class TokenResponse:
 
 class OAuthError(RuntimeError):
     """Raised when an OAuth flow cannot complete."""
+
+
+class OpenAICodexOAuthProvider:
+    """Registered OpenAI Codex subscription OAuth behavior."""
+
+    id = OPENAI_CODEX_OAUTH_PROVIDER
+    name = "OpenAI Codex (ChatGPT subscription)"
+    flow_kinds: tuple[OAuthFlowKind, ...] = ("browser",)
+
+    async def login(self, callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+        if callbacks.method == "device_code":
+            raise OAuthError("OpenAI Codex device-code login is not implemented in Tau yet")
+        return await login_openai_codex(
+            on_auth=callbacks.on_auth,
+            on_prompt=callbacks.on_prompt,
+            on_manual_code_input=callbacks.on_manual_code_input,
+            on_progress=callbacks.on_progress,
+        )
+
+    async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+        if not oauth_credential_is_expired(credential):
+            return credential
+        return await refresh_openai_codex_token(credential.refresh)
+
+    def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+        return OAuthRuntimeAuth(api_key=credential.access)
 
 
 class _LocalOAuthServer:
@@ -429,7 +446,13 @@ def _validate_state(state: str | None, expected_state: str) -> None:
         raise OAuthError("OAuth state mismatch")
 
 
-async def _start_local_oauth_server(state: str) -> _LocalOAuthServer | None:
+async def _start_local_oauth_server(
+    state: str,
+    *,
+    callback_port: int = OPENAI_CODEX_CALLBACK_PORT,
+    callback_path: str = "/auth/callback",
+    success_message: str = "OpenAI authentication completed. You can close this window.",
+) -> _LocalOAuthServer | None:
     host = environ.get("TAU_OAUTH_CALLBACK_HOST", "127.0.0.1")
     loop = asyncio.get_running_loop()
     future: asyncio.Future[str | None] = loop.create_future()
@@ -438,7 +461,7 @@ async def _start_local_oauth_server(state: str) -> _LocalOAuthServer | None:
         def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
             try:
                 parsed = urlparse(self.path)
-                if parsed.path != "/auth/callback":
+                if parsed.path != callback_path:
                     self._finish(404, _oauth_html("Callback route not found."))
                     return
                 params = parse_qs(parsed.query)
@@ -451,7 +474,7 @@ async def _start_local_oauth_server(state: str) -> _LocalOAuthServer | None:
                     return
                 self._finish(
                     200,
-                    _oauth_html("OpenAI authentication completed. You can close this window."),
+                    _oauth_html(success_message),
                 )
                 if not future.done():
                     loop.call_soon_threadsafe(future.set_result, code)
@@ -470,7 +493,7 @@ async def _start_local_oauth_server(state: str) -> _LocalOAuthServer | None:
             self.wfile.write(encoded)
 
     try:
-        server = ThreadingHTTPServer((host, OPENAI_CODEX_CALLBACK_PORT), CallbackHandler)
+        server = ThreadingHTTPServer((host, callback_port), CallbackHandler)
     except OSError:
         return None
     thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/src/tau_coding/oauth_anthropic.py
+++ b/src/tau_coding/oauth_anthropic.py
@@ -1,0 +1,235 @@
+"""Anthropic Claude Pro/Max OAuth provider."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import webbrowser
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from tau_ai.http import create_async_client
+from tau_coding.credentials import OAuthCredential
+from tau_coding.oauth import (
+    OAuthError,
+    _start_local_oauth_server,
+    create_pkce_pair,
+    oauth_credential_is_expired,
+    parse_authorization_input,
+)
+from tau_coding.oauth_types import (
+    OAuthAuthInfo,
+    OAuthFlowKind,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthRuntimeAuth,
+)
+
+ANTHROPIC_OAUTH_PROVIDER = "anthropic"
+ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944a1962f5e"
+ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+ANTHROPIC_REDIRECT_URI = "http://localhost:53692/callback"
+ANTHROPIC_SCOPE = (
+    "org:create_api_key user:profile user:inference user:sessions:claude_code "
+    "user:mcp_servers user:file_upload"
+)
+ANTHROPIC_CALLBACK_PORT = 53692
+ANTHROPIC_TOKEN_SKEW_MS = 5 * 60 * 1000
+
+
+async def login_anthropic(
+    *,
+    on_auth: Callable[[OAuthAuthInfo], None],
+    on_prompt: Callable[[OAuthPrompt], Awaitable[str]],
+    on_manual_code_input: Callable[[], Awaitable[str]] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+    open_browser: bool = True,
+    client: httpx.AsyncClient | None = None,
+) -> OAuthCredential:
+    """Run Anthropic's authorization-code + PKCE login flow."""
+    verifier, challenge = create_pkce_pair()
+    params = {
+        "code": "true",
+        "client_id": ANTHROPIC_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": ANTHROPIC_REDIRECT_URI,
+        "scope": ANTHROPIC_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": verifier,
+    }
+    url = f"{ANTHROPIC_AUTHORIZE_URL}?{urlencode(params)}"
+    server = await _start_local_oauth_server(
+        verifier,
+        callback_port=ANTHROPIC_CALLBACK_PORT,
+        callback_path="/callback",
+        success_message="Anthropic authentication completed. You can close this window.",
+    )
+    on_auth(
+        OAuthAuthInfo(
+            url=url,
+            instructions=(
+                "Complete login in your browser. If the browser is on another machine, "
+                "paste the final redirect URL here."
+            ),
+        )
+    )
+    if open_browser:
+        webbrowser.open(url)
+
+    try:
+        value = await _wait_for_input(server, on_manual_code_input)
+        if value is None:
+            value = await on_prompt(
+                OAuthPrompt(
+                    message="Paste the authorization code or full redirect URL:",
+                    placeholder=ANTHROPIC_REDIRECT_URI,
+                )
+            )
+        parsed = parse_authorization_input(value)
+        if parsed.state is not None and parsed.state != verifier:
+            raise OAuthError("OAuth state mismatch")
+        if not parsed.code:
+            raise OAuthError("Missing authorization code")
+        on_progress and on_progress("Exchanging authorization code for tokens...")
+        return await _anthropic_token_request(
+            {
+                "grant_type": "authorization_code",
+                "client_id": ANTHROPIC_CLIENT_ID,
+                "code": parsed.code,
+                "state": parsed.state or verifier,
+                "redirect_uri": ANTHROPIC_REDIRECT_URI,
+                "code_verifier": verifier,
+            },
+            client=client,
+            action="exchange",
+        )
+    finally:
+        if server is not None:
+            server.close()
+
+
+async def refresh_anthropic_token(
+    refresh_token: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> OAuthCredential:
+    """Refresh Anthropic OAuth credentials."""
+    return await _anthropic_token_request(
+        {
+            "grant_type": "refresh_token",
+            "client_id": ANTHROPIC_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        client=client,
+        action="refresh",
+        previous_refresh=refresh_token,
+    )
+
+
+async def _anthropic_token_request(
+    data: dict[str, str],
+    *,
+    client: httpx.AsyncClient | None,
+    action: str,
+    previous_refresh: str | None = None,
+) -> OAuthCredential:
+    owns_client = client is None
+    active_client = client or create_async_client(timeout=30)
+    try:
+        response = await active_client.post(
+            ANTHROPIC_TOKEN_URL,
+            json=data,
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+        )
+    finally:
+        if owns_client:
+            await active_client.aclose()
+    if response.status_code >= 400:
+        raise OAuthError(f"Anthropic token {action} failed ({response.status_code})")
+    raw = response.json()
+    if not isinstance(raw, dict):
+        raise OAuthError(f"Anthropic token {action} response must be an object")
+    access = _required_string(raw, "access_token", action=action)
+    refresh = _optional_string(raw, "refresh_token") or previous_refresh
+    expires_in = raw.get("expires_in")
+    if refresh is None:
+        raise OAuthError(f"Anthropic token {action} response missing refresh_token")
+    if not isinstance(expires_in, int | float) or isinstance(expires_in, bool) or expires_in <= 0:
+        raise OAuthError(f"Anthropic token {action} response missing expires_in")
+    return OAuthCredential(
+        access=access,
+        refresh=refresh,
+        expires=int(time.time() * 1000 + expires_in * 1000 - ANTHROPIC_TOKEN_SKEW_MS),
+    )
+
+
+async def _wait_for_input(
+    server: Any,
+    manual_callback: Callable[[], Awaitable[str]] | None,
+) -> str | None:
+    tasks: list[asyncio.Task[str | None]] = []
+    if server is not None:
+        tasks.append(asyncio.create_task(server.wait_for_code()))
+    if manual_callback is not None:
+        tasks.append(asyncio.create_task(_manual_value(manual_callback)))
+    if not tasks:
+        return None
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    if server is not None:
+        server.cancel_wait()
+    return next(iter(done)).result()
+
+
+async def _manual_value(callback: Callable[[], Awaitable[str]]) -> str:
+    return await callback()
+
+
+def _required_string(raw: dict[str, Any], name: str, *, action: str) -> str:
+    value = raw.get(name)
+    if not isinstance(value, str) or not value:
+        raise OAuthError(f"Anthropic token {action} response missing {name}")
+    return value
+
+
+def _optional_string(raw: dict[str, Any], name: str) -> str | None:
+    value = raw.get(name)
+    return value if isinstance(value, str) and value else None
+
+
+class AnthropicOAuthProvider:
+    """Registered Anthropic Claude subscription OAuth behavior."""
+
+    id = ANTHROPIC_OAUTH_PROVIDER
+    name = "Anthropic (Claude Pro/Max)"
+    flow_kinds: tuple[OAuthFlowKind, ...] = ("browser",)
+
+    async def login(self, callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+        return await login_anthropic(
+            on_auth=callbacks.on_auth,
+            on_prompt=callbacks.on_prompt,
+            on_manual_code_input=callbacks.on_manual_code_input,
+            on_progress=callbacks.on_progress,
+        )
+
+    async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+        if not oauth_credential_is_expired(credential):
+            return credential
+        return await refresh_anthropic_token(credential.refresh)
+
+    def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+        return OAuthRuntimeAuth(
+            api_key=credential.access,
+            headers={
+                "Authorization": f"Bearer {credential.access}",
+                "anthropic-beta": "claude-code-20250219,oauth-2025-04-20",
+                "user-agent": "claude-cli/tau",
+                "x-app": "cli",
+            },
+        )

--- a/src/tau_coding/oauth_device.py
+++ b/src/tau_coding/oauth_device.py
@@ -1,0 +1,109 @@
+"""RFC 8628-style device authorization polling helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from tau_coding.oauth import OAuthError
+
+DevicePollStatus = Literal["complete", "pending", "slow_down", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class DevicePollResult[T]:
+    """Result of one device-token polling request."""
+
+    status: DevicePollStatus
+    value: T | None = None
+    message: str | None = None
+    interval_seconds: float | None = None
+
+
+async def poll_oauth_device_code[T](
+    poll: Callable[[], Awaitable[DevicePollResult[T]]],
+    *,
+    interval_seconds: float | None = None,
+    expires_in_seconds: float | None = None,
+    wait_before_first_poll: bool = False,
+    cancel_event: asyncio.Event | None = None,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> T:
+    """Poll an OAuth device flow with RFC 8628 timing and cancellation."""
+    interval = _poll_interval(interval_seconds)
+    deadline = monotonic() + expires_in_seconds if expires_in_seconds is not None else math.inf
+    if wait_before_first_poll:
+        await _wait(min(interval, max(deadline - monotonic(), 0)), cancel_event, sleep=sleep)
+
+    saw_slow_down = False
+    while monotonic() < deadline:
+        _raise_if_cancelled(cancel_event)
+        result = await poll()
+        if result.status == "complete":
+            if result.value is None:
+                raise OAuthError("Device flow returned no credential")
+            return result.value
+        if result.status == "failed":
+            raise OAuthError(result.message or "Device authorization failed")
+        if result.status == "slow_down":
+            saw_slow_down = True
+            interval = (
+                _poll_interval(result.interval_seconds)
+                if result.interval_seconds is not None
+                else interval + 5
+            )
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            break
+        await _wait(min(interval, remaining), cancel_event, sleep=sleep)
+
+    suffix = " after one or more slow_down responses" if saw_slow_down else ""
+    raise OAuthError(f"Device flow timed out{suffix}")
+
+
+def _poll_interval(value: float | None) -> float:
+    if value is None or not math.isfinite(value) or value <= 0:
+        return 5
+    return max(value, 1)
+
+
+async def _wait(
+    seconds: float,
+    cancel_event: asyncio.Event | None,
+    *,
+    sleep: Callable[[float], Awaitable[None]],
+) -> None:
+    _raise_if_cancelled(cancel_event)
+    if seconds <= 0:
+        return
+    if cancel_event is None:
+        await sleep(seconds)
+        return
+
+    async def run_sleep() -> None:
+        await sleep(seconds)
+
+    sleep_task: asyncio.Task[None] = asyncio.create_task(run_sleep())
+    cancel_task = asyncio.create_task(cancel_event.wait())
+    done, pending = await asyncio.wait(
+        {sleep_task, cancel_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    for task in pending:
+        task.cancel()
+    if cancel_task in done and cancel_event.is_set():
+        sleep_task.cancel()
+        raise OAuthError("Login cancelled")
+    cancel_task.cancel()
+    await sleep_task
+
+
+def _raise_if_cancelled(cancel_event: asyncio.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise OAuthError("Login cancelled")

--- a/src/tau_coding/oauth_github_copilot.py
+++ b/src/tau_coding/oauth_github_copilot.py
@@ -1,0 +1,285 @@
+"""GitHub Copilot OAuth device-code provider."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from tau_ai.http import create_async_client
+from tau_coding.credentials import OAuthCredential
+from tau_coding.oauth import OAuthError, oauth_credential_is_expired
+from tau_coding.oauth_device import DevicePollResult, poll_oauth_device_code
+from tau_coding.oauth_types import (
+    OAuthDeviceCodeInfo,
+    OAuthFlowKind,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthRuntimeAuth,
+    oauth_metadata_string,
+)
+
+GITHUB_COPILOT_OAUTH_PROVIDER = "github-copilot"
+GITHUB_COPILOT_CLIENT_ID = "Iv1.b507a08c87ecfe98"
+GITHUB_COPILOT_API_VERSION = "2026-06-01"
+GITHUB_COPILOT_TOKEN_SKEW_MS = 5 * 60 * 1000
+GITHUB_COPILOT_HEADERS = {
+    "User-Agent": "GitHubCopilotChat/0.35.0",
+    "Editor-Version": "vscode/1.107.0",
+    "Editor-Plugin-Version": "copilot-chat/0.35.0",
+    "Copilot-Integration-Id": "vscode-chat",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubDeviceCode:
+    """Validated GitHub device authorization response."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    interval_seconds: float
+    expires_in_seconds: float
+
+
+def normalize_github_domain(value: str) -> str | None:
+    """Normalize a GitHub Enterprise URL/domain to a hostname."""
+    stripped = value.strip()
+    if not stripped:
+        return None
+    parsed = urlparse(stripped if "://" in stripped else f"https://{stripped}")
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    return parsed.hostname
+
+
+def github_copilot_base_url(token: str | None, enterprise_domain: str | None = None) -> str:
+    """Derive the Copilot API URL encoded in a short-lived Copilot token."""
+    if token:
+        for field in token.split(";"):
+            key, separator, value = field.partition("=")
+            if separator and key == "proxy-ep" and value:
+                api_host = f"api.{value.removeprefix('proxy.')}"
+                return f"https://{api_host}"
+    if enterprise_domain:
+        return f"https://copilot-api.{enterprise_domain}"
+    return "https://api.individual.githubcopilot.com"
+
+
+async def login_github_copilot(
+    callbacks: OAuthLoginCallbacks,
+    *,
+    client: httpx.AsyncClient | None = None,
+    cancel_event: asyncio.Event | None = None,
+) -> OAuthCredential:
+    """Run GitHub's device flow and exchange its token for Copilot auth."""
+    domain_input = await callbacks.on_prompt(
+        OAuthPrompt(
+            message="GitHub Enterprise URL/domain (blank for github.com)",
+            placeholder="company.ghe.com",
+            allow_empty=True,
+        )
+    )
+    if cancel_event is not None and cancel_event.is_set():
+        raise OAuthError("Login cancelled")
+    enterprise_domain = normalize_github_domain(domain_input)
+    if domain_input.strip() and enterprise_domain is None:
+        raise OAuthError("Invalid GitHub Enterprise URL/domain")
+    domain = enterprise_domain or "github.com"
+
+    owns_client = client is None
+    active_client = client or create_async_client(timeout=30)
+    try:
+        device = await _start_device_flow(domain, active_client)
+        callbacks.on_device_code(
+            OAuthDeviceCodeInfo(
+                user_code=device.user_code,
+                verification_uri=device.verification_uri,
+                interval_seconds=device.interval_seconds,
+                expires_in_seconds=device.expires_in_seconds,
+            )
+        )
+        github_token = await _poll_github_access_token(
+            domain,
+            device,
+            active_client,
+            cancel_event=cancel_event,
+        )
+        if callbacks.on_progress:
+            callbacks.on_progress("Exchanging GitHub token for Copilot access...")
+        return await refresh_github_copilot_token(
+            OAuthCredential(
+                access=github_token,
+                refresh=github_token,
+                expires=1,
+                metadata=({"enterprise_domain": enterprise_domain} if enterprise_domain else {}),
+            ),
+            client=active_client,
+        )
+    finally:
+        if owns_client:
+            await active_client.aclose()
+
+
+async def refresh_github_copilot_token(
+    credential: OAuthCredential,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> OAuthCredential:
+    """Exchange a long-lived GitHub token for a short-lived Copilot token."""
+    enterprise_domain = oauth_metadata_string(credential.metadata, "enterprise_domain")
+    domain = enterprise_domain or "github.com"
+    owns_client = client is None
+    active_client = client or create_async_client(timeout=30)
+    try:
+        response = await active_client.get(
+            f"https://api.{domain}/copilot_internal/v2/token",
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {credential.refresh}",
+                **GITHUB_COPILOT_HEADERS,
+            },
+        )
+    finally:
+        if owns_client:
+            await active_client.aclose()
+    raw = _response_object(response, "Copilot token")
+    token = _required_string(raw, "token", "Copilot token")
+    expires_at = raw.get("expires_at")
+    if not isinstance(expires_at, int | float) or isinstance(expires_at, bool):
+        raise OAuthError("Copilot token response missing expires_at")
+    return OAuthCredential(
+        access=token,
+        refresh=credential.refresh,
+        expires=int(expires_at * 1000 - GITHUB_COPILOT_TOKEN_SKEW_MS),
+        account_id=credential.account_id,
+        metadata=dict(credential.metadata),
+    )
+
+
+async def _start_device_flow(domain: str, client: httpx.AsyncClient) -> GitHubDeviceCode:
+    response = await client.post(
+        f"https://{domain}/login/device/code",
+        data={"client_id": GITHUB_COPILOT_CLIENT_ID, "scope": "read:user"},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": GITHUB_COPILOT_HEADERS["User-Agent"],
+        },
+    )
+    raw = _response_object(response, "GitHub device code")
+    uri = _required_string(raw, "verification_uri", "GitHub device code")
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme not in {"http", "https"} or not parsed_uri.netloc:
+        raise OAuthError("Untrusted verification_uri in device code response")
+    interval = raw.get("interval", 5)
+    expires_in = raw.get("expires_in")
+    if not isinstance(interval, int | float) or isinstance(interval, bool):
+        raise OAuthError("GitHub device code response has invalid interval")
+    if not isinstance(expires_in, int | float) or isinstance(expires_in, bool):
+        raise OAuthError("GitHub device code response missing expires_in")
+    return GitHubDeviceCode(
+        device_code=_required_string(raw, "device_code", "GitHub device code"),
+        user_code=_required_string(raw, "user_code", "GitHub device code"),
+        verification_uri=uri,
+        interval_seconds=float(interval),
+        expires_in_seconds=float(expires_in),
+    )
+
+
+async def _poll_github_access_token(
+    domain: str,
+    device: GitHubDeviceCode,
+    client: httpx.AsyncClient,
+    *,
+    cancel_event: asyncio.Event | None,
+) -> str:
+    async def poll() -> DevicePollResult[str]:
+        response = await client.post(
+            f"https://{domain}/login/oauth/access_token",
+            data={
+                "client_id": GITHUB_COPILOT_CLIENT_ID,
+                "device_code": device.device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": GITHUB_COPILOT_HEADERS["User-Agent"],
+            },
+        )
+        raw = _response_object(response, "GitHub device token", accept_oauth_error=True)
+        access_token = raw.get("access_token")
+        if isinstance(access_token, str) and access_token:
+            return DevicePollResult(status="complete", value=access_token)
+        error = raw.get("error")
+        if error == "authorization_pending":
+            return DevicePollResult(status="pending")
+        if error == "slow_down":
+            interval = raw.get("interval")
+            return DevicePollResult(
+                status="slow_down",
+                interval_seconds=float(interval) if isinstance(interval, int | float) else None,
+            )
+        description = raw.get("error_description")
+        suffix = f": {description}" if isinstance(description, str) and description else ""
+        return DevicePollResult(status="failed", message=f"Device flow failed: {error}{suffix}")
+
+    return await poll_oauth_device_code(
+        poll,
+        interval_seconds=device.interval_seconds,
+        expires_in_seconds=device.expires_in_seconds,
+        wait_before_first_poll=True,
+        cancel_event=cancel_event,
+    )
+
+
+def _response_object(
+    response: httpx.Response,
+    label: str,
+    *,
+    accept_oauth_error: bool = False,
+) -> dict[str, Any]:
+    if response.status_code >= 400 and not accept_oauth_error:
+        raise OAuthError(f"{label} request failed ({response.status_code})")
+    try:
+        raw = response.json()
+    except ValueError as exc:
+        raise OAuthError(f"{label} response was not valid JSON") from exc
+    if not isinstance(raw, dict):
+        raise OAuthError(f"{label} response must be an object")
+    return raw
+
+
+def _required_string(raw: dict[str, Any], name: str, label: str) -> str:
+    value = raw.get(name)
+    if not isinstance(value, str) or not value:
+        raise OAuthError(f"{label} response missing {name}")
+    return value
+
+
+class GitHubCopilotOAuthProvider:
+    """Registered GitHub Copilot OAuth behavior."""
+
+    id = GITHUB_COPILOT_OAUTH_PROVIDER
+    name = "GitHub Copilot"
+    flow_kinds: tuple[OAuthFlowKind, ...] = ("device_code",)
+
+    async def login(self, callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+        return await login_github_copilot(callbacks)
+
+    async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+        if not oauth_credential_is_expired(credential):
+            return credential
+        return await refresh_github_copilot_token(credential)
+
+    def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+        enterprise_domain = oauth_metadata_string(credential.metadata, "enterprise_domain")
+        return OAuthRuntimeAuth(
+            api_key=credential.access,
+            base_url=github_copilot_base_url(credential.access, enterprise_domain),
+            headers=GITHUB_COPILOT_HEADERS,
+        )

--- a/src/tau_coding/oauth_registry.py
+++ b/src/tau_coding/oauth_registry.py
@@ -1,0 +1,55 @@
+"""Built-in and extension-ready OAuth provider registry."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from tau_coding.oauth import OpenAICodexOAuthProvider
+from tau_coding.oauth_anthropic import AnthropicOAuthProvider
+from tau_coding.oauth_github_copilot import GitHubCopilotOAuthProvider
+from tau_coding.oauth_types import OAuthProvider
+
+_BUILTIN_PROVIDERS: tuple[OAuthProvider, ...] = tuple(
+    [AnthropicOAuthProvider(), GitHubCopilotOAuthProvider(), OpenAICodexOAuthProvider()]
+)
+_registry: dict[str, OAuthProvider] = {provider.id: provider for provider in _BUILTIN_PROVIDERS}
+
+
+def get_oauth_provider(provider_id: str) -> OAuthProvider | None:
+    """Return a registered OAuth provider by stable provider ID."""
+    return _registry.get(provider_id)
+
+
+def get_oauth_providers() -> tuple[OAuthProvider, ...]:
+    """Return all registered OAuth providers in registration order."""
+    return tuple(_registry.values())
+
+
+def oauth_provider_ids() -> frozenset[str]:
+    """Return IDs accepted by Tau's subscription login flow."""
+    return frozenset(_registry)
+
+
+def register_oauth_provider(provider: OAuthProvider) -> None:
+    """Register or replace an OAuth provider implementation."""
+    if not provider.id.strip():
+        raise ValueError("OAuth provider id must not be empty")
+    _registry[provider.id] = provider
+
+
+def unregister_oauth_provider(provider_id: str) -> None:
+    """Remove a custom provider or restore a replaced built-in provider."""
+    builtin = next(
+        (provider for provider in _BUILTIN_PROVIDERS if provider.id == provider_id),
+        None,
+    )
+    if builtin is None:
+        _registry.pop(provider_id, None)
+    else:
+        _registry[provider_id] = builtin
+
+
+def reset_oauth_providers(providers: Iterable[OAuthProvider] = _BUILTIN_PROVIDERS) -> None:
+    """Reset the registry, primarily for deterministic extension tests."""
+    _registry.clear()
+    _registry.update((provider.id, provider) for provider in providers)

--- a/src/tau_coding/oauth_types.py
+++ b/src/tau_coding/oauth_types.py
@@ -1,0 +1,127 @@
+"""Provider-neutral OAuth contracts used by Tau's coding application."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from tau_agent.types import JSONValue
+from tau_coding.credentials import OAuthCredential
+
+OAuthFlowKind = Literal["browser", "device_code"]
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthAuthInfo:
+    """Authorization URL and optional instructions for a browser flow."""
+
+    url: str
+    instructions: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthDeviceCodeInfo:
+    """User-facing values returned by an OAuth device authorization request."""
+
+    user_code: str
+    verification_uri: str
+    interval_seconds: float | None = None
+    expires_in_seconds: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthPrompt:
+    """Text input requested by an OAuth provider before or during login."""
+
+    message: str
+    placeholder: str | None = None
+    allow_empty: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthSelectOption:
+    """One choice in a provider-defined OAuth selection prompt."""
+
+    id: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthSelectPrompt:
+    """Selection input requested by an OAuth provider."""
+
+    message: str
+    options: tuple[OAuthSelectOption, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthRuntimeAuth:
+    """Request authentication derived from a stored OAuth credential."""
+
+    api_key: str
+    base_url: str | None = None
+    headers: Mapping[str, str] | None = None
+
+
+AuthCallback = Callable[[OAuthAuthInfo], None]
+DeviceCodeCallback = Callable[[OAuthDeviceCodeInfo], None]
+PromptCallback = Callable[[OAuthPrompt], Awaitable[str]]
+SelectCallback = Callable[[OAuthSelectPrompt], Awaitable[str | None]]
+ManualCodeCallback = Callable[[], Awaitable[str]]
+ProgressCallback = Callable[[str], None]
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthLoginCallbacks:
+    """Frontend-independent callbacks available to an OAuth login flow."""
+
+    on_auth: AuthCallback
+    on_device_code: DeviceCodeCallback
+    on_prompt: PromptCallback
+    on_select: SelectCallback
+    on_progress: ProgressCallback | None = None
+    on_manual_code_input: ManualCodeCallback | None = None
+    method: OAuthFlowKind | None = None
+
+
+class OAuthProvider(Protocol):
+    """Provider-specific OAuth behavior registered with Tau."""
+
+    @property
+    def id(self) -> str:
+        """Stable provider/credential identifier."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """User-facing provider name."""
+        ...
+
+    @property
+    def flow_kinds(self) -> Sequence[OAuthFlowKind]:
+        """Interactive flow families supported by this provider."""
+        ...
+
+    async def login(self, callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+        """Complete login and return credentials to persist."""
+        ...
+
+    async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+        """Refresh an expired credential."""
+        ...
+
+    def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+        """Convert stored credentials to request auth."""
+        ...
+
+
+def oauth_metadata_string(
+    metadata: Mapping[str, JSONValue],
+    name: str,
+) -> str | None:
+    """Return one non-empty string from provider-specific OAuth metadata."""
+    value = metadata.get(name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -25,6 +25,7 @@ ProviderApi = Literal[
 ]
 ModelInput = Literal["text", "image"]
 ThinkingLevelMap = dict[ThinkingLevel, str | None]
+AuthMethod = Literal["api_key", "oauth"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,6 +89,7 @@ class ProviderCatalogEntry:
     thinking_models: tuple[str, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    auth_methods: tuple[AuthMethod, ...] = ("api_key",)
 
 
 def _load_builtin_catalog() -> tuple[ProviderCatalogEntry, ...]:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -23,6 +23,7 @@ from tau_ai import (
 from tau_ai.env import DEFAULT_OPENAI_COMPATIBLE_BASE_URL
 from tau_coding.catalog_loader import effective_catalog, save_user_catalog_entries
 from tau_coding.credentials import FileCredentialStore, credentials_path
+from tau_coding.oauth_registry import get_oauth_provider
 from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
@@ -1535,11 +1536,14 @@ def provider_has_usable_credentials(
 ) -> bool:
     """Return whether Tau can attempt calls for this provider without prompting setup."""
     if provider.credential_name and credential_reader is not None:
-        if isinstance(provider, OpenAICodexProviderConfig):
-            get_oauth = getattr(credential_reader, "get_oauth", None)
-            if get_oauth is not None and get_oauth(provider.credential_name) is not None:
-                return True
-        elif credential_reader.get(provider.credential_name):
+        get_oauth = getattr(credential_reader, "get_oauth", None)
+        if (
+            get_oauth_provider(provider.name) is not None
+            and get_oauth is not None
+            and get_oauth(provider.credential_name) is not None
+        ):
+            return True
+        if credential_reader.get(provider.credential_name):
             return True
     return bool(environ.get(provider.api_key_env))
 
@@ -1818,6 +1822,13 @@ def _api_key_from_provider(
         credential = credential_reader.get(provider.credential_name)
         if credential:
             return credential
+        get_oauth = getattr(credential_reader, "get_oauth", None)
+        if get_oauth_provider(provider.name) is not None and get_oauth is not None:
+            oauth_credential = get_oauth(provider.credential_name)
+            if oauth_credential is not None:
+                access = getattr(oauth_credential, "access", None)
+                if isinstance(access, str) and access:
+                    return access
 
     api_key = environ.get(provider.api_key_env)
     if api_key:

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from os import environ
 from typing import Protocol
 
 from tau_ai import (
+    AnthropicConfig,
     AnthropicProvider,
     GoogleGenerativeAIProvider,
     MistralConversationsProvider,
@@ -14,6 +16,7 @@ from tau_ai import (
     OpenAICodexCredentials,
     OpenAICodexProvider,
     OpenAICompatibleProvider,
+    RuntimeProviderAuth,
 )
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.oauth import (
@@ -21,6 +24,8 @@ from tau_coding.oauth import (
     oauth_credential_is_expired,
     refresh_openai_codex_token,
 )
+from tau_coding.oauth_registry import get_oauth_provider
+from tau_coding.oauth_types import OAuthProvider
 from tau_coding.provider_config import (
     AnthropicProviderConfig,
     OpenAICodexProviderConfig,
@@ -55,14 +60,27 @@ def create_model_provider(
         validate_provider_model(provider, model)
     credentials = credential_store or FileCredentialStore()
     if isinstance(provider, AnthropicProviderConfig):
-        return AnthropicProvider(
-            anthropic_config_from_provider(
-                provider,
-                credential_reader=credentials,
-                model=model,
-                thinking_level=thinking_level,
-            )
+        credential = _oauth_credential(provider, credentials)
+        config = anthropic_config_from_provider(
+            provider,
+            credential_reader=credentials,
+            model=model,
+            thinking_level=thinking_level,
         )
+        if credential is not None:
+            runtime_auth = _required_oauth_provider(provider.name).runtime_auth(credential)
+            config = replace(
+                config,
+                api_key=runtime_auth.api_key,
+                bearer_auth=True,
+                headers={**dict(config.headers or {}), **dict(runtime_auth.headers or {})},
+                oauth_system_prompt="You are Claude Code, Anthropic's official CLI for Claude.",
+                credential_resolver=OAuthRuntimeCredentialResolver(
+                    provider,
+                    credential_store=credentials,
+                ),
+            )
+        return AnthropicProvider(config)
     if isinstance(provider, OpenAICodexProviderConfig):
         return OpenAICodexProvider(
             OpenAICodexConfig(
@@ -84,17 +102,51 @@ def create_model_provider(
             )
         )
     if isinstance(provider, OpenAICompatibleProviderConfig):
-        config = openai_compatible_config_from_provider(
+        credential = _oauth_credential(provider, credentials)
+        compatible_config = openai_compatible_config_from_provider(
             provider,
             credential_reader=credentials,
             model=model,
             thinking_level=thinking_level,
         )
-        if provider.api == "google-generative-ai":
-            return GoogleGenerativeAIProvider(config)
-        if provider.api == "mistral-conversations":
-            return MistralConversationsProvider(config)
-        return OpenAICompatibleProvider(config)
+        if credential is not None:
+            runtime_auth = _required_oauth_provider(provider.name).runtime_auth(credential)
+            compatible_config = replace(
+                compatible_config,
+                api_key=runtime_auth.api_key,
+                base_url=runtime_auth.base_url or compatible_config.base_url,
+                headers={
+                    **dict(compatible_config.headers or {}),
+                    **dict(runtime_auth.headers or {}),
+                },
+                credential_resolver=OAuthRuntimeCredentialResolver(
+                    provider,
+                    credential_store=credentials,
+                ),
+            )
+        selected_api = compatible_config.api
+        if selected_api == "anthropic-messages":
+            if credential is None:
+                raise ProviderConfigError(
+                    "Anthropic-protocol models on openai-compatible providers require OAuth"
+                )
+            anthropic_config = AnthropicConfig(
+                api_key=compatible_config.api_key,
+                base_url=compatible_config.base_url,
+                headers=compatible_config.headers,
+                timeout_seconds=compatible_config.timeout_seconds,
+                max_retries=compatible_config.max_retries,
+                max_retry_delay_seconds=compatible_config.max_retry_delay_seconds,
+                provider_name=compatible_config.provider_name,
+                bearer_auth=True,
+                credential_resolver=compatible_config.credential_resolver,
+            )
+            return AnthropicProvider(anthropic_config)
+        if selected_api == "google-generative-ai":
+            return GoogleGenerativeAIProvider(compatible_config)
+        if selected_api == "mistral-conversations":
+            return MistralConversationsProvider(compatible_config)
+        return OpenAICompatibleProvider(compatible_config)
     raise ProviderConfigError(f"Unsupported provider config: {provider.name}")
 
 
@@ -143,6 +195,8 @@ class OpenAICodexCredentialResolver:
             credential = self._credential_store.get_oauth(credential_name)
             if credential is not None:
                 credential = await self._refresh_if_needed(credential_name, credential)
+                if credential.account_id is None:
+                    raise RuntimeError("OpenAI Codex OAuth credential is missing account_id")
                 return OpenAICodexCredentials(
                     access_token=credential.access,
                     account_id=credential.account_id,
@@ -168,5 +222,56 @@ class OpenAICodexCredentialResolver:
         if not oauth_credential_is_expired(credential):
             return credential
         refreshed = await refresh_openai_codex_token(credential.refresh)
-        self._credential_store.set_oauth(credential_name, refreshed)
+        if refreshed != credential:
+            self._credential_store.set_oauth(credential_name, refreshed)
         return refreshed
+
+
+def _oauth_credential(
+    provider: ProviderConfig,
+    credential_store: FileCredentialStore,
+) -> OAuthCredential | None:
+    if provider.credential_name is None or get_oauth_provider(provider.name) is None:
+        return None
+    return credential_store.get_oauth(provider.credential_name)
+
+
+class OAuthRuntimeCredentialResolver:
+    """Refresh provider-neutral OAuth credentials immediately before a request."""
+
+    def __init__(
+        self,
+        provider: ProviderConfig,
+        *,
+        credential_store: FileCredentialStore,
+    ) -> None:
+        self._provider = provider
+        self._credential_store = credential_store
+
+    async def __call__(self) -> RuntimeProviderAuth:
+        credential_name = self._provider.credential_name
+        if credential_name is None:
+            raise RuntimeError(f"Provider {self._provider.name} has no credential name")
+        credential = self._credential_store.get_oauth(credential_name)
+        if credential is None:
+            raise RuntimeError(
+                f"Missing OAuth credentials for {self._provider.name}. "
+                f"Run /login {self._provider.name}."
+            )
+        oauth_provider = _required_oauth_provider(self._provider.name)
+        refreshed = await oauth_provider.refresh(credential)
+        if refreshed != credential:
+            self._credential_store.set_oauth(credential_name, refreshed)
+        auth = oauth_provider.runtime_auth(refreshed)
+        return RuntimeProviderAuth(
+            api_key=auth.api_key,
+            base_url=auth.base_url,
+            headers=auth.headers,
+        )
+
+
+def _required_oauth_provider(provider_name: str) -> OAuthProvider:
+    oauth_provider = get_oauth_provider(provider_name)
+    if oauth_provider is None:
+        raise RuntimeError(f"No OAuth implementation is registered for {provider_name}")
+    return oauth_provider

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1368,40 +1368,30 @@ class LoginMethodPickerScreen(ModalScreen[str | None]):
         Binding("enter", "select_cursor", "Select", show=False, priority=True),
     ]
 
-    def __init__(
-        self,
-        *,
-        theme: TuiTheme,
-        provider: ProviderCatalogEntry | None = None,
-    ) -> None:
+    def __init__(self, *, theme: TuiTheme) -> None:
         super().__init__()
         self.theme = theme
-        self.provider = provider
 
     def compose(self) -> ComposeResult:
         """Compose the login method picker."""
-        title = "Login" if self.provider is None else f"Login: {self.provider.display_name}"
-        methods = [
-            ListItem(
-                Label("Subscription — OAuth account", markup=False),
-                id="login-method-subscription",
-            ),
-            ListItem(
-                Label("API key — built-in provider", markup=False),
-                id="login-method-api-key",
-            ),
-        ]
-        if self.provider is None:
-            methods.append(
+        with Vertical(id="login-method-picker"):
+            yield Static("Login", id="login-method-title")
+            yield Static("Choose how to authenticate.", id="login-method-intro")
+            yield LoginMethodListView(
+                ListItem(
+                    Label("Subscription — OAuth account", markup=False),
+                    id="login-method-subscription",
+                ),
+                ListItem(
+                    Label("API key — built-in provider", markup=False),
+                    id="login-method-api-key",
+                ),
                 ListItem(
                     Label("Custom provider — OpenAI-compatible", markup=False),
                     id="login-method-custom",
-                )
+                ),
+                id="login-method-list",
             )
-        with Vertical(id="login-method-picker"):
-            yield Static(title, id="login-method-title")
-            yield Static("Choose how to authenticate.", id="login-method-intro")
-            yield LoginMethodListView(*methods, id="login-method-list")
             yield Static("Enter selects - Escape closes", id="login-method-help")
 
     def on_mount(self) -> None:
@@ -4271,18 +4261,6 @@ class TauTuiApp(App[None]):
         entry = builtin_provider_entry(provider_name)
         if entry is None:
             self._notify(f"Unknown provider: {provider_name}", severity="error")
-            return
-        if method is None and set(entry.auth_methods) == {"api_key", "oauth"}:
-            self.push_screen(
-                LoginMethodPickerScreen(
-                    theme=self.tui_settings.resolved_theme,
-                    provider=entry,
-                ),
-                callback=lambda selected_method: self._open_login(
-                    entry.name,
-                    method=selected_method,
-                ),
-            )
             return
         use_oauth = method == "subscription" or (
             method is None and "api_key" not in entry.auth_methods

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1368,30 +1368,40 @@ class LoginMethodPickerScreen(ModalScreen[str | None]):
         Binding("enter", "select_cursor", "Select", show=False, priority=True),
     ]
 
-    def __init__(self, *, theme: TuiTheme) -> None:
+    def __init__(
+        self,
+        *,
+        theme: TuiTheme,
+        provider: ProviderCatalogEntry | None = None,
+    ) -> None:
         super().__init__()
         self.theme = theme
+        self.provider = provider
 
     def compose(self) -> ComposeResult:
         """Compose the login method picker."""
-        with Vertical(id="login-method-picker"):
-            yield Static("Login", id="login-method-title")
-            yield Static("Choose how to authenticate.", id="login-method-intro")
-            yield LoginMethodListView(
-                ListItem(
-                    Label("Subscription — OAuth account", markup=False),
-                    id="login-method-subscription",
-                ),
-                ListItem(
-                    Label("API key — built-in provider", markup=False),
-                    id="login-method-api-key",
-                ),
+        title = "Login" if self.provider is None else f"Login: {self.provider.display_name}"
+        methods = [
+            ListItem(
+                Label("Subscription — OAuth account", markup=False),
+                id="login-method-subscription",
+            ),
+            ListItem(
+                Label("API key — built-in provider", markup=False),
+                id="login-method-api-key",
+            ),
+        ]
+        if self.provider is None:
+            methods.append(
                 ListItem(
                     Label("Custom provider — OpenAI-compatible", markup=False),
                     id="login-method-custom",
-                ),
-                id="login-method-list",
+                )
             )
+        with Vertical(id="login-method-picker"):
+            yield Static(title, id="login-method-title")
+            yield Static("Choose how to authenticate.", id="login-method-intro")
+            yield LoginMethodListView(*methods, id="login-method-list")
             yield Static("Enter selects - Escape closes", id="login-method-help")
 
     def on_mount(self) -> None:
@@ -4261,6 +4271,18 @@ class TauTuiApp(App[None]):
         entry = builtin_provider_entry(provider_name)
         if entry is None:
             self._notify(f"Unknown provider: {provider_name}", severity="error")
+            return
+        if method is None and set(entry.auth_methods) == {"api_key", "oauth"}:
+            self.push_screen(
+                LoginMethodPickerScreen(
+                    theme=self.tui_settings.resolved_theme,
+                    provider=entry,
+                ),
+                callback=lambda selected_method: self._open_login(
+                    entry.name,
+                    method=selected_method,
+                ),
+            )
             return
         use_oauth = method == "subscription" or (
             method is None and "api_key" not in entry.auth_methods

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import traceback
-from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -73,7 +73,15 @@ from tau_coding.extensions.api import (
     SlotWidgetContent,
     SlotWidgetFactory,
 )
-from tau_coding.oauth import OAuthAuthInfo, OAuthPrompt, login_openai_codex
+from tau_coding.oauth import login_openai_codex
+from tau_coding.oauth_registry import get_oauth_provider, oauth_provider_ids
+from tau_coding.oauth_types import (
+    OAuthAuthInfo,
+    OAuthDeviceCodeInfo,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthSelectPrompt,
+)
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ProviderCatalogEntry,
@@ -1988,18 +1996,26 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | None]):
         Binding("escape", "cancel", "Cancel"),
     ]
 
-    def __init__(self, provider: ProviderCatalogEntry, *, theme: TuiTheme) -> None:
+    def __init__(
+        self,
+        provider: ProviderCatalogEntry,
+        *,
+        theme: TuiTheme,
+        login: Callable[[OAuthLoginCallbacks], Awaitable[OAuthCredential]] | None = None,
+    ) -> None:
         super().__init__()
         self.provider = provider
         self.theme = theme
+        self._login = login
         self._manual_code_future: asyncio.Future[str] | None = None
         self._manual_code_value: str | None = None
+        self._prompt_allows_empty = False
 
     def compose(self) -> ComposeResult:
         """Compose the OAuth login prompt."""
         with Vertical(id="login-screen"):
             yield Static(f"Login: {self.provider.display_name}", id="login-title")
-            yield Static("Complete the browser login, or paste the redirect URL.", id="login-help")
+            yield Static("Follow the provider instructions to complete login.", id="login-help")
             yield Static("", id="login-oauth-url")
             yield Input(
                 placeholder="Paste redirect URL or authorization code",
@@ -2014,10 +2030,19 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | None]):
 
     async def _run_login(self) -> None:
         try:
-            credential = await login_openai_codex(
-                on_auth=self._show_auth,
-                on_prompt=self._prompt_for_code,
-                on_manual_code_input=self._manual_code_input,
+            oauth_provider = get_oauth_provider(self.provider.name)
+            login = self._login or (oauth_provider.login if oauth_provider is not None else None)
+            if login is None:
+                raise RuntimeError(f"No OAuth implementation for {self.provider.name}")
+            credential = await login(
+                OAuthLoginCallbacks(
+                    on_auth=self._show_auth,
+                    on_device_code=self._show_device_code,
+                    on_prompt=self._prompt_for_code,
+                    on_select=self._select_option,
+                    on_progress=self._show_progress,
+                    on_manual_code_input=self._manual_code_input,
+                )
             )
         except Exception as exc:  # noqa: BLE001 - surface OAuth failures in the TUI
             self.query_one("#login-help", Static).update(f"OAuth failed: {exc}")
@@ -2029,9 +2054,26 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | None]):
         if info.instructions:
             self.query_one("#login-help", Static).update(info.instructions)
 
+    def _show_device_code(self, info: OAuthDeviceCodeInfo) -> None:
+        self.query_one("#login-oauth-url", Static).update(info.verification_uri)
+        self.query_one("#login-help", Static).update(
+            f"Open the URL and enter code: {info.user_code}"
+        )
+
+    def _show_progress(self, message: str) -> None:
+        self.query_one("#login-help", Static).update(message)
+
     async def _prompt_for_code(self, prompt: OAuthPrompt) -> str:
         self.query_one("#login-help", Static).update(prompt.message)
-        return await self._manual_code_input()
+        self._prompt_allows_empty = prompt.allow_empty
+        try:
+            return await self._manual_code_input()
+        finally:
+            self._prompt_allows_empty = False
+
+    async def _select_option(self, prompt: OAuthSelectPrompt) -> str | None:
+        self.query_one("#login-help", Static).update(prompt.message)
+        return prompt.options[0].id if prompt.options else None
 
     async def _manual_code_input(self) -> str:
         if self._manual_code_value is not None:
@@ -2049,7 +2091,7 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | None]):
             return
         event.stop()
         value = event.value.strip()
-        if not value:
+        if not value and not self._prompt_allows_empty:
             return
         self._manual_code_value = value
         if self._manual_code_future is not None and not self._manual_code_future.done():
@@ -4151,13 +4193,21 @@ class TauTuiApp(App[None]):
                 providers,
                 theme=self.tui_settings.resolved_theme,
             ),
-            callback=self._handle_login_provider_result,
+            callback=lambda provider_name: self._handle_login_provider_result(
+                provider_name,
+                method=method,
+            ),
         )
 
-    def _handle_login_provider_result(self, provider_name: str | None) -> None:
+    def _handle_login_provider_result(
+        self,
+        provider_name: str | None,
+        *,
+        method: str | None = None,
+    ) -> None:
         if provider_name is None:
             return
-        self._open_login(provider_name)
+        self._open_login(provider_name, method=method)
 
     def _open_custom_provider_login(self) -> None:
         self.push_screen(
@@ -4207,14 +4257,32 @@ class TauTuiApp(App[None]):
         self._notify(f"Saved custom provider {result.display_name}.")
         self._refresh()
 
-    def _open_login(self, provider_name: str) -> None:
+    def _open_login(self, provider_name: str, *, method: str | None = None) -> None:
         entry = builtin_provider_entry(provider_name)
         if entry is None:
             self._notify(f"Unknown provider: {provider_name}", severity="error")
             return
-        if entry.kind == "openai-codex":
+        use_oauth = method == "subscription" or (
+            method is None and "api_key" not in entry.auth_methods
+        )
+        if use_oauth and get_oauth_provider(entry.name) is not None:
+            login = None
+            if entry.name == "openai-codex":
+
+                async def login(callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+                    return await login_openai_codex(
+                        on_auth=callbacks.on_auth,
+                        on_prompt=callbacks.on_prompt,
+                        on_manual_code_input=callbacks.on_manual_code_input,
+                        on_progress=callbacks.on_progress,
+                    )
+
             self.push_screen(
-                OAuthLoginScreen(entry, theme=self.tui_settings.resolved_theme),
+                OAuthLoginScreen(
+                    entry,
+                    theme=self.tui_settings.resolved_theme,
+                    login=login,
+                ),
                 callback=lambda credential: self._handle_oauth_login_result(entry, credential),
             )
             return
@@ -5022,13 +5090,14 @@ def _login_provider_label(provider: ProviderCatalogEntry) -> str:
 def _subscription_login_providers(
     providers: Sequence[ProviderCatalogEntry],
 ) -> tuple[ProviderCatalogEntry, ...]:
-    return tuple(provider for provider in providers if provider.kind == "openai-codex")
+    provider_ids = oauth_provider_ids()
+    return tuple(provider for provider in providers if provider.name in provider_ids)
 
 
 def _api_key_login_providers(
     providers: Sequence[ProviderCatalogEntry],
 ) -> tuple[ProviderCatalogEntry, ...]:
-    return tuple(provider for provider in providers if provider.kind != "openai-codex")
+    return tuple(provider for provider in providers if "api_key" in provider.auth_methods)
 
 
 def _stored_credential_providers(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -60,6 +60,7 @@ from tau_ai import ProviderErrorEvent, ProviderEvent
 from tau_ai.provider import CancellationToken
 from tau_coding.catalog_loader import save_user_catalog_entries
 from tau_coding.commands import (
+    LOGIN_PROVIDER_ALIASES,
     CommandRegistry,
     create_default_command_registry,
     format_reload_summary,
@@ -2950,7 +2951,7 @@ class TauTuiApp(App[None]):
             if command.custom_provider_login_requested:
                 self._open_custom_provider_login()
             if command.login_provider is not None:
-                self._open_login(command.login_provider)
+                self._open_login(command.login_provider, method=command.login_method)
             if command.logout_picker_requested:
                 self._open_logout_picker()
             if command.logout_provider is not None:
@@ -4749,7 +4750,10 @@ class TauTuiApp(App[None]):
             skills=self.session.skills,
             prompt_templates=self.session.prompt_templates,
             model_names=self.session.available_models,
-            provider_names=self.session.available_providers,
+            provider_names=(
+                *self.session.available_providers,
+                *LOGIN_PROVIDER_ALIASES,
+            ),
             thinking_levels=getattr(self.session, "available_thinking_levels", ()),
             theme_names=BUILTIN_TUI_THEME_NAMES,
             session_options=_session_options(self.session),

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1272,8 +1272,48 @@ class CommandOutputScreen(ModalScreen[None]):
         self.query_one("#command-output-scroll", CommandOutputScroll).action_scroll_down()
 
 
+class LoginProviderSearchInput(Input):
+    """Search input that keeps provider-picker navigation local."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("escape", "cancel", "Cancel", show=False, priority=True),
+        Binding("up", "cursor_up", "Up", show=False, priority=True),
+        Binding("down", "cursor_down", "Down", show=False, priority=True),
+    ]
+
+    def _picker(self) -> LoginProviderPickerScreen:
+        return cast(LoginProviderPickerScreen, self.screen)
+
+    def on_key(self, event: Key) -> None:
+        """Route picker control keys before the input edits its text."""
+        if event.key == "up":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_up()
+        elif event.key == "down":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_down()
+        elif event.key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.action_cancel()
+
+    def action_cursor_up(self) -> None:
+        """Move the provider picker selection up."""
+        self._picker().action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        """Move the provider picker selection down."""
+        self._picker().action_cursor_down()
+
+    def action_cancel(self) -> None:
+        """Close the provider picker."""
+        self._picker().action_cancel()
+
+
 class LoginProviderPickerScreen(ModalScreen[str | None]):
-    """Provider picker for the TUI login flow."""
+    """Searchable provider picker for the TUI login flow."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = [
         Binding("escape", "cancel", "Cancel"),
@@ -1291,6 +1331,7 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
     ) -> None:
         super().__init__()
         self.providers = tuple(providers)
+        self.visible_providers = self.providers
         self.theme = theme
         self.title_text = title
 
@@ -1298,6 +1339,10 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
         """Compose the provider picker."""
         with Vertical(id="login-provider-picker"):
             yield Static(self.title_text, id="login-provider-title")
+            yield LoginProviderSearchInput(
+                placeholder="Search providers",
+                id="login-provider-search",
+            )
             yield ListView(
                 *[
                     ListItem(Label(_login_provider_label(provider), markup=False))
@@ -1308,10 +1353,24 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
             yield Static("Enter selects - Escape closes", id="login-provider-help")
 
     def on_mount(self) -> None:
-        """Focus the provider list."""
-        provider_list = self.query_one("#login-provider-list", ListView)
-        provider_list.index = 0
-        provider_list.focus()
+        """Focus the provider search field."""
+        self.query_one("#login-provider-search", Input).focus()
+        self._refresh_provider_list()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter providers as the search value changes."""
+        if event.input.id != "login-provider-search":
+            return
+        event.stop()
+        self.visible_providers = _filter_login_providers(self.providers, event.value)
+        self._refresh_provider_list()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Select the highlighted provider from the search field."""
+        if event.input.id != "login-provider-search":
+            return
+        event.stop()
+        self._select_visible_provider()
 
     def on_key(self, event: Key) -> None:
         """Route provider picker keys to the list."""
@@ -1327,7 +1386,8 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Dismiss with the selected provider name."""
-        self.dismiss(self.providers[event.index].name)
+        event.stop()
+        self._select_visible_provider()
 
     def action_cursor_up(self) -> None:
         """Move to the previous provider."""
@@ -1339,11 +1399,35 @@ class LoginProviderPickerScreen(ModalScreen[str | None]):
 
     def action_select_cursor(self) -> None:
         """Select the highlighted provider."""
-        self.query_one("#login-provider-list", ListView).action_select_cursor()
+        self._select_visible_provider()
 
     def action_cancel(self) -> None:
         """Close without selecting a provider."""
         self.dismiss(None)
+
+    def _select_visible_provider(self) -> None:
+        provider_list = self.query_one("#login-provider-list", ListView)
+        index = provider_list.index
+        if index is None or not self.visible_providers:
+            return
+        self.dismiss(self.visible_providers[index].name)
+
+    def _refresh_provider_list(self) -> None:
+        provider_list = self.query_one("#login-provider-list", ListView)
+        provider_list.clear()
+        provider_list.extend(
+            [
+                ListItem(Label(_login_provider_label(provider), markup=False))
+                for provider in self.visible_providers
+            ]
+        )
+        provider_list.index = 0 if self.visible_providers else None
+        help_text = (
+            "Enter selects - Escape closes"
+            if self.visible_providers
+            else "No matching providers - Escape closes"
+        )
+        self.query_one("#login-provider-help", Static).update(help_text)
 
 
 @dataclass(frozen=True, slots=True)
@@ -2504,6 +2588,7 @@ class TauTuiApp(App[None]):
         max-height: 10;
     }
 
+    #login-provider-search,
     #model-picker-search {
         height: 3;
         margin-bottom: 1;
@@ -5145,6 +5230,20 @@ def _model_picker_label(
     )
     suffix = " [scoped]" if scoped else ""
     return f"{marker}{choice.provider_name}:{choice.model}{suffix}"
+
+
+def _filter_login_providers(
+    providers: Sequence[ProviderCatalogEntry],
+    query: str,
+) -> tuple[ProviderCatalogEntry, ...]:
+    normalized = query.strip().casefold()
+    if not normalized:
+        return tuple(providers)
+    return tuple(
+        provider
+        for provider in providers
+        if normalized in provider.name.casefold() or normalized in provider.display_name.casefold()
+    )
 
 
 def _filter_model_choices(choices: Sequence[ModelChoice], query: str) -> tuple[ModelChoice, ...]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -342,6 +342,27 @@ def test_login_command_requests_provider_login(tmp_path: Path) -> None:
     assert result.login_provider == "openai"
 
 
+def test_login_command_resolves_anthropic_auth_aliases(tmp_path: Path) -> None:
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    api_result = registry.execute(session, "/login anthropic-api")
+    subscription_result = registry.execute(session, "/login anthropic-subscription")
+
+    assert api_result.login_provider == "anthropic"
+    assert api_result.login_method == "api-key"
+    assert subscription_result.login_provider == "anthropic"
+    assert subscription_result.login_method == "subscription"
+
+
+def test_login_command_lists_auth_aliases_for_unknown_provider(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/login missing")
+
+    assert result.message is not None
+    assert "anthropic-api" in result.message
+    assert "anthropic-subscription" in result.message
+
+
 def test_login_command_requests_custom_provider_login(tmp_path: Path) -> None:
     result = create_default_command_registry().execute(FakeSession(tmp_path), "/login custom")
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -46,3 +46,41 @@ def test_file_credential_store_round_trips_oauth_credentials(tmp_path) -> None:
     assert store.get("openai-codex") is None
     assert store.get_oauth("openai-codex") == credential
     assert '"type": "oauth"' in path.read_text(encoding="utf-8")
+
+
+def test_file_credential_store_round_trips_extensible_oauth_metadata(tmp_path) -> None:
+    path = tmp_path / "credentials.json"
+    store = FileCredentialStore(path)
+    credential = OAuthCredential(
+        access="copilot-access",
+        refresh="github-token",
+        expires=123456,
+        metadata={
+            "enterprise_domain": "ghe.example.com",
+            "available_model_ids": ["gpt-5.4", "claude-sonnet-4.6"],
+        },
+    )
+
+    store.set_oauth("github-copilot", credential)
+
+    assert store.get_oauth("github-copilot") == credential
+    assert '"account_id"' not in path.read_text(encoding="utf-8")
+    assert not list(tmp_path.glob(".credentials.json.*"))
+
+
+def test_file_credential_store_loads_legacy_codex_oauth_shape(tmp_path) -> None:
+    path = tmp_path / "credentials.json"
+    path.write_text(
+        '{"openai-codex":{"type":"oauth","access":"a","refresh":"r",'
+        '"expires":123,"account_id":"account"}}',
+        encoding="utf-8",
+    )
+
+    credential = FileCredentialStore(path).get_oauth("openai-codex")
+
+    assert credential == OAuthCredential(
+        access="a",
+        refresh="r",
+        expires=123,
+        account_id="account",
+    )

--- a/tests/test_oauth_providers.py
+++ b/tests/test_oauth_providers.py
@@ -1,0 +1,273 @@
+import asyncio
+from typing import cast
+
+import httpx
+import pytest
+
+from tau_coding.credentials import FileCredentialStore, OAuthCredential
+from tau_coding.oauth import OAuthError
+from tau_coding.oauth_anthropic import (
+    ANTHROPIC_CLIENT_ID,
+    ANTHROPIC_TOKEN_URL,
+    refresh_anthropic_token,
+)
+from tau_coding.oauth_device import DevicePollResult, poll_oauth_device_code
+from tau_coding.oauth_github_copilot import (
+    GITHUB_COPILOT_CLIENT_ID,
+    github_copilot_base_url,
+    login_github_copilot,
+    normalize_github_domain,
+    refresh_github_copilot_token,
+)
+from tau_coding.oauth_registry import (
+    get_oauth_provider,
+    oauth_provider_ids,
+    register_oauth_provider,
+    reset_oauth_providers,
+    unregister_oauth_provider,
+)
+from tau_coding.oauth_types import (
+    OAuthDeviceCodeInfo,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthProvider,
+    OAuthRuntimeAuth,
+    OAuthSelectPrompt,
+)
+from tau_coding.provider_config import provider_config_from_catalog_entry
+from tau_coding.provider_runtime import OAuthRuntimeCredentialResolver
+
+
+def _callbacks(
+    *,
+    prompt: str = "",
+    device_codes: list[OAuthDeviceCodeInfo] | None = None,
+) -> OAuthLoginCallbacks:
+    async def on_prompt(_prompt: OAuthPrompt) -> str:
+        return prompt
+
+    async def on_select(_prompt: OAuthSelectPrompt) -> str | None:
+        return None
+
+    return OAuthLoginCallbacks(
+        on_auth=lambda _info: None,
+        on_device_code=lambda info: device_codes.append(info) if device_codes is not None else None,
+        on_prompt=on_prompt,
+        on_select=on_select,
+    )
+
+
+@pytest.mark.anyio
+async def test_refresh_anthropic_token_uses_json_and_redacts_failed_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == ANTHROPIC_TOKEN_URL
+        assert request.headers["content-type"] == "application/json"
+        assert request.content
+        assert ANTHROPIC_CLIENT_ID.encode() in request.content
+        return httpx.Response(401, text="secret-token-body")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(OAuthError) as error:
+            await refresh_anthropic_token("refresh-secret", client=client)
+
+    assert "401" in str(error.value)
+    assert "secret-token-body" not in str(error.value)
+    assert "refresh-secret" not in str(error.value)
+
+
+@pytest.mark.anyio
+async def test_refresh_anthropic_token_returns_provider_neutral_credential() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "anthropic-access",
+                "refresh_token": "anthropic-refresh",
+                "expires_in": 3600,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        credential = await refresh_anthropic_token("old-refresh", client=client)
+
+    assert credential.access == "anthropic-access"
+    assert credential.refresh == "anthropic-refresh"
+    assert credential.account_id is None
+    assert credential.expires > 0
+
+
+@pytest.mark.anyio
+async def test_github_copilot_device_login_and_token_exchange() -> None:
+    device_codes: list[OAuthDeviceCodeInfo] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/device/code":
+            assert f"client_id={GITHUB_COPILOT_CLIENT_ID}" in request.content.decode()
+            return httpx.Response(
+                200,
+                json={
+                    "device_code": "device-secret",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": "https://github.com/login/device",
+                    "interval": 0,
+                    "expires_in": 60,
+                },
+            )
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"access_token": "github-token"})
+        if request.url.path == "/copilot_internal/v2/token":
+            assert request.headers["authorization"] == "Bearer github-token"
+            return httpx.Response(
+                200,
+                json={
+                    "token": "tid=1;exp=9999999999;proxy-ep=proxy.business.githubcopilot.com",
+                    "expires_at": 9999999999,
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        credential = await login_github_copilot(
+            _callbacks(device_codes=device_codes),
+            client=client,
+        )
+
+    assert device_codes == [
+        OAuthDeviceCodeInfo(
+            user_code="ABCD-1234",
+            verification_uri="https://github.com/login/device",
+            interval_seconds=0,
+            expires_in_seconds=60,
+        )
+    ]
+    assert credential.refresh == "github-token"
+    assert credential.access.startswith("tid=1")
+    assert github_copilot_base_url(credential.access) == ("https://api.business.githubcopilot.com")
+
+
+@pytest.mark.anyio
+async def test_github_copilot_rejects_untrusted_device_verification_uri() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "device_code": "device",
+                "user_code": "code",
+                "verification_uri": "file:///tmp/not-safe",
+                "interval": 5,
+                "expires_in": 60,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(OAuthError, match="Untrusted verification_uri"):
+            await login_github_copilot(_callbacks(), client=client)
+
+
+@pytest.mark.anyio
+async def test_refresh_github_copilot_preserves_enterprise_metadata() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.ghe.example.com"
+        return httpx.Response(200, json={"token": "copilot", "expires_at": 9999999999})
+
+    original = OAuthCredential(
+        access="old",
+        refresh="github-token",
+        expires=1,
+        metadata={"enterprise_domain": "ghe.example.com"},
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        refreshed = await refresh_github_copilot_token(original, client=client)
+
+    assert refreshed.metadata == original.metadata
+    assert normalize_github_domain("https://ghe.example.com/path") == "ghe.example.com"
+    assert github_copilot_base_url(None, "ghe.example.com") == (
+        "https://copilot-api.ghe.example.com"
+    )
+
+
+@pytest.mark.anyio
+async def test_device_poll_slow_down_and_cancel() -> None:
+    sleeps: list[float] = []
+    results = iter(
+        [
+            DevicePollResult[str](status="slow_down"),
+            DevicePollResult(status="complete", value="done"),
+        ]
+    )
+
+    async def fake_poll() -> DevicePollResult[str]:
+        return next(results)
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    assert (
+        await poll_oauth_device_code(
+            fake_poll,
+            interval_seconds=1,
+            expires_in_seconds=60,
+            sleep=fake_sleep,
+        )
+        == "done"
+    )
+    assert sleeps == [6]
+
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+    with pytest.raises(OAuthError, match="Login cancelled"):
+        await poll_oauth_device_code(fake_poll, cancel_event=cancel_event)
+
+
+@pytest.mark.anyio
+async def test_runtime_oauth_resolver_refreshes_and_persists_atomically(tmp_path) -> None:
+    class FakeOAuthProvider:
+        id = "github-copilot"
+        name = "Fake GitHub Copilot"
+        flow_kinds = ("device_code",)
+
+        async def login(self, _callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+            raise AssertionError("not used")
+
+        async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+            return OAuthCredential(
+                access="new-access",
+                refresh=credential.refresh,
+                expires=9999999999999,
+                metadata=dict(credential.metadata),
+            )
+
+        def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+            return OAuthRuntimeAuth(
+                api_key=credential.access,
+                base_url="https://api.business.githubcopilot.com",
+            )
+
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "github-copilot",
+        OAuthCredential(access="old", refresh="github", expires=1),
+    )
+    provider = provider_config_from_catalog_entry("github-copilot")
+    fake = cast(OAuthProvider, FakeOAuthProvider())
+    register_oauth_provider(fake)
+    try:
+        auth = await OAuthRuntimeCredentialResolver(provider, credential_store=store)()
+    finally:
+        unregister_oauth_provider("github-copilot")
+        reset_oauth_providers()
+
+    assert auth.api_key == "new-access"
+    assert auth.base_url == "https://api.business.githubcopilot.com"
+    saved = store.get_oauth("github-copilot")
+    assert saved is not None
+    assert saved.access == "new-access"
+    assert not list(tmp_path.glob(".credentials.json.*"))
+
+
+def test_builtin_oauth_registry_matches_supported_subscription_providers() -> None:
+    assert oauth_provider_ids() == {"anthropic", "github-copilot", "openai-codex"}
+    anthropic = get_oauth_provider("anthropic")
+    assert anthropic is not None
+    assert anthropic.name == "Anthropic (Claude Pro/Max)"
+    assert get_oauth_provider("missing") is None

--- a/tests/test_oauth_tui.py
+++ b/tests/test_oauth_tui.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+from textual.widgets import Input, Static
+
+from tau_coding.oauth_types import OAuthPrompt
+from tau_coding.provider_catalog import builtin_provider_entry
+from tau_coding.tui.app import OAuthLoginScreen
+from tau_coding.tui.config import TAU_DARK_THEME
+
+
+@pytest.mark.anyio
+async def test_oauth_screen_accepts_blank_provider_prompt() -> None:
+    provider = builtin_provider_entry("github-copilot")
+    assert provider is not None
+    screen = OAuthLoginScreen(provider, theme=TAU_DARK_THEME)
+    screen.compose()
+
+    # Exercise the prompt/input handshake inside a minimal Textual app context.
+    from textual.app import App
+
+    class TestApp(App[None]):
+        def on_mount(self) -> None:
+            self.push_screen(screen)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        prompt_task = asyncio.create_task(
+            screen._prompt_for_code(OAuthPrompt(message="Enterprise domain", allow_empty=True))
+        )
+        await pilot.pause()
+        screen.query_one("#login-oauth-code", Input).value = ""
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert await prompt_task == ""
+        assert str(screen.query_one("#login-help", Static).render()) == "Enterprise domain"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -198,6 +198,7 @@ def test_builtin_catalog_golden_nvidia_entry() -> None:
 def test_builtin_catalog_golden_kimi_entries() -> None:
     moonshot = builtin_provider_entry("moonshotai")
     assert moonshot is not None
+    assert moonshot.display_name == "Moonshot AI (Kimi)"
     assert moonshot.default_model == "kimi-k2.7-code"
     assert "kimi-k2.7-code" in moonshot.models
     assert moonshot.context_windows is not None

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -78,6 +78,9 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "opencode-go",
+        "opencode",
+        "github-copilot",
     ]
 
 
@@ -125,6 +128,21 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
     assert entry.thinking_models == ()
     assert entry.thinking_default == "medium"
     assert entry.thinking_parameter == "anthropic.thinking"
+    assert entry.auth_methods == ("api_key", "oauth")
+
+
+def test_builtin_catalog_oauth_and_opencode_auth_methods() -> None:
+    codex = builtin_provider_entry("openai-codex")
+    copilot = builtin_provider_entry("github-copilot")
+    opencode_go = builtin_provider_entry("opencode-go")
+    opencode = builtin_provider_entry("opencode")
+
+    assert codex is not None and codex.auth_methods == ("oauth",)
+    assert copilot is not None and copilot.auth_methods == ("oauth",)
+    assert opencode_go is not None and opencode_go.auth_methods == ("api_key",)
+    assert opencode is not None and opencode.auth_methods == ("api_key",)
+    assert opencode_go.api_key_env == "OPENCODE_API_KEY"
+    assert opencode.api_key_env == "OPENCODE_API_KEY"
 
 
 def test_builtin_catalog_golden_nvidia_entry() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -61,6 +61,9 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "xiaomi-token-plan-cn",
         "xiaomi-token-plan-ams",
         "xiaomi-token-plan-sgp",
+        "opencode-go",
+        "opencode",
+        "github-copilot",
     ]
     assert settings.providers[0].default_model == DEFAULT_MODEL
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1,12 +1,14 @@
 import pytest
 
-from tau_ai import OpenAICodexProvider
+from tau_ai import AnthropicProvider, OpenAICodexProvider, OpenAICompatibleProvider
 from tau_coding import provider_runtime
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.provider_config import (
+    AnthropicProviderConfig,
     OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfigError,
+    provider_config_from_catalog_entry,
 )
 from tau_coding.provider_runtime import OpenAICodexCredentialResolver, create_model_provider
 
@@ -20,6 +22,47 @@ def test_create_model_provider_returns_openai_codex_provider(tmp_path) -> None:
     )
 
     assert isinstance(provider, OpenAICodexProvider)
+
+
+def test_create_model_provider_uses_anthropic_oauth_runtime_auth(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "anthropic",
+        OAuthCredential(
+            access="anthropic-oauth-access",
+            refresh="anthropic-refresh",
+            expires=9999999999999,
+        ),
+    )
+
+    provider = create_model_provider(AnthropicProviderConfig(), credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.bearer_auth is True
+    assert provider._config.credential_resolver is not None
+    assert provider._config.oauth_system_prompt is not None
+    assert provider._config.headers is not None
+    assert provider._config.headers["Authorization"] == "Bearer anthropic-oauth-access"
+
+
+def test_create_model_provider_uses_copilot_token_base_url(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "github-copilot",
+        OAuthCredential(
+            access="tid=1;proxy-ep=proxy.business.githubcopilot.com",
+            refresh="github-token",
+            expires=9999999999999,
+        ),
+    )
+    provider = create_model_provider(
+        provider_config_from_catalog_entry("github-copilot"),
+        credential_store=store,
+    )
+
+    assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider._config.base_url == "https://api.business.githubcopilot.com"
+    assert provider._config.credential_resolver is not None
 
 
 def test_create_model_provider_rejects_model_not_declared_for_provider(tmp_path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4960,6 +4960,76 @@ async def test_tui_login_subscription_opens_oauth_provider_picker() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_login_api_provider_picker_filters_by_name_and_display_name() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginMethodPickerScreen)
+        app.screen.action_cursor_down()
+        app.screen.action_select_cursor()
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginProviderPickerScreen)
+        search = app.screen.query_one("#login-provider-search", Input)
+        assert search.has_focus
+        search.value = "kimi"
+        await pilot.pause()
+
+        provider_list = app.screen.query_one("#login-provider-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in provider_list.children]
+        assert "Moonshot AI (Kimi) — moonshotai" in labels
+        assert "Kimi Code subscription — kimi-code" in labels
+
+        search.value = "moonshotai"
+        await pilot.pause()
+        labels = [str(item.query_one(Label).render()) for item in provider_list.children]
+        assert labels == [
+            "Moonshot AI (Kimi) — moonshotai",
+            "Moonshot AI (China) — moonshotai-cn",
+        ]
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+        assert app.screen.provider.name == "moonshotai"
+
+
+@pytest.mark.anyio
+async def test_tui_login_api_provider_picker_handles_no_matches() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, LoginMethodPickerScreen)
+        app.screen.action_cursor_down()
+        app.screen.action_select_cursor()
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginProviderPickerScreen)
+        search = app.screen.query_one("#login-provider-search", Input)
+        search.value = "no-such-provider"
+        await pilot.pause()
+
+        provider_list = app.screen.query_one("#login-provider-list", ListView)
+        assert len(provider_list.children) == 0
+        assert provider_list.index is None
+        help_text = app.screen.query_one("#login-provider-help", Static)
+        assert str(help_text.render()) == "No matching providers - Escape closes"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, LoginProviderPickerScreen)
+
+
+@pytest.mark.anyio
 async def test_tui_login_api_key_opens_api_provider_picker() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4570,6 +4570,52 @@ async def test_tui_login_saves_provider_key(
 
 
 @pytest.mark.anyio
+async def test_tui_direct_anthropic_login_can_select_oauth() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login anthropic"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginMethodPickerScreen)
+        title = app.screen.query_one("#login-method-title", Static)
+        assert str(title.render()) == "Login: Anthropic"
+        method_list = app.screen.query_one("#login-method-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in method_list.children]
+        assert labels == [
+            "Subscription — OAuth account",
+            "API key — built-in provider",
+        ]
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, OAuthLoginScreen)
+        assert app.screen.provider.name == "anthropic"
+
+
+@pytest.mark.anyio
+async def test_tui_direct_anthropic_login_can_select_api_key() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login anthropic"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginMethodPickerScreen)
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginScreen)
+        assert app.screen.provider.name == "anthropic"
+
+
+@pytest.mark.anyio
 async def test_tui_login_openai_codex_saves_oauth_credentials(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4911,7 +4911,11 @@ async def test_tui_login_subscription_opens_oauth_provider_picker() -> None:
         assert isinstance(app.screen, LoginProviderPickerScreen)
         provider_list = app.screen.query_one("#login-provider-list", ListView)
         labels = [str(item.query_one(Label).render()) for item in provider_list.children]
-        assert labels == ["OpenAI Codex subscription — openai-codex"]
+        assert labels == [
+            "OpenAI Codex subscription — openai-codex",
+            "Anthropic — anthropic",
+            "GitHub Copilot — github-copilot",
+        ]
         assert "gpt-5.5" not in "\n".join(labels)
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4570,52 +4570,6 @@ async def test_tui_login_saves_provider_key(
 
 
 @pytest.mark.anyio
-async def test_tui_direct_anthropic_login_can_select_oauth() -> None:
-    app = TauTuiApp(FakeSession())
-
-    async with app.run_test() as pilot:
-        prompt = app.query_one("#prompt")
-        prompt.value = "/login anthropic"
-        await pilot.press("enter")
-        await pilot.pause()
-
-        assert isinstance(app.screen, LoginMethodPickerScreen)
-        title = app.screen.query_one("#login-method-title", Static)
-        assert str(title.render()) == "Login: Anthropic"
-        method_list = app.screen.query_one("#login-method-list", ListView)
-        labels = [str(item.query_one(Label).render()) for item in method_list.children]
-        assert labels == [
-            "Subscription — OAuth account",
-            "API key — built-in provider",
-        ]
-
-        await pilot.press("enter")
-        await pilot.pause()
-
-        assert isinstance(app.screen, OAuthLoginScreen)
-        assert app.screen.provider.name == "anthropic"
-
-
-@pytest.mark.anyio
-async def test_tui_direct_anthropic_login_can_select_api_key() -> None:
-    app = TauTuiApp(FakeSession())
-
-    async with app.run_test() as pilot:
-        prompt = app.query_one("#prompt")
-        prompt.value = "/login anthropic"
-        await pilot.press("enter")
-        await pilot.pause()
-
-        assert isinstance(app.screen, LoginMethodPickerScreen)
-        await pilot.press("down")
-        await pilot.press("enter")
-        await pilot.pause()
-
-        assert isinstance(app.screen, LoginScreen)
-        assert app.screen.provider.name == "anthropic"
-
-
-@pytest.mark.anyio
 async def test_tui_login_openai_codex_saves_oauth_credentials(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -238,6 +238,18 @@ class FakeSession:
             return CommandResult(handled=True, login_picker_requested=True)
         if text in {"/login custom", "/login new", "/login add"}:
             return CommandResult(handled=True, custom_provider_login_requested=True)
+        if text == "/login anthropic-api":
+            return CommandResult(
+                handled=True,
+                login_provider="anthropic",
+                login_method="api-key",
+            )
+        if text == "/login anthropic-subscription":
+            return CommandResult(
+                handled=True,
+                login_provider="anthropic",
+                login_method="subscription",
+            )
         if text.startswith("/login "):
             return CommandResult(handled=True, login_provider=text.removeprefix("/login "))
         if text == "/logout":
@@ -4567,6 +4579,34 @@ async def test_tui_login_saves_provider_key(
     assert session.prompt_texts == []
     assert all(item.text != "stored-openai-key" for item in app.state.items)
     assert (tmp_path / ".tau" / "credentials.json").read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_tui_anthropic_subscription_alias_opens_oauth() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login anthropic-subscription"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, OAuthLoginScreen)
+        assert app.screen.provider.name == "anthropic"
+
+
+@pytest.mark.anyio
+async def test_tui_anthropic_api_alias_opens_api_key_login() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login anthropic-api"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LoginScreen)
+        assert app.screen.provider.name == "anthropic"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -337,6 +337,21 @@ def test_login_argument_completion_uses_available_providers() -> None:
     assert [item.display for item in state.items] == ["openai", "openrouter"]
 
 
+def test_login_argument_completion_includes_anthropic_auth_aliases() -> None:
+    state = build_completion_state(
+        "/login anthropic-",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        provider_names=("anthropic", "anthropic-api", "anthropic-subscription"),
+    )
+
+    assert [item.display for item in state.items] == [
+        "anthropic-api",
+        "anthropic-subscription",
+    ]
+
+
 def test_logout_argument_completion_uses_available_providers() -> None:
     state = build_completion_state(
         "/logout op",

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -9,7 +9,8 @@ OpenAI-compatible endpoints (including local models).
 
 ## The fastest setup: `/login`
 
-Start Tau and use `/login` to connect a provider:
+Start Tau and use `/login` to connect a provider. The provider picker includes
+a search field, which is especially useful for the longer API-key provider list:
 
 ```bash
 tau
@@ -29,7 +30,7 @@ tau
 
 Built-in providers include **OpenAI**, **Anthropic**, **OpenAI Codex**
 (subscription), **GitHub Copilot**, **OpenCode Go**, **OpenCode Zen**,
-**Moonshot AI**, **Kimi Code** (subscription), **OpenRouter**, **Hugging Face**,
+**Moonshot AI (Kimi)**, **Kimi Code** (subscription), **OpenRouter**, **Hugging Face**,
 and **NVIDIA NIM**.
 
 ### OAuth subscriptions

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -19,7 +19,8 @@ tau
 /login              # choose a login method
 /login openai       # save an OpenAI API key
 /login openai-codex # authenticate a Codex/ChatGPT subscription via OAuth
-/login anthropic    # choose Anthropic OAuth or save an API key
+/login anthropic-subscription # authenticate Claude Pro/Max via OAuth
+/login anthropic-api # save an Anthropic API key
 /login github-copilot # authenticate GitHub Copilot with a device code
 /login opencode-go  # save an OpenCode Go API key
 /login nvidia       # save an NVIDIA NIM API key
@@ -45,8 +46,11 @@ GitHub Copilot asks for a GitHub Enterprise Server URL/domain. Leave it blank
 for `github.com`. Device login also works in SSH/headless sessions: open the
 shown verification URL on any device and enter the displayed code.
 
-Anthropic also appears under **API key**, because `ANTHROPIC_API_KEY` remains a
-supported alternative. OAuth subscription requests use Anthropic's required
+Anthropic uses distinct direct-login aliases so the authentication method is
+unambiguous: `/login anthropic-subscription` starts OAuth, while
+`/login anthropic-api` saves an API key. The top-level `/login` picker still
+lists Anthropic under both **Subscription / OAuth** and **API key**. OAuth
+subscription requests use Anthropic's required
 Claude Code identity and may be billed as extra usage rather than consuming
 ordinary Claude plan limits. Check Anthropic's current account terms before
 using it.

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -1,6 +1,6 @@
 ---
 title: Providers & models
-description: Connect OpenAI, Anthropic, Codex, OpenRouter, Hugging Face, or a local model — and switch models any time.
+description: Connect OAuth subscriptions, API-key providers, or a local model — and switch models any time.
 ---
 
 A **provider** is the service hosting AI models; a **model** is the specific one
@@ -19,13 +19,58 @@ tau
 /login              # choose a login method
 /login openai       # save an OpenAI API key
 /login openai-codex # authenticate a Codex/ChatGPT subscription via OAuth
+/login anthropic    # choose Anthropic OAuth or save an API key
+/login github-copilot # authenticate GitHub Copilot with a device code
+/login opencode-go  # save an OpenCode Go API key
 /login nvidia       # save an NVIDIA NIM API key
 /login custom       # add an OpenAI-compatible custom provider
 ```
 
 Built-in providers include **OpenAI**, **Anthropic**, **OpenAI Codex**
-(subscription), **Moonshot AI**, **Kimi Code** (subscription), **OpenRouter**,
-**Hugging Face**, and **NVIDIA NIM**.
+(subscription), **GitHub Copilot**, **OpenCode Go**, **OpenCode Zen**,
+**Moonshot AI**, **Kimi Code** (subscription), **OpenRouter**, **Hugging Face**,
+and **NVIDIA NIM**.
+
+### OAuth subscriptions
+
+Choose **Subscription / OAuth** in `/login` for:
+
+| Tau provider | Login flow | Prerequisite |
+| --- | --- | --- |
+| `openai-codex` | Browser callback with pasted-code fallback | A supported ChatGPT/Codex subscription |
+| `anthropic` | Browser callback with PKCE and pasted-code fallback | Claude Pro/Max with Anthropic extra usage available |
+| `github-copilot` | GitHub device code | An active Copilot plan; organization policy must allow the selected model |
+
+GitHub Copilot asks for a GitHub Enterprise Server URL/domain. Leave it blank
+for `github.com`. Device login also works in SSH/headless sessions: open the
+shown verification URL on any device and enter the displayed code.
+
+Anthropic also appears under **API key**, because `ANTHROPIC_API_KEY` remains a
+supported alternative. OAuth subscription requests use Anthropic's required
+Claude Code identity and may be billed as extra usage rather than consuming
+ordinary Claude plan limits. Check Anthropic's current account terms before
+using it.
+
+OAuth tokens refresh automatically. `/logout` removes Tau's local credential,
+but does not revoke the grant remotely; use the provider's account settings for
+remote revocation.
+
+### OpenCode Go and Zen
+
+OpenCode Go and OpenCode Zen are **API-key providers**, not OAuth providers.
+Sign in at the OpenCode console, subscribe to Go or fund Zen, copy the API key,
+and then run:
+
+```text
+/login opencode-go  # subscription limits; https://opencode.ai/zen/go/v1
+/login opencode     # Zen pay-as-you-go; https://opencode.ai/zen/v1
+```
+
+Both can also read `OPENCODE_API_KEY`. Tau stores their saved credentials under
+separate `opencode-go` and `opencode` names, allowing different keys when
+needed. Available models and plan limits change over time; consult the
+[OpenCode Go](https://opencode.ai/docs/go) and
+[OpenCode Zen](https://opencode.ai/docs/zen) pages for the current list.
 
 ### Moonshot AI API vs. Kimi Code
 
@@ -44,8 +89,9 @@ credential names, so `/login moonshotai` and `/login kimi-code` can configure
 both at once. The distinct environment variable names provide the same
 separation when credentials are supplied through the shell.
 
-Credentials saved through `/login` live in `~/.tau/credentials.json` (private
-permissions). The custom-provider
+Credentials saved through `/login` live in `~/.tau/credentials.json` with
+private `0600` permissions and atomic file replacement. The file is not
+encrypted; protect your Tau home directory and do not share its contents. The custom-provider
 flow asks for the provider name, display name, base URL, API-key environment
 variable, default model, and API key; it writes the provider definition to
 `~/.tau/catalog.toml` and runtime preferences to `~/.tau/providers.json`.
@@ -68,10 +114,13 @@ Use these slash commands inside Tau:
 Saved credentials take precedence over environment variables. `/logout` only
 edits saved credentials — it never touches your environment or `providers.json`.
 
-{{% note title="Codex subscription" %}}
-`/login openai-codex` opens the OpenAI OAuth flow, listens for the local
-callback, and also accepts a pasted redirect URL or code. It refreshes expired
-access tokens automatically. It's separate from the API-key `openai` provider.
+{{% note title="OAuth troubleshooting" %}}
+Browser login can fall back to a pasted redirect URL/code when the callback
+port is unavailable or the browser runs on another machine. Copilot uses a
+device code instead. A denied or expired code requires a new `/login`. If a
+Copilot model reports that it is unsupported, enable it in Copilot Chat's model
+selector or ask your organization administrator; provider/model access varies
+by plan and policy.
 {{% /note %}}
 
 ## Choosing and switching models
@@ -228,5 +277,6 @@ catalog, then add the header to the matching provider preference in
 
 For a given provider, Tau uses, in order: a stored credential in
 `~/.tau/credentials.json`, then the environment variable named by the provider's
-`api_key_env`. Use `/login` for built-in providers or `/login custom` for
-OpenAI-compatible custom providers.
+`api_key_env`. OAuth credentials are refreshed immediately before a request and
+the replacement is saved atomically. Use `/login` for built-in providers or
+`/login custom` for OpenAI-compatible custom providers.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -13,7 +13,7 @@ those locations and file formats.
 ~/.tau/
 ├── catalog.toml        # optional provider/model catalog overlay
 ├── providers.json      # provider/model preferences
-├── credentials.json    # saved API keys / OAuth tokens (private permissions)
+├── credentials.json    # saved API keys / OAuth tokens (0600, atomic writes)
 ├── settings.json       # general settings (e.g. shell command prefix)
 ├── tui.json            # TUI theme + keybindings
 ├── sessions/           # saved sessions, per project
@@ -161,7 +161,9 @@ Provider preferences live in `~/.tau/providers.json`:
   their session history. `timeout_seconds` defaults to `60` (> 0); `max_retries`
   defaults to `2`; `max_retry_delay_seconds` defaults to `1` (both ≥ 0).
 - API keys and OAuth credentials are **not** stored here — they live in
-  `~/.tau/credentials.json`. Resolution order: stored credential, then the env
+  `~/.tau/credentials.json` (private but not encrypted). OAuth objects may contain
+  provider metadata such as a GitHub Enterprise domain and are refreshed
+  automatically. Resolution order: stored credential, then the env
   var named by `api_key_env`.
 - The selected model must be present in that provider's `models` list. Add
   custom or local model names to `models` before using them as defaults,

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -20,7 +20,7 @@ command palette with **Ctrl+K**.
 | `/model` | Open the model picker |
 | `/scoped-models` | Choose favorite models for the Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |
-| `/login [provider]` | Save credentials for a built-in provider |
+| `/login [provider]` | Connect a built-in provider with OAuth or an API key |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
 | `/hotkeys` | Show the keyboard shortcuts |

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -20,7 +20,7 @@ command palette with **Ctrl+K**.
 | `/model` | Open the model picker |
 | `/scoped-models` | Choose favorite models for the Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |
-| `/login [provider]` | Connect a built-in provider with OAuth or an API key |
+| `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
 | `/hotkeys` | Show the keyboard shortcuts |


### PR DESCRIPTION
## Summary

- add a typed, provider-neutral OAuth registry and frontend callback contract in `tau_coding`
- port Anthropic Claude Pro/Max browser OAuth and GitHub Copilot device OAuth, including GitHub Enterprise domain routing
- route existing OpenAI Codex OAuth through the same registry while preserving legacy credentials
- add OpenCode Go and OpenCode Zen as accurately labeled API-key providers
- make OAuth credentials extensible and atomically persisted, with request-time refresh
- document the pinned Pi audit, architecture/security choices, provider setup, exclusions, and follow-ups

Closes #370.

## Architecture

OAuth orchestration, setup UX, refresh policy, and local credentials remain in `tau_coding`. `tau_ai` accepts only request-time auth material and protocol details. `tau_agent` remains provider/UI neutral.

The implementation supports browser callback and RFC 8628 device-code capabilities. Radius is documented but excluded because it is Pi's first-party gateway. OpenCode Go/Zen use their documented `OPENCODE_API_KEY` flow and are not presented as OAuth.

## Testing

- `uv run pytest` — 971 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `git diff --check`

Live paid-account OAuth smoke tests are intentionally not automated; the sanitized release checklist is documented in `dev-notes/architecture/oauth-provider-parity.md`.
