### PR TITLE
Add Pi-shaped extension turn metadata

### DIFF
--- a/dev-notes/architecture/phase-21-extensions.md
+++ b/dev-notes/architecture/phase-21-extensions.md
@@ -218,8 +218,11 @@ the tool (fail-safe).
 > `tau_coding.events`: handlers receive `(event, context)`, streamed provider events
 > are nested under `message_update.assistant_message_event`, tool executors receive
 > `(tool_call_id, arguments, signal, on_update)`, and custom messages use the
-> dedicated `CustomMessage` role. See the published extension guide and
-> `dev-notes/design/pi-event-migration-audit.md` for the final shape.
+> dedicated `CustomMessage` role. The session-to-extension adapter additionally
+> enriches `turn_start` with Pi's zero-based `turn_index` and millisecond
+> `timestamp`, and `turn_end` with the matching `turn_index`; portable
+> `tau_agent` events remain session-agnostic. See the published extension guide
+> and `dev-notes/design/pi-event-migration-audit.md` for the final shape.
 
 Observation events reuse the `AgentEvent` `type` literals directly:
 `agent_start`, `agent_end`, `turn_start`, `turn_end`, `message_start`,

--- a/src/tau_coding/extensions/__init__.py
+++ b/src/tau_coding/extensions/__init__.py
@@ -32,6 +32,8 @@ from tau_coding.extensions.api import (
     ToolCallHookResult,
     ToolResultHookEvent,
     ToolResultHookResult,
+    TurnEndEvent,
+    TurnStartEvent,
     UiBridge,
 )
 from tau_coding.extensions.loader import (
@@ -86,6 +88,8 @@ __all__ = [
     "ToolCallHookResult",
     "ToolResultHookEvent",
     "ToolResultHookResult",
+    "TurnEndEvent",
+    "TurnStartEvent",
     "UiBridge",
     "discover_extensions",
     "extension_dirs",

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, cast
 
-from tau_agent.messages import AgentMessage
+from tau_agent.messages import AgentMessage, ToolResultMessage
 from tau_agent.tools import AgentTool, AgentToolResult
 from tau_agent.types import JSONValue
 
@@ -310,6 +310,30 @@ class ExtensionGeneration:
         """Raise :class:`ExtensionError` when this generation is stale."""
         if self._stale_message is not None:
             raise ExtensionError(self._stale_message)
+
+
+@dataclass(frozen=True, slots=True)
+class TurnStartEvent:
+    """Pi-shaped extension event fired at the start of a turn.
+
+    The portable agent event intentionally has no session metadata. The coding
+    session adapter adds the zero-based turn index and millisecond timestamp
+    before dispatching the event to extensions.
+    """
+
+    turn_index: int
+    timestamp: int
+    type: Literal["turn_start"] = field(default="turn_start", init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class TurnEndEvent:
+    """Pi-shaped extension event fired after one assistant/tool turn."""
+
+    turn_index: int
+    message: AgentMessage
+    tool_results: list[ToolResultMessage]
+    type: Literal["turn_end"] = field(default="turn_end", init=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -6,9 +6,12 @@ from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from inspect import isawaitable
 from pathlib import Path
+from time import time_ns
 from typing import Literal, Protocol
 
-from tau_agent.events import AgentEvent
+from tau_agent.events import AgentEvent, AgentStartEvent
+from tau_agent.events import TurnEndEvent as AgentTurnEndEvent
+from tau_agent.events import TurnStartEvent as AgentTurnStartEvent
 from tau_agent.messages import AgentMessage, TextContent
 from tau_agent.tools import (
     AgentTool,
@@ -49,6 +52,8 @@ from tau_coding.extensions.api import (
     ToolCallHookResult,
     ToolResultHookEvent,
     ToolResultHookResult,
+    TurnEndEvent,
+    TurnStartEvent,
     UiBridge,
 )
 from tau_coding.extensions.loader import (
@@ -160,6 +165,7 @@ class ExtensionRuntime:
         self._ui: UiBridge = ui or NullUiBridge()
         self._turn_requested: TurnRequestedCallback | None = None
         self._harness_unsubscribe: Callable[[], None] | None = None
+        self._extension_turn_index = 0
         self._generation = ExtensionGeneration()
 
     # -- loading -----------------------------------------------------------
@@ -818,7 +824,24 @@ class ExtensionRuntime:
                 self._record_runtime_failure(extension, event_type, exc)
 
     async def _on_agent_event(self, event: AgentEvent) -> None:
-        await self.emit_event(event)
+        """Adapt core turn events to Pi's extension-facing session metadata."""
+        extension_event: object = event
+        if isinstance(event, AgentStartEvent):
+            self._extension_turn_index = 0
+        elif isinstance(event, AgentTurnStartEvent):
+            extension_event = TurnStartEvent(
+                turn_index=self._extension_turn_index,
+                timestamp=time_ns() // 1_000_000,
+            )
+        elif isinstance(event, AgentTurnEndEvent):
+            extension_event = TurnEndEvent(
+                turn_index=self._extension_turn_index,
+                message=event.message,
+                tool_results=list(event.tool_results),
+            )
+        await self.emit_event(extension_event)
+        if isinstance(event, AgentTurnEndEvent):
+            self._extension_turn_index += 1
 
     async def _emit_lifecycle(self, event_name: str, payload: object) -> None:
         for extension, handler in self._handlers_for(event_name):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+import time
 from pathlib import Path
 from typing import cast
 
@@ -909,6 +910,73 @@ async def test_agent_event_fan_out_and_wildcard(tmp_path: Path) -> None:
 
     assert len(specific) == 1
     assert len(wildcard) == 2
+
+
+async def test_extension_turn_events_include_pi_session_metadata(tmp_path: Path) -> None:
+    from tau_agent.events import AgentStartEvent
+    from tau_agent.events import TurnEndEvent as AgentTurnEndEvent
+    from tau_agent.events import TurnStartEvent as AgentTurnStartEvent
+    from tau_agent.messages import UserMessage
+    from tau_coding.extensions import TurnEndEvent, TurnStartEvent
+
+    runtime = ExtensionRuntime()
+    api = _register_inline_extension(runtime, "turn_observer")
+    specific: list[object] = []
+    wildcard: list[object] = []
+    api.on("turn_start", lambda event, context: specific.append(event))
+    api.on("turn_end", lambda event, context: specific.append(event))
+    api.on("agent_event", lambda event, context: wildcard.append(event))
+
+    listeners: list[object] = []
+    runtime.attach_harness_listener(  # type: ignore[arg-type]
+        lambda listener: (listeners.append(listener), lambda: None)[1]
+    )
+    dispatch = listeners[0]
+    message = UserMessage(content="done")
+
+    await dispatch(AgentStartEvent())  # type: ignore[operator]
+    before_ms = time.time_ns() // 1_000_000
+    await dispatch(AgentTurnStartEvent())  # type: ignore[operator]
+    await dispatch(AgentTurnEndEvent(message=message))  # type: ignore[operator]
+    await dispatch(AgentTurnStartEvent())  # type: ignore[operator]
+
+    first_start, first_end, second_start = specific
+    assert isinstance(first_start, TurnStartEvent)
+    assert before_ms <= first_start.timestamp <= time.time_ns() // 1_000_000
+    assert first_start.turn_index == first_end.turn_index == 0
+    assert isinstance(first_end, TurnEndEvent)
+    assert first_end.message == message
+    assert first_end.tool_results == []
+    assert isinstance(second_start, TurnStartEvent)
+    assert second_start.turn_index == 1
+    assert wildcard[-3:] == specific
+
+
+async def test_extension_turn_index_resets_for_each_agent_run(tmp_path: Path) -> None:
+    from tau_agent.events import AgentStartEvent
+    from tau_agent.events import TurnEndEvent as AgentTurnEndEvent
+    from tau_agent.events import TurnStartEvent as AgentTurnStartEvent
+    from tau_agent.messages import UserMessage
+    from tau_coding.extensions import TurnStartEvent
+
+    runtime = ExtensionRuntime()
+    api = _register_inline_extension(runtime, "turn_observer")
+    seen: list[TurnStartEvent] = []
+    api.on("turn_start", lambda event, context: seen.append(event))
+    listeners: list[object] = []
+    runtime.attach_harness_listener(  # type: ignore[arg-type]
+        lambda listener: (listeners.append(listener), lambda: None)[1]
+    )
+    dispatch = listeners[0]
+    message = UserMessage(content="done")
+
+    await dispatch(AgentStartEvent())  # type: ignore[operator]
+    await dispatch(AgentTurnStartEvent())  # type: ignore[operator]
+    await dispatch(AgentTurnEndEvent(message=message))  # type: ignore[operator]
+    await dispatch(AgentStartEvent())  # type: ignore[operator]
+    await dispatch(AgentTurnStartEvent())  # type: ignore[operator]
+
+    assert [event.turn_index for event in seen] == [0, 0]
 
 
 async def test_message_end_event_surfaces_provider_usage(tmp_path: Path) -> None:

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -301,7 +301,12 @@ Observation events mirror the canonical agent/session stream — subscribe by
 `message_update` contains the provider event in `assistant_message_event`
 (text/thinking/tool-call start, delta, and end). Handlers receive
 `(event, context)` and run on the session event loop. `message_end` carries
-provider token usage at `event.message.usage`.
+provider token usage at `event.message.usage`. Extension `turn_start` and
+`turn_end` events are session-enriched like Pi's: both carry the same zero-based
+`turn_index`, `turn_start` also carries a Unix-millisecond `timestamp`, and the
+index increments after `turn_end` (then resets on the next `agent_start`). These
+extension payloads are defined in `tau_coding.extensions`; the portable
+`tau_agent` turn events intentionally remain free of session metadata.
 
 Lifecycle and intercepting hooks:
 


### PR DESCRIPTION
## Summary

- add extension-specific `TurnStartEvent` and `TurnEndEvent` payloads matching Pi 0.80.6
- track a zero-based turn index in the session-to-extension adapter
- add a Unix-millisecond timestamp to extension `turn_start` events
- preserve the portable `tau_agent` event protocol for session/frontend consumers
- deliver enriched turn payloads to both specific handlers and the `agent_event` wildcard
- document the distinction between portable agent events and session-enriched extension events

## Behavior

The extension runtime now resets its turn index on `agent_start`, dispatches matching indices on `turn_start` and `turn_end`, increments after `turn_end`, and resets for the next run. Frontend and SDK subscribers continue receiving the unchanged canonical core/session events.

## Validation

- `uv run pytest -q` — 950 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src` — 80 source files clean
- `git diff --check`
