### PR TITLE
Document the canonical event streams

### DIFF
--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -291,22 +291,61 @@ your own on `session_shutdown`.
 
 ### Events
 
-Observation events mirror the canonical agent/session stream — subscribe by
-`type`: `agent_start`, `agent_end`, `agent_settled`, `turn_start`, `turn_end`,
-`message_start`, `message_update`, `message_end`, `tool_execution_start`,
-`tool_execution_update`, `tool_execution_end`, `queue_update`,
-`compaction_start`, `compaction_end`, `entry_appended`,
-`session_info_changed`, `thinking_level_changed`, `auto_retry_start`, and
-`auto_retry_end`. Use `agent_event` for the complete stream. A
-`message_update` contains the provider event in `assistant_message_event`
-(text/thinking/tool-call start, delta, and end). Handlers receive
-`(event, context)` and run on the session event loop. `message_end` carries
-provider token usage at `event.message.usage`. Extension `turn_start` and
-`turn_end` events are session-enriched like Pi's: both carry the same zero-based
-`turn_index`, `turn_start` also carries a Unix-millisecond `timestamp`, and the
-index increments after `turn_end` (then resets on the next `agent_start`). These
-extension payloads are defined in `tau_coding.extensions`; the portable
-`tau_agent` turn events intentionally remain free of session metadata.
+Observation events mirror the canonical agent/session stream. Handlers receive
+`(event, context)`, run on the session event loop, and may subscribe to one
+`type` or use `agent_event` for the complete stream.
+
+| Event | Important payload |
+|---|---|
+| `agent_start` | — |
+| `agent_end` | `messages`, `will_retry` on the session form |
+| `agent_settled` | —; no retry, compaction, or queued continuation remains |
+| `turn_start` | `turn_index`, Unix-millisecond `timestamp` |
+| `turn_end` | matching `turn_index`, `message`, `tool_results` |
+| `message_start` / `message_end` | `message`; assistant usage is at `message.usage` |
+| `message_update` | `message`, nested `assistant_message_event` |
+| `tool_execution_start` | `tool_call_id`, `tool_name`, `args` |
+| `tool_execution_update` | the call fields plus `partial_result` |
+| `tool_execution_end` | the call fields plus `result`, `is_error` |
+| `queue_update` | `steering`, `follow_up` |
+| `compaction_start` | `reason` (`manual`, `threshold`, or `overflow`) |
+| `compaction_end` | `reason`, `result`, `aborted`, `will_retry`, `error_message` |
+| `entry_appended` | persisted session `entry` |
+| `session_info_changed` | session `name` |
+| `thinking_level_changed` | `level` |
+| `auto_retry_start` | `attempt`, `max_attempts`, `delay_ms`, `error_message` |
+| `auto_retry_end` | `success`, `attempt`, `final_error` |
+
+`message_update.assistant_message_event` is the provider-neutral incremental
+stream. Its nested `type` is one of `text_start`, `text_delta`, `text_end`,
+`thinking_start`, `thinking_delta`, `thinking_end`, `toolcall_start`,
+`toolcall_delta`, or `toolcall_end`. Terminal provider events become
+`message_end`, rather than another `message_update`.
+
+Extension turn events are session-enriched like Pi's. `turn_start` and its
+matching `turn_end` carry the same zero-based `turn_index`; `turn_start` also
+carries a Unix-millisecond `timestamp`. The runtime increments the index after
+`turn_end` and resets it on the next `agent_start`:
+
+```python
+from tau_coding.extensions import TurnEndEvent, TurnStartEvent
+
+
+def setup(tau):
+    @tau.on("turn_start")
+    def on_turn_start(event: TurnStartEvent, context):
+        context.api.notify(
+            f"turn {event.turn_index} started at {event.timestamp}", "info"
+        )
+
+    @tau.on("turn_end")
+    def on_turn_end(event: TurnEndEvent, context):
+        assert event.turn_index >= 0
+```
+
+These enriched payloads are defined in `tau_coding.extensions`. The portable
+`tau_agent.events.TurnStartEvent` and `TurnEndEvent` intentionally omit session
+metadata, so reusable agent code stays independent of session policy.
 
 Lifecycle and intercepting hooks:
 

--- a/website/content/internals/agent-loop.md
+++ b/website/content/internals/agent-loop.md
@@ -32,17 +32,29 @@ is what makes the loop reusable across every frontend.
 
 Every meaningful step is observable as an event, so print mode, Rich rendering,
 and the Textual TUI all share the same core. Frontends render from these
-provider-neutral events — never from raw provider chunks. The main event types
-include:
+provider-neutral events — never from raw provider chunks. The portable `tau_agent.events.AgentEvent` stream contains:
 
 - `AgentStartEvent` / `AgentEndEvent` — a run begins / ends
-- `MessageStartEvent` / `MessageDeltaEvent` / `MessageEndEvent` — streamed
-  assistant text
-- `ThinkingDeltaEvent` — optional streamed reasoning (hidden by default)
+- `TurnStartEvent` / `TurnEndEvent` — one assistant response and its tool results
+- `MessageStartEvent` / `MessageUpdateEvent` / `MessageEndEvent` — a message's
+  lifecycle
 - `ToolExecutionStartEvent` / `ToolExecutionUpdateEvent` / `ToolExecutionEndEvent`
   — a tool runs
-- `QueueUpdateEvent` — pending steering / follow-up prompts
-- `ErrorEvent` — recoverable or fatal errors
+
+Streaming detail is nested under
+`MessageUpdateEvent.assistant_message_event`. Those provider-neutral nested
+events cover text, thinking, and tool-call start/delta/end updates. Provider
+completion or failure is represented by the final assistant message delivered
+through `MessageEndEvent`.
+
+`tau_coding.events.CodingSessionEvent` extends that portable stream for
+frontends and SDK users with `agent_settled`, queue updates, compaction,
+session-entry/session-info changes, thinking-level changes, and automatic-retry
+events. Extensions observe those same event names, but the session-to-extension
+adapter enriches `turn_start` with a zero-based `turn_index` and millisecond
+`timestamp`, and `turn_end` with the matching index. See
+[Extensions]({{< relref "../guides/extensions.md#events" >}}) for their complete
+payload table.
 
 Because the contract is *events*, a frontend's job is reduced to: send a prompt,
 consume the stream, draw what you see.

--- a/website/content/internals/custom-frontend.md
+++ b/website/content/internals/custom-frontend.md
@@ -34,10 +34,14 @@ async for event in session.prompt(user_text):
     render_event(event)
 ```
 
-The stream yields provider-neutral `AgentEvent` values from `tau_agent.events`
-(see [the agent loop]({{< relref "./agent-loop.md" >}}) for the list). Render from these, never
-from provider-specific chunks. Treat `AgentStartEvent`/`AgentEndEvent` and
-non-recoverable `ErrorEvent` as the source of truth for "is the agent working?".
+The stream yields provider-neutral `CodingSessionEvent` values: portable
+`AgentEvent` values from `tau_agent.events` plus session-level values from
+`tau_coding.events` (see [the agent loop]({{< relref "./agent-loop.md" >}})).
+Render from these, never from provider-specific chunks. Use `agent_start` to
+enter the running state and `agent_settled`—not merely `agent_end`—to leave it,
+because automatic compaction, retry, or queued continuation may follow an
+`agent_end`. Provider failures arrive as assistant messages whose
+`stop_reason` is `"error"`, followed by the normal turn/run lifecycle.
 
 ## Steering and follow-ups
 


### PR DESCRIPTION
## Summary

- add a complete published extension event table with canonical payload fields
- document nested provider-neutral `message_update.assistant_message_event` variants
- document Pi-shaped extension `turn_start`/`turn_end` metadata and provide a handler example
- distinguish portable `tau_agent` events, coding-session events, and session-enriched extension events
- update frontend guidance to use `agent_settled` as the final idle boundary and canonical assistant error messages
- replace stale `MessageDeltaEvent`, `ThinkingDeltaEvent`, and `ErrorEvent` documentation

## Validation

- `uv run pytest -q tests/test_extensions.py tests/test_pi_event_protocol.py` — 112 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src` — 80 source files clean
- `hugo --minify` — 31 pages built
- `git diff --check`
