### PR TITLE
Add Kimi K3 model support

### DIFF
--- a/dev-notes/kimi-k3-model-catalog.md
+++ b/dev-notes/kimi-k3-model-catalog.md
@@ -1,0 +1,30 @@
+# Kimi K3 model catalog support
+
+Tau's built-in `kimi-code` provider now exposes Kimi K3 through the model ID
+`k3`. It uses the existing Kimi Code subscription endpoint and credential:
+
+- endpoint: `https://api.kimi.com/coding/v1`
+- environment variable: `KIMI_CODE_API_KEY`
+- saved credential name: `kimi-code`
+
+Kimi documents a context window of up to 1,048,576 tokens for eligible plans.
+The catalog records that maximum so Tau's context budgeting can use it; the API
+may reject requests beyond the user's plan entitlement.
+
+K3 currently accepts only `max` reasoning effort. Tau maps its `xhigh` thinking
+level to the API value `max` and excludes all other thinking levels for this
+model. `kimi-for-coding` remains the default to avoid silently changing existing
+users' selected rolling model.
+
+## Verify
+
+```bash
+uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+After `/login kimi-code`, choose `kimi-code:k3` from `/model` or start Tau with
+`--provider kimi-code --model k3`. Kimi recommends beginning a new session when
+switching models because the old model's context cache cannot be reused.

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3859,16 +3859,27 @@ kind = "openai-compatible"
 base_url = "https://api.kimi.com/coding/v1"
 api_key_env = "KIMI_CODE_API_KEY"
 credential_name = "kimi-code"
-models = ["kimi-for-coding"]
+models = ["k3", "kimi-for-coding"]
 default_model = "kimi-for-coding"
-docs_url = "https://www.kimi.ai/code/console"
+docs_url = "https://www.kimi.com/code/docs/en/kimi-code/models"
 api = "openai-completions"
-thinking_levels = ["medium"]
+thinking_levels = ["medium", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
+k3 = 1048576
 kimi-for-coding = 262144
+
+[providers.model_metadata.k3]
+name = "Kimi K3"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = true, maxTokensField = "max_tokens", supportsStrictMode = false }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { xhigh = "max" }
+unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
 
 [providers.model_metadata.kimi-for-coding]
 name = "Kimi for Coding (latest)"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -230,9 +230,23 @@ def test_builtin_catalog_golden_kimi_entries() -> None:
     assert coding.base_url == "https://api.kimi.com/coding/v1"
     assert coding.api_key_env == "KIMI_CODE_API_KEY"
     assert coding.credential_name == "kimi-code"
-    assert coding.models == ("kimi-for-coding",)
+    assert coding.models == ("k3", "kimi-for-coding")
     assert coding.default_model == "kimi-for-coding"
-    assert coding.context_windows == {"kimi-for-coding": 262_144}
+    assert coding.context_windows == {"k3": 1_048_576, "kimi-for-coding": 262_144}
+
+    k3 = coding.model_metadata["k3"]
+    assert k3.name == "Kimi K3"
+    assert k3.reasoning is True
+    assert k3.input == ("text",)
+    assert k3.context_window == 1_048_576
+    assert k3.thinking_level_map == {
+        "off": None,
+        "minimal": None,
+        "low": None,
+        "medium": None,
+        "high": None,
+        "xhigh": "max",
+    }
 
     latest = coding.model_metadata["kimi-for-coding"]
     assert latest.name == "Kimi for Coding (latest)"

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -692,6 +692,21 @@ def test_openai_compatible_config_from_provider_sets_reasoning_effort(
     assert plain.reasoning_effort is None
 
 
+def test_kimi_k3_maps_xhigh_thinking_to_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIMI_CODE_API_KEY", "test-key")
+    settings = load_provider_settings(TauPaths(home=Path("/missing")))
+    provider = settings.get_provider("kimi-code")
+
+    config = openai_compatible_config_from_provider(
+        provider,
+        model="k3",
+        thinking_level="xhigh",
+    )
+
+    assert provider_thinking_levels(provider, model="k3") == ("xhigh",)
+    assert config.reasoning_effort == "max"
+
+
 def test_openai_compatible_config_from_provider_rejects_unsupported_thinking_level(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -86,7 +86,14 @@ different endpoints, and charge against different billing plans:
 | Tau provider | Access and billing | Model | Endpoint | Environment variable |
 | --- | --- | --- | --- | --- |
 | `moonshotai` | Pay-as-you-go key from the [Kimi Open Platform](https://platform.kimi.ai/console/api-keys) | `kimi-k2.7-code` | `https://api.moonshot.ai/v1` | `MOONSHOT_API_KEY` |
-| `kimi-code` | Subscription key from the [Kimi Code console](https://www.kimi.ai/code/console) | Rolling `kimi-for-coding` alias | `https://api.kimi.com/coding/v1` | `KIMI_CODE_API_KEY` |
+| `kimi-code` | Subscription key from the [Kimi Code console](https://www.kimi.com/code/console) | `k3` or rolling `kimi-for-coding` alias | `https://api.kimi.com/coding/v1` | `KIMI_CODE_API_KEY` |
+
+Kimi K3 uses the `k3` model ID and supports up to a 1,048,576-token context
+window on eligible plans. Its reasoning effort is currently fixed at `max`,
+which Tau exposes as the `xhigh` thinking level. Start a new session when
+switching to K3 so the previous model's context cache is not re-prefilled. See
+[Kimi's model documentation](https://www.kimi.com/code/docs/en/kimi-code/models)
+for current plan availability and context limits.
 
 A key for one service should not be treated as interchangeable with a key for
 the other. Tau stores them independently under the `moonshotai` and `kimi-code`


### PR DESCRIPTION
## Summary

- add Kimi K3 (`k3`) to the built-in Kimi Code subscription provider
- configure its up-to-1M context window and map Tau's `xhigh` thinking level to Kimi's required `max` reasoning effort
- document K3 setup, plan-dependent limits, and the recommendation to start a new session when switching models

## Testing

- `uv run pytest` (952 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --minify` (passed with the repository's existing missing taxonomy layout warning)
- Pagefind could not be run locally because the configured npm registry timed out; CI will run it

## Source

- https://www.kimi.com/code/docs/en/kimi-code/models
