### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.1.6"
+version = "0.2.0"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,25 @@
 [
   {
+    "version": "0.2.0",
+    "date": "2026-07-16",
+    "sections": {
+      "New": [
+        "Add Pi-compatible agent, provider, coding-session, and extension event streams with canonical lifecycle and settlement events.",
+        "Add OAuth login parity for Anthropic, GitHub Copilot, and OpenCode providers.",
+        "Add Kimi K3 model support."
+      ],
+      "Changed": [
+        "Replace the legacy runtime message, event, tool, session, and extension protocol with strict Pi-compatible contracts.",
+        "Enrich extension turn events with turn indexes and timestamps.",
+        "Keep tau_agent independent of tau_ai by moving portable provider contracts into the agent package."
+      ],
+      "Fixed": [
+        "Migrate legacy Tau v1 sessions, including null usage costs, at the persistence boundary.",
+        "Improve interactive OAuth login modal navigation."
+      ]
+    }
+  },
+  {
     "version": "0.1.6",
     "date": "2026-07-15",
     "sections": {

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare Tau `0.2.0`, a pre-1.0 minor release for the breaking Pi-compatible runtime protocol introduced since `0.1.6`.

- bump `tau-ai` from `0.1.6` to `0.2.0` in `pyproject.toml` and `uv.lock`
- add bundled `0.2.0` release notes covering the canonical event/message/tool/session/extension contracts
- include the OAuth provider parity, Kimi K3 support, and fixes shipped since `0.1.6`

## Breaking change

The legacy runtime protocol has been replaced by strict Pi-compatible message, event, tool, session, and extension contracts. Event consumers and extensions may need migration, so this uses a pre-1.0 minor version bump.

## Validation

- `uv run pytest -q` — 952 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv build --out-dir /tmp/tau-release-build-0.2.0`
- built `tau_ai-0.2.0` wheel and source distribution
