### PR TITLE
feat: add support for OpenCode Go provider

### DIFF
--- a/dev-notes/opencode-go-support.md
+++ b/dev-notes/opencode-go-support.md
@@ -7,8 +7,10 @@
 | `deepseek-v4-flash` | DeepSeek V4 Flash | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | `high` | `high`, `xhigh` (max) | `reasoning_effort` | 1,000,000 | 384,000 | Effort values: `"high"`, `"max"`. Inherits from `deepseek/deepseek-v4-flash`. |
 | `glm-5.2` | GLM 5.2 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | `high` | `high`, `xhigh` (max) | `reasoning_effort` | 1,000,000 | 131,072 | Effort values: `"high"`, `"max"`. Inherits from `zhipuai/glm-5.2`. |
 | `glm-5.1` | GLM 5.1 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 202,752 | 32,768 | Always-on reasoning. No reasoning options defined in TOML. |
+| `grok-4.5` | Grok 4.5 | `https://opencode.ai/zen/go/v1` | OpenAI | Toggleable | `medium` | `off` (none), `low`, `medium`, `high` | `reasoning_effort` | 1,000,000 | — | Tiered pricing: 200K+ tokens cost 2x. Inherits from `xai/grok-4.5`. |
 | `kimi-k2.7-code` | Kimi K2.7 Code | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 262,144 | 262,144 | Always-on reasoning. Resolved from compiled models.dev catalog. |
 | `kimi-k2.6` | Kimi K2.6 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 262,144 | 65,536 | Always-on reasoning. No reasoning options defined in TOML. |
+| `kimi-k3` | Kimi K3 | `https://opencode.ai/zen/go/v1` | OpenAI | Toggleable | `xhigh` | `xhigh` (max) | `reasoning_effort` | 262,144 | — | Effort value: `"max"` only. Inherits from `moonshotai/kimi-k3`. 2x usage pricing. |
 | `mimo-v2.5-pro` | MiMo V2.5 Pro | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 1,048,576 | 128,000 | Always-on reasoning. No reasoning options defined in TOML. |
 | `mimo-v2.5` | MiMo V2.5 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 1,000,000 | 128,000 | Always-on reasoning. No reasoning options defined in TOML. |
 | `minimax-m3` | MiniMax M3 | `https://opencode.ai/zen/go/v1` | Anthropic | Toggleable | `high` | `off`, `high` (on) | `thinking` type (`adaptive` / `disabled`) | 1,000,000 | 131,072 | Mapped toggle: `high` -> `"adaptive"`. Inherits from `minimax/MiniMax-M3`. |
@@ -52,3 +54,11 @@ The following capabilities of OpenCode Go / Zen Free models are currently unsupp
 ### 4. Always-On Reasoning Models
 - **Problem**: Upstream has no native way to declare always-on reasoning models (models where reasoning cannot be toggled off or customized, but thinking parameters must NOT be sent in the API payload to prevent errors). In upstream, excluding a model from the provider's `thinking_models` list disables its reasoning display entirely (rendering it as `"unavailable"` in the UI).
 - **Solution**: Set `reasoning = true` on the model metadata and exclude the model from the provider's `thinking_models` list. Our implementation detects these models by verifying that `reasoning` is `True` while supported `levels` is empty `()`. The TUI and CLI then format these models with the static `"always on"` label and disable custom level adjustments.
+
+### 5. Anthropic-Protocol Model Routing (minimax-m3, minimax-m2.7, qwen3.7-max, qwen3.7-plus, qwen3.6-plus)
+- **Problem**: These models use `@ai-sdk/anthropic` but were routed through the OpenAI-compatible endpoint because the catalog did not specify `api = "anthropic-messages"` in model_metadata.
+- **Solution**: Added `api = "anthropic-messages"` and `thinking_parameter = "anthropic.thinking"` to model_metadata for each Anthropic-protocol model. The runtime now correctly morphs to `AnthropicProvider` with model-specific thinking configuration (budget tokens for Qwen, adaptive toggle for MiniMax M3, no controls for always-on models).
+
+### 6. Model-Specific Thinking Parameter Override
+- **Problem**: Provider-level `thinking_parameter` cannot describe mixed-transport providers where some models use `reasoning_effort` (OpenAI) and others use `anthropic.thinking` (Anthropic).
+- **Solution**: Added `thinking_parameter` field to `ProviderModelMetadata` and `ModelCatalogMetadata`. Model-specific values override the provider-level default when constructing runtime configs.

--- a/dev-notes/opencode-go-support.md
+++ b/dev-notes/opencode-go-support.md
@@ -1,0 +1,54 @@
+# OpenCode Go & Zen Free Models Capabilities
+
+| Model Name | Display Name | Base URL | API | Thinking | Default Level | Thinking Modes | API Parameter / Payload Mapped | Context Window | Max Output / Reasoning Tokens | Additional Details |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **Go Models** | | | | | | | | | | |
+| `deepseek-v4-pro` | DeepSeek V4 Pro | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | `high` | `high`, `xhigh` (max) | `reasoning_effort` | 1,000,000 | 384,000 | Effort values: `"high"`, `"max"`. Inherits from `deepseek/deepseek-v4-pro`. |
+| `deepseek-v4-flash` | DeepSeek V4 Flash | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | `high` | `high`, `xhigh` (max) | `reasoning_effort` | 1,000,000 | 384,000 | Effort values: `"high"`, `"max"`. Inherits from `deepseek/deepseek-v4-flash`. |
+| `glm-5.2` | GLM 5.2 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | `high` | `high`, `xhigh` (max) | `reasoning_effort` | 1,000,000 | 131,072 | Effort values: `"high"`, `"max"`. Inherits from `zhipuai/glm-5.2`. |
+| `glm-5.1` | GLM 5.1 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 202,752 | 32,768 | Always-on reasoning. No reasoning options defined in TOML. |
+| `kimi-k2.7-code` | Kimi K2.7 Code | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 262,144 | 262,144 | Always-on reasoning. Resolved from compiled models.dev catalog. |
+| `kimi-k2.6` | Kimi K2.6 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 262,144 | 65,536 | Always-on reasoning. No reasoning options defined in TOML. |
+| `mimo-v2.5-pro` | MiMo V2.5 Pro | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 1,048,576 | 128,000 | Always-on reasoning. No reasoning options defined in TOML. |
+| `mimo-v2.5` | MiMo V2.5 | `https://opencode.ai/zen/go/v1` | OpenAI | Always on | N/A | None | None | 1,000,000 | 128,000 | Always-on reasoning. No reasoning options defined in TOML. |
+| `minimax-m3` | MiniMax M3 | `https://opencode.ai/zen/go/v1` | Anthropic | Toggleable | `high` | `off`, `high` (on) | `thinking` type (`adaptive` / `disabled`) | 1,000,000 | 131,072 | Mapped toggle: `high` -> `"adaptive"`. Inherits from `minimax/MiniMax-M3`. |
+| `minimax-m2.7` | MiniMax M2.7 | `https://opencode.ai/zen/go/v1` | Anthropic | Always on | N/A | None | None | 204,800 | 131,072 | Always-on reasoning. No reasoning options defined in TOML. |
+| `qwen3.7-max` | Qwen 3.7 Max | `https://opencode.ai/zen/go/v1` | Anthropic | Toggleable | `high` | `off` (disabled), `low` (2048), `medium` (4096), `high` (8192), `xhigh` (16384) | `output_config.task_budget` | 1,000,000 | 65,536 | Supports `toggle` and `budget_tokens` (max 262,144 reasoning tokens). |
+| `qwen3.7-plus` | Qwen 3.7 Plus | `https://opencode.ai/zen/go/v1` | Anthropic | Toggleable | `high` | `off` (disabled), `low` (2048), `medium` (4096), `high` (8192), `xhigh` (16384) | `output_config.task_budget` | 1,000,000 | 65,536 | Supports `toggle` and `budget_tokens` (max 262,144 reasoning tokens). |
+| `qwen3.6-plus` | Qwen 3.6 Plus | `https://opencode.ai/zen/go/v1` | Anthropic | Toggleable | `high` | `off` (disabled), `low` (2048), `medium` (4096), `high` (8192), `xhigh` (8192/16384) | `output_config.task_budget` | 1,000,000 | 65,536 | Supports `toggle` and `budget_tokens` (max 81,920 reasoning tokens). |
+| **Zen Free Models** | | | | | | | | | | |
+| `big-pickle` | Big Pickle | `https://opencode.ai/zen/v1` | OpenAI | Always on | N/A | None | None | 200,000 | 32,000 | Always-on reasoning. Routed to Zen v1. |
+| `deepseek-v4-flash-free` | DeepSeek V4 Flash Free | `https://opencode.ai/zen/v1` | OpenAI | Toggleable | `high` | `off`, `high`, `xhigh` (max) | `reasoning_effort` | 200,000 | 128,000 | Mapped to Zen v1. Effort values: `"high"`, `"max"`. |
+| `hy3-free` | Hy3 Free | `https://opencode.ai/zen/v1` | OpenAI | Always on | N/A | None | None | 256,000 | 64,000 | Always-on reasoning. Routed to Zen v1. |
+| `mimo-v2.5-free` | MiMo V2.5 Free | `https://opencode.ai/zen/v1` | OpenAI | Always on | N/A | None | None | 200,000 | 32,000 | Always-on reasoning. Routed to Zen v1. |
+| `nemotron-3-ultra-free` | Nemotron 3 Ultra Free | `https://opencode.ai/zen/v1` | OpenAI | Always on | N/A | None | None | 1,000,000 | 128,000 | Always-on reasoning. Routed to Zen v1. |
+| `north-mini-code-free` | North Mini Code Free | `https://opencode.ai/zen/v1` | OpenAI | Toggleable | `high` | `off` (none), `high` | `reasoning_effort` | 256,000 | 64,000 | Inherits from `cohere/north-mini-code-1-0`. Effort values: `"none"`, `"high"`. |
+
+## Sources Used
+
+- `anomalyco/models.dev` repository on GitHub (`dev` branch):
+  - [opencode-go/models/](https://github.com/anomalyco/models.dev/tree/dev/providers/opencode-go/models)
+  - [opencode/models/](https://github.com/anomalyco/models.dev/tree/dev/providers/opencode/models)
+  - Compiled [models.json](https://models.dev/models.json) (compiled models.dev catalog registry)
+- `anomalyco/opencode` repository on GitHub (`dev` branch):
+  - [opencode.ai/zen/go/v1](https://github.com/anomalyco/opencode/tree/dev)
+
+## Gaps & Upstream Capabilities Limitations
+
+The following capabilities of OpenCode Go / Zen Free models are currently unsupported in upstream Tau and require local implementations:
+
+### 1. Hybrid Protocols per Provider (Mixed OpenAI & Anthropic API models)
+- **Problem**: Upstream Tau strictly assumes a provider serves models via a single client/API protocol class (either `openai-compatible` or `anthropic`/Messages API). Under a unified aggregator like `opencode-go`, some models use the OpenAI `/chat/completions` schema, while others (like Qwen and Minimax) are served via the Anthropic `/messages` API.
+- **Solution**: Check model-specific metadata configuration `api = "anthropic-messages"` inside `create_model_provider` and dynamically morph the configuration class into `AnthropicProviderConfig` at runtime.
+
+### 2. Toggle-Only Anthropic Thinking (MiniMax M3)
+- **Problem**: Upstream's Anthropic provider handles thinking via either `budget` mode (which expects an integer token count) or `adaptive` mode (which always appends `output_config.effort` to the request payload). Toggle-only models like `minimax-m3` reject the `effort` config payload and require a pure `{ "thinking": { "type": "adaptive" } }` payload.
+- **Solution**: Introduce the `thinking_type: Literal["adaptive", "disabled"]` runtime parameter to bypass the `output_config` payload and send a pure toggle to the endpoint.
+
+### 3. Model-Specific Thinking Level Display Labels
+- **Problem**: Provider-level thinking levels are mapped to standard canonical levels (like `high`, `xhigh`). Some models require mapping these canonical levels to custom UI display labels (e.g., mapping `high` to `"on"` or `"none"` in the CLI/TUI). Upstream does not support model-specific display label overrides.
+- **Solution**: Implement `thinking_level_labels` mapping on the model catalog metadata to translate canonical levels to display strings for CLI/TUI widgets.
+
+### 4. Always-On Reasoning Models
+- **Problem**: Upstream has no native way to declare always-on reasoning models (models where reasoning cannot be toggled off or customized, but thinking parameters must NOT be sent in the API payload to prevent errors). In upstream, excluding a model from the provider's `thinking_models` list disables its reasoning display entirely (rendering it as `"unavailable"` in the UI).
+- **Solution**: Set `reasoning = true` on the model metadata and exclude the model from the provider's `thinking_models` list. Our implementation detects these models by verifying that `reasoning` is `True` while supported `levels` is empty `()`. The TUI and CLI then format these models with the static `"always on"` label and disable custom level adjustments.

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -362,9 +362,14 @@ def _build_messages_payload(
         ),
         "messages": [_anthropic_message(message) for message in messages],
     }
-    if thinking_mode == "adaptive" and thinking_effort is not None:
+    if thinking_mode == "disabled":
+        payload["thinking"] = {"type": "disabled"}
+    elif thinking_mode == "adaptive" and thinking_effort is not None:
         payload["thinking"] = {"type": "adaptive", "display": "summarized"}
         payload["output_config"] = {"effort": thinking_effort}
+    elif thinking_mode == "adaptive":
+        # Toggle-only model with thinking enabled (no effort field)
+        payload["thinking"] = {"type": "adaptive", "display": "summarized"}
     elif thinking_budget_tokens is not None:
         payload["thinking"] = {
             "type": "enabled",

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -82,6 +82,7 @@ class _CatalogModelMetadata(BaseModel):
     thinking_level_map: dict[ThinkingLevel, _NonEmptyString] = {}
     thinking_level_labels: dict[ThinkingLevel, _NonEmptyString] = {}
     unsupported_thinking_levels: tuple[ThinkingLevel, ...] = ()
+    thinking_parameter: ThinkingParameter | None = None
 
 
 class _CatalogProvider(BaseModel):
@@ -398,6 +399,7 @@ def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatal
         compat=_json_object(metadata.compat, "model_metadata.compat"),
         thinking_level_map=thinking_level_map,
         thinking_level_labels=dict(metadata.thinking_level_labels),
+        thinking_parameter=metadata.thinking_parameter,
     )
 
 
@@ -527,6 +529,8 @@ def _raw_model_metadata_from_entry(metadata: ModelCatalogMetadata) -> dict[str, 
         raw["unsupported_thinking_levels"] = unsupported
     if metadata.thinking_level_labels:
         raw["thinking_level_labels"] = dict(metadata.thinking_level_labels)
+    if metadata.thinking_parameter is not None:
+        raw["thinking_parameter"] = metadata.thinking_parameter
     return raw
 
 

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -80,6 +80,7 @@ class _CatalogModelMetadata(BaseModel):
     headers: dict[_NonEmptyString, _NonEmptyString] = {}
     compat: dict[_NonEmptyString, Any] = {}
     thinking_level_map: dict[ThinkingLevel, _NonEmptyString] = {}
+    thinking_level_labels: dict[ThinkingLevel, _NonEmptyString] = {}
     unsupported_thinking_levels: tuple[ThinkingLevel, ...] = ()
 
 
@@ -396,6 +397,7 @@ def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatal
         headers=dict(metadata.headers),
         compat=_json_object(metadata.compat, "model_metadata.compat"),
         thinking_level_map=thinking_level_map,
+        thinking_level_labels=dict(metadata.thinking_level_labels),
     )
 
 
@@ -523,6 +525,8 @@ def _raw_model_metadata_from_entry(metadata: ModelCatalogMetadata) -> dict[str, 
         raw["thinking_level_map"] = thinking_level_map
     if unsupported:
         raw["unsupported_thinking_levels"] = unsupported
+    if metadata.thinking_level_labels:
+        raw["thinking_level_labels"] = dict(metadata.thinking_level_labels)
     return raw
 
 

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -67,6 +67,9 @@ class CommandSession(Protocol):
     def thinking_level(self) -> str: ...
 
     @property
+    def thinking_level_label(self) -> str: ...
+
+    @property
     def available_thinking_levels(self) -> Sequence[str]: ...
 
     @property
@@ -662,7 +665,7 @@ def _thinking_command(context: CommandContext) -> CommandResult:
 
 def _thinking_status_lines(session: CommandSession) -> list[str]:
     if tuple(session.available_thinking_levels):
-        return [f"Thinking mode: {session.thinking_level}"]
+        return [f"Thinking mode: {session.thinking_level_label}"]
     if getattr(session, "thinking_is_always_on", False):
         return ["Thinking mode: always on"]
     lines = ["Thinking mode: unavailable"]

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -629,6 +629,12 @@ def _thinking_command(context: CommandContext) -> CommandResult:
         return CommandResult(handled=True, message="\n".join(lines))
 
     if not available:
+        always_on = getattr(session, "thinking_is_always_on", False)
+        if always_on:
+            return CommandResult(
+                handled=True,
+                message=f"Thinking mode is always on for {session.provider_name}:{session.model}",
+            )
         message = f"Thinking controls are unavailable for {session.provider_name}:{session.model}"
         reason = _thinking_unavailable_reason(session)
         if reason:
@@ -657,6 +663,8 @@ def _thinking_command(context: CommandContext) -> CommandResult:
 def _thinking_status_lines(session: CommandSession) -> list[str]:
     if tuple(session.available_thinking_levels):
         return [f"Thinking mode: {session.thinking_level}"]
+    if getattr(session, "thinking_is_always_on", False):
+        return ["Thinking mode: always on"]
     lines = ["Thinking mode: unavailable"]
     reason = _thinking_unavailable_reason(session)
     if reason:

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6268,28 +6268,115 @@ kind = "openai-compatible"
 base_url = "https://opencode.ai/zen/go/v1"
 api_key_env = "OPENCODE_API_KEY"
 credential_name = "opencode-go"
-models = ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.1", "glm-5.2", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.7", "minimax-m3", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"]
-default_model = "kimi-k2.7-code"
+models = [
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "glm-5.2",
+  "glm-5.1",
+  "kimi-k2.7-code",
+  "kimi-k2.6",
+  "minimax-m3",
+  "minimax-m2.7",
+  "mimo-v2.5-pro",
+  "mimo-v2.5",
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-plus",
+  "big-pickle",
+  "deepseek-v4-flash-free",
+  "hy3-free",
+  "mimo-v2.5-free",
+  "nemotron-3-ultra-free",
+  "north-mini-code-free",
+]
+default_model = "deepseek-v4-pro"
 docs_url = "https://opencode.ai/docs/go"
-api = "openai-completions"
-thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_levels = ["off", "low", "medium", "high", "xhigh"]
+thinking_models = [
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "glm-5.2",
+  "minimax-m3",
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-plus",
+  "deepseek-v4-flash-free",
+  "north-mini-code-free",
+]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
-"deepseek-v4-flash" = 1000000
-"deepseek-v4-pro" = 1000000
+"glm-5.2" = 1000000
 "glm-5.1" = 202752
-"glm-5.2" = 202752
-"kimi-k2.6" = 262144
 "kimi-k2.7-code" = 262144
-"mimo-v2.5" = 262144
-"mimo-v2.5-pro" = 262144
+"kimi-k2.6" = 262144
+"deepseek-v4-pro" = 1000000
+"deepseek-v4-flash" = 1000000
+"mimo-v2.5" = 1000000
+"mimo-v2.5-pro" = 1048576
+"minimax-m3" = 1000000
 "minimax-m2.7" = 204800
-"minimax-m3" = 204800
-"qwen3.6-plus" = 1000000
 "qwen3.7-max" = 1000000
 "qwen3.7-plus" = 1000000
+"qwen3.6-plus" = 1000000
+"deepseek-v4-flash-free" = 200000
+"mimo-v2.5-free" = 200000
+"big-pickle" = 200000
+"north-mini-code-free" = 256000
+"nemotron-3-ultra-free" = 1000000
+"hy3-free" = 256000
+
+[providers.model_metadata."deepseek-v4-flash-free"]
+base_url = "https://opencode.ai/zen/v1"
+thinking_level_map = {high = "high", xhigh = "max"}
+thinking_level_labels = {xhigh = "max"}
+unsupported_thinking_levels = ["minimal", "low", "medium"]
+
+[providers.model_metadata."mimo-v2.5-free"]
+base_url = "https://opencode.ai/zen/v1"
+reasoning = true
+
+[providers.model_metadata."big-pickle"]
+base_url = "https://opencode.ai/zen/v1"
+reasoning = true
+
+[providers.model_metadata."north-mini-code-free"]
+base_url = "https://opencode.ai/zen/v1"
+thinking_level_map = {off = "none", high = "high"}
+unsupported_thinking_levels = ["minimal", "low", "medium", "xhigh"]
+
+[providers.model_metadata."nemotron-3-ultra-free"]
+base_url = "https://opencode.ai/zen/v1"
+reasoning = true
+
+[providers.model_metadata."hy3-free"]
+base_url = "https://opencode.ai/zen/v1"
+reasoning = true
+
+[providers.model_metadata."glm-5.2"]
+thinking_level_map = {high = "high", xhigh = "max"}
+thinking_level_labels = {xhigh = "max"}
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
+
+[providers.model_metadata."glm-5.1"]
+reasoning = true
+
+[providers.model_metadata."kimi-k2.7-code"]
+reasoning = true
+
+[providers.model_metadata."kimi-k2.6"]
+reasoning = true
+
+[providers.model_metadata."deepseek-v4-pro"]
+thinking_level_map = {high = "high", xhigh = "max"}
+thinking_level_labels = {xhigh = "max"}
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
+
+[providers.model_metadata."deepseek-v4-flash"]
+thinking_level_map = {high = "high", xhigh = "max"}
+thinking_level_labels = {xhigh = "max"}
+unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
 
 [[providers]]
 name = "opencode"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6273,8 +6273,10 @@ models = [
   "deepseek-v4-flash",
   "glm-5.2",
   "glm-5.1",
+  "grok-4.5",
   "kimi-k2.7-code",
   "kimi-k2.6",
+  "kimi-k3",
   "minimax-m3",
   "minimax-m2.7",
   "mimo-v2.5-pro",
@@ -6296,6 +6298,8 @@ thinking_models = [
   "deepseek-v4-pro",
   "deepseek-v4-flash",
   "glm-5.2",
+  "grok-4.5",
+  "kimi-k3",
   "minimax-m3",
   "qwen3.7-max",
   "qwen3.7-plus",
@@ -6326,6 +6330,8 @@ thinking_parameter = "reasoning_effort"
 "north-mini-code-free" = 256000
 "nemotron-3-ultra-free" = 1000000
 "hy3-free" = 256000
+"kimi-k3" = 262144
+"grok-4.5" = 1000000
 
 [providers.model_metadata."deepseek-v4-flash-free"]
 base_url = "https://opencode.ai/zen/v1"
@@ -6377,6 +6383,54 @@ unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
 thinking_level_map = {high = "high", xhigh = "max"}
 thinking_level_labels = {xhigh = "max"}
 unsupported_thinking_levels = ["off", "minimal", "low", "medium"]
+
+[providers.model_metadata."kimi-k3"]
+thinking_level_map = {xhigh = "max"}
+thinking_level_labels = {xhigh = "max"}
+unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
+
+[providers.model_metadata."grok-4.5"]
+thinking_level_map = {off = "none", low = "low", medium = "medium", high = "high"}
+thinking_level_labels = {}
+unsupported_thinking_levels = ["minimal", "xhigh"]
+
+[providers.model_metadata."minimax-m3"]
+api = "anthropic-messages"
+reasoning = true
+thinking_level_map = {off = "disabled", high = "adaptive"}
+thinking_level_labels = {off = "off", high = "on"}
+unsupported_thinking_levels = ["minimal", "low", "medium", "xhigh"]
+compat = {forceAdaptiveThinking = true}
+thinking_parameter = "anthropic.thinking"
+
+[providers.model_metadata."minimax-m2.7"]
+api = "anthropic-messages"
+reasoning = true
+unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+
+[providers.model_metadata."qwen3.7-max"]
+api = "anthropic-messages"
+reasoning = true
+thinking_level_map = {off = "disabled", low = "low", medium = "medium", high = "high", xhigh = "xhigh"}
+thinking_level_labels = {}
+unsupported_thinking_levels = ["minimal"]
+thinking_parameter = "anthropic.thinking"
+
+[providers.model_metadata."qwen3.7-plus"]
+api = "anthropic-messages"
+reasoning = true
+thinking_level_map = {off = "disabled", low = "low", medium = "medium", high = "high", xhigh = "xhigh"}
+thinking_level_labels = {}
+unsupported_thinking_levels = ["minimal"]
+thinking_parameter = "anthropic.thinking"
+
+[providers.model_metadata."qwen3.6-plus"]
+api = "anthropic-messages"
+reasoning = true
+thinking_level_map = {off = "disabled", low = "low", medium = "medium", high = "high", xhigh = "xhigh"}
+thinking_level_labels = {}
+unsupported_thinking_levels = ["minimal"]
+thinking_parameter = "anthropic.thinking"
 
 [[providers]]
 name = "opencode"

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -53,6 +53,7 @@ class ModelCatalogMetadata:
     compat: dict[str, JSONValue] = field(default_factory=dict)
     thinking_level_map: ThinkingLevelMap = field(default_factory=dict)
     thinking_level_labels: dict[ThinkingLevel, str] = field(default_factory=dict)
+    thinking_parameter: ThinkingParameter | None = None
 
 
 def model_cost_for_input_tokens(

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -52,6 +52,7 @@ class ModelCatalogMetadata:
     headers: dict[str, str] = field(default_factory=dict)
     compat: dict[str, JSONValue] = field(default_factory=dict)
     thinking_level_map: ThinkingLevelMap = field(default_factory=dict)
+    thinking_level_labels: dict[ThinkingLevel, str] = field(default_factory=dict)
 
 
 def model_cost_for_input_tokens(

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -74,6 +74,7 @@ class ProviderModelMetadata:
     compat: dict[str, Any] = field(default_factory=dict)
     thinking_level_map: dict[ThinkingLevel, str | None] = field(default_factory=dict)
     thinking_level_labels: dict[ThinkingLevel, str] = field(default_factory=dict)
+    thinking_parameter: ThinkingParameter | None = None
 
     def to_json(self) -> dict[str, Any]:
         """Serialize this model metadata to JSON-compatible data."""
@@ -101,6 +102,7 @@ class ProviderModelMetadata:
             "compat": dict(self.compat),
             "thinking_level_map": dict(self.thinking_level_map),
             "thinking_level_labels": dict(self.thinking_level_labels),
+            "thinking_parameter": self.thinking_parameter,
         }
 
 
@@ -471,6 +473,7 @@ def _provider_model_metadata_from_catalog(
             compat=dict(metadata.compat),
             thinking_level_map=dict(metadata.thinking_level_map),
             thinking_level_labels=dict(metadata.thinking_level_labels),
+            thinking_parameter=metadata.thinking_parameter,
         )
         for model, metadata in model_metadata.items()
     }
@@ -908,6 +911,7 @@ def _merge_provider_model_metadata(
             compat={**base.compat, **metadata.compat},
             thinking_level_map={**base.thinking_level_map, **metadata.thinking_level_map},
             thinking_level_labels={**base.thinking_level_labels, **metadata.thinking_level_labels},
+            thinking_parameter=metadata.thinking_parameter or base.thinking_parameter,
         )
     return merged
 
@@ -1053,6 +1057,7 @@ def _catalog_model_metadata_from_provider(
             compat=dict(metadata.compat),
             thinking_level_map=dict(metadata.thinking_level_map),
             thinking_level_labels=dict(metadata.thinking_level_labels),
+            thinking_parameter=metadata.thinking_parameter,
         )
         for model, metadata in metadata_by_model.items()
     }
@@ -2222,10 +2227,17 @@ def _model_metadata_dict(
                 item.get("thinking_level_map", {}),
                 f"{field_name}.{model}.thinking_level_map",
             ),
-            thinking_level_labels=cast("dict[ThinkingLevel, str]", _string_dict(
-                item.get("thinking_level_labels", {}),
-                f"{field_name}.{model}.thinking_level_labels",
-            )),
+            thinking_level_labels=cast(
+                "dict[ThinkingLevel, str]",
+                _string_dict(
+                    item.get("thinking_level_labels", {}),
+                    f"{field_name}.{model}.thinking_level_labels",
+                ),
+            ),
+            thinking_parameter=_optional_thinking_parameter(
+                item.get("thinking_parameter"),
+                f"{field_name}.{model}.thinking_parameter",
+            ),
         )
     return items
 

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1332,6 +1332,35 @@ def provider_thinking_unavailable_reason(
     return None
 
 
+def provider_thinking_is_always_on(
+    provider: ProviderConfig,
+    *,
+    model: str | None = None,
+) -> bool:
+    """Return whether built-in metadata declares reasoning as always enabled."""
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is None or metadata.reasoning is not True:
+        return False
+    levels = provider_thinking_levels(provider, model=selected_model)
+    return len(levels) == 0
+
+
+def provider_thinking_level_label(
+    provider: ProviderConfig,
+    level: str,
+    *,
+    model: str | None = None,
+) -> str:
+    """Return the provider-facing display label for a canonical Tau level."""
+    normalized = normalize_thinking_level(level)
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is not None and normalized in metadata.thinking_level_labels:
+        return metadata.thinking_level_labels[normalized]
+    return normalized
+
+
 def _levels_from_thinking_map(
     thinking_level_map: dict[ThinkingLevel, str | None],
 ) -> tuple[ThinkingLevel, ...]:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -73,6 +73,7 @@ class ProviderModelMetadata:
     headers: dict[str, str] = field(default_factory=dict)
     compat: dict[str, Any] = field(default_factory=dict)
     thinking_level_map: dict[ThinkingLevel, str | None] = field(default_factory=dict)
+    thinking_level_labels: dict[ThinkingLevel, str] = field(default_factory=dict)
 
     def to_json(self) -> dict[str, Any]:
         """Serialize this model metadata to JSON-compatible data."""
@@ -99,6 +100,7 @@ class ProviderModelMetadata:
             "headers": dict(self.headers),
             "compat": dict(self.compat),
             "thinking_level_map": dict(self.thinking_level_map),
+            "thinking_level_labels": dict(self.thinking_level_labels),
         }
 
 
@@ -468,6 +470,7 @@ def _provider_model_metadata_from_catalog(
             headers=dict(metadata.headers),
             compat=dict(metadata.compat),
             thinking_level_map=dict(metadata.thinking_level_map),
+            thinking_level_labels=dict(metadata.thinking_level_labels),
         )
         for model, metadata in model_metadata.items()
     }
@@ -904,6 +907,7 @@ def _merge_provider_model_metadata(
             headers={**base.headers, **metadata.headers},
             compat={**base.compat, **metadata.compat},
             thinking_level_map={**base.thinking_level_map, **metadata.thinking_level_map},
+            thinking_level_labels={**base.thinking_level_labels, **metadata.thinking_level_labels},
         )
     return merged
 
@@ -1048,6 +1052,7 @@ def _catalog_model_metadata_from_provider(
             headers=dict(metadata.headers),
             compat=dict(metadata.compat),
             thinking_level_map=dict(metadata.thinking_level_map),
+            thinking_level_labels=dict(metadata.thinking_level_labels),
         )
         for model, metadata in metadata_by_model.items()
     }
@@ -2188,6 +2193,10 @@ def _model_metadata_dict(
                 item.get("thinking_level_map", {}),
                 f"{field_name}.{model}.thinking_level_map",
             ),
+            thinking_level_labels=cast("dict[ThinkingLevel, str]", _string_dict(
+                item.get("thinking_level_labels", {}),
+                f"{field_name}.{model}.thinking_level_labels",
+            )),
         )
     return items
 

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -8,7 +8,7 @@ from typing import Protocol
 
 from tau_agent.provider import ModelProvider
 from tau_ai.anthropic import AnthropicProvider
-from tau_ai.env import AnthropicConfig, RuntimeProviderAuth
+from tau_ai.env import AnthropicConfig, OpenAICompatibleConfig, RuntimeProviderAuth
 from tau_ai.google import GoogleGenerativeAIProvider
 from tau_ai.mistral import MistralConversationsProvider
 from tau_ai.openai_codex import (
@@ -125,16 +125,12 @@ def create_model_provider(
             )
         selected_api = compatible_config.api
         if selected_api == "anthropic-messages":
-            anthropic_config = AnthropicConfig(
-                api_key=compatible_config.api_key,
-                base_url=compatible_config.base_url,
-                headers=compatible_config.headers,
-                timeout_seconds=compatible_config.timeout_seconds,
-                max_retries=compatible_config.max_retries,
-                max_retry_delay_seconds=compatible_config.max_retry_delay_seconds,
-                provider_name=compatible_config.provider_name,
+            anthropic_config = _anthropic_config_from_compatible(
+                compatible_config,
+                provider=provider,
+                model=model,
+                thinking_level=thinking_level,
                 bearer_auth=credential is not None,
-                credential_resolver=compatible_config.credential_resolver,
             )
             return AnthropicProvider(anthropic_config)
         if selected_api == "google-generative-ai":
@@ -169,6 +165,72 @@ def _codex_reasoning_effort(
     if normalized == "minimal":
         return "low"
     return reasoning_effort_for_level(normalized)
+
+
+def _anthropic_config_from_compatible(
+    compatible_config: OpenAICompatibleConfig,
+    *,
+    provider: ProviderConfig,
+    model: str | None,
+    thinking_level: ThinkingLevel | None,
+    bearer_auth: bool,
+) -> AnthropicConfig:
+    """Build AnthropicConfig from an OpenAI-compatible config with model-specific thinking."""
+    from tau_coding.provider_config import _metadata_for_model
+
+    selected_model = model or provider.default_model
+    metadata = _metadata_for_model(provider, selected_model)
+
+    # Determine thinking parameter: model-specific overrides provider-level
+    thinking_parameter = None
+    if metadata is not None and metadata.thinking_parameter is not None:
+        thinking_parameter = metadata.thinking_parameter
+    elif isinstance(provider, OpenAICompatibleProviderConfig):
+        thinking_parameter = provider.thinking_parameter
+
+    # Build thinking config based on the thinking parameter type
+    thinking_budget_tokens = None
+    thinking_effort = None
+    thinking_mode = "budget"
+
+    if thinking_parameter == "anthropic.thinking" and thinking_level is not None:
+        normalized = normalize_thinking_level(thinking_level)
+        # Check if forceAdaptiveThinking is set in compat
+        compat = metadata.compat if metadata is not None else {}
+        if compat.get("forceAdaptiveThinking") is True:
+            thinking_mode = "disabled" if normalized == "off" else "adaptive"
+        else:
+            # Map thinking level to budget tokens
+            if normalized == "off":
+                thinking_mode = "disabled"
+            else:
+                thinking_budget_tokens = {
+                    "minimal": 1024,
+                    "low": 2048,
+                    "medium": 4096,
+                    "high": 8192,
+                    "xhigh": 16384,
+                }.get(normalized)
+    elif thinking_parameter in {"reasoning_effort", "reasoning.effort"}:
+        # For OpenAI-style reasoning_effort, pass it as thinking_effort
+        if thinking_level is not None:
+            normalized = normalize_thinking_level(thinking_level)
+            if normalized != "off":
+                thinking_effort = reasoning_effort_for_level(normalized)
+
+    return AnthropicConfig(
+        api_key=compatible_config.api_key,
+        base_url=compatible_config.base_url,
+        headers=dict(compatible_config.headers) if compatible_config.headers else None,
+        timeout_seconds=compatible_config.timeout_seconds,
+        max_retries=compatible_config.max_retries,
+        max_retry_delay_seconds=compatible_config.max_retry_delay_seconds,
+        provider_name=compatible_config.provider_name,
+        bearer_auth=bearer_auth,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_effort=thinking_effort,
+        thinking_mode=thinking_mode,
+    )
 
 
 class OpenAICodexCredentialResolver:

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -125,10 +125,6 @@ def create_model_provider(
             )
         selected_api = compatible_config.api
         if selected_api == "anthropic-messages":
-            if credential is None:
-                raise ProviderConfigError(
-                    "Anthropic-protocol models on openai-compatible providers require OAuth"
-                )
             anthropic_config = AnthropicConfig(
                 api_key=compatible_config.api_key,
                 base_url=compatible_config.base_url,
@@ -137,7 +133,7 @@ def create_model_provider(
                 max_retries=compatible_config.max_retries,
                 max_retry_delay_seconds=compatible_config.max_retry_delay_seconds,
                 provider_name=compatible_config.provider_name,
-                bearer_auth=True,
+                bearer_auth=credential is not None,
                 credential_resolver=compatible_config.credential_resolver,
             )
             return AnthropicProvider(anthropic_config)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -84,6 +84,8 @@ from tau_coding.provider_config import (
     load_provider_settings,
     provider_default_thinking_level,
     provider_has_usable_credentials,
+    provider_thinking_is_always_on,
+    provider_thinking_level_label,
     provider_thinking_levels,
     provider_thinking_unavailable_reason,
     resolve_provider_selection,
@@ -584,6 +586,29 @@ class CodingSession:
         if provider is None:
             return "Active provider settings are not available"
         return provider_thinking_unavailable_reason(provider, model=self.model)
+
+    @property
+    def thinking_is_always_on(self) -> bool:
+        """Return whether the active model's reasoning cannot be disabled."""
+        provider = self._active_provider_config()
+        return provider is not None and provider_thinking_is_always_on(
+            provider,
+            model=self.model,
+        )
+
+    @property
+    def thinking_level_label(self) -> str:
+        """Return the provider-facing label for the active thinking state."""
+        if self.thinking_is_always_on:
+            return "always on"
+        provider = self._active_provider_config()
+        if provider is None:
+            return self._thinking_level
+        return provider_thinking_level_label(
+            provider,
+            self._thinking_level,
+            model=self.model,
+        )
 
     @property
     def storage(self) -> SessionStorage:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1571,6 +1571,10 @@ def _thinking_level(session: SessionSummarySource) -> str:
         if getattr(session, "thinking_is_always_on", False):
             return "always on"
         return "unavailable"
+    # Prefer model-specific thinking level label over raw level
+    label = getattr(session, "thinking_level_label", None)
+    if label:
+        return str(label)
     explicit_level = getattr(session, "thinking_level", None)
     if explicit_level:
         return str(explicit_level)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1568,6 +1568,8 @@ def _context_file_label(path: Path, *, cwd: Path) -> str:
 def _thinking_level(session: SessionSummarySource) -> str:
     available = getattr(session, "available_thinking_levels", None)
     if available == ():
+        if getattr(session, "thinking_is_always_on", False):
+            return "always on"
         return "unavailable"
     explicit_level = getattr(session, "thinking_level", None)
     if explicit_level:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -39,6 +39,7 @@ class FakeSession:
         self.auto_compact_token_threshold = 200
         self.context_window_tokens = 584
         self.thinking_level = "medium"
+        self.thinking_level_label = "medium"
         self.available_thinking_levels = ("off", "minimal", "low", "medium", "high", "xhigh")
         self.thinking_unavailable_reason: str | None = None
         self.tui_theme = "tau-dark"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -533,3 +533,173 @@ def test_user_catalog_provider_appears_with_existing_settings_file(tmp_path: Pat
     )
     settings = load_provider_settings(paths)
     assert settings.get_provider("nebius").models[0] == "deepseek-ai/DeepSeek-V4-Pro"
+
+
+# --- OpenCode Go regression tests ---
+
+
+def test_opencode_go_provider_membership_and_default_model() -> None:
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+    assert entry.display_name == "OpenCode Go"
+    assert entry.kind == "openai-compatible"
+    assert entry.base_url == "https://opencode.ai/zen/go/v1"
+    assert entry.api_key_env == "OPENCODE_API_KEY"
+    assert entry.default_model == "deepseek-v4-pro"
+    assert "minimax-m3" in entry.models
+    assert "qwen3.7-max" in entry.models
+    assert "kimi-k3" in entry.models
+    assert "grok-4.5" in entry.models
+
+
+def test_opencode_go_context_windows() -> None:
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+    assert entry.context_windows is not None
+    assert entry.context_windows["deepseek-v4-pro"] == 1_000_000
+    assert entry.context_windows["minimax-m3"] == 1_000_000
+    assert entry.context_windows["qwen3.7-max"] == 1_000_000
+    assert entry.context_windows["kimi-k3"] == 262_144
+    assert entry.context_windows["grok-4.5"] == 1_000_000
+
+
+def test_opencode_go_anthropic_protocol_transport() -> None:
+    """Anthropic-protocol models must have api = anthropic-messages in metadata."""
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+    for model in ["minimax-m3", "minimax-m2.7", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus"]:
+        metadata = entry.model_metadata.get(model)
+        assert metadata is not None, f"{model} missing from model_metadata"
+        assert metadata.api == "anthropic-messages", f"{model} api should be anthropic-messages"
+
+
+def test_opencode_go_thinking_levels_per_model() -> None:
+    from tau_coding.provider_config import ProviderSettings, provider_thinking_levels
+
+    settings = ProviderSettings()
+    opencode_go = settings.get_provider("opencode-go")
+
+    # Anthropic-protocol toggle models
+    assert provider_thinking_levels(opencode_go, model="minimax-m3") == ("off", "high")
+    assert provider_thinking_levels(opencode_go, model="qwen3.7-max") == (
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+    assert provider_thinking_levels(opencode_go, model="qwen3.7-plus") == (
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+    assert provider_thinking_levels(opencode_go, model="qwen3.6-plus") == (
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+
+    # Always-on models (no configurable levels)
+    assert provider_thinking_levels(opencode_go, model="minimax-m2.7") == ()
+    assert provider_thinking_levels(opencode_go, model="glm-5.1") == ()
+    assert provider_thinking_levels(opencode_go, model="kimi-k2.7-code") == ()
+
+    # OpenAI-compatible effort models
+    assert provider_thinking_levels(opencode_go, model="kimi-k3") == ("xhigh",)
+    assert provider_thinking_levels(opencode_go, model="grok-4.5") == (
+        "off",
+        "low",
+        "medium",
+        "high",
+    )
+    assert provider_thinking_levels(opencode_go, model="deepseek-v4-pro") == ("high", "xhigh")
+
+
+def test_opencode_go_thinking_parameter_per_model() -> None:
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+
+    # Anthropic-protocol models should have anthropic.thinking parameter
+    for model in ["minimax-m3", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus"]:
+        metadata = entry.model_metadata.get(model)
+        assert metadata is not None
+        assert metadata.thinking_parameter == "anthropic.thinking", f"{model} thinking_parameter"
+
+    # minimax-m2.7 has no thinking parameter (always-on)
+    metadata = entry.model_metadata.get("minimax-m2.7")
+    assert metadata is not None
+    assert metadata.thinking_parameter is None
+
+
+def test_opencode_go_wire_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify wire payload construction for distinct thinking shapes."""
+    from tau_coding.provider_config import ProviderSettings
+    from tau_coding.provider_runtime import create_model_provider
+
+    monkeypatch.setenv("OPENCODE_API_KEY", "test-key")
+    settings = ProviderSettings()
+    opencode_go = settings.get_provider("opencode-go")
+
+    # DeepSeek/GLM: OpenAI-compatible with reasoning_effort
+    provider = create_model_provider(opencode_go, model="deepseek-v4-pro", thinking_level="high")
+    assert type(provider).__name__ == "OpenAICompatibleProvider"
+
+    # Qwen: Anthropic with budget thinking
+    provider = create_model_provider(opencode_go, model="qwen3.7-max", thinking_level="high")
+    assert type(provider).__name__ == "AnthropicProvider"
+    assert provider._config.thinking_mode == "budget"
+    assert provider._config.thinking_budget_tokens == 8192
+
+    # MiniMax M3: Anthropic with adaptive toggle
+    provider = create_model_provider(opencode_go, model="minimax-m3", thinking_level="high")
+    assert type(provider).__name__ == "AnthropicProvider"
+    assert provider._config.thinking_mode == "adaptive"
+    assert provider._config.thinking_budget_tokens is None
+
+    # MiniMax M3 off: disabled
+    provider = create_model_provider(opencode_go, model="minimax-m3", thinking_level="off")
+    assert provider._config.thinking_mode == "disabled"
+
+    # Always-on model: no thinking controls
+    provider = create_model_provider(opencode_go, model="minimax-m2.7")
+    assert type(provider).__name__ == "AnthropicProvider"
+    assert provider._config.thinking_budget_tokens is None
+    assert provider._config.thinking_effort is None
+
+
+def test_opencode_go_zen_base_url_overrides() -> None:
+    """Free models and some Go models route to Zen v1 or v2 endpoints."""
+    entry = builtin_provider_entry("opencode-go")
+    assert entry is not None
+
+    # Zen v1 models
+    assert entry.model_metadata["big-pickle"].base_url == "https://opencode.ai/zen/v1"
+    assert entry.model_metadata["deepseek-v4-flash-free"].base_url == "https://opencode.ai/zen/v1"
+    assert entry.model_metadata["hy3-free"].base_url == "https://opencode.ai/zen/v1"
+
+    # Go models use provider base_url (zen/go/v1) - no model_metadata override
+    assert (
+        entry.model_metadata.get("deepseek-v4-pro") is None
+        or entry.model_metadata["deepseek-v4-pro"].base_url is None
+    )
+
+
+def test_opencode_go_always_on_models_detected() -> None:
+    from tau_coding.provider_config import ProviderSettings, provider_thinking_is_always_on
+
+    settings = ProviderSettings()
+    opencode_go = settings.get_provider("opencode-go")
+
+    assert provider_thinking_is_always_on(opencode_go, model="minimax-m2.7") is True
+    assert provider_thinking_is_always_on(opencode_go, model="glm-5.1") is True
+    assert provider_thinking_is_always_on(opencode_go, model="kimi-k2.7-code") is True
+    assert provider_thinking_is_always_on(opencode_go, model="big-pickle") is True
+
+    # Models with configurable thinking are not always-on
+    assert provider_thinking_is_always_on(opencode_go, model="minimax-m3") is False
+    assert provider_thinking_is_always_on(opencode_go, model="qwen3.7-max") is False
+    assert provider_thinking_is_always_on(opencode_go, model="deepseek-v4-pro") is False

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1324,3 +1324,51 @@ def test_openai_compatible_provider_config_rejects_invalid_retries() -> None:
         OpenAICompatibleProviderConfig(name="local", max_retries=-1)
     with pytest.raises(ProviderConfigError, match="0 or greater"):
         OpenAICompatibleProviderConfig(name="local", max_retry_delay_seconds=-1)
+
+
+# --- Thinking level label tests ---
+
+
+def test_thinking_level_labels_from_model_metadata() -> None:
+    """Model-specific thinking_level_labels override canonical level names."""
+    from tau_coding.provider_config import (
+        ProviderSettings,
+        provider_thinking_level_label,
+    )
+
+    settings = ProviderSettings()
+    opencode_go = settings.get_provider("opencode-go")
+
+    # deepseek-v4-pro: xhigh -> "max"
+    assert provider_thinking_level_label(opencode_go, "xhigh", model="deepseek-v4-pro") == "max"
+    assert provider_thinking_level_label(opencode_go, "high", model="deepseek-v4-pro") == "high"
+
+    # minimax-m3: high -> "on", off -> "off"
+    assert provider_thinking_level_label(opencode_go, "high", model="minimax-m3") == "on"
+    assert provider_thinking_level_label(opencode_go, "off", model="minimax-m3") == "off"
+
+    # qwen3.7-max: no custom labels, returns canonical
+    assert provider_thinking_level_label(opencode_go, "high", model="qwen3.7-max") == "high"
+    assert provider_thinking_level_label(opencode_go, "xhigh", model="qwen3.7-max") == "xhigh"
+
+
+def test_provider_model_metadata_thinking_parameter_roundtrip() -> None:
+    """thinking_parameter survives JSON serialization and catalog reload."""
+    from tau_coding.provider_config import ProviderSettings
+
+    settings = ProviderSettings()
+    opencode_go = settings.get_provider("opencode-go")
+
+    # Verify thinking_parameter is preserved in model metadata
+    minimax_m3_metadata = opencode_go.model_metadata.get("minimax-m3")
+    assert minimax_m3_metadata is not None
+    assert minimax_m3_metadata.thinking_parameter == "anthropic.thinking"
+
+    qwen_metadata = opencode_go.model_metadata.get("qwen3.7-max")
+    assert qwen_metadata is not None
+    assert qwen_metadata.thinking_parameter == "anthropic.thinking"
+
+    # OpenAI-compatible models have no model-level thinking_parameter
+    deepseek_metadata = opencode_go.model_metadata.get("deepseek-v4-pro")
+    assert deepseek_metadata is not None
+    assert deepseek_metadata.thinking_parameter is None


### PR DESCRIPTION
**Note**: This PR is a continuation of the original #284, which was accidentally closed during a refactor of the personal fork. This is the same branch and changeset.

Upd: needed to isolate the branch with this commit, hence had to reopen. The old PR is [here](https://github.com/huggingface/tau/pull/188).

This PR adds OpenCode Go as a provider along with all 13 models it currently offers.

The settings for each models are cross-referenced with [Anomalyco's own model declarations](https://github.com/anomalyco/models.dev/tree/dev/providers/opencode-go/models).

Caveat: OpenCode Go serves different models through different API shapes. Because of that, the PR adds support for model-scoped provider overrides, like transport kind (Anthropic/OpenAI), thinking levels, defaults, display labels, API values, and always-on reasoning. The point is to keep the UI honest: we don't show thinking levels that can't actually be selected, or do something else entirely.

For example, Qwen models send Anthropic-style budgeted thinking and can explicitly disable reasoning, MiniMax M3 uses adaptive/disabled, while DeepSeek/GLM effort models expose only the supported high/max levels.

Always-reasoning models do not show a selector, and Tau sends no fake reasoning control for them.

I tried to keep the changes provider-agnostic, so they can be reused for other mixed-behavior catalogs. For example, DeepSeek R1 on OpenRouter.