### PR TITLE
Bundle Tau self-knowledge and improve the system prompt

### DIFF
--- a/dev-notes/architecture/bundled-self-knowledge.md
+++ b/dev-notes/architecture/bundled-self-knowledge.md
@@ -1,0 +1,41 @@
+# Bundled Tau self-knowledge
+
+Tau now follows Pi's progressive-disclosure approach to product knowledge. The default system prompt identifies installed documentation and examples, while first-party skills provide detailed contributor workflows only when a task matches.
+
+## What changed
+
+Packaged resources now live under `src/tau_coding/data/`:
+
+```text
+docs/       concise routing references for Tau topics
+examples/   readable extension examples
+skills/     first-party Agent Skills
+```
+
+The prompt mirrors Pi's documentation block, adapted to Tau's Python architecture and published concepts. It points to extensions, skills, models, CLI commands, TUI behavior, and architecture without injecting those documents into every request. The default guidelines also add general coding discipline for inspecting project instructions, preserving unrelated work, using repository-native commands, validating changes, reporting checks honestly, and asking before destructive or materially ambiguous operations.
+
+Two skills ship initially:
+
+- `create-tau-extension`
+- `tau-model-catalog`
+
+Bundled skills have the lowest precedence. User and project skills can override them by name, preserving Tau's existing resource precedence model.
+
+## Why
+
+The old prompt knew how to operate tools but did not tell the model where Tau's own APIs and workflows were documented. Repository `AGENTS.md` helped only when Tau was running inside its source checkout. Installed Tau sessions now retain product knowledge without bloating the base prompt, and general coding tasks remain governed by project context and task-specific skills.
+
+## Architecture
+
+Self-documentation belongs to `tau_coding`, not the portable `tau_agent` harness. `self_docs.py` resolves installed resource paths, `resources.py` includes bundled skills before filesystem resources, and `system_prompt.py` emits Pi-style routing hints. Hatch packages the resources as part of `tau_coding`.
+
+## Verification
+
+```bash
+uv run pytest tests/test_system_prompt.py tests/test_skills.py tests/test_resources.py tests/test_package_metadata.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+cd website && hugo --minify && npx --yes pagefind@latest --site public
+```

--- a/dev-notes/architecture/phase-10-system-prompt.md
+++ b/dev-notes/architecture/phase-10-system-prompt.md
@@ -61,6 +61,12 @@ Guidelines:
 
 Guidelines are de-duplicated in deterministic order.
 
+The default prompt also mirrors Pi's progressive-disclosure documentation block,
+adapted for Tau. It points to packaged Tau docs and examples for extensions,
+skills, providers/models, commands, TUI behavior, and architecture, and tells the
+model to read them only for Tau-specific questions. Custom prompts still replace
+this default documentation block.
+
 ## Custom prompts
 
 If `custom_prompt` is supplied, it replaces the default Tau identity, tools, and guidelines sections.

--- a/src/tau_coding/data/docs/README.md
+++ b/src/tau_coding/data/docs/README.md
@@ -1,0 +1,12 @@
+# Tau documentation
+
+Tau is a minimalist Python coding-agent harness inspired by Pi. Use these installed references when a user asks how to configure, extend, or contribute to Tau.
+
+- [Extensions](extensions.md): build Python extensions, custom tools, commands, hooks, dialogs, and renderers.
+- [Skills](skills.md): install reusable task knowledge and prompt templates.
+- [Models](models.md): configure providers and models or change Tau's built-in catalog.
+- [CLI](cli.md): command-line and slash-command entry points.
+- [TUI](tui.md): interactive interface behavior.
+- [Architecture](architecture.md): package boundaries and contributor design rules.
+
+Read only the references relevant to the task, then follow their links and the active project's instructions.

--- a/src/tau_coding/data/docs/architecture.md
+++ b/src/tau_coding/data/docs/architecture.md
@@ -1,0 +1,19 @@
+# Tau architecture
+
+Tau preserves Pi's separation of concerns:
+
+```text
+AgentHarness = reusable agent brain
+AgentSession = coding-agent environment
+TUI = one possible frontend
+```
+
+Packages:
+
+- `tau_ai`: provider/model streaming and provider-neutral events.
+- `tau_agent`: portable harness, loop, tools, messages, events, and sessions.
+- `tau_coding`: CLI application, resources, skills, extensions, commands, persistence, rendering, and TUI integration.
+
+Keep `tau_agent` independent of Typer, Rich, Textual, application resource locations, and provider-specific assumptions. Prefer typed data models, explicit async boundaries, deterministic fakes, and small abstractions.
+
+In a Tau checkout, read `AGENTS.md`, `website/content/internals/architecture.md`, and relevant `dev-notes/architecture/` documents before broad architectural changes.

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -1,0 +1,11 @@
+# Tau CLI and commands
+
+Tau supports print mode and a Textual interactive TUI. The CLI entry point is `tau_coding.cli:app`.
+
+For current user-facing behavior in a Tau checkout, read:
+
+- `website/content/reference/cli.md`
+- `website/content/reference/slash-commands.md`
+- `src/tau_coding/commands.py`
+
+Keep command parsing and application-specific resource loading in `tau_coding`, not the reusable `tau_agent` harness. When changing behavior, test both command results and the relevant print/TUI integration, then update published reference documentation.

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -1,0 +1,29 @@
+# Tau extensions
+
+Tau extensions are Python modules that can register custom tools and slash commands, observe lifecycle events, intercept tool calls and results, show UI dialogs, and customize message rendering.
+
+## Start here
+
+For complete API documentation, read the repository's published guide when working in a Tau checkout:
+
+- `website/content/guides/extensions.md`
+- `dev-notes/architecture/phase-21-extensions.md`
+
+Installed examples are under `examples/extensions/` next to these docs. Read the relevant example completely before implementing an extension.
+
+## Locations
+
+- `~/.tau/extensions/`: discovered by default.
+- `<project>/.tau/extensions/`: enabled explicitly with `--project-extensions`.
+- `tau -x PATH`: explicitly load a file or directory.
+
+An extension defines `setup(tau)`. Project extensions execute arbitrary Python and are disabled by default; enable only trusted repositories.
+
+## Development checklist
+
+1. Confirm the requested capability exists in the extension API before inventing a workaround.
+2. Keep extension behavior out of `tau_agent`; extensions belong to `tau_coding`.
+3. Use `tau_agent` types for portable messages and tools, and keep Textual behind Tau's UI adapter APIs.
+4. Start from the closest installed example.
+5. Add deterministic tests with fake providers/tools when changing Tau's extension implementation.
+6. Run the repository's documented tests, Ruff checks, formatting, and mypy.

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -1,0 +1,27 @@
+# Tau providers and models
+
+Tau separates provider/model streaming (`tau_ai`), the portable harness (`tau_agent`), and application configuration (`tau_coding`).
+
+## User configuration
+
+Use `/login` and `/model` for built-in providers. The custom-provider flow supports OpenAI-compatible endpoints. Durable provider settings live under Tau's home directory; consult the published `website/content/guides/providers-and-models.md` in a Tau checkout for the current schema and authentication behavior.
+
+## Changing the built-in catalog
+
+Use the bundled `tau-model-catalog` skill when adding or updating a first-party model/provider. The source of truth is:
+
+```text
+src/tau_coding/data/catalog.toml
+```
+
+Do not guess model IDs, context limits, modalities, reasoning values, output limits, or pricing. Verify them in official provider documentation. Confirm Tau supports the transport before adding a provider. Preserve existing defaults unless a change is intentional.
+
+Relevant tests usually include:
+
+```text
+tests/test_provider_catalog.py
+tests/test_provider_config.py
+tests/test_provider_runtime.py
+```
+
+Update published provider docs and add a development note for substantial user-facing changes.

--- a/src/tau_coding/data/docs/skills.md
+++ b/src/tau_coding/data/docs/skills.md
@@ -1,0 +1,29 @@
+# Tau skills and prompt templates
+
+Skills provide reusable task knowledge. Prompt templates save prompts that users invoke by name.
+
+## Skills
+
+A skill follows the Agent Skills structure:
+
+```text
+<skills-dir>/<skill-name>/SKILL.md
+```
+
+Tau loads skills in increasing precedence:
+
+1. first-party skills bundled with Tau
+2. `~/.tau/skills/`
+3. `~/.agents/skills/`
+4. `<cwd>/.tau/skills/`
+5. `<cwd>/.agents/skills/`
+
+A higher-precedence skill with the same name overrides the lower one. Tau places only each skill's name, description, and path in the system prompt; the model reads the full file when its description matches the task. Use `/skill:<name>` for explicit invocation.
+
+## Prompt templates
+
+Templates load from user and project `.tau/prompts/` and `.agents/prompts/` directories. They are prompt shortcuts, not background knowledge, and may contain `{{ variable }}` placeholders.
+
+Use a skill for reference know-how and a template for a frequently repeated prompt. Run `/reload` after changing resources in an active TUI session.
+
+When modifying Tau's resource system, read `src/tau_coding/skills.py`, `src/tau_coding/resources.py`, and `website/content/guides/skills-and-prompts.md`, then test discovery, precedence, diagnostics, prompt formatting, and reload behavior.

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -1,0 +1,11 @@
+# Tau TUI
+
+Tau's full interactive interface uses Textual behind an adapter boundary. `tau_agent` emits provider-neutral events; `tau_coding.tui` consumes and renders them.
+
+For current behavior in a Tau checkout, read:
+
+- `website/content/guides/tui.md`
+- `website/content/reference/keybindings.md`
+- `src/tau_coding/tui/`
+
+Do not introduce Textual dependencies into `tau_agent`. Keep reusable behavior in the harness/session layers and UI behavior in the adapter. Use Textual pilot tests and fake providers for deterministic interaction tests.

--- a/src/tau_coding/data/examples/extensions/hello_tool.py
+++ b/src/tau_coding/data/examples/extensions/hello_tool.py
@@ -1,0 +1,41 @@
+"""Minimal Tau extension that registers a custom tool."""
+
+from collections.abc import Mapping
+
+from tau_agent.messages import TextContent
+from tau_agent.tools import (
+    AgentTool,
+    AgentToolResult,
+    ToolCancellationToken,
+    ToolUpdateCallback,
+)
+from tau_agent.types import JSONValue
+from tau_coding.extensions import ExtensionAPI
+
+
+async def _run_hello(
+    tool_call_id: str,
+    arguments: Mapping[str, JSONValue],
+    signal: ToolCancellationToken | None = None,
+    on_update: ToolUpdateCallback | None = None,
+) -> AgentToolResult:
+    del tool_call_id, signal, on_update
+    who = str(arguments.get("who", "world"))
+    return AgentToolResult(content=[TextContent(text=f"Hello, {who}!")])
+
+
+def setup(tau: ExtensionAPI) -> None:
+    """Register the hello tool."""
+    tau.register_tool(
+        AgentTool(
+            name="hello",
+            label="hello",
+            description="Greet someone by name.",
+            parameters={
+                "type": "object",
+                "properties": {"who": {"type": "string"}},
+            },
+            execute_fn=_run_hello,
+            prompt_snippet="Greet someone by name.",
+        )
+    )

--- a/src/tau_coding/data/skills/create-tau-extension/SKILL.md
+++ b/src/tau_coding/data/skills/create-tau-extension/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: create-tau-extension
+description: Create or modify a Tau Python extension with custom tools, commands, hooks, dialogs, or message rendering. Use for Tau extension requests.
+---
+
+# Create a Tau extension
+
+1. Read the installed `docs/extensions.md` and the closest example under `examples/extensions/` relative to Tau's packaged documentation paths in the system prompt.
+2. In a Tau checkout, also read `website/content/guides/extensions.md` and the relevant extension API implementation before coding.
+3. Put user extensions in `~/.tau/extensions/`; project extensions require explicit trust through `--project-extensions`. Use `tau -x PATH` for isolated testing.
+4. Define `setup(tau)` and use documented registration APIs. Do not reach into private session or Textual internals.
+5. Keep portable tool/message types in `tau_agent`; keep application and UI integration in `tau_coding`.
+6. For Tau core changes, add deterministic tests with fake providers/tools and cover reload/lifecycle behavior when applicable.
+7. Run relevant focused tests followed by `uv run pytest`, Ruff lint, Ruff format check, and mypy.
+8. Update `website/content/guides/extensions.md` and add a development note for user-facing architectural changes.
+
+Never enable an untrusted project extension: extensions execute arbitrary Python in the Tau process.

--- a/src/tau_coding/data/skills/tau-model-catalog/SKILL.md
+++ b/src/tau_coding/data/skills/tau-model-catalog/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tau-model-catalog
+description: Add or update models and providers in Tau's built-in catalog, including verified metadata, reasoning mappings, tests, documentation, and validation.
+---
+
+# Tau model catalog
+
+Use this workflow for changes to Tau's built-in providers or models. Keep discovery focused.
+
+## Relevant files
+
+- `src/tau_coding/data/catalog.toml`: source of truth.
+- `tests/test_provider_catalog.py`: golden metadata tests.
+- `tests/test_provider_config.py`: thinking and request-config mappings.
+- `tests/test_provider_runtime.py`: runtime construction when transport changes.
+- `website/content/guides/providers-and-models.md`: published setup docs.
+- `dev-notes/catalog-model-safety.md`: validation guidance.
+- `src/tau_coding/data/release-notes/releases.json`: inspect; update only when appropriate.
+
+## Workflow
+
+1. Decide whether this is a model on an existing provider or a new provider.
+2. Read official provider/API documentation and verify the exact model ID, endpoint, transport, authentication, context window, modalities, output limit, reasoning values, pricing, and plan restrictions.
+3. Never guess undocumented metadata. Omit optional values or preserve existing defaults.
+4. Confirm Tau supports the API transport before adding a provider.
+5. Preserve the existing `default_model` unless changing it is intentional.
+6. Match nearby TOML compatibility metadata.
+
+Use focused searches rather than repository-wide model dumps:
+
+```bash
+rg -n 'name = "<provider>"|<model-id>' src/tau_coding/data/catalog.toml
+rg -n '<provider>|<model-id>' tests/test_provider_catalog.py tests/test_provider_config.py tests/test_provider_runtime.py
+rg -n '<provider>|<model-name>' website/content/guides/providers-and-models.md dev-notes/
+```
+
+## Thinking mappings
+
+Tau levels are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Provider-level `thinking_levels` must include every level needed by its models. Use model metadata when the wire value differs or a model supports only a subset:
+
+```toml
+thinking_level_map = { xhigh = "max" }
+unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
+```
+
+Test both the exposed levels and the actual API value produced by provider configuration.
+
+## Verification
+
+Add tests for provider membership, context/metadata, thinking filtering, wire mapping, and intentionally preserved defaults. Run:
+
+```bash
+uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py tests/test_provider_runtime.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+cd website && hugo --minify && npx --yes pagefind@latest --site public
+```
+
+Update published docs and add a beginner-friendly development note for substantial behavior. Link authoritative documentation and mention plan-dependent limits. Report any check that cannot run and why.

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
+from tau_coding.self_docs import tau_builtin_skills_path
 
 
 class ResourceError(ValueError):
@@ -67,7 +68,7 @@ class TauResourcePaths:
         ``README.md``, ``AGENTS.md``, etc.).
         """
         paths = self._paths()
-        dirs = [self.skills_dir]
+        dirs = [tau_builtin_skills_path(), self.skills_dir]
         if self.agents_root is not None:
             dirs.append(self.agents_root / "skills")
         if self.cwd is not None:

--- a/src/tau_coding/self_docs.py
+++ b/src/tau_coding/self_docs.py
@@ -1,0 +1,28 @@
+"""Locations of Tau's packaged self-documentation and examples."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_DATA_ROOT = _PACKAGE_ROOT / "data"
+
+
+def tau_readme_path() -> Path:
+    """Return the installed overview document for Tau-aware tasks."""
+    return _DATA_ROOT / "docs" / "README.md"
+
+
+def tau_docs_path() -> Path:
+    """Return the installed Tau self-documentation directory."""
+    return _DATA_ROOT / "docs"
+
+
+def tau_examples_path() -> Path:
+    """Return the installed Tau example directory."""
+    return _DATA_ROOT / "examples"
+
+
+def tau_builtin_skills_path() -> Path:
+    """Return the directory containing first-party Tau skills."""
+    return _DATA_ROOT / "skills"

--- a/src/tau_coding/system_prompt.py
+++ b/src/tau_coding/system_prompt.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from xml.sax.saxutils import escape
 
 from tau_agent.tools import AgentTool
+from tau_coding.self_docs import tau_docs_path, tau_examples_path, tau_readme_path
 from tau_coding.skills import Skill
 
 
@@ -57,6 +58,7 @@ def build_system_prompt(options: BuildSystemPromptOptions) -> str:
         "\n\nIn addition to the tools above, you may have access to other custom tools "
         "depending on the project."
         f"\n\nGuidelines:\n{format_guidelines(options.tools, options.extra_guidelines)}"
+        f"\n\n{format_tau_documentation()}"
     )
 
     prompt += append_section
@@ -66,6 +68,29 @@ def build_system_prompt(options: BuildSystemPromptOptions) -> str:
     prompt += f"\nCurrent date: {current_date.isoformat()}"
     prompt += f"\nCurrent working directory: {cwd}"
     return prompt
+
+
+def format_tau_documentation() -> str:
+    """Format Pi-style routing hints to Tau's installed reference material."""
+    readme_path = _format_path(tau_readme_path())
+    docs_path = _format_path(tau_docs_path())
+    examples_path = _format_path(tau_examples_path())
+    return (
+        "Tau documentation (read only when the user asks about Tau itself, its SDK, "
+        "extensions, skills, providers, models, commands, or TUI):\n"
+        f"- Main documentation: {readme_path}\n"
+        f"- Additional docs: {docs_path}\n"
+        f"- Examples: {examples_path} (extensions and custom tools)\n"
+        "- When reading Tau docs or examples, resolve docs/... under Additional docs and "
+        "examples/... under Examples, not the current working directory\n"
+        "- When asked about: extensions (docs/extensions.md, examples/extensions/), "
+        "skills and prompt templates (docs/skills.md), providers and adding models "
+        "(docs/models.md), CLI and slash commands (docs/cli.md), TUI usage "
+        "(docs/tui.md), Tau architecture and packages (docs/architecture.md)\n"
+        "- When working on Tau topics, read the docs and examples, and follow .md "
+        "cross-references before implementing\n"
+        "- Always read relevant Tau .md files completely and follow links to related docs"
+    )
 
 
 def format_available_tools(tools: Sequence[AgentTool]) -> str:
@@ -104,6 +129,13 @@ def collect_prompt_guidelines(
     for guideline in extra_guidelines:
         add(guideline)
 
+    add("Inspect relevant files and project instructions before editing")
+    add("Make focused changes that preserve the project's architecture and style")
+    add("Do not overwrite or discard unrelated user changes")
+    add("Use the project's documented commands and package manager")
+    add("Run relevant tests, formatting, linting, and type checks after changes")
+    add("Report checks honestly; never claim a command passed unless you ran it")
+    add("Ask before destructive operations or materially ambiguous design choices")
     add("Be concise in your responses")
     add("Show file paths clearly when working with files")
     return guidelines

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from tau_coding.provider_config import (
 )
 from tau_coding.rendering import PrintOutputMode
 from tau_coding.resources import TauResourcePaths
+from tau_coding.skills import load_skills
 from tau_coding.system_prompt import BuildSystemPromptOptions, build_system_prompt
 from tau_coding.tools import create_coding_tools
 from tau_coding.update_check import (
@@ -335,8 +336,13 @@ async def test_run_print_mode_prints_final_assistant_text(
     assert captured.out == "Hello\n"
     assert captured.err == ""
     assert provider.calls[0][0] == "fake"
+    resource_paths = TauResourcePaths(root=tmp_path / "resources", agents_root=None)
     assert provider.calls[0][1] == build_system_prompt(
-        BuildSystemPromptOptions(cwd=tmp_path, tools=create_coding_tools(cwd=tmp_path))
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            tools=create_coding_tools(cwd=tmp_path),
+            skills=load_skills(resource_paths),
+        )
     )
     assert [tool.name for tool in provider.calls[0][3]] == ["read", "write", "edit", "bash"]
 
@@ -359,7 +365,11 @@ async def test_run_print_mode_system_command_prints_prompt_without_provider_call
 
     captured = capsys.readouterr()
     expected_system = build_system_prompt(
-        BuildSystemPromptOptions(cwd=tmp_path, tools=create_coding_tools(cwd=tmp_path))
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            tools=create_coding_tools(cwd=tmp_path),
+            skills=load_skills(TauResourcePaths(root=tmp_path / "resources", agents_root=None)),
+        )
     )
     assert ok is True
     assert captured.out == f"{expected_system}\n"

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1969,7 +1969,11 @@ async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
 
     _events = await _collect_session_events(session.prompt("/skill:testing add tests"))
 
-    assert [skill.name for skill in session.skills] == ["testing"]
+    assert {skill.name for skill in session.skills} == {
+        "create-tau-extension",
+        "tau-model-catalog",
+        "testing",
+    }
     assert '<skill name="testing" location="' in provider.calls[0][2][0].content
     assert "References are relative to" in provider.calls[0][2][0].content
     assert provider.calls[0][2][0].content.endswith("</skill>\n\nadd tests")
@@ -2186,7 +2190,7 @@ async def test_session_loads_with_resource_diagnostics_instead_of_failing(
 
     session = await CodingSession.load(config)
 
-    assert [skill.name for skill in session.skills] == ["good"]
+    assert "good" in {skill.name for skill in session.skills}
     assert len(session.resource_diagnostics) == 1
     assert (
         "bare .md files are no longer treated as skills" in session.resource_diagnostics[0].message
@@ -2215,7 +2219,10 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
             resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
         )
     )
-    assert session.skills == ()
+    assert {skill.name for skill in session.skills} == {
+        "create-tau-extension",
+        "tau-model-catalog",
+    }
     assert session.context_files == ()
 
     skills_dir = resource_root / "skills" / "testing"
@@ -2233,11 +2240,15 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
     entries_after = await storage.read_all()
     _events = await _collect_session_events(session.prompt("Hello"))
 
-    assert summary.skills.after == 1
+    assert summary.skills.after == 3
     assert summary.context_files.after == 1
     assert summary.system_prompt_rebuilt is True
     assert entries_after == entries_before
-    assert [skill.name for skill in session.skills] == ["testing"]
+    assert {skill.name for skill in session.skills} == {
+        "create-tau-extension",
+        "tau-model-catalog",
+        "testing",
+    }
     assert [Path(context_file.path).name for context_file in session.context_files] == ["AGENTS.md"]
     assert "Reloaded project rules." in provider.calls[0][1]
     assert "<name>testing</name>" in provider.calls[0][1]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -7,6 +7,13 @@ from zipfile import ZipFile
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_NOTES_SOURCE_PATH = ROOT / "src" / "tau_coding" / "data" / "release-notes" / "releases.json"
 RELEASE_NOTES_WHEEL_PATH = "tau_coding/data/release-notes/releases.json"
+BUILTIN_RESOURCE_WHEEL_PATHS = {
+    "tau_coding/data/docs/README.md",
+    "tau_coding/data/docs/extensions.md",
+    "tau_coding/data/examples/extensions/hello_tool.py",
+    "tau_coding/data/skills/create-tau-extension/SKILL.md",
+    "tau_coding/data/skills/tau-model-catalog/SKILL.md",
+}
 
 
 def test_python_version_floor_matches_package_metadata() -> None:
@@ -47,3 +54,4 @@ def test_wheel_includes_release_notes_package_data(tmp_path: Path) -> None:
         wheel_files = set(wheel.namelist())
 
     assert RELEASE_NOTES_WHEEL_PATH in wheel_files
+    assert wheel_files >= BUILTIN_RESOURCE_WHEEL_PATHS

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,9 @@ def test_resource_paths_use_tau_subdirectories(tmp_path: Path) -> None:
 
     assert paths.skills_dir == tmp_path / "skills"
     assert paths.prompts_dir == tmp_path / "prompts"
-    assert paths.skills_dirs == (tmp_path / "skills",)
+    assert paths.skills_dirs[1:] == (tmp_path / "skills",)
+    assert paths.skills_dirs[0].name == "skills"
+    assert paths.skills_dirs[0].parent.name == "data"
     assert paths.prompts_dirs == (tmp_path / "prompts",)
 
 
@@ -24,7 +26,7 @@ def test_resource_paths_include_agents_and_project_directories(tmp_path: Path) -
         paths=TauPaths(home=tau_home, agents_home=agents_home),
     )
 
-    assert paths.skills_dirs == (
+    assert paths.skills_dirs[1:] == (
         tau_home / "skills",
         agents_home / "skills",
         cwd / ".tau" / "skills",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -15,8 +15,11 @@ from tau_coding import (
 from tau_coding.resources import ResourceError
 
 
-def test_load_skills_missing_directory_returns_empty(tmp_path: Path) -> None:
-    assert load_skills(TauResourcePaths(root=tmp_path, agents_root=None)) == []
+def test_load_skills_includes_bundled_first_party_skills(tmp_path: Path) -> None:
+    skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
+
+    assert [skill.name for skill in skills] == ["create-tau-extension", "tau-model-catalog"]
+    assert all("tau_coding/data/skills" in skill.path.as_posix() for skill in skills)
 
 
 def test_load_skills_from_directory(tmp_path: Path) -> None:
@@ -34,9 +37,15 @@ def test_load_skills_from_directory(tmp_path: Path) -> None:
 
     skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
 
-    assert [skill.name for skill in skills] == ["git-review", "python-testing"]
-    assert skills[0].description == "Git Review"
-    assert skills[1].description == "Test Python code"
+    skill_by_name = {skill.name: skill for skill in skills}
+    assert set(skill_by_name) == {
+        "create-tau-extension",
+        "git-review",
+        "python-testing",
+        "tau-model-catalog",
+    }
+    assert skill_by_name["git-review"].description == "Git Review"
+    assert skill_by_name["python-testing"].description == "Test Python code"
 
 
 def test_load_skills_includes_user_and_project_agents_directories(tmp_path: Path) -> None:
@@ -55,7 +64,31 @@ def test_load_skills_includes_user_and_project_agents_directories(tmp_path: Path
 
     skills = load_skills(TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd))
 
-    assert [skill.name for skill in skills] == ["project-skill", "user-skill"]
+    assert {skill.name for skill in skills} == {
+        "create-tau-extension",
+        "project-skill",
+        "tau-model-catalog",
+        "user-skill",
+    }
+
+
+def test_user_skill_overrides_bundled_skill(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "tau-model-catalog"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("# Custom catalog workflow", encoding="utf-8")
+
+    skills, diagnostics = load_skills_with_diagnostics(
+        TauResourcePaths(root=tmp_path, agents_root=None)
+    )
+
+    catalog_skill = next(skill for skill in skills if skill.name == "tau-model-catalog")
+    assert catalog_skill.path == skill_path
+    assert any(
+        diagnostic.name == "tau-model-catalog"
+        and "overrides lower-precedence resource" in diagnostic.message
+        for diagnostic in diagnostics
+    )
 
 
 def test_project_agents_skill_overrides_user_agents_skill(tmp_path: Path) -> None:
@@ -72,9 +105,9 @@ def test_project_agents_skill_overrides_user_agents_skill(tmp_path: Path) -> Non
 
     skills = load_skills(TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd))
 
-    assert len(skills) == 1
-    assert skills[0].path == cwd / ".agents" / "skills" / "review" / "SKILL.md"
-    assert skills[0].description == "Project Review"
+    review = next(skill for skill in skills if skill.name == "review")
+    assert review.path == cwd / ".agents" / "skills" / "review" / "SKILL.md"
+    assert review.description == "Project Review"
 
 
 def test_load_skills_with_diagnostics_reports_overrides(tmp_path: Path) -> None:
@@ -92,8 +125,8 @@ def test_load_skills_with_diagnostics_reports_overrides(tmp_path: Path) -> None:
         TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd)
     )
 
-    assert [skill.name for skill in skills] == ["review"]
-    assert skills[0].path == cwd / ".tau" / "skills" / "review" / "SKILL.md"
+    review = next(skill for skill in skills if skill.name == "review")
+    assert review.path == cwd / ".tau" / "skills" / "review" / "SKILL.md"
     override_diagnostics = [
         d for d in diagnostics if "overrides lower-precedence resource" in d.message
     ]
@@ -120,7 +153,7 @@ def test_load_skills_with_diagnostics_reports_bare_md_migration_hint(
         TauResourcePaths(root=tmp_path, agents_root=None)
     )
 
-    assert [skill.name for skill in skills] == ["good"]
+    assert "good" in {skill.name for skill in skills}
     migration_diagnostics = [d for d in diagnostics if d.severity == "info"]
     assert len(migration_diagnostics) == 1
     assert migration_diagnostics[0].name == "legacy"
@@ -143,7 +176,7 @@ def test_agents_root_is_not_a_skills_directory(tmp_path: Path) -> None:
 
     skills = load_skills(TauResourcePaths(root=tmp_path / ".tau", agents_root=agents_home))
 
-    assert skills == []
+    assert {skill.name for skill in skills} == {"create-tau-extension", "tau-model-catalog"}
 
 
 def test_agents_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
@@ -161,7 +194,7 @@ def test_agents_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
     paths = TauResourcePaths(root=tmp_path / ".tau", agents_root=agents_home)
     skills = load_skills(paths)
 
-    assert [s.name for s in skills] == ["my-skill"]
+    assert "my-skill" in {skill.name for skill in skills}
 
 
 def test_tau_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
@@ -178,7 +211,7 @@ def test_tau_skills_dir_ignores_bare_md_files(tmp_path: Path) -> None:
     paths = TauResourcePaths(root=tmp_path, agents_root=None)
     skills = load_skills(paths)
 
-    assert [s.name for s in skills] == ["my-skill"]
+    assert "my-skill" in {skill.name for skill in skills}
 
 
 def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) -> None:
@@ -190,8 +223,9 @@ def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) ->
     expanded = expand_skill_command("/skill:testing add parser tests", skills)
 
     assert expanded is not None
-    assert f'<skill name="testing" location="{skills[0].path}">' in expanded
-    assert f"References are relative to {skills[0].path.parent}." in expanded
+    testing = next(skill for skill in skills if skill.name == "testing")
+    assert f'<skill name="testing" location="{testing.path}">' in expanded
+    assert f"References are relative to {testing.path.parent}." in expanded
     assert "Run pytest." in expanded
     assert expanded.endswith("</skill>\n\nadd parser tests")
 
@@ -255,6 +289,9 @@ def test_build_skill_index(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    assert build_skill_index(load_skills(TauResourcePaths(root=tmp_path, agents_root=None))) == (
-        "Available skills:\n- testing: Test things"
-    )
+    index = build_skill_index(load_skills(TauResourcePaths(root=tmp_path, agents_root=None)))
+
+    assert "Available skills:" in index
+    assert "- create-tau-extension:" in index
+    assert "- tau-model-catalog:" in index
+    assert "- testing: Test things" in index

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -39,6 +39,12 @@ def test_default_prompt_includes_tools_guidelines_date_and_cwd(tmp_path: Path) -
     assert "Available tools:\n- read: Read file contents" in prompt
     assert "- Use bash for file operations like ls, rg, find" in prompt
     assert "- Use read to examine files instead of cat or sed." in prompt
+    assert "- Inspect relevant files and project instructions before editing" in prompt
+    assert "- Do not overwrite or discard unrelated user changes" in prompt
+    assert "- Report checks honestly; never claim a command passed unless you ran it" in prompt
+    assert "Tau documentation (read only when the user asks about Tau itself" in prompt
+    assert "adding models (docs/models.md)" in prompt
+    assert "extensions (docs/extensions.md, examples/extensions/)" in prompt
     assert prompt.endswith(f"Current date: 2026-06-17\nCurrent working directory: {tmp_path}")
 
 
@@ -77,6 +83,7 @@ def test_custom_prompt_replaces_default_but_keeps_append_context_and_date(tmp_pa
 
     assert prompt.startswith("Custom base.\n\nExtra rules.")
     assert "Available tools:" not in prompt
+    assert "Tau documentation" not in prompt
     assert '<project_instructions path="/repo/AGENTS.md">' in prompt
     assert "Follow rules." in prompt
     assert "Current date: 2026-06-17" in prompt

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -13,6 +13,7 @@ Skills are loaded from these locations, in increasing precedence (later
 overrides earlier on name clashes):
 
 ```text
+Tau's bundled first-party skills
 ~/.tau/skills/
 ~/.agents/skills/
 ~/.agents/
@@ -69,6 +70,11 @@ mkdir review && mv review.md review/SKILL.md
 This matches the Agent Skills spec and applies uniformly across `.tau/` and
 `.agents/` locations.
 {{% /tip %}}
+
+Tau ships with first-party `create-tau-extension` and `tau-model-catalog`
+skills so installed copies know the supported workflows for extending Tau and
+maintaining its built-in provider catalog. Define a user or project skill with
+the same name to override the bundled workflow.
 
 Tau lists loaded skills in the system prompt so the model knows they exist and
 can read the full file (via the `read` tool) when relevant. Invoke one


### PR DESCRIPTION
## Summary

- adapt Pi's system-prompt self-documentation block for Tau and add general coding workflow guidelines
- package concise Tau docs and an extension example so installed copies can answer Tau-specific questions without relying on a source checkout
- bundle first-party `create-tau-extension` and `tau-model-catalog` skills at the lowest resource precedence, allowing user/project overrides
- document the bundled-resource behavior and verify wheel packaging

## Testing

- `uv run pytest` (953 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify` (passed with the existing taxonomy layout warning)
- local Pagefind could not download from the configured npm registry because it timed out; CI will run it
- `uv build --wheel` and inspected the wheel for bundled docs, examples, and skills
