### PR TITLE
Fix tests opening Anthropic OAuth browser

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,17 @@
+import webbrowser
 from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def prevent_browser_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail tests that accidentally launch an external browser."""
+
+    def fail_browser_open(url: str, *_args: object, **_kwargs: object) -> bool:
+        pytest.fail(f"Test attempted to open a browser URL: {url}")
+
+    monkeypatch.setattr(webbrowser, "open", fail_browser_open)
 
 
 def isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4618,7 +4618,19 @@ async def test_tui_login_saves_provider_key(
 
 
 @pytest.mark.anyio
-async def test_tui_anthropic_subscription_alias_opens_oauth() -> None:
+async def test_tui_anthropic_subscription_alias_opens_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    login_started = asyncio.Event()
+
+    class FakeOAuthProvider:
+        async def login(self, _callbacks: object) -> OAuthCredential:
+            login_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    fake_provider = FakeOAuthProvider()
+    monkeypatch.setattr(tui_app, "get_oauth_provider", lambda _name: fake_provider)
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -4629,6 +4641,7 @@ async def test_tui_anthropic_subscription_alias_opens_oauth() -> None:
 
         assert isinstance(app.screen, OAuthLoginScreen)
         assert app.screen.provider.name == "anthropic"
+        assert login_started.is_set()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- replace the real Anthropic OAuth provider in the subscription-alias TUI test with a fake provider
- add an autouse pytest guard that fails if any test attempts to launch an external browser
- retain coverage that the Anthropic subscription alias opens and starts the OAuth screen

## Testing

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --minify` (from `website/`)

## Notes

- `npx --yes pagefind@latest --site public` timed out locally during package resolution with no output.
