### PR TITLE
fix: discover Codex context limits at runtime

### DIFF
--- a/dev-notes/architecture/codex-runtime-model-limits.md
+++ b/dev-notes/architecture/codex-runtime-model-limits.md
@@ -1,0 +1,153 @@
+# Codex runtime model limits
+
+Issue: [#389](https://github.com/huggingface/tau/issues/389)
+
+## Production incident
+
+A long-running Tau session used `gpt-5.6-sol` through the `openai-codex` OAuth
+provider. Its last successful request reported roughly 371,440 cached plus
+uncached input tokens. The next request failed with
+`context_length_exceeded`.
+
+Tau had copied the direct OpenAI API's 1.05M context metadata into the Codex
+subscription catalog, so its default compaction threshold was 1,033,616 tokens.
+The request actually went to `https://chatgpt.com/backend-api/codex/responses`,
+where Codex subscription limits are independently configured. Reports from the
+server-delivered Codex catalog showed profiles around 372K and, in later
+rollouts, 272K. Tau therefore never compacted before the real backend ceiling.
+
+This is a serving-surface problem, not a contradiction in the public API model
+page: direct API access and ChatGPT/Codex OAuth can use different limits for the
+same model ID.
+
+## Directions considered
+
+### Hard-code a 500K Codex window
+
+This is deterministic and avoids another startup request, but 500K is a total
+budget often described as 372K input plus 128K output. Tau's old compaction
+formula treated `context_window` as the usable input budget and subtracted only
+16,384 tokens. A 500K entry would therefore compact around 483K, after the
+reported 372K input ceiling, and would not fix the incident.
+
+A lower hard-coded value is useful as a safe fallback. This change uses 272K for
+GPT-5.6 Codex variants, matching the most conservative recently observed Codex
+catalog profile. Direct OpenAI API entries remain 1.05M. Static values alone are
+not the long-term answer because Codex has changed them during rollouts and can
+vary them by account.
+
+### Discover the authenticated Codex catalog
+
+The official Codex client requests:
+
+```text
+GET <codex-base>/models?client_version=<version>
+```
+
+For Tau's default base URL, that resolves to:
+
+```text
+https://chatgpt.com/backend-api/codex/models
+```
+
+The request uses the same refreshed OAuth token, ChatGPT account ID, and
+originator headers as response requests. Model entries can include:
+
+```text
+slug
+context_window
+max_context_window
+effective_context_window_percent
+auto_compact_token_limit
+```
+
+Dynamic discovery reflects the actual serving surface and account. Its drawback
+is that this is a Codex product endpoint rather than the public OpenAI API model
+contract, so its schema or availability can change.
+
+## Decision
+
+Use **dynamic discovery with a conservative static fallback**.
+
+`tau_ai` owns the authenticated request and defensive parsing. It implements the
+optional provider-neutral `ModelLimitsProvider` capability and returns a typed
+`RuntimeModelLimits` value. It ignores malformed entries and caches one catalog
+per provider instance.
+
+`tau_coding` asks for limits when a session loads and again after a provider or
+model switch, before sending the next prompt. It applies the live raw context
+window and either the provider's explicit compaction limit or Codex's 90% raw
+window default. Discovery failures are non-fatal: the configured provider
+catalog remains active and `/session` reports the source and error.
+
+`tau_agent` is unchanged. It receives a ready provider and remains independent
+of OAuth, model catalogs, Tau home paths, and compaction policy.
+
+This first implementation deliberately avoids a persistent live-catalog cache.
+An in-memory cache prevents duplicate requests within one runtime provider;
+every new session gets a fresh account-specific value. A disk cache would need
+an expiry policy, ETag handling, credential/account partitioning, atomic writes,
+and a clear rule for whether stale values are safer than conservative built-in
+fallbacks. Those concerns can be added later without changing the discovery
+protocol.
+
+## Limit semantics
+
+`RuntimeModelLimits` keeps four concepts separate:
+
+- raw context window
+- maximum output tokens, when advertised
+- effective context percentage
+- explicit auto-compaction threshold, when advertised
+
+When no threshold is returned, Tau uses 90% of the raw context window and clamps
+it to the effective window. This mirrors the official Codex client's default and
+leaves headroom for provider framing, tools, instructions, and output.
+
+Tau's character-based usage estimator remains approximate. Earlier compaction
+is intentional near a hard remote limit.
+
+## Failure behavior
+
+Catalog discovery cannot prevent every overflow: the backend can change between
+discovery and a response, or token estimation can undercount provider framing.
+Tau's existing overflow path remains the second line of defense: recognize a
+context overflow, compact older messages, and retry once. Dynamic discovery
+makes the proactive path accurate enough that emergency recovery should be
+rare.
+
+## Testing
+
+Deterministic tests use `httpx.MockTransport` and a fake model-limit provider.
+They cover:
+
+- authenticated Codex model-catalog URL and headers
+- defensive parsing and in-memory caching
+- live context/compaction values in a coding session
+- non-fatal fallback when discovery fails
+- separation between direct API and Codex built-in metadata
+
+Run:
+
+```bash
+uv run pytest tests/test_tau_ai.py tests/test_coding_session.py \
+  tests/test_provider_catalog.py tests/test_provider_runtime.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+cd website && hugo --minify && npx --yes pagefind@latest --site public
+```
+
+## Manual validation
+
+1. Log in with `/login openai-codex`.
+2. Select a GPT-5.6 model.
+3. Start or resume a session.
+4. Run `/session`.
+5. Confirm that `Context window source` is `provider live catalog` and that the
+   displayed limit/compaction threshold match `codex debug models` for the same
+   account.
+6. Block the models request or use invalid discovery data and confirm Tau starts
+   with `configured catalog`, reports the non-fatal discovery failure, and can
+   still send a normal model request.

--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -44,6 +44,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Phase 17.5: TUI Transcript Wrapping](./phase-17-5-transcript-wrapping.md)
 - [Phase 18: Provider Configuration Foundation](./phase-18-provider-config-foundation.md)
 - [Config-driven Provider Catalog](./config-driven-provider-catalog.md)
+- [Codex Runtime Model Limits](./codex-runtime-model-limits.md)
 - [Provider Retry Events](./provider-retries.md)
 - [Provider/model safety and HTTP error details](./provider-model-safety.md)
 - [Phase 19: Project Context Discovery and Reload](./phase-19-context-discovery.md)

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -31,6 +31,7 @@ from tau_ai.events import (
 from tau_ai.fake import FakeProvider
 from tau_ai.google import GoogleGenerativeAIProvider
 from tau_ai.mistral import MistralConversationsProvider
+from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
 from tau_ai.openai_codex import (
     DEFAULT_OPENAI_CODEX_BASE_URL,
     OpenAICodexConfig,

--- a/src/tau_ai/model_limits.py
+++ b/src/tau_ai/model_limits.py
@@ -1,0 +1,48 @@
+"""Optional runtime model-limit discovery contracts for provider adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeModelLimits:
+    """Provider-reported limits for one model on the active serving surface."""
+
+    context_window: int
+    max_output_tokens: int | None = None
+    effective_context_window_percent: int = 100
+    auto_compact_token_limit: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.context_window <= 0:
+            raise ValueError("context_window must be positive")
+        if self.max_output_tokens is not None and self.max_output_tokens <= 0:
+            raise ValueError("max_output_tokens must be positive")
+        if not 1 <= self.effective_context_window_percent <= 100:
+            raise ValueError("effective_context_window_percent must be between 1 and 100")
+        if self.auto_compact_token_limit is not None and self.auto_compact_token_limit <= 0:
+            raise ValueError("auto_compact_token_limit must be positive")
+
+    @property
+    def effective_context_window(self) -> int:
+        """Return the provider's usable window after its requested headroom."""
+        return max(1, self.context_window * self.effective_context_window_percent // 100)
+
+    @property
+    def effective_auto_compact_token_limit(self) -> int:
+        """Return an explicit limit or the Codex-compatible 90% default."""
+        default_limit = max(1, self.context_window * 9 // 10)
+        if self.auto_compact_token_limit is None:
+            return min(default_limit, self.effective_context_window)
+        return min(self.auto_compact_token_limit, self.effective_context_window)
+
+
+@runtime_checkable
+class ModelLimitsProvider(Protocol):
+    """Optional provider capability for serving-surface-specific model limits."""
+
+    async def discover_model_limits(self, model: str) -> RuntimeModelLimits | None:
+        """Return live limits for ``model``, or ``None`` when it is not advertised."""
+        ...

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -39,6 +39,7 @@ from tau_ai.env import (
 from tau_ai.events import AssistantMessageEvent
 from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
+from tau_ai.model_limits import RuntimeModelLimits
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
@@ -71,6 +72,10 @@ class OpenAICodexConfig:
     reasoning_effort: str | None = None
     reasoning_summary: str = "auto"
     provider_name: str = "OpenAI Codex"
+    # The Codex catalog filters models by the official client's compatibility
+    # version. This is the oldest known version that advertises GPT-5.6.
+    client_version: str = "0.144.3"
+    model_catalog_timeout_seconds: float = 5.0
 
 
 class OpenAICodexProvider:
@@ -85,12 +90,39 @@ class OpenAICodexProvider:
         self._config = config
         self._client = client
         self._owns_client = client is None
+        self._discovered_model_limits: dict[str, RuntimeModelLimits] | None = None
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client if this provider created it."""
         if self._client is not None and self._owns_client:
             await self._client.aclose()
             self._client = None
+
+    async def discover_model_limits(self, model: str) -> RuntimeModelLimits | None:
+        """Discover model limits from the authenticated Codex model catalog."""
+        if self._discovered_model_limits is None:
+            self._discovered_model_limits = await self._fetch_model_limits()
+        return self._discovered_model_limits.get(model)
+
+    async def _fetch_model_limits(self) -> dict[str, RuntimeModelLimits]:
+        client = self._get_client()
+        credentials = await self._config.credential_resolver()
+        headers = _build_codex_headers(
+            self._config.headers,
+            access_token=credentials.access_token,
+            account_id=credentials.account_id,
+            originator=self._config.originator,
+        )
+        headers["accept"] = "application/json"
+        headers.pop("content-type", None)
+        response = await client.get(
+            _resolve_codex_models_url(self._config.base_url),
+            params={"client_version": self._config.client_version},
+            headers=headers,
+            timeout=self._config.model_catalog_timeout_seconds,
+        )
+        response.raise_for_status()
+        return _parse_codex_model_limits(response.json())
 
     def stream_response(
         self,
@@ -808,6 +840,50 @@ def _resolve_codex_url(base_url: str) -> str:
     if normalized.endswith("/codex"):
         return f"{normalized}/responses"
     return f"{normalized}/codex/responses"
+
+
+def _resolve_codex_models_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/codex/responses"):
+        return f"{normalized.removesuffix('/responses')}/models"
+    if normalized.endswith("/codex"):
+        return f"{normalized}/models"
+    return f"{normalized}/codex/models"
+
+
+def _parse_codex_model_limits(payload: object) -> dict[str, RuntimeModelLimits]:
+    if not isinstance(payload, Mapping):
+        return {}
+    models = payload.get("models")
+    if not isinstance(models, list):
+        return {}
+
+    parsed: dict[str, RuntimeModelLimits] = {}
+    for item in models:
+        if not isinstance(item, Mapping):
+            continue
+        model = item.get("slug")
+        context_window = _positive_int(item.get("context_window")) or _positive_int(
+            item.get("max_context_window")
+        )
+        if not isinstance(model, str) or not model or context_window is None:
+            continue
+        effective_percent = _positive_int(item.get("effective_context_window_percent")) or 100
+        if effective_percent > 100:
+            continue
+        parsed[model] = RuntimeModelLimits(
+            context_window=context_window,
+            max_output_tokens=_positive_int(item.get("max_output_tokens")),
+            effective_context_window_percent=effective_percent,
+            auto_compact_token_limit=_positive_int(item.get("auto_compact_token_limit")),
+        )
+    return parsed
+
+
+def _positive_int(value: object) -> int | None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value
 
 
 def _split_tool_call_id(value: str) -> tuple[str, str | None]:

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -403,6 +403,12 @@ def _status_command(context: CommandContext) -> CommandResult:
         f"Estimated context tokens: {session.context_token_estimate}",
         f"Context window: {session.context_window_tokens}",
     ]
+    context_window_source = getattr(session, "context_window_source", None)
+    if context_window_source:
+        lines.append(f"Context window source: {context_window_source}")
+    discovery_error = getattr(session, "model_limits_discovery_error", None)
+    if discovery_error:
+        lines.append(f"Model limit discovery: unavailable ({discovery_error})")
     if context_usage is not None:
         lines.append(
             "Context token breakdown: "

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -468,10 +468,12 @@ thinking_default = "medium"
 thinking_parameter = "reasoning.effort"
 
 [providers.context_windows]
-"gpt-5.6" = 1050000
-"gpt-5.6-sol" = 1050000
-"gpt-5.6-terra" = 1050000
-"gpt-5.6-luna" = 1050000
+# Conservative Codex-subscription fallbacks. The authenticated live catalog
+# overrides these values because Codex limits can vary by rollout/account.
+"gpt-5.6" = 272000
+"gpt-5.6-sol" = 272000
+"gpt-5.6-terra" = 272000
+"gpt-5.6-luna" = 272000
 "gpt-5.5" = 272000
 "gpt-5.4" = 272000
 "gpt-5.4-mini" = 400000
@@ -483,7 +485,7 @@ thinking_parameter = "reasoning.effort"
 name = "GPT-5.6"
 reasoning = true
 input = ["text", "image"]
-context_window = 1050000
+context_window = 272000
 max_tokens = 128000
 cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
@@ -493,7 +495,7 @@ unsupported_thinking_levels = ["minimal"]
 name = "GPT-5.6 Sol"
 reasoning = true
 input = ["text", "image"]
-context_window = 1050000
+context_window = 272000
 max_tokens = 128000
 cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
@@ -503,7 +505,7 @@ unsupported_thinking_levels = ["minimal"]
 name = "GPT-5.6 Terra"
 reasoning = true
 input = ["text", "image"]
-context_window = 1050000
+context_window = 272000
 max_tokens = 128000
 cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 3.125 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }
@@ -513,7 +515,7 @@ unsupported_thinking_levels = ["minimal"]
 name = "GPT-5.6 Luna"
 reasoning = true
 input = ["text", "image"]
-context_window = 1050000
+context_window = 272000
 max_tokens = 128000
 cost = { input = 1, output = 6, cacheRead = 0.1, cacheWrite = 1.25 }
 thinking_level_map = { off = "none", xhigh = "xhigh" }

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -39,6 +39,7 @@ from tau_agent.session.jsonl import entry_to_json_line
 from tau_agent.session.tree import SessionTreeError, path_to_entry
 from tau_agent.tools import AgentTool
 from tau_agent.types import JSONValue
+from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
 from tau_coding.branch_summary import summarize_branch_messages_with_model
 from tau_coding.commands import CommandRegistry, CommandResult, create_default_command_registry
 from tau_coding.context import discover_project_context_with_diagnostics
@@ -287,6 +288,9 @@ class CodingSession:
             credentials_path(self._resource_paths.paths) if self._resource_paths.paths else None
         )
         self._last_diagnostic_log_path: Path | None = None
+        self._runtime_model_limits: RuntimeModelLimits | None = None
+        self._runtime_model_limits_key: tuple[str, str] | None = None
+        self._model_limits_discovery_error: str | None = None
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -384,6 +388,7 @@ class CodingSession:
         await session._persist_loaded_interrupted_tool_repairs()
         session._sync_thinking_level_to_active_model()
         session._refresh_runtime_provider()
+        await session._refresh_runtime_model_limits()
         if fresh_extension_runtime:
             extension_runtime.bind(session)
             # Attach to session._harness, not the local `harness`:
@@ -654,15 +659,38 @@ class CodingSession:
             return None
         if self._auto_compact_token_threshold is not None:
             return self._auto_compact_token_threshold
+        if self._runtime_model_limits_key == (self.provider_name, self.model):
+            limits = self._runtime_model_limits
+            if limits is not None:
+                return limits.effective_auto_compact_token_limit
         return auto_compaction_threshold_for_context_window(self.context_window_tokens)
 
     @property
     def context_window_tokens(self) -> int:
-        """Return the active model's configured context window, or Tau's fallback."""
+        """Return the active model's discovered or configured context window."""
+        if self._runtime_model_limits_key == (self.provider_name, self.model):
+            limits = self._runtime_model_limits
+            if limits is not None:
+                return limits.context_window
         provider = self._active_provider_config()
         if provider is None:
             return DEFAULT_CONTEXT_WINDOW_TOKENS
         return provider.context_windows.get(self.model, DEFAULT_CONTEXT_WINDOW_TOKENS)
+
+    @property
+    def context_window_source(self) -> str:
+        """Return where the active context-window limit came from."""
+        if (
+            self._runtime_model_limits_key == (self.provider_name, self.model)
+            and self._runtime_model_limits is not None
+        ):
+            return "provider live catalog"
+        return "configured catalog"
+
+    @property
+    def model_limits_discovery_error(self) -> str | None:
+        """Return the last non-fatal live model-limit discovery error."""
+        return self._model_limits_discovery_error
 
     @property
     def command_registry(self) -> CommandRegistry:
@@ -910,6 +938,7 @@ class CodingSession:
         self._harness.config.provider = provider
         self._provider_name = provider_config.name
         self._runtime_provider_config = provider_config
+        self._invalidate_runtime_model_limits()
         self._harness.config.model = model
         self._thinking_level = thinking_level
         if persist_default:
@@ -1033,6 +1062,27 @@ class CodingSession:
         self._owned_providers.append(provider)
         self._harness.config.provider = provider
         self._runtime_provider_config = provider_config
+        self._invalidate_runtime_model_limits()
+
+    def _invalidate_runtime_model_limits(self) -> None:
+        self._runtime_model_limits = None
+        self._runtime_model_limits_key = None
+        self._model_limits_discovery_error = None
+
+    async def _refresh_runtime_model_limits(self) -> None:
+        key = (self.provider_name, self.model)
+        if self._runtime_model_limits_key == key:
+            return
+        self._runtime_model_limits = None
+        self._runtime_model_limits_key = key
+        self._model_limits_discovery_error = None
+        provider = self._harness.config.provider
+        if not isinstance(provider, ModelLimitsProvider):
+            return
+        try:
+            self._runtime_model_limits = await provider.discover_model_limits(self.model)
+        except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
+            self._model_limits_discovery_error = f"{type(exc).__name__}: {exc}"
 
     async def reload(self) -> CodingReloadSummary:
         """Reload resources and extensions with an awaited lifecycle boundary.
@@ -1466,6 +1516,7 @@ class CodingSession:
                 "CodingSession is already running; pass streaming_behavior to queue a message."
             )
 
+        await self._refresh_runtime_model_limits()
         await self._try_auto_compact(context=context, phase="auto_compact_before_prompt")
         persisted_count = len(self._harness.messages)
         auto_name_attempted = False
@@ -1583,6 +1634,7 @@ class CodingSession:
     async def continue_(self) -> AsyncIterator[CodingSessionEvent]:
         """Continue the agent from restored state and persist new messages."""
         context = self._diagnostic_context()
+        await self._refresh_runtime_model_limits()
         persisted_count = len(self._harness.messages)
         try:
             events = self._harness.continue_()

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -27,7 +27,7 @@ from tau_agent.session import (
     SessionInfoEntry,
     ThinkingLevelChangeEntry,
 )
-from tau_ai import CancellationToken, FakeProvider, ModelProvider
+from tau_ai import CancellationToken, FakeProvider, ModelProvider, RuntimeModelLimits
 from tau_ai.events import AssistantMessageEvent
 from tau_coding import (
     CodingSession,
@@ -85,6 +85,26 @@ class SwitchableFakeProvider:
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class ModelLimitsFakeProvider(FakeProvider):
+    def __init__(
+        self,
+        scripts: list[list[AssistantMessageEvent]],
+        *,
+        limits: RuntimeModelLimits | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(scripts)
+        self.limits = limits
+        self.error = error
+        self.discovery_calls: list[str] = []
+
+    async def discover_model_limits(self, model: str) -> RuntimeModelLimits | None:
+        self.discovery_calls.append(model)
+        if self.error is not None:
+            raise self.error
+        return self.limits
 
 
 class RaisingProvider:
@@ -2513,6 +2533,82 @@ async def test_session_auto_compacts_with_pi_style_default_threshold(
 
     assert len(compactions) == 1
     assert compactions[0].summary == "Default threshold summary"
+
+
+@pytest.mark.anyio
+async def test_session_uses_live_provider_limits_for_compaction_threshold(
+    tmp_path: Path,
+) -> None:
+    provider = ModelLimitsFakeProvider(
+        [],
+        limits=RuntimeModelLimits(
+            context_window=372_000,
+            max_output_tokens=128_000,
+            effective_context_window_percent=95,
+        ),
+    )
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=("gpt-5.6-sol",),
+                default_model="gpt-5.6-sol",
+                context_windows={"gpt-5.6-sol": 272_000},
+            ),
+        ),
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="gpt-5.6-sol",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+        )
+    )
+
+    assert provider.discovery_calls == ["gpt-5.6-sol"]
+    assert session.context_window_tokens == 372_000
+    assert session.auto_compact_token_threshold == 334_800
+    assert session.context_window_source == "provider live catalog"
+    assert session.model_limits_discovery_error is None
+
+
+@pytest.mark.anyio
+async def test_session_falls_back_when_live_model_limit_discovery_fails(
+    tmp_path: Path,
+) -> None:
+    provider = ModelLimitsFakeProvider([], error=RuntimeError("catalog unavailable"))
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=("gpt-5.6-sol",),
+                default_model="gpt-5.6-sol",
+                context_windows={"gpt-5.6-sol": 272_000},
+            ),
+        ),
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="gpt-5.6-sol",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+        )
+    )
+
+    assert session.context_window_tokens == 272_000
+    assert session.auto_compact_token_threshold == 255_616
+    assert session.context_window_source == "configured catalog"
+    assert session.model_limits_discovery_error == "RuntimeError: catalog unavailable"
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -131,6 +131,21 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
     assert entry.auth_methods == ("api_key", "oauth")
 
 
+def test_builtin_catalog_separates_openai_api_and_codex_context_limits() -> None:
+    openai = builtin_provider_entry("openai")
+    codex = builtin_provider_entry("openai-codex")
+
+    assert openai is not None
+    assert codex is not None
+    assert openai.context_windows is not None
+    assert codex.context_windows is not None
+    assert openai.context_windows["gpt-5.6-sol"] == 1_050_000
+    assert codex.context_windows["gpt-5.6-sol"] == 272_000
+    assert codex.context_windows["gpt-5.6-terra"] == 272_000
+    assert codex.context_windows["gpt-5.6-luna"] == 272_000
+    assert codex.model_metadata["gpt-5.6-sol"].context_window == 272_000
+
+
 def test_builtin_catalog_oauth_and_opencode_auth_methods() -> None:
     codex = builtin_provider_entry("openai-codex")
     copilot = builtin_provider_entry("github-copilot")

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -30,6 +30,7 @@ from tau_ai import (
     OpenAICodexProvider,
     OpenAICompatibleConfig,
     OpenAICompatibleProvider,
+    RuntimeModelLimits,
     TextDeltaEvent,
     ThinkingDeltaEvent,
     ToolCallEndEvent,
@@ -783,6 +784,61 @@ async def test_openai_compatible_provider_includes_plain_http_error_body_in_mess
         "body": "bad request details",
         "attempts": 1,
     }
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_discovers_and_caches_live_model_limits() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "slug": "gpt-5.6-sol",
+                        "context_window": 372_000,
+                        "max_context_window": 372_000,
+                        "effective_context_window_percent": 95,
+                        "auto_compact_token_limit": 330_000,
+                        "max_output_tokens": 128_000,
+                    },
+                    {"slug": "invalid", "context_window": -1},
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                client_version="0.2.0",
+            ),
+            client=client,
+        )
+
+        limits = await provider.discover_model_limits("gpt-5.6-sol")
+        cached = await provider.discover_model_limits("gpt-5.6-sol")
+
+    assert limits == RuntimeModelLimits(
+        context_window=372_000,
+        max_output_tokens=128_000,
+        effective_context_window_percent=95,
+        auto_compact_token_limit=330_000,
+    )
+    assert cached == limits
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://chatgpt.test/backend-api/codex/models?client_version=0.2.0"
+    )
+    assert requests[0].headers["authorization"] == "Bearer access-token"
+    assert requests[0].headers["chatgpt-account-id"] == "account-1"
+    assert requests[0].headers["accept"] == "application/json"
 
 
 @pytest.mark.anyio

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -13,6 +13,8 @@ Run `/session` in the TUI to see a rough estimate:
 
 ```text
 Estimated context tokens: <count>
+Context window: <count>
+Context window source: configured catalog | provider live catalog
 Context token breakdown: system=<count>, messages=<count>, tools=<count>
 Thinking mode: <mode>
 ```
@@ -35,8 +37,11 @@ When it compacts, Tau asks the model to summarize older messages, keeps a recent
 suffix of the conversation, and continues. The original session file is never
 edited — only the *active context* sent to the provider changes.
 
-The default threshold follows the model's context window minus a reserve. You can
-override it for a run:
+The default threshold follows the model's context window minus a reserve. Providers
+that advertise an explicit runtime threshold can override that default. In particular,
+Codex subscription sessions discover account/rollout-specific limits from Codex's
+authenticated model catalog because those limits can differ from the public OpenAI API.
+You can override the resulting threshold for a run:
 
 ```bash
 tau --auto-compact-threshold 100000

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -60,6 +60,26 @@ OAuth tokens refresh automatically. `/logout` removes Tau's local credential,
 but does not revoke the grant remotely; use the provider's account settings for
 remote revocation.
 
+#### Codex subscription context limits
+
+OpenAI's public API and the ChatGPT/Codex subscription are separate serving
+surfaces. A model with the same ID can have a smaller, rollout-specific context
+window through Codex OAuth than through an API key. For example, the public
+GPT-5.6 Sol API advertises a 1.05M-token window, while Codex has advertised
+substantially smaller limits through its authenticated model catalog.
+
+Tau queries that catalog when a Codex session starts and uses the returned
+context window and automatic-compaction threshold for the session. If discovery
+is unavailable, Tau falls back to conservative Codex-specific values from its
+built-in catalog; it does not reuse the public API limit. `/session` reports both
+the active value and whether it came from the live provider catalog or Tau's
+configured fallback.
+
+Live limits can vary by account or rollout and may change independently of Tau.
+A discovery failure is non-fatal: Tau reports it in `/session` and continues with
+the fallback. Direct OpenAI API sessions retain the context limits documented on
+the API model page.
+
 ### OpenCode Go and Zen
 
 OpenCode Go and OpenCode Zen are **API-key providers**, not OAuth providers.


### PR DESCRIPTION
## Brief description

Fix Codex subscription context overflows caused by reusing direct OpenAI API metadata for the OAuth serving surface.

This PR explores both directions from #389 and chooses **authenticated runtime discovery with a conservative static fallback**:

- adds an optional provider-neutral `ModelLimitsProvider` capability in `tau_ai`
- queries the authenticated Codex `/models` catalog with the same refreshed OAuth credentials/account headers used for responses
- defensively parses per-model context, effective-window, output, and compaction metadata
- caches the catalog for the lifetime of the runtime provider
- applies live limits before a coding session sends a prompt
- uses the Codex-compatible 90% compaction default when no explicit threshold is advertised
- keeps direct OpenAI API GPT-5.6 metadata at 1.05M
- lowers Codex GPT-5.6 static fallbacks to a conservative 272K when discovery is unavailable
- shows the context-window source and non-fatal discovery errors in `/session`
- documents the production incident, alternatives, architecture, and user behavior

A 500K hard-coded total window alone was rejected because Tau's previous formula would compact around 483K, after the observed 372K Codex input ceiling. Dynamic discovery handles account/rollout changes; the lower static profile keeps offline/failure behavior safe.

## User experience improvement

Long-running Codex OAuth sessions now compact before the account's actual Codex limit instead of waiting for the public API's 1.05M threshold and becoming stuck on `context_length_exceeded`.

Users can inspect whether Tau obtained the active value from the provider or its built-in fallback. Catalog discovery is best-effort: a network/schema failure does not prevent startup or normal requests.

## Issue

Closes #389.

## Manual validation

1. Run `/login openai-codex` and select `gpt-5.6-sol`.
2. Start or resume a session.
3. Run `/session`.
4. Confirm it reports `Context window source: provider live catalog` and a provider-specific context/compaction limit.
5. Compare the value with the same account's Codex model catalog (`codex debug models`, when supported by the installed Codex version).
6. Block or fail the `/codex/models` request and start another session.
7. Confirm Tau remains usable, reports `Context window source: configured catalog`, displays the discovery failure, and uses the conservative fallback.
8. Confirm an API-key `openai:gpt-5.6-sol` session still reports the public 1.05M context profile.

A local credentialed smoke test returned the current live Codex value for `gpt-5.6-sol` as 272,000 tokens without exposing credentials or account metadata.

## Validation performed

- `uv run pytest` — 969 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — passed
- `cd website && hugo --minify` — passed (existing taxonomy-layout warning only)
- `npx --yes pagefind@latest --site public` — passed after retrying against the public npm registry; the configured Hugging Face npm mirror initially timed out
