### PR TITLE
Fix light theme code block background

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -173,6 +173,13 @@ class ThemedMarkdownWidget(TextualMarkdown):
         scrollbar-size-horizontal: 1;
     }
 
+    /* Textual's built-in `MarkdownFence:light` rule (type + pseudo-class)
+       outranks the plain descendant selector above, so restate the themed
+       background for light themes. */
+    ThemedMarkdownWidget MarkdownFence:light {
+        background: $tau-markdown-code-block-background;
+    }
+
     ThemedMarkdownWidget MarkdownTableContent {
         keyline: thin $tau-markdown-table-border;
     }

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -97,6 +97,7 @@ from tau_coding.tui.config import (
     TAU_LIGHT_THEME,
     TuiKeybindings,
     TuiSettings,
+    TuiTheme,
     tui_settings_path,
 )
 from tau_coding.tui.state import TOOL_SPINNER_FRAMES, ChatItem, TuiState
@@ -2349,6 +2350,32 @@ async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized()
         assert finalized_fence.max_scroll_x > 0
         assert finalized_fence.styles.scrollbar_size_horizontal == 1
         assert finalized_fence.show_horizontal_scrollbar is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "theme",
+    [TAU_DARK_THEME, TAU_LIGHT_THEME, HIGH_CONTRAST_THEME],
+    ids=lambda theme: theme.name,
+)
+async def test_transcript_code_fence_uses_theme_background(theme: TuiTheme) -> None:
+    """Code fences keep Tau's themed background for every built-in theme.
+
+    Regression test: Textual's built-in `MarkdownFence:light` rule outranks
+    Tau's plain `ThemedMarkdownWidget MarkdownFence` selector, which used to
+    leave light-theme code fences with a transparent white background.
+    """
+    app = TauTuiApp(
+        FakeSession([AssistantMessage(content="```python\nx = 1\n```")]),
+        tui_settings=TuiSettings(theme=theme.name),
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        fence = app.query_one("MarkdownFence")
+
+    assert fence.styles.background == Color.parse(theme.markdown_code_block_background)
 
 
 def test_tui_app_uses_configured_theme_css_variables() -> None:


### PR DESCRIPTION
## Fix light theme code block background

### What

In the `tau-light` theme, Markdown code fences in the transcript rendered **without a visible background**, unlike `tau-dark` and `high-contrast`, which show code blocks on a distinct `#161b21` surface.

Root cause: Textual's built-in stylesheet ships a `MarkdownFence:light { background: white 30%; }` rule. Its selector (type + pseudo-class) has higher specificity than Tau's plain `ThemedMarkdownWidget MarkdownFence` descendant selector, so in light mode Tau's `$tau-markdown-code-block-background` was overridden with a 30%-alpha white — invisible on the white transcript. Dark themes were unaffected because Tau's selector beats Textual's base `MarkdownFence` rule.

Fix: restate the themed background in a `:light`-scoped rule in `ThemedMarkdownWidget.DEFAULT_CSS`, mirroring how Tau already forces its inline-code colors with `!important` against Textual's `:light`/`:dark` inline-code rules. This covers both the static transcript widget and the streaming widget (`StreamingTranscriptMessageWidget` subclasses `ThemedMarkdownWidget`).

### How it improves user experience

Code blocks in the light theme are now visually delimited on a soft `#f1f5f9` surface — the color the theme already defined (`markdown_code_block_background`) but which was never applied — making fenced code easier to scan and consistent with the dark and high-contrast themes.

### Issue

No open issue — reported directly as a light-theme visual bug (code blocks missing the background that dark and contrast themes show).

### How to manually validate

1. Run the TUI with the light theme: `tau --theme tau-light` (or switch with `/theme` inside the app).
2. Ask the agent for a code snippet (or resume any session containing a fenced code block).
3. Confirm fenced code blocks render on a light gray `#f1f5f9` background, while inline code stays background-free.
4. Switch to `tau-dark` and `high-contrast` and confirm code blocks still render on `#161b21`.

Automated coverage: `test_transcript_code_fence_uses_theme_background` (parametrized over all three built-in themes) asserts the rendered `MarkdownFence` background equals each theme's `markdown_code_block_background`; it fails on `main` for `tau-light` and passes with this fix.

### Checks run locally

- `uv run pytest` — 973 passed
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy` — clean
