### PR TITLE
Fix light theme code block background

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -173,6 +173,13 @@ class ThemedMarkdownWidget(TextualMarkdown):
         scrollbar-size-horizontal: 1;
     }
 
+    /* Textual's built-in `MarkdownFence:light` rule (type + pseudo-class)
+       outranks the plain descendant selector above, so restate the themed
+       background for light themes. */
+    ThemedMarkdownWidget MarkdownFence:light {
+        background: $tau-markdown-code-block-background;
+    }
+
     ThemedMarkdownWidget MarkdownTableContent {
         keyline: thin $tau-markdown-table-border;
     }

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -14,7 +14,6 @@ from tau_agent import (
     TextContent,
     ToolCall,
     ToolResultMessage,
-    UserMessage,
 )
 from tau_agent.types import JSONValue
 from tau_ai import FakeProvider
@@ -189,10 +188,10 @@ def test_queue_mutators_return_canonical_snapshots() -> None:
     )
 
     harness.steer("First")
-    harness.steer("Second")
-    harness.follow_up("Later")
-    assert harness.pop_latest_steering() == UserMessage(content="Second")
-    assert harness.pop_latest_follow_up() == UserMessage(content="Later")
+    second = harness.steer("Second").steering[-1]
+    later = harness.follow_up("Later").follow_up[-1]
+    assert harness.pop_latest_steering() == second
+    assert harness.pop_latest_follow_up() == later
     assert [message.text for message in harness.queued_messages.steering] == ["First"]
 
     cleared = harness.clear_queues()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -97,6 +97,7 @@ from tau_coding.tui.config import (
     TAU_LIGHT_THEME,
     TuiKeybindings,
     TuiSettings,
+    TuiTheme,
     tui_settings_path,
 )
 from tau_coding.tui.state import TOOL_SPINNER_FRAMES, ChatItem, TuiState
@@ -2349,6 +2350,32 @@ async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized()
         assert finalized_fence.max_scroll_x > 0
         assert finalized_fence.styles.scrollbar_size_horizontal == 1
         assert finalized_fence.show_horizontal_scrollbar is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "theme",
+    [TAU_DARK_THEME, TAU_LIGHT_THEME, HIGH_CONTRAST_THEME],
+    ids=lambda theme: theme.name,
+)
+async def test_transcript_code_fence_uses_theme_background(theme: TuiTheme) -> None:
+    """Code fences keep Tau's themed background for every built-in theme.
+
+    Regression test: Textual's built-in `MarkdownFence:light` rule outranks
+    Tau's plain `ThemedMarkdownWidget MarkdownFence` selector, which used to
+    leave light-theme code fences with a transparent white background.
+    """
+    app = TauTuiApp(
+        FakeSession([AssistantMessage(content="```python\nx = 1\n```")]),
+        tui_settings=TuiSettings(theme=theme.name),
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        fence = app.query_one("MarkdownFence")
+
+    assert fence.styles.background == Color.parse(theme.markdown_code_block_background)
 
 
 def test_tui_app_uses_configured_theme_css_variables() -> None:


### PR DESCRIPTION
## Description

Ensure fenced code blocks use Tau's configured code-block background in the light TUI theme. The light-specific selector prevents Textual's built-in `MarkdownFence:light` style from overriding Tau's theme color.

A regression test verifies the configured background in all three built-in themes. This PR also stabilizes an unrelated queue snapshot test exposed by CI by comparing the returned canonical messages instead of constructing new messages with millisecond timestamps.

## User experience

Code blocks now remain visually distinct from the white transcript background in `tau-light`, matching the clear code-block treatment already present in dark and high-contrast modes.

## Issue

No linked issue.

## Manual validation

1. Start Tau's TUI.
2. Run `/theme tau-light`.
3. Display an assistant response containing a fenced code block.
4. Confirm the code block has a light gray (`#f1f5f9`) background instead of blending into the white transcript.
5. Switch to `tau-dark` and `high-contrast` and confirm their code-block backgrounds remain unchanged.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-light-codeblock-dist`
- `hugo --minify` (from `website/`)

The local Pagefind step could not download `pagefind` because the configured npm registry timed out; GitHub CI runs the equivalent documentation step.
