### PR TITLE
Add minimalist Rich and prompt_toolkit TUI

### DIFF
--- a/dev-notes/architecture/rich-prompt-toolkit-tui.md
+++ b/dev-notes/architecture/rich-prompt-toolkit-tui.md
@@ -1,0 +1,86 @@
+# Rich + prompt_toolkit minimalist TUI
+
+## What was added
+
+Tau now includes a second built-in interactive frontend:
+
+```bash
+tau --tui rich
+```
+
+It uses `prompt_toolkit` for multiline editing, history, key handling, and
+completion, and Rich `Live`/`Layout` for a full-screen transcript. The existing
+Textual frontend remains the default and the complete product surface.
+
+Both frontends are created around the same `CodingSession` and consume events
+through the Textual-free `TuiEventAdapter` and `TuiState`:
+
+```text
+CodingSession -> CodingSessionEvent -> TuiEventAdapter -> TuiState
+                                                    -> Textual
+                                                    -> Rich Live/Layout
+```
+
+No frontend dependency was added to `tau_agent`.
+
+## Product decisions
+
+The goal is a useful coding loop, not a second implementation of every Textual
+widget. The Rich frontend keeps:
+
+- restored and streaming transcript output
+- Markdown and compact tool-result rendering
+- multiline input, history, and command/skill/template completion
+- registered slash commands, direct `!`/`!!` shell commands, resume by id,
+  compaction, clear/new/quit, and thinking-level arguments
+- session/model/thinking/context status in one line
+- queued-message display when queue events are received
+- terminal-tab activity and clean provider/session startup behavior
+
+The following PRD features are deliberately rejected for this frontend because
+they would recreate a widget framework on top of `prompt_toolkit`:
+
+- permanent sidebar and shortcut footer
+- model/session/tree/theme/login pickers and modal login flows
+- extension-provided Textual widgets, main views, and key interceptors
+- mouse-scoped message selection and Textual Markdown streaming widgets
+- simultaneous steering/follow-up input during a run
+- configurable Textual themes and Textual keybinding names
+
+When a command needs a picker, the frontend explains that the user should supply
+an argument or restart with `--tui textual`. Extensions still participate in the
+session, tools, hooks, commands, and renderers, but extension UI components are
+Textual-only. This keeps the alternate frontend honest and small instead of
+providing incomplete imitations of complex controls.
+
+## Interaction model
+
+- `Enter` inserts a newline.
+- `Alt+Enter` submits.
+- `Tab` accepts completion.
+- `Ctrl+C` cancels prompt editing; during provider work it requests terminal
+  interruption through the normal process signal path.
+- `Ctrl+D` exits from an empty prompt.
+
+The bottom toolbar is contextual input help, not a second session-information
+surface. Session facts stay on one status line and detailed information remains
+available through `/session`.
+
+## Testing
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+Manual smoke test:
+
+```bash
+uv run tau --tui rich
+```
+
+Submit a multiline prompt with Alt+Enter, run `!pwd`, open `/session`, and resume
+a known id with `/resume <id>`. Commands that require a picker should show the
+Textual fallback guidance rather than failing.

--- a/dev-notes/design/prd-tau-coding-tui.md
+++ b/dev-notes/design/prd-tau-coding-tui.md
@@ -1,0 +1,876 @@
+---
+title: "PRD — tau_coding: Coding-Agent Layer & Interactive TUI"
+status: normative
+audience: implementers recreating or evolving Tau's coding-agent frontend
+---
+
+# PRD: `tau_coding` — Coding-Agent Layer and Terminal UI
+
+This document is a **product/architecture requirements specification** for Tau's
+coding-agent layer (`tau_coding`) and its built-in Textual TUI. It consolidates
+everything learned across the project's commit history, pull requests, and issue
+tracker (through v0.2.0, ~PR #380 / issue #373), including the **edge cases and
+fixes found along the way**, so a new TUI can be recreated from scratch without
+re-discovering them.
+
+It is written to be sufficient to rebuild the frontend against the stable core
+(`tau_agent`, `tau_ai`) without reading the current implementation.
+
+---
+
+## 1. Purpose and scope
+
+### 1.1 What `tau_coding` is
+
+`tau_coding` is the **coding-agent application layer**. It wraps the portable
+agent harness (`tau_agent`) with everything a coding assistant needs on a real
+machine:
+
+- a persistent, resumable **session** (conversation + session tree on disk)
+- provider/model **configuration and credentials**
+- **skills**, **prompt templates**, **project instructions** (AGENTS.md)
+- built-in **coding tools** (read/write/edit/bash)
+- **slash commands**, **context compaction**, **session branching**
+- an **extension system**
+- one or more **frontends**: print mode, JSON event mode, and the interactive TUI
+
+### 1.2 What this PRD covers
+
+- The `CodingSession` environment contract a frontend drives.
+- The **canonical event stream** a frontend consumes.
+- The **interactive TUI**: layout, widgets, keybindings, pickers, streaming,
+  autocomplete, theming, terminal integration.
+- **Non-goal:** the internals of `tau_agent` (agent loop, harness, session tree
+  primitives) and `tau_ai` (provider streaming). Those are dependencies, specified
+  only by the contract `tau_coding` relies on.
+
+### 1.3 Architectural boundary (inviolable)
+
+```text
+AgentHarness  = reusable brain          (tau_agent)
+AgentSession  = coding-agent environment (tau_coding.session.CodingSession)
+TUI           = one possible frontend    (tau_coding.tui)
+```
+
+Rules that have held since Phase 0 and must continue to hold:
+
+- `tau_agent` **must not** import Textual, Rich, Typer, CLI, resource-path, or
+  rendering code. (Enforced by `tests/test_pi_event_protocol.py` layering checks.)
+- `tau_coding` → `tau_agent` → `tau_ai`. Never invert. (See issue #317 — a
+  `tau_agent`/`tau_ai` import cycle had to be broken by inverting a dependency.)
+- The frontend **renders from events and session state**; it never reads
+  provider-specific chunks and never reaches into private session internals.
+- UI policy (keybindings, themes, pickers, layout) lives **entirely** in
+  `tau_coding.tui`, never in the core.
+
+---
+
+## 2. The contract a frontend builds against
+
+A TUI is a consumer of `CodingSession`. The following is the stable surface.
+(Reference: `website/content/internals/custom-frontend.md`.)
+
+### 2.1 Driving a turn
+
+```python
+async for event in session.prompt(user_text):
+    render(event)
+```
+
+- The stream yields `CodingSessionEvent` values (§3).
+- **Overlapping runs are rejected.** A second `session.prompt(...)` while a run
+  is active must pass `streaming_behavior="steer"` or `"follow_up"` (§2.4).
+- Provider failures arrive as an assistant message with `stop_reason == "error"`,
+  then normal lifecycle events — not as exceptions out of the stream.
+
+### 2.2 Lifecycle / settlement events
+
+Use:
+
+- `agent_start` → enter the **running** state.
+- `agent_settled` → leave the running state. **Do not** use `agent_end` for this:
+  auto-compaction, auto-retry, or queued continuation may follow `agent_end`,
+  and the run is not truly idle until `agent_settled`.
+
+### 2.3 Slash commands
+
+Before treating input as a prompt:
+
+```python
+result = session.handle_command(text)
+```
+
+If `result.handled`, apply the requested effects (`exit_requested`,
+`clear_requested`, `new_session_requested`, `compact_summary`, `resume_session_id`,
+picker requests, `message`, …) and render reference output **outside** the durable
+conversation (§7.4). `/skill:<name>` is **not** a command — pass it through to
+`session.prompt(...)`, which expands it before the run.
+
+### 2.4 Steering and follow-ups (mid-run input)
+
+While a run is active, submitting queues instead of starting a run:
+
+- `streaming_behavior="steer"` — injected after the current assistant turn.
+- `streaming_behavior="follow_up"` — injected only when the run would stop.
+
+`QueueUpdateEvent` carries pending queued text for display. Ownership of queues
+lives in `tau_agent`; expansion and persistence live in `tau_coding`; the frontend
+only decides keybindings and presentation. (See `dev-notes/architecture/queued-steering-follow-ups.md`.)
+
+### 2.5 Restoring a session
+
+Initialize the visible transcript from `session.messages` (the reference
+implementation is `TuiState.load_messages()`). Restored `ToolResultMessage`s
+preserve structured metadata (e.g. edit patches), so tool results render without
+reading JSONL. For switching, use `SessionManager.list_sessions(cwd)` then
+`await session.resume(session_id)`, then rebuild the transcript from
+`session.messages`.
+
+### 2.6 Cancellation
+
+```python
+session.cancel()
+```
+
+Keep consuming events until the stream ends. Cancellation is an **intentional
+stop, not an error** — render the terminal cancellation as a status, not an
+error row (§8.5).
+
+### 2.7 Picker data (read directly from the session)
+
+`command_registry.list_commands()`, `skills`, `prompt_templates`,
+`available_model_choices`, `available_models`, `available_providers`,
+`thinking_level`, `available_thinking_levels`, `session_manager`. For a model
+from another provider: `set_provider(...)` then `set_model(...)`.
+
+---
+
+## 3. Canonical event stream
+
+The frontend consumes a Pi-compatible event protocol (migrated in PR #375; see
+`dev-notes/design/pi-event-migration-audit.md` and the canonical-event-stream
+reference). Two families:
+
+### 3.1 Portable agent events (`tau_agent.events`)
+
+`agent_start`, `agent_end`, `turn_start`, `turn_end`, `message_start`,
+`message_update`, `message_end`, `tool_execution_start`, `tool_execution_update`,
+`tool_execution_end`.
+
+- **Streamed provider deltas are nested**: a `MessageUpdateEvent` carries an
+  `assistant_message_event` that is one of `TextDeltaEvent`, `ThinkingDeltaEvent`,
+  etc. Frontends must switch on the nested event, not on flat delta types.
+  (Provider content ordering is preserved in canonical streams — do not reorder;
+  see "preserve provider content ordering" fix.)
+- `ToolExecutionStartEvent` carries `(tool_call_id, tool_name, args)`.
+- `ToolExecutionUpdateEvent` carries `(tool_call_id, partial_result)` — a progress
+  line, **not** a re-renderable partial result (lighter than Pi's `onUpdate`).
+- `ToolExecutionEndEvent` carries `(tool_call_id, tool_name, result, is_error)`.
+
+### 3.2 Session-own events (`tau_coding.events`)
+
+`SessionAgentEndEvent` (`agent_end` + `messages` + `will_retry`),
+`AgentSettledEvent`, `QueueUpdateEvent` (`steering`, `follow_up`),
+`CompactionStartEvent`/`CompactionEndEvent` (with `reason`: manual | threshold |
+overflow, `aborted`, `will_retry`, `error_message`), `EntryAppendedEvent`,
+`SessionInfoChangedEvent` (name), `ThinkingLevelChangedEvent`,
+`AutoRetryStartEvent` (`attempt`, `max_attempts`, `delay_ms`, `error_message`),
+`AutoRetryEndEvent` (`success`, `attempt`, `final_error`).
+
+### 3.3 Ordered thinking / content blocks (v0.2.0, issue #368, PR #371)
+
+Assistant output is an **ordered sequence of typed content blocks** (thinking and
+text, with provider signatures), persisted in session JSONL. This is the canonical
+fix for thinking history/replay/ordering. Frontends must render thinking **in
+position** from the message's ordered blocks, not reconstruct standalone thinking
+rows from transient deltas (the old, buggy approach — see §8.6 / issue #275 and
+the "thought process is different than Pi" issue #296: Pi interleaves thinking and
+tool calls, and Tau must model that).
+
+---
+
+## 4. Frontend architecture (the adapter seam)
+
+The single most important design decision (ADR 0001): **the TUI is split into a
+Textual-free display core and a Textual shell**, so event→display logic is
+testable without a terminal and so the frontend could be swapped.
+
+```text
+CodingSession.prompt()  →  CodingSessionEvent
+        ↓
+TuiEventAdapter  (tau_coding/tui/adapter.py)   — Textual-free
+        ↓  mutates
+TuiState         (tau_coding/tui/state.py)     — Textual-free display state
+        ↓  rendered by
+TranscriptView / widgets (tau_coding/tui/widgets.py, app.py)  — Textual
+```
+
+### 4.1 `TuiState` — display-only state
+
+- `items: list[ChatItem]` — the durable visible transcript rows.
+- `assistant_buffer: str` — the in-flight streaming assistant text.
+- `running: bool`, `error: str | None`.
+- `show_tool_results: bool` (Ctrl+O), `show_thinking: bool` (Ctrl+T).
+- `queued_steering`, `queued_follow_up: tuple[str, ...]`.
+- `skills`, and lazily-resolved renderers: `custom_renderer`,
+  `tool_call_renderer`, `tool_result_renderer` (installed by the extension
+  runtime; resolved **lazily at render time** so content restored before the
+  runtime connects still picks up renderers on next redraw).
+- `tool_spinner: str | None` — current spinner frame for an executing tool row.
+
+**`ChatItem`** roles: `user`, `assistant`, `tool`, `error`, `status`, `thinking`,
+`skill`, `branch_summary`, `compaction_summary`, `custom`. Carries optional
+`tool_call_id`, `tool_result_text`, the raw `tool_result` object, `update_text`,
+`tool_name`, `tool_arguments`, `started_at`, `always_show_tool_result`,
+`custom_type`, `details`.
+
+### 4.2 `TuiEventAdapter` — event → state
+
+A pure function-per-event mapping with **no Textual import**. Key behaviors:
+
+- `agent_start` → `running=True`, clear error. `agent_end`/`agent_settled` →
+  flush assistant buffer, `running=False`.
+- Nested `message_update` → append `TextDeltaEvent.delta` to `assistant_buffer`;
+  `ThinkingDeltaEvent.delta` → `add_thinking_delta` (coalesce consecutive thinking
+  deltas into one trailing thinking item).
+- `message_end` (user) → `add_user_message` (with branch/compaction/skill
+  compaction — §4.3). `message_end` (assistant): on `stop_reason in
+  {"error","aborted"}` add an **error** item and stop; else add the assistant item.
+- `tool_execution_start` → flush assistant buffer, `add_tool_call`.
+- `tool_execution_end` → `record_tool_result`.
+- `auto_retry_start` → a transient **status** row (`… <error>`).
+
+### 4.3 `add_user_message` compaction (presentation-only)
+
+`add_user_message` recognizes special user-authored messages and renders them
+compactly, without changing what goes to the model:
+
+- `custom_type` set → a `custom` item (rendered via the registered renderer, raw
+  text as fallback).
+- Branch-summary text → a collapsed `branch_summary` item ("Branch summary
+  (Ctrl+O to expand)").
+- Compaction-summary text → a collapsed `compaction_summary` item.
+- A `/skill:<name>` invocation → a `skill` item plus a separate `user` item for
+  any additional instructions.
+
+### 4.4 Skill/tool presentation
+
+- A `read` tool call whose path matches a loaded skill's path renders as
+  `Loading skill: <name>` (role `skill`), not a raw read (issue #123, #51).
+- Tool invocations render as terse human-readable lines: `read path:a-b`,
+  `edit path`, `write path`, `$ command (timeout Ns)`; bash uses the invocation
+  directly; others are prefixed `→ `. Unknown/extra args fall back to a truncated
+  `name {args}` (≤160 chars).
+- Tool results render as `✓ name` / `✗ name` plus a preview (§5.4) and, for
+  successful `edit`, an inline unified-diff "Patch:" block.
+
+---
+
+## 5. Transcript rendering (Textual)
+
+### 5.1 Widget-per-message, not one big RichLog (issue #156)
+
+The transcript is a scroll container (`TranscriptView`, a `VerticalScroll`) of
+individually selectable message widgets (`TranscriptMessageWidget`), **not** a
+single `RichLog`. Each message widget owns selected-text extraction for its own
+rendered block, so mouse selection stays scoped to one message and copying does
+not bleed into neighbors (issues #19, #32, #58, #83, #150).
+
+- **Streaming** assistant/thinking blocks use a `StreamingTranscriptMessageWidget`
+  (a Textual `MarkdownStream`-backed widget) so Markdown renders incrementally
+  without wrapper-driven selection flicker.
+- **Non-streamed** blocks use `TranscriptMessageWidget` with a themed Rich
+  renderable.
+- Assistant text renders as Markdown (headings, bullets, quotes, links, inline
+  code, emphasis). User/tool/status/error stay literal except explicit code/patch
+  renderers. Fenced code uses Pygments when the language is known; **unknown
+  fence labels fall back to plain code** rather than breaking (issue #66, manual
+  check #4 in phase-23 notes).
+
+### 5.2 Scroll-follow with user opt-out (issues #156, #175)
+
+Toad-style scroll anchoring:
+
+- Follow output (auto-scroll to bottom) **only while the user is at the bottom**.
+- If the user scrolls up, **stop following** so they can review earlier context
+  during a long stream (regression fixed in #177/#175).
+- Scrolling back to the bottom re-engages follow. A user-driven turn or explicit
+  jump-to-bottom forces follow.
+- Implementation: `watch_scroll_y` clears `_follow_output` when scrolling up and
+  sets it when reaching `max_scroll_y`; follow-scroll is deferred to
+  `call_after_refresh` so layout settles first.
+
+### 5.3 Text selection discipline (issues #150, #212, #213)
+
+- **Disable text selection while streaming**; re-enable when idle
+  (`_sync_text_selection_state`), because drag-selection during re-layout flickers
+  and corrupts.
+- A Markdown block only allows native selection **once mounted** (`allow_select`
+  guard) — selection before mount crashes (issue #213).
+- Copying wrapped lines must map rendered→source coordinates correctly across
+  soft-wrapped visual lines (issue #150, fixed in #154).
+
+### 5.4 Tool-result previews (issue #102, #30, #18)
+
+- Collapsed by default; **Ctrl+O** toggles full output.
+- Preview limits: tool result ≤ 8 lines / 2000 chars; edit patch ≤ 32 lines;
+  interactive bash output ≤ 120 lines. Truncation appends a hint:
+  `[Preview only: N more lines, additional text hidden from the TUI.]`
+- The full result is always kept in the durable session for model context/replay.
+
+### 5.5 Activity indicator (issues #35, #50, #64, #82)
+
+- A spinner row **directly above the prompt** (not in a top status line), with a
+  slow fade between accent colors (`ACTIVITY_TICK_SECONDS = 0.15`, blended over 24
+  steps). It resets to idle on complete/cancel/fail.
+- Tool rows show a braille spinner frame standing in for the static `→ `/`▸ `
+  marker while executing, plus a live elapsed time once a run exceeds 1s (quick
+  reads/edits never flash `(0s)`).
+
+### 5.6 Footer & status (issues #61, #65, #75, #86)
+
+- The built-in **Textual Footer** is the single shortcut-hint surface — do not add
+  a custom hint row. It swaps binding sets: normal / completion-open / running.
+- **No top "ready/queued" status bar** (removed in #86) — queue feedback lives in
+  the stacked queued-messages row above the prompt (§6.6), and the header carries
+  session identity (§9.1).
+
+---
+
+## 6. The prompt input
+
+### 6.1 Multiline TextArea with completion bindings
+
+`PromptInput` is a `TextArea` (not a single-line `Input`) supporting
+**Shift+Enter** for newline (issue #17, #25). It exposes `value`/`cursor_position`
+compatibility aliases and merges a base binding map with mode-specific binding
+maps (`normal`/`completion`/`running`) that drive the footer.
+
+### 6.2 Large-paste placeholder (issues #211, #300)
+
+- A bracketed paste over **2000 chars** is not rendered inline. Insert a compact
+  placeholder: `[Pasted content #N: X,XXX characters, Y lines, Z.Z KB]`.
+- The full content is stored and **substituted back at submit**
+  (`text_for_submission`).
+- **Invalidate stored content if the placeholder is edited away** so stale content
+  is never sent (`sync_pending_paste`). Cleared on submit/clear.
+
+### 6.3 Shell mode highlighting (issues #49, #146)
+
+`!`/`!!` prefixes highlight in the accent color (the input gets a `-shell-mode`
+class and the prefix span is stylized). `! cmd` runs and records output **in
+context**; `!! cmd` runs without adding to context. Rendered like a tool call:
+immediate `$ cmd` running row, then `✓/✗ bash · added/not added to context` plus a
+≤120-line output preview (issue #146).
+
+### 6.4 Prompt history recall (issue #172)
+
+**Up on an empty prompt** recalls the most recently submitted prompt for editing.
+Guard: only into an empty input (so an accidental Up doesn't erase an in-progress
+draft). History is reseeded from restored `UserMessage`s on resume.
+
+### 6.5 Queued-message recall (issues #305, #307)
+
+**Up on an empty prompt while running** pulls the latest queued message back for
+editing. Follow-ups take priority; if none, pop a steering message
+(`pop_latest_follow_up_message` then `pop_latest_steering_message` on the
+session). The bug was that steering recall was missing — both must be supported.
+
+### 6.6 Queued messages display (issues #28, #53, #127)
+
+Pending steering/follow-ups stack above the prompt as `↪ steering · queued: …` /
+`↪ follow-up · queued: …` rows (shortened wording per #127). Editable per §6.5.
+
+### 6.7 Focus behavior
+
+Clicking anywhere returns focus to the prompt — **except** while an extension
+main view is open (a subagent viewer owns the main area and its keyboard; yanking
+focus would reroute Esc/typing to the chat). Clicking the prompt itself always
+focuses natively.
+
+---
+
+## 7. Slash commands & command output
+
+### 7.1 Command set (Pi-aligned, pruned in #95)
+
+`/quit` (alias `/exit`), `/new`, `/session`, `/system`, `/compact [instructions]`,
+`/export [--format html|jsonl] [dest]`, `/resume [session-id]`, `/tree`,
+`/name <new name>`, `/model`, `/scoped-models`, `/theme [name]`,
+`/login [provider]`, `/logout [provider]`, `/reload`, `/hotkeys`, and dynamic
+`/skill:<name> [request]`.
+
+### 7.2 Unknown slash input passes through (issues #350, #351)
+
+Only **registered** commands are consumed locally. Any other slash-prefixed input
+— including absolute paths like `/tmp/x` or `/Users/me/file.png` — is sent to the
+model as a normal prompt. (Root cause: a leading-`/` filepath was parsed as a
+command, not found, and **silently discarded**.) Do not reject unknown commands;
+pass them through.
+
+### 7.3 `/skill:` is prompt expansion, not a command
+
+`/skill:<name>` expands the named skill into the prompt and runs it as a turn. It
+is a prompt-expansion path, deliberately **not** in the command registry.
+
+### 7.4 Command output routing (issues #121, #122, #124, phase-23)
+
+Command output is **transient UI**, not transcript content:
+
+- Short confirmations → a Textual **notification** (e.g. `/name` → "Session
+  renamed: …"; no notification for "new session started" or thinking toggles).
+- Multi-line reference output (`/session`, `/hotkeys`, etc.) → a **dismissible
+  modal** (`CommandOutputScreen`).
+- Only `/reload` and `/system` render **inline** in the transcript
+  (`_command_message_uses_transcript`).
+
+### 7.5 Notification de-duplication (issue #81)
+
+Identical `(message, severity)` notifications must not stack. Track active
+notification keys; suppress a repeat until the existing one expires
+(`NOTIFICATION_TIMEOUT`).
+
+### 7.6 Busy-state guards
+
+- `/tree` while the agent is running → show the friendly message
+  `"Tau is still working. Press Escape to interrupt before using /tree."` and
+  restore the draft — **not** an internal error (issue #277; the recursion crash
+  was separately fixed by iterative tree traversal, #298).
+- `/compact` while running/queued → notify to wait, restore the draft. While a
+  compaction is already active → notify and restore.
+
+---
+
+## 8. Streaming, submission, and perceived-latency fixes
+
+These are the subtle, hard-won behaviors. Recreate them faithfully.
+
+### 8.1 Optimistic user-message rendering (issues #166, #271, #272)
+
+The transcript is event-authoritative, which made submission feel laggy in long
+threads (the user row only appeared after the harness emitted the durable
+`MessageEndEvent`, after persistence). Fix: **optimistically append** the
+submitted user message immediately, **incrementally** (append a widget, not a full
+redraw), then **dedupe** the later confirmed user `MessageEndEvent` so it isn't
+rendered twice.
+
+Rules:
+
+- Only optimistic-render **plain prompts** — text that is non-empty and does
+  **not** start with `/` (`_should_optimistically_render_prompt`). Slash-command
+  prompts (custom-prompt expansions) render only from the confirmed event,
+  avoiding duplicate raw+expanded rows (issues #278, #282).
+- **Custom messages are never optimistic** (their `custom_type`/`details` arrive
+  only on the confirmed event; an equality-based dedupe would double-render).
+- Dedupe matches on **exact content equality** for the same run id
+  (`_consume_optimistic_user_event`).
+- **Extension `input` hooks can transform** the text, so the confirmed message may
+  differ from the optimistic one. Reconcile by **rewriting the optimistic item in
+  place** (`_replace_transformed_optimistic_user_message`) instead of appending a
+  second row. This runs after exact-match, and is safe because the run's own
+  prompt confirmation is its first user event — a queued steering/follow-up can
+  never be mistaken for it.
+- Track optimistic messages per **run id**; clear a run's unconfirmed optimistic
+  messages when it ends. A stale run id must stop applying events (guards against
+  late events from a cancelled worker mutating a new run).
+
+### 8.2 Incremental streaming updates (avoid full redraws)
+
+`_apply_streaming_transcript_event` applies each event to mounted widgets without
+remounting the transcript:
+
+- text/thinking delta → `append_assistant_delta` / `append_thinking_delta`;
+- `message_end` (assistant) → `finish_assistant_message`;
+- `tool_execution_start` → finalize the active assistant block, append the tool
+  item;
+- `tool_execution_update` → finalize assistant, update the matching tool item;
+- fall back to `_refresh()` (full redraw) only when the transcript isn't mounted
+  (e.g. a modal is on the screen stack) or for events that need chrome only.
+
+Finalize any active streaming block before starting another block (thinking →
+assistant → tool), so interleaving renders in order.
+
+### 8.3 Throttle streaming updates (issue #322)
+
+Batch high-frequency assistant/thinking deltas behind a short timer, and **flush
+pending deltas immediately at message/tool/run boundaries** to preserve ordering.
+Prevents per-token re-layout churn on long streams.
+
+### 8.4 Thinking-toggle performance & ordering (issues #248, #275, #256)
+
+- **Ctrl+T must be O(thinking blocks), not O(transcript).** Use a targeted
+  `update_thinking_visibility` that removes/re-inserts only thinking widgets and
+  preserves scroll position when not following — never a full rebuild.
+- **Ordering bug (#275):** after toggling, thinking blocks must remain **in their
+  original position** (between the user turn and the assistant turn that produced
+  them), not jump to the bottom. Reinsert thinking widgets **before** the correct
+  non-thinking sibling, and render a single collapsed "hidden thinking"
+  placeholder when `show_thinking` is off.
+- Streaming thinking goes to the active thinking widget; a finalized thinking
+  block stays put.
+
+### 8.5 Cancellation is not an error (issues #96, #99, #47)
+
+- **Esc** is a two-step flow: first press requests graceful cancellation via
+  `session.cancel()` (provider/tools observe a cancellation token, e.g. `bash`
+  honors it); second press interrupts the worker immediately.
+- Render the terminal cancellation as **status text**, not an error row.
+- Ignore late events from a cancelled worker (run-id guard, §8.1).
+
+### 8.6 Interleaved thinking/tool calls (issue #296)
+
+Pi runs tool calls **inside** the thought process; Tau must model thinking and
+tool calls interleaved in one assistant turn. Render each in stream order and
+persist ordered content blocks (§3.3). Do not force all thinking to a single
+leading block.
+
+---
+
+## 9. Chrome: header, sidebar, footer, terminal
+
+### 9.1 Header & terminal tab title (issues #244, #260, #304)
+
+- Header shows `Tau` + session name (`Tau — <name>`, default "Untitled session").
+  Keep it a **single row**: Textual's `Header` toggles a `-tall` (3-row) class on
+  click, which makes the sidebar jump — override it to stay one row (issue #336).
+- Terminal tab title via OSC 0 (`terminal_title.py`): `τ` when idle/untitled,
+  `τ | <name>` for named sessions, and a braille `⠋ …` running frame while active.
+  Sanitize control bytes, cap length (120), skip when `TERM=dumb`, non-tty, `CI`,
+  or `TAU_TERMINAL_TITLE` is off. Restore a neutral title on exit. Writes are
+  deduped and best-effort (disable on stream failure).
+
+### 9.2 Sidebar (issues #29, #30, #37, #38, #279)
+
+- Shows provider/model, thinking mode, tools, skills, prompt templates, context
+  files (AGENTS.md), and a context estimate. Logo `τ = 2π`.
+- **Responsive**: auto-hide below a min width/height (`SIDEBAR_MIN_WIDTH=96`,
+  `SIDEBAR_MIN_HEIGHT=24`); show a `CompactSessionInfo` single-line row under the
+  prompt on narrow layouts.
+- `sidebar_position` in `tui.json`: `left` (default) / `right` / `off`.
+
+### 9.3 Layout skeleton (CSS ids)
+
+`Header`, `#workspace` → `#sidebar` + `#main-pane`; `#main-pane` → `#transcript`
+(or extension `#main-slot`), `#above-prompt-slot`, `#queued-messages`,
+`#compact-session-info`, `#prompt-row` (`#prompt-prefix` + `#prompt`),
+`#below-prompt-slot`, `#autocomplete`, `Footer`. Extension slots (`#main-slot`,
+`#above/below-prompt-slot`) are the component seam (§12).
+
+---
+
+## 10. Autocomplete
+
+### 10.1 Completion sources (`build_completion_state`)
+
+- Slash commands, `/skill:<name>` (and other `:`-namespaced), prompt templates
+  (invoked by filename, no slash), `@file` references, shell path completion after
+  `!`/`!!`, and **argument values** for `/model`, `/login`, `/theme`, `/resume`.
+- `@` file search skips hidden/generated dirs (`.git`, `.venv`, `node_modules`,
+  `__pycache__`, `build`, `dist`, `.tau`, caches), caps at 50 results (issue #48).
+
+### 10.2 Behavior rules
+
+- **Hide after argument text starts**: once a custom-prompt/skill command is
+  followed by a space and argument text, stop showing suggestions (issue #173).
+- **Alias/prefix ordering**: prioritize alias matches correctly (issue #114).
+- **Enter applies, doesn't submit**: pressing Enter while a highlighted completion
+  would change the prompt applies it; it does not submit (phase-23).
+- **Stable height while typing** (issue #299): size the suggestion window from a
+  line budget (max ~16 visible lines, fraction of terminal height, min transcript
+  lines preserved) so it doesn't shrink/grow per keystroke (also #206 viewport
+  sizing).
+- `/model` can open a modal picker; `/resume` suggests indexed session ids (with
+  title/model/cwd metadata, newest-first).
+
+---
+
+## 11. Pickers and modals
+
+All are `ModalScreen`s with consistent keyboard nav (Up/Down, Enter select, Esc
+cancel) and themed `ListView` highlight.
+
+- **SessionPickerScreen** (Ctrl+R, `/resume`) — indexed sessions w/ metadata.
+  Selecting in `/session` output auto-copies selected text (issue #268, #270).
+- **TreePickerScreen** (`/tree`) — branch from an earlier entry; offers
+  branch-with-summary and custom-summary instructions
+  (`BranchSummaryInstructionsScreen`); can toggle tool calls. Selecting a **user
+  message** restores history to just before it and **prefills the input** with its
+  text rather than replaying it (issue #143).
+- **ModelPickerScreen** (`/model`) — two modes (all / scoped) toggled with Tab;
+  **Space** toggles a model into the scoped list; search input. (Issues #21, #33,
+  #60.)
+- **ThemePickerScreen** (`/theme`).
+- **Login flow** — `LoginProviderPickerScreen` (searchable), `LoginScreen`
+  (API key), `OAuthLoginScreen` (device-code / auth-url / manual-code / select
+  prompts), `CustomProviderLoginScreen` (multi-field, focus-next navigation),
+  `LoginMethodPickerScreen`. Anthropic uses explicit aliases
+  `anthropic-subscription` / `anthropic-api` (issue, PR #372). Keyboard navigation
+  through the whole flow was a specific fix (#6c14f839).
+- **Extension dialogs** — `ExtensionSelectScreen`, `ExtensionConfirmScreen`,
+  `ExtensionInputScreen` (async, future/callback-based — not `push_screen_wait`,
+  which needs a worker context; see §12).
+
+---
+
+## 12. Extension system UI surface
+
+The extension system (phase-21, PR #320, #366) touches the TUI through deliberate
+seams. A recreated TUI must provide:
+
+- **UI bridge** (`_TuiExtensionUiBridge`): `select`/`confirm`/`input` (async,
+  `push_screen` + `asyncio.Future`, timeout in seconds, no-op defaults on
+  timeout) and `notify`. Installed via `runtime.set_ui_bridge(...)` in `on_mount`,
+  **then** `session.emit_pending_session_start()` (idempotent) so `session_start`
+  handlers can use dialogs/notifications.
+- **Renderers installed into `TuiState`**: `custom_renderer`,
+  `tool_call_renderer`, `tool_result_renderer` — resolved lazily (§4.1). Malformed
+  markup never crashes the frontend (`Text.from_markup` under a guard, fallback to
+  literal).
+- **Component seam** (adopted via the component-seam experiment): slot widgets and
+  a main-area view. `#main-slot` replaces the transcript when an extension main
+  view is open; `#above/below-prompt-slot` host small widgets. Widget type is
+  Textual `Widget`; prefer strings where they suffice. While a main view is open,
+  don't steal focus to the prompt (§6.7).
+- **Key interceptors**: pre-dispatch key handlers registered by extensions.
+- **Reload lifecycle ordering** (PR #366): await `session_shutdown` on the
+  outgoing generation **before** clearing host UI, then invalidate generations,
+  purge `tau_extension_*` modules, re-import, re-run `setup`, rebuild tools and
+  the command registry, re-subscribe, and emit `session_start(reason="reload")`.
+  Every `ExtensionAPI`/`context` read checks a generation token and raises on a
+  stale generation so orphaned background tasks fail loudly.
+- **Failure isolation**: a raising extension handler/widget is quarantined and
+  recorded as a diagnostic; dispatch continues (fail-safe only for `tool_call`,
+  which blocks the tool). A broken extension never crashes the session.
+
+---
+
+## 13. Startup, settings, and robustness
+
+### 13.1 Startup model/provider resolution (`run_tui_app`)
+
+- `--resume` and `--new-session` are mutually exclusive (validated).
+- Resolve provider/model from explicit flags, then a resumed record
+  (`_selection_from_session_record`: provider+model **atomically**; legacy records
+  missing provider fall back to a scoped match or any credentialed provider that
+  lists the model), then the default — but only if it has usable credentials, else
+  the first usable provider (`_first_usable_startup_selection`).
+- **Bad `--model` → clean error, not a traceback** (issue #265): catch
+  `ProviderConfigError` and print an actionable message.
+- If no provider authenticates, open the TUI anyway with a
+  `LoginRequiredProvider` placeholder that surfaces "Login required…" as a
+  provider error on first prompt.
+
+### 13.2 Deferred session creation (issues #119, #142, #179)
+
+Do **not** create the JSONL transcript or index entry on startup/`/new` — only on
+the **first durable session mutation** (first message). Opening Tau just to run
+`/resume` must not leave an empty resumable session. (Regressed once as #179 —
+guard it.)
+
+### 13.3 Release notes & update check must never crash startup (issues #313, #339)
+
+- `releases.json` is **bundled inside the package** (`src/tau_coding/data/release-notes/`)
+  — a wheel that omits it caused `FileNotFoundError` at startup.
+- Loading release notes is **guarded**: a missing/malformed file is treated as
+  empty notes (a quiet no-op), matching the docstring. Startup proceeds.
+- The PyPI update check caches in `~/.tau/cache/update-check.json`, refreshes ≤
+  once/day, and is skipped under `CI` or `TAU_NO_UPDATE_CHECK=1`.
+
+### 13.4 TUI settings (`~/.tau/tui.json`) with strict validation
+
+- Fields: `theme`, `keybindings`, `auto_copy_selection`, `sidebar_position`.
+  Unknown fields, unknown theme/key names, empty keys, and **duplicate key
+  assignments** are rejected (fail early). Legacy keybinding names are tolerated.
+- **One theme system** (issue #281, PR #319): Textual's native theme registry is
+  constrained to Tau's themes (`tau-dark`, `tau-light`, `high-contrast`) and maps
+  to the same durable `theme` setting — no second, non-persistent theme engine.
+  Tau themes feed both Textual CSS variables and Rich renderers for consistency.
+- The CLI must **force UTF-8** on stdout/stderr (Windows cp1252 crashes on
+  non-ASCII model output; issues #285, #290) — reconfigure non-UTF-8 streams at
+  import, `errors="replace"`.
+
+### 13.5 Session index & storage robustness (issues #354, #360, #301, #269)
+
+- **JSONL split on `\n` only**, never `str.splitlines()` — U+2028/U+2029/U+0085
+  are written unescaped into JSON strings and would split a valid line, bricking
+  the session on next load (PR #354).
+- **Append-only index upsert**: the read-filter-rewrite `_upsert` raced with
+  concurrent Tau instances in the same folder, silently dropping entries (PR
+  #360). Append one record per write; dedupe last-writer-wins at read time.
+  Recover orphaned sessions (file exists but no index entry).
+- **Persist interrupted tool repairs on resume** (PR #269): dangling tool calls
+  from a cancelled run are repaired and persisted so resume doesn't break.
+- **Migrate null usage costs** at the persistence boundary (legacy sessions).
+- Auto-naming failures must be **non-fatal** to the turn and must not block
+  persistence (issues #306, #312).
+
+### 13.6 Provider/model consistency on navigation (issues #226, #247, #249, #258, #261, #353, #356)
+
+- Restore **provider+model atomically** on `/resume` and `/tree`; validate
+  compatibility before switching; never combine a model from one provider with
+  another provider. Legacy records without a provider preserve the current one.
+- `/tree` rewind must **not** apply historical model changes to runtime config —
+  preserve the currently active model (keep replayed state for transcript rebuild
+  only).
+- **Ignore orphaned provider preferences** (saved prefs for providers no longer
+  configured) rather than erroring (PR #353).
+- **Remember thinking level per scoped model** (`thinking_defaults` in
+  `providers.json`) and **apply it at startup** for the resolved model — including
+  validating it against the model's available levels (issue #356: a saved `xhigh`
+  default was ignored and the session fell back to an invalid `medium`).
+
+---
+
+## 14. Platform & environment edge cases
+
+- **CJK IME input** (issue #337): require **Textual ≥ 8.2.8**. Earlier versions
+  mis-parse kitty-keyboard IME commits, inserting escape garbage like
+  `[49;;20320:22909u` instead of `你好`. Pin the floor in `pyproject.toml`.
+- **Windows** (issues #216, #285, #290, #325, #326): Python ≥ 3.12; force UTF-8
+  streams (§13.4); tests must never touch the real `~/.tau` (isolate to tmp);
+  path/shell differences covered in `test_coding_session`.
+- **SOCKS proxies** (issues #221, #303): normalize `socks://` → `socks5://` before
+  creating httpx clients (httpx rejects the generic scheme); honor
+  `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY`.
+- **Provider retries** (issues #34, #333, #334): retry transient errors; Anthropic
+  must retry 425, 529, and 5xx above 504 like other providers. Retry surfaces as
+  `auto_retry_start` status rows.
+- **Drag-and-drop files into the input** (issue #170): open requirement.
+
+---
+
+## 15. Configuration surface (durable files)
+
+The TUI reads/writes (atomically, with `.bak` backups, reloading before a targeted
+change):
+
+- `~/.tau/tui.json` — theme, keybindings, `auto_copy_selection`, `sidebar_position`.
+- `~/.tau/providers.json` — default provider/model, scoped models,
+  `thinking_defaults`, headers, timeout/retry. Scoped models persist for Ctrl+P.
+- `~/.tau/credentials.json` — API keys/OAuth (0600, atomic). Resolution: stored
+  credential → env var. `/login` writes here; `/logout` removes only saved creds.
+- `~/.tau/catalog.toml` — user provider/model overlay (user-level only; **no
+  project-level catalog** so cloning a repo can't redirect `base_url`/credentials).
+- `~/.tau/settings.json` — `shellCommandPrefix` for aliases (§6.3 note).
+- `~/.tau/sessions/<cleaned-path>-<hash>/` — per-project session transcripts + index.
+
+---
+
+## 16. Default keybindings (remappable)
+
+| Key | Action |
+| --- | --- |
+| `Enter` | Submit (or apply highlighted completion); while running → queue steering |
+| `Shift+Enter` | Newline |
+| `Alt+Enter` | Queue follow-up |
+| `Esc` | Cancel run (two-step) |
+| `Up` (empty prompt) | Recall last prompt; while running → edit latest queued message |
+| `Tab` | Accept completion |
+| `Up`/`Down` | Move completions |
+| `Ctrl+K` | Command palette |
+| `Ctrl+R` | Session picker |
+| `Ctrl+P` | Cycle scoped models |
+| `Shift+Tab` | Cycle thinking level |
+| `Ctrl+T` | Toggle thinking display |
+| `Ctrl+O` | Toggle full tool output |
+| `Ctrl+C` | Clear prompt |
+| `Ctrl+D` | Quit |
+
+`Shift+Tab` may arrive as `backtab` on some terminals — accept both
+(`_is_thinking_cycle_key`).
+
+---
+
+## 17. Performance requirements (regression-prone)
+
+1. **Submission** feels instant in long threads → optimistic incremental render (§8.1).
+2. **Streaming** doesn't re-layout per token → throttle + targeted widget updates (§8.2, §8.3).
+3. **Ctrl+T** scales with thinking blocks, not transcript length (§8.4).
+4. **Ctrl+P scoped-model switch** is near-instant — avoid re-rendering/re-initializing
+   more than needed (issues #263, #266, #264).
+5. **Code blocks** don't flicker scrollbars while streaming (issue #254, #255) —
+   hide horizontal scrollbars during stream; stabilize on finalize. Horizontal
+   scrolling of code blocks must work when not streaming (issue #190).
+6. **Autocomplete** window keeps stable height while typing (§10.2).
+7. **/tree and session traversal** are **iterative**, never recursive (issue #277,
+   PR #298) — long sessions must not hit `RecursionError`.
+
+---
+
+## 18. Testing strategy
+
+- **Adapter/state are Textual-free** — test event→state mapping without a terminal
+  (`test_tui_adapter.py`).
+- **App-level** tests drive `TauTuiApp` with a fake session/provider
+  (`test_tui_app.py`): optimistic render/dedupe/transform, streaming increments,
+  cancellation, queued recall, paste placeholders, pickers, completion stability,
+  thinking-toggle ordering.
+- **Widget/markdown** tests (`test_tui_components.py`, `test_tui_autocomplete.py`,
+  `test_tui_config.py`).
+- **Layering** tests assert `tau_agent` has no Textual/app imports.
+- Reference manual-validation checklist in `dev-notes/architecture/phase-23-tui-polish.md`.
+
+---
+
+## 19. Open requirements / future work (tracked)
+
+- Custom TUI support / frontend swapping (issue #205) — the adapter seam is the
+  foundation; this PRD's contract (§2) is the stable surface.
+- Drag-and-drop files into the input (issue #170).
+- Command palette, diff viewer, dedicated patch slot (issue #323, PR #324).
+- Configurable context-usage display (PR #359).
+- Desktop notifications via OSC 9 (PR #349).
+- Data-driven JSON themes with user/project discovery (PR #374).
+- `--continue`/`-c` resume flag (PR #331).
+- Pluggable session storage as a public extension point (issue #341).
+- Raw LLM API observability (issue #110).
+
+---
+
+## 20. Appendix: edge-case → fix index
+
+| # | Edge case | Fix |
+|---|---|---|
+| 271/272 | Submit lag in long threads | Optimistic incremental user render + dedupe |
+| 278/282 | Custom-prompt shown twice | Skip optimistic render for `/` prompts |
+| 166 | Display blocked on persistence | Decouple display from durable event |
+| 337 | CJK IME garbled | Require Textual ≥ 8.2.8 |
+| 305/307 | Up doesn't recall steering | Pop steering queue too |
+| 275 | Thinking jumps to bottom on toggle | Reinsert in position; targeted update |
+| 248/256 | Ctrl+T slow in long threads | O(thinking) targeted update |
+| 254/255 | Code-block scrollbar flicker | Hide scrollbar while streaming |
+| 263/266/264 | Ctrl+P provider-switch lag | Lightweight switch, less re-render |
+| 265 | Bad `--model` traceback | Clean actionable error |
+| 247/249/258/261 | Provider/model mismatch on /tree,/resume | Atomic validated restore; preserve active model |
+| 226 | Unavailable auto-selected model | Validate + better provider error detail |
+| 353 | Orphaned provider preferences | Ignore gracefully |
+| 356 | Saved thinking level ignored at startup | Apply + validate per-model default |
+| 350/351 | `/path` treated as command | Pass unknown slash input through |
+| 336 | Header click layout jump | Keep header single-row |
+| 339/313 | Missing releases.json crash | Bundle file; guard load |
+| 354 | JSONL split on U+2028 bricks session | Split on `\n` only |
+| 360 | Concurrent index writes drop entries | Append-only upsert; recover orphans |
+| 269/301 | Interrupted tool repair lost on resume | Persist repairs |
+| 306/312 | Auto-naming failure blocks turn | Non-fatal naming |
+| 325/326 | Windows tests touch real ~/.tau | Isolate to tmp |
+| 285/290 | Windows cp1252 crash | Force UTF-8 streams |
+| 221/303 | socks:// proxy unsupported | Normalize to socks5:// |
+| 333/334 | Anthropic 529/5xx not retried | Retry like other providers |
+| 296 | Thinking not interleaved w/ tools | Ordered content blocks (§3.3) |
+| 277/298 | /tree RecursionError | Iterative traversal + friendly busy message |
+| 179/119/142 | Empty sessions persisted | Defer creation to first message |
+| 150/154 | Copy broken on wrapped lines | Correct rendered→source mapping |
+| 175/177 | Scrollback locked while streaming | Follow only at bottom |
+| 173 | Autocomplete lingers into args | Hide after argument starts |
+| 172 | No prompt recall | Up recalls last prompt into empty input |
+| 211/300 | Huge paste floods input | Placeholder + restore-on-submit |
+| 81 | Duplicate notifications stack | Dedupe active keys |
+| 86 | Redundant top status bar | Remove; queue feedback above prompt |
+| 143 | Tree replays user msg mid-turn | Restore history + prefill input |
+| 146 | `!` commands look foreign | Render like tool calls |
+| 125 | Can't change thinking while busy | Allow; applies to next turn |
+| 120 | OpenAI reasoning hidden | Surface reasoning deltas to Ctrl+T |
+| 281/319 | Two theme systems | Unify on Tau themes, persist |
+| 366 | Extension reload ordering | Await shutdown before UI teardown |
+| 164 | Input disabled during compaction | Allow typing; guard submit |
+| 322 | Per-token re-layout churn | Throttle + boundary flush |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "anyio>=4.0",
     "httpx[socks]>=0.27",
     "packaging>=24.0",
+    "prompt-toolkit>=3.0.50",
     "pydantic>=2.0",
     "pygments>=2.18",
     "rich>=13.0",

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -6,7 +6,7 @@ import contextlib
 import sys
 from os import environ
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import anyio
 import typer
@@ -188,6 +188,13 @@ def main(
         PrintOutputMode,
         typer.Option("--output", "-o", help="Output mode for print mode."),
     ] = PrintOutputMode.text,
+    tui: Annotated[
+        Literal["textual", "rich"],
+        typer.Option(
+            "--tui",
+            help="Interactive frontend: 'textual' (full) or 'rich' (minimal).",
+        ),
+    ] = "textual",
     resume: Annotated[
         str | None,
         typer.Option("--resume", help="Resume a session id in TUI mode."),
@@ -302,6 +309,7 @@ def main(
                 extension_paths,
                 not no_extensions,
                 project_extensions,
+                tui,
             )
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -346,8 +354,9 @@ async def run_openai_tui(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    tui: Literal["textual", "rich"] = "textual",
 ) -> None:
-    """Run the Textual TUI with the default OpenAI-compatible provider."""
+    """Run the selected TUI with the default OpenAI-compatible provider."""
     release_notes_notice = startup_release_notes_notice(_current_version())
     startup_notices = [
         notice
@@ -369,6 +378,7 @@ async def run_openai_tui(
         extension_paths=extension_paths,
         extensions_enabled=extensions_enabled,
         project_extensions_enabled=project_extensions_enabled,
+        frontend=tui,
     )
 
 

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -1,6 +1,6 @@
 # Tau TUI
 
-Tau's full interactive interface uses Textual behind an adapter boundary. `tau_agent` emits provider-neutral events; `tau_coding.tui` consumes and renders them.
+Tau's default full interactive interface uses Textual behind an adapter boundary. A minimalist Rich + prompt_toolkit frontend is available with `tau --tui rich`. Both consume provider-neutral events from `tau_agent`; frontend policy stays in `tau_coding`.
 
 For current behavior in a Tau checkout, read:
 

--- a/src/tau_coding/rich_tui.py
+++ b/src/tau_coding/rich_tui.py
@@ -66,12 +66,13 @@ class RichTuiRenderer:
     notice: str | None = None
 
     def layout(self) -> Layout:
-        root = Layout(name="root")
-        root.split_column(
-            Layout(self._transcript(), name="transcript", ratio=1),
-            Layout(self._queue(), name="queue", size=self._queue_height()),
-            Layout(self._status(), name="status", size=1),
-        )
+        root = Layout(name="root", size=max(4, Console().height - 3))
+        sections = [Layout(self._transcript(), name="transcript", ratio=1)]
+        queue_height = self._queue_height()
+        if queue_height:
+            sections.append(Layout(self._queue(), name="queue", size=queue_height))
+        sections.append(Layout(self._status(), name="status", size=1))
+        root.split_column(*sections)
         return root
 
     def _transcript(self) -> RenderableType:
@@ -100,7 +101,7 @@ class RichTuiRenderer:
                     vertical="middle",
                 )
             )
-        return Group(*rows)
+        return Align.left(Group(*rows), vertical="bottom")
 
     def _queue(self) -> RenderableType:
         lines = [f"↪ steer: {text}" for text in self.state.queued_steering]
@@ -204,18 +205,11 @@ class RichPromptTui:
     async def run(self) -> None:
         """Run until EOF or /quit, keeping all session ownership outside the UI."""
         await self.session.emit_pending_session_start()
-        self._live = Live(
-            self.renderer.layout(),
-            console=self.console,
-            screen=True,
-            auto_refresh=False,
-            vertical_overflow="ellipsis",
-        )
-        self._live.start(refresh=True)
         pending = self.initial_prompt
         try:
             with patch_stdout(raw=True):
                 while not self._exit:
+                    self._show_static_transcript()
                     try:
                         text = (
                             pending
@@ -227,10 +221,37 @@ class RichPromptTui:
                         break
                     text = text.strip()
                     if text:
-                        await self._submit(text)
+                        self._start_live_transcript()
+                        try:
+                            await self._submit(text)
+                        finally:
+                            self._stop_live_transcript()
         finally:
             self._title.restore()
-            self._live.stop()
+            self._stop_live_transcript()
+
+    def _show_static_transcript(self) -> None:
+        """Render a stable frame before prompt_toolkit takes control of input."""
+        self.console.clear()
+        self.console.print(self.renderer.layout())
+
+    def _start_live_transcript(self) -> None:
+        """Let Rich own the terminal only while output is actively changing."""
+        self.console.clear()
+        self._live = Live(
+            self.renderer.layout(),
+            console=self.console,
+            screen=False,
+            auto_refresh=False,
+            vertical_overflow="crop",
+        )
+        self._live.start(refresh=True)
+
+    def _stop_live_transcript(self) -> None:
+        live = self._live
+        self._live = None
+        if live is not None:
+            live.stop()
 
     async def _submit(self, text: str) -> None:
         terminal = parse_terminal_command(text)

--- a/src/tau_coding/rich_tui.py
+++ b/src/tau_coding/rich_tui.py
@@ -1,0 +1,339 @@
+"""Minimal interactive frontend built with Rich and prompt_toolkit.
+
+This frontend intentionally keeps a smaller surface than the Textual app: one
+transcript, one prompt, one contextual status line, and completion for commands.
+Detailed pickers and extension-owned widgets remain Textual-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.patch_stdout import patch_stdout
+from rich.align import Align
+from rich.console import Console, Group, RenderableType
+from rich.layout import Layout
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.text import Text
+
+from tau_coding.session import CodingSession, parse_terminal_command
+from tau_coding.tui.adapter import TuiEventAdapter
+from tau_coding.tui.config import TAU_DARK_THEME, TuiTheme
+from tau_coding.tui.state import TuiState, format_terminal_command_result_block
+from tau_coding.tui.terminal_title import TerminalTitleController
+from tau_coding.tui.widgets import render_chat_item
+
+
+class RichTuiCompleter(Completer):
+    """Complete the deliberately small public input vocabulary."""
+
+    def __init__(self, session: CodingSession) -> None:
+        self.session = session
+
+    def get_completions(self, document: Document, complete_event: object) -> Any:
+        del complete_event
+        text = document.text_before_cursor
+        if not text or any(character.isspace() for character in text):
+            return
+        candidates = [
+            f"/{command.name}" for command in self.session.command_registry.list_commands()
+        ]
+        candidates.extend(f"/skill:{skill.name}" for skill in self.session.skills)
+        candidates.extend(template.name for template in self.session.prompt_templates)
+        for candidate in sorted(set(candidates)):
+            if candidate.startswith(text):
+                yield Completion(candidate, start_position=-len(text))
+
+
+@dataclass(slots=True)
+class RichTuiRenderer:
+    """Turn Textual-free display state into one stable Rich layout."""
+
+    session: CodingSession
+    state: TuiState
+    theme: TuiTheme = TAU_DARK_THEME
+    notice: str | None = None
+
+    def layout(self) -> Layout:
+        root = Layout(name="root")
+        root.split_column(
+            Layout(self._transcript(), name="transcript", ratio=1),
+            Layout(self._queue(), name="queue", size=self._queue_height()),
+            Layout(self._status(), name="status", size=1),
+        )
+        return root
+
+    def _transcript(self) -> RenderableType:
+        rows: list[RenderableType] = []
+        if self.notice:
+            rows.extend((Text(self.notice, style=self.theme.muted_text), Text("")))
+        for item in self.state.items:
+            if item.role == "thinking" and not self.state.show_thinking:
+                continue
+            rows.append(
+                render_chat_item(
+                    item,
+                    theme=self.theme,
+                    show_tool_results=self.state.show_tool_results,
+                    custom_markup=self.state.resolve_custom_markup(
+                        item, expanded=self.state.show_tool_results
+                    ),
+                )
+            )
+        if self.state.assistant_buffer:
+            rows.append(Markdown(self.state.assistant_buffer))
+        if not rows:
+            rows.append(
+                Align.center(
+                    Text("τ\nAsk a question or type /hotkeys", style=self.theme.muted_text),
+                    vertical="middle",
+                )
+            )
+        return Group(*rows)
+
+    def _queue(self) -> RenderableType:
+        lines = [f"↪ steer: {text}" for text in self.state.queued_steering]
+        lines.extend(f"↪ follow-up: {text}" for text in self.state.queued_follow_up)
+        return Text("\n".join(lines), style=self.theme.muted_text)
+
+    def _queue_height(self) -> int:
+        return min(4, self.state.queued_message_count) if self.state.queued_message_count else 0
+
+    def _status(self) -> RenderableType:
+        branch = _git_branch_label(self.session)
+        activity = "working" if self.state.running else "ready"
+        context = _context_percent(self.session)
+        left = f" {self.session.cwd.name}{branch}"
+        right = (
+            f"{activity} · {self.session.provider_name}:{self.session.model} · "
+            f"{self.session.thinking_level} · ctx {context} "
+        )
+        width = max(1, Console().width)
+        gap = max(1, width - len(left) - len(right))
+        return Text(left + (" " * gap) + right, style=self.theme.muted_text)
+
+
+def _git_branch_label(session: CodingSession) -> str:
+    """Return a cheap branch label without making startup depend on git."""
+    head = session.cwd / ".git" / "HEAD"
+    try:
+        value = head.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    return f":{value.rpartition('/')[-1]}" if value.startswith("ref:") else ""
+
+
+def _context_percent(session: CodingSession) -> str:
+    window = session.context_window_tokens
+    if window <= 0:
+        return "?"
+    return f"{min(999, round(session.context_token_estimate / window * 100))}%"
+
+
+class RichPromptTui:
+    """A transcript-first Tau frontend with no persistent sidebar or help bar."""
+
+    def __init__(
+        self,
+        session: CodingSession,
+        *,
+        startup_notices: Sequence[str] = (),
+        initial_prompt: str | None = None,
+    ) -> None:
+        self.session = session
+        self.state = TuiState(skills=session.skills)
+        self.state.load_messages(session.messages)
+        self.adapter = TuiEventAdapter(self.state)
+        self.renderer = RichTuiRenderer(
+            session,
+            self.state,
+            notice="\n".join(startup_notices) or None,
+        )
+        self.initial_prompt = initial_prompt
+        self.console = Console()
+        self._title = TerminalTitleController()
+        self._exit = False
+        self._live: Live | None = None
+        self._history = InMemoryHistory()
+        for message in session.messages:
+            text = getattr(message, "text", None)
+            if isinstance(text, str) and text:
+                self._history.append_string(text)
+        self._prompt = PromptSession[str](
+            history=self._history,
+            completer=RichTuiCompleter(session),
+            complete_while_typing=True,
+            multiline=True,
+            key_bindings=self._keybindings(),
+            bottom_toolbar=self._toolbar,
+        )
+
+    def _keybindings(self) -> KeyBindings:
+        bindings = KeyBindings()
+
+        @bindings.add("escape", "enter")
+        def _submit(event: Any) -> None:
+            event.current_buffer.validate_and_handle()
+
+        @bindings.add("c-d")
+        def _quit(event: Any) -> None:
+            if event.current_buffer.text:
+                event.current_buffer.delete()
+            else:
+                event.app.exit(exception=EOFError)
+
+        return bindings
+
+    def _toolbar(self) -> ANSI:
+        return ANSI(
+            "\x1b[2m Alt+Enter submit · Enter newline · Tab complete · "
+            "Ctrl+C cancel input · Ctrl+D quit \x1b[0m"
+        )
+
+    async def run(self) -> None:
+        """Run until EOF or /quit, keeping all session ownership outside the UI."""
+        await self.session.emit_pending_session_start()
+        self._live = Live(
+            self.renderer.layout(),
+            console=self.console,
+            screen=True,
+            auto_refresh=False,
+            vertical_overflow="ellipsis",
+        )
+        self._live.start(refresh=True)
+        pending = self.initial_prompt
+        try:
+            with patch_stdout(raw=True):
+                while not self._exit:
+                    try:
+                        text = (
+                            pending
+                            if pending is not None
+                            else await self._prompt.prompt_async("τ ")
+                        )
+                        pending = None
+                    except (EOFError, KeyboardInterrupt):
+                        break
+                    text = text.strip()
+                    if text:
+                        await self._submit(text)
+        finally:
+            self._title.restore()
+            self._live.stop()
+
+    async def _submit(self, text: str) -> None:
+        terminal = parse_terminal_command(text)
+        if terminal is not None:
+            result = await self.session.run_terminal_command(
+                terminal.command,
+                add_to_context=terminal.add_to_context,
+            )
+            self.state.add_item("user", f"$ {terminal.command}")
+            self.state.add_item(
+                "tool",
+                format_terminal_command_result_block(
+                    ok=result.ok,
+                    added_to_context=terminal.add_to_context,
+                    output=result.output,
+                ),
+                always_show_tool_result=True,
+            )
+            self._refresh()
+            return
+
+        command = self.session.handle_command(text)
+        if command.handled:
+            await self._apply_command(command)
+            return
+
+        try:
+            async for event in self.session.prompt(text):
+                self.adapter.apply(event)
+                self._title.update(
+                    getattr(self.session, "session_title", None),
+                    running=self.state.running,
+                )
+                self._refresh()
+                await asyncio.sleep(0)
+        except KeyboardInterrupt:
+            self.session.cancel()
+            self.state.add_item("status", "Cancelled")
+        finally:
+            self._refresh()
+
+    async def _apply_command(self, command: Any) -> None:
+        if command.exit_requested:
+            self._exit = True
+        elif command.clear_requested:
+            self.state.clear()
+        elif command.new_session_requested:
+            self.state.clear()
+            command = _with_message(command, await self.session.new_session())
+        elif command.compact_summary is not None:
+            command = _with_message(command, await self.session.compact(command.compact_summary))
+        elif command.resume_session_id is not None:
+            command = _with_message(command, await self.session.resume(command.resume_session_id))
+            self.state.clear()
+            self.state.load_messages(self.session.messages)
+        elif command.thinking_level is not None:
+            command = _with_message(
+                command, await self.session.set_thinking_level(command.thinking_level)
+            )
+        elif any(
+            (
+                command.resume_picker_requested,
+                command.tree_picker_requested,
+                command.login_picker_requested,
+                command.custom_provider_login_requested,
+                command.logout_picker_requested,
+                command.model_picker_requested,
+                command.scoped_models_picker_requested,
+                command.theme_picker_requested,
+            )
+        ):
+            command = _with_message(
+                command,
+                "This minimalist frontend has no picker. Supply the command argument or "
+                "restart with --tui textual.",
+            )
+        if command.message:
+            self.renderer.notice = command.message
+        self._refresh()
+
+    def _refresh(self) -> None:
+        if self._live is not None:
+            self._live.update(self.renderer.layout(), refresh=True)
+
+
+def _with_message(command: Any, message: str) -> Any:
+    """Avoid coupling this frontend to every CommandResult constructor field."""
+    from dataclasses import replace
+
+    return replace(command, message=message)
+
+
+async def run_rich_tui(
+    session: CodingSession,
+    *,
+    startup_notices: Sequence[str] = (),
+    initial_prompt: str | None = None,
+) -> None:
+    """Run the built-in Rich/prompt_toolkit frontend."""
+    app = RichPromptTui(
+        session,
+        startup_notices=startup_notices,
+        initial_prompt=initial_prompt,
+    )
+    with suppress(EOFError):
+        await app.run()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5775,8 +5775,9 @@ async def run_tui_app(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    frontend: Literal["textual", "rich"] = "textual",
 ) -> None:
-    """Create the default provider/session and run the Textual app."""
+    """Create the default provider/session and run the selected built-in TUI."""
     if new_session and session_id is not None:
         raise RuntimeError("--resume and --new-session cannot be used together")
 
@@ -5853,14 +5854,24 @@ async def run_tui_app(
         legacy_notices = (startup_notice,) if startup_notice else ()
         error_notices = (startup_error_notice,) if startup_error_notice else ()
         all_startup_notices = tuple((*error_notices, *startup_notices, *legacy_notices))
-        app = TauTuiApp(
-            session,
-            tui_settings=load_tui_settings(),
-            startup_message=startup_message,
-            startup_notices=all_startup_notices,
-            initial_prompt=initial_prompt,
-        )
-        await app.run_async()
+        if frontend == "rich":
+            from tau_coding.rich_tui import run_rich_tui
+
+            rich_notices = ((startup_message,) if startup_message else ()) + all_startup_notices
+            await run_rich_tui(
+                session,
+                startup_notices=rich_notices,
+                initial_prompt=initial_prompt,
+            )
+        else:
+            app = TauTuiApp(
+                session,
+                tui_settings=load_tui_settings(),
+                startup_message=startup_message,
+                startup_notices=all_startup_notices,
+                initial_prompt=initial_prompt,
+            )
+            await app.run_async()
     finally:
         if session is not None:
             close_session = getattr(session, "aclose", None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,33 @@ def test_cli_without_prompt_invokes_tui_runner(
     assert calls == [(None, tmp_path, None, False, None, None, None)]
 
 
+def test_cli_selects_rich_tui(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    selected: list[object] = []
+
+    async def fake_run_openai_tui(*args: object) -> None:
+        selected.append(args[-1])
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["--tui", "rich"])
+
+    assert result.exit_code == 0
+    assert selected == ["rich"]
+
+
+def test_cli_rejects_unknown_tui(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+
+    result = CliRunner().invoke(app, ["--tui", "unknown"])
+
+    assert result.exit_code == 2
+    assert "Invalid value" in result.output
+    assert "textual" in result.output
+    assert "rich" in result.output
+
+
 def test_cli_positional_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_rich_tui.py
+++ b/tests/test_rich_tui.py
@@ -70,3 +70,14 @@ def test_renderer_keeps_session_details_in_one_status_line(tmp_path: Path) -> No
     assert "test-provider:test-model" in output
     assert "medium" in output
     assert "ctx 25%" in output
+    assert "Layout(name='queue'" not in output
+
+
+def test_renderer_only_allocates_queue_space_when_messages_are_queued(tmp_path: Path) -> None:
+    state = TuiState(queued_follow_up=("check the tests",))
+    renderer = RichTuiRenderer(fake_session(tmp_path), state)
+    console = Console(record=True, width=100, height=12)
+
+    console.print(renderer.layout())
+
+    assert "↪ follow-up: check the tests" in console.export_text()

--- a/tests/test_rich_tui.py
+++ b/tests/test_rich_tui.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
+from rich.console import Console
+
+from tau_coding.rich_tui import RichTuiCompleter, RichTuiRenderer
+from tau_coding.session import CodingSession
+from tau_coding.tui.state import TuiState
+
+
+class FakeRegistry:
+    def list_commands(self) -> list[SimpleNamespace]:
+        return [SimpleNamespace(name="session"), SimpleNamespace(name="model")]
+
+
+def fake_session(tmp_path: Path) -> CodingSession:
+    return cast(
+        CodingSession,
+        SimpleNamespace(
+            command_registry=FakeRegistry(),
+            skills=(SimpleNamespace(name="review"),),
+            prompt_templates=(SimpleNamespace(name="fix-tests"),),
+            cwd=tmp_path,
+            provider_name="test-provider",
+            model="test-model",
+            thinking_level="medium",
+            context_window_tokens=1000,
+            context_token_estimate=250,
+        ),
+    )
+
+
+def test_completer_offers_commands_skills_and_templates(tmp_path: Path) -> None:
+    completer = RichTuiCompleter(fake_session(tmp_path))
+
+    slash = list(
+        completer.get_completions(
+            Document("/s"), cast(Any, CompleteEvent(completion_requested=True))
+        )
+    )
+    skill = list(
+        completer.get_completions(
+            Document("/skill:r"), cast(Any, CompleteEvent(completion_requested=True))
+        )
+    )
+    template = list(
+        completer.get_completions(
+            Document("fix"), cast(Any, CompleteEvent(completion_requested=True))
+        )
+    )
+
+    assert [item.text for item in slash] == ["/session", "/skill:review"]
+    assert [item.text for item in skill] == ["/skill:review"]
+    assert [item.text for item in template] == ["fix-tests"]
+
+
+def test_renderer_keeps_session_details_in_one_status_line(tmp_path: Path) -> None:
+    state = TuiState()
+    state.add_item("assistant", "Hello **Tau**")
+    renderer = RichTuiRenderer(fake_session(tmp_path), state)
+    console = Console(record=True, width=100, height=12)
+
+    console.print(renderer.layout())
+    output = console.export_text()
+
+    assert "Hello Tau" in output
+    assert "test-provider:test-model" in output
+    assert "medium" in output
+    assert "ctx 25%" in output

--- a/uv.lock
+++ b/uv.lock
@@ -355,6 +355,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -533,6 +545,7 @@ dependencies = [
     { name = "anyio" },
     { name = "httpx", extra = ["socks"] },
     { name = "packaging" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pygments" },
     { name = "rich" },
@@ -552,6 +565,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "packaging", specifier = ">=24.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.50" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygments", specifier = ">=2.18" },
     { name = "rich", specifier = ">=13.0" },
@@ -626,4 +640,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -3,9 +3,22 @@ title: The interactive session
 description: Get fluent in Tau's terminal UI — prompting, steering, the command palette, tool output, and pickers.
 ---
 
-Running `tau` with no arguments opens the interactive terminal UI (TUI). This is
+Running `tau` with no arguments opens the full Textual terminal UI (TUI). This is
 where most work happens. This guide covers the moving parts; for the exact keys
 see [Keyboard shortcuts]({{< relref "../reference/keybindings.md" >}}).
+
+Tau also ships an intentionally smaller Rich + prompt_toolkit frontend:
+
+```bash
+tau --tui rich
+```
+
+It keeps the transcript, streaming output, multiline history, completion, shell
+commands, and one compact session-status line, while omitting sidebars and
+picker/widget surfaces. Press **Alt+Enter** to submit and **Enter** for a newline.
+Commands that need a picker should be given an argument (for example,
+`/resume <id>`) or run after restarting with `--tui textual`. The rest of this
+guide describes the default Textual frontend.
 
 ## Sending a prompt
 

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -39,6 +39,7 @@ one-time release-notes message to the transcript with the new features and fixes
 | `-m, --model TEXT` | Model to request from the provider |
 | `--provider TEXT` | Configured provider name to use |
 | `--cwd PATH` | Working directory for the built-in tools |
+| `--tui [textual\|rich]` | Interactive frontend: full Textual UI (default) or minimalist Rich UI |
 | `-o, --output [text\|json\|transcript]` | Output mode for print mode (default `text`) |
 | `--resume TEXT` | Resume a session id in the TUI |
 | `--new-session` | Start a new session instead of resuming the default |


### PR DESCRIPTION
## Description

Adds a second built-in interactive frontend selected with `tau --tui rich`. It combines Rich `Live`/`Layout` for a transcript-first full-screen display with prompt_toolkit for multiline editing, history, completion, and key handling.

The existing Textual frontend remains the default and full-featured experience. The new frontend deliberately keeps the useful coding loop—streaming transcript, compact tools, shell input, slash commands, session restore, and one status line—without recreating Textual's sidebar, modal/widget system, or picker framework.

The PR also adds the frontend-selection seam, tests, the normative TUI PRD used for the implementation, an architecture note documenting accepted and rejected scope, and user-facing documentation.

## User experience

- Offers a quiet, sidebar-free interface focused on transcript and prompt.
- Keeps model, thinking mode, context usage, repository, and activity in one compact line.
- Supports multiline prompts, history, and command/skill/template completion.
- Gives actionable guidance when a picker-only command requires the full Textual UI.
- Preserves the existing default, so this is opt-in and non-disruptive.

## Related issue

Addresses #205 by introducing named built-in TUI selection and validating the frontend boundary. Third-party frontend discovery remains deferred.

## Manual validation

```bash
uv run tau --tui rich
```

1. Submit a multiline prompt with `Alt+Enter` (`Enter` inserts a newline).
2. Confirm assistant text and tool calls stream into the transcript.
3. Run `!pwd` and `!!pwd` and confirm context status is reported.
4. Run `/session` and `/resume <known-session-id>`.
5. Run a picker-only command such as `/model`; confirm it recommends supplying an argument or using `--tui textual`.
6. Exit from an empty prompt with `Ctrl+D`.

## Validation performed

- `uv run pytest` — 974 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
