### PR TITLE
Fix provider error recovery and TUI reporting

### DIFF
--- a/dev-notes/provider-error-recovery.md
+++ b/dev-notes/provider-error-recovery.md
@@ -1,0 +1,50 @@
+# Provider error recovery and visible TUI failures
+
+## What changed
+
+Tau now keeps empty failed or aborted assistant messages in durable session
+history without replaying those messages to providers. The Textual frontend also
+projects terminal assistant failures into the mounted transcript immediately,
+including any partial assistant text that arrived before the failure.
+
+## Why it exists
+
+A production Kimi session exhausted retries with HTTP 429. Tau persisted the
+failure as an assistant message with no content. The user's next prompt replayed
+that empty assistant turn through the OpenAI-compatible chat format, and Kimi
+rejected the request with HTTP 400. Tau recorded the second failure internally,
+but incremental TUI rendering finalized an empty assistant widget instead of
+mounting the error item, so the run appeared to stop silently.
+
+## Architecture
+
+The fix preserves Tau's layer boundaries:
+
+- `tau_agent.loop` derives provider-facing context from canonical harness
+  history. Empty terminal failures are omitted only at this boundary; the
+  original messages remain available to sessions, branches, and diagnostics.
+- `tau_coding.tui.state` defines the canonical display projection for failed
+  assistant messages: replayable partial text followed by an error block.
+- `tau_coding.tui.app` rebuilds the transcript once at the terminal failure
+  event. This is not a high-frequency streaming path and guarantees that live
+  rendering matches restored session rendering.
+
+Only empty `error` and `aborted` assistant turns are filtered. A failed message
+with text, thinking, or tool-call content remains in provider context for now so
+this focused fix does not silently discard a partial response. A broader policy
+for partially failed turns and unmatched tool calls can be handled separately.
+
+## How to test
+
+```bash
+uv run pytest tests/test_agent_loop.py tests/test_tui_adapter.py tests/test_tui_app.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+The regression tests prove that an empty failed turn remains in harness history
+but is absent from the next provider call, restored failures retain their visible
+error, and a mounted Textual transcript shows the provider error during a live
+run.

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -114,7 +114,7 @@ async def run_agent_loop(
                 provider=provider,
                 model=model,
                 system=system,
-                messages=messages,
+                messages=_provider_context(messages),
                 tools=tools,
                 signal=signal,
             ):
@@ -166,6 +166,24 @@ async def run_agent_loop(
         break
 
     yield AgentEndEvent(messages=new_messages)
+
+
+def _provider_context(messages: list[AgentMessage]) -> list[AgentMessage]:
+    """Return replayable messages while retaining failures in durable history.
+
+    Providers cannot consistently accept an assistant turn with no content. Tau
+    persists terminal failures for diagnostics, but an empty failed or aborted
+    turn is not model context and must not poison the next request.
+    """
+    return [
+        message
+        for message in messages
+        if not (
+            isinstance(message, AssistantMessage)
+            and message.stop_reason in {"error", "aborted"}
+            and not message.content
+        )
+    ]
 
 
 async def _assistant_events(

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -60,17 +60,15 @@ class TuiEventAdapter:
                     details=message.details if isinstance(message.details, dict) else None,
                 )
             elif isinstance(message, AssistantMessage):
+                # Replace provisional delta rows with the final canonical
+                # message so persisted block boundaries and ordering win.
+                start = self._assistant_start_item_index
+                if start is not None:
+                    del self.state.items[start:]
                 if message.stop_reason in {"error", "aborted"}:
-                    text = message.error_message or "Error"
-                    self.state.error = text
+                    self.state.add_assistant_error(message)
                     self.state.running = False
-                    self.state.add_item("error", f"Error: {text}")
                 else:
-                    # Replace provisional delta rows with the final canonical
-                    # message so persisted block boundaries and ordering win.
-                    start = self._assistant_start_item_index
-                    if start is not None:
-                        del self.state.items[start:]
                     self.state.add_assistant_message(message, include_tool_calls=False)
                 self.state.assistant_buffer = ""
                 self._assistant_start_item_index = None

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3924,6 +3924,12 @@ class TauTuiApp(App[None]):
                 self._sync_header_title()
                 return
             if isinstance(event.message, AssistantMessage):
+                if event.message.stop_reason in {"error", "aborted"}:
+                    # The adapter projected any partial response plus the error
+                    # into canonical display state. Rebuild once at this terminal
+                    # boundary so the mounted transcript cannot drop the error.
+                    self._refresh()
+                    return
                 visible_blocks = [
                     block
                     for block in event.message.content

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -317,7 +317,10 @@ class TuiState:
                     details=message.details if isinstance(message.details, dict) else None,
                 )
             elif isinstance(message, AssistantMessage):
-                self.add_assistant_message(message)
+                if message.stop_reason in {"error", "aborted"}:
+                    self.add_assistant_error(message)
+                else:
+                    self.add_assistant_message(message)
             elif isinstance(message, ToolResultMessage):
                 self.record_tool_result(
                     message.tool_call_id,
@@ -354,6 +357,13 @@ class TuiState:
                     self.add_item("assistant", block.text)
             elif include_tool_calls:
                 self.add_tool_call(block)
+
+    def add_assistant_error(self, message: AssistantMessage) -> None:
+        """Project any partial response followed by its terminal error."""
+        self.add_assistant_message(message, include_tool_calls=False)
+        text = message.error_message or "Error"
+        self.error = text
+        self.add_item("error", f"Error: {text}")
 
     def _read_skill_name(self, tool_call: ToolCall) -> str | None:
         if tool_call.name != "read":

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -273,6 +273,49 @@ async def test_agent_loop_converts_provider_error_to_assistant_error_message() -
 
 
 @pytest.mark.anyio
+async def test_agent_loop_excludes_empty_failed_assistant_from_next_provider_call() -> None:
+    messages: list[AgentMessage] = []
+    recovered = AssistantMessage(content="recovered", model="fake")
+    provider = FakeProvider(
+        [
+            [assistant_error("provider failed")],
+            [assistant_start(), assistant_done(recovered)],
+        ]
+    )
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[],
+            prompts=[UserMessage(content="hello")],
+        )
+    )
+    failed = messages[-1]
+    assert isinstance(failed, AssistantMessage)
+    assert failed.stop_reason == "error"
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[],
+            prompts=[UserMessage(content="continue")],
+        )
+    )
+
+    assert failed in messages
+    replayed = provider.calls[1][2]
+    assert [message.text for message in replayed] == ["hello", "continue"]
+    assert failed not in replayed
+    assert messages[-1] is recovered
+
+
+@pytest.mark.anyio
 async def test_agent_loop_injects_steering_and_follow_up_messages() -> None:
     call = ToolCall(id="call-1", name="work", arguments={})
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2686,9 +2686,15 @@ async def test_session_compacts_and_retries_once_after_context_overflow(
         "Second answer",
         "Trigger overflow.",
     ]
-    overflow_error = provider.calls[4][2][4]
-    assert isinstance(overflow_error, AssistantMessage)
-    assert overflow_error.stop_reason == "error"
+    assert len(provider.calls[4][2]) == 4
+    overflow_errors = [
+        entry.message
+        for entry in entries
+        if entry.type == "message"
+        and isinstance(entry.message, AssistantMessage)
+        and entry.message.stop_reason == "error"
+    ]
+    assert len(overflow_errors) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -209,6 +209,26 @@ def test_tui_adapter_records_assistant_error_and_aborted_message() -> None:
     assert state.assistant_buffer == ""
 
 
+def test_tui_state_restores_partial_assistant_response_and_error() -> None:
+    state = TuiState()
+
+    state.load_messages(
+        [
+            AssistantMessage(
+                content="partial response",
+                stop_reason="error",
+                error_message="provider failed",
+            )
+        ]
+    )
+
+    assert [(item.role, item.text) for item in state.items] == [
+        ("assistant", "partial response"),
+        ("error", "Error: provider failed"),
+    ]
+    assert state.error == "provider failed"
+
+
 def test_tool_formatters_keep_human_readable_output() -> None:
     from tau_agent import ToolCall
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6053,6 +6053,31 @@ async def test_tui_prompt_worker_shows_diagnostic_log_path_for_error_event(tmp_p
 
 
 @pytest.mark.anyio
+async def test_tui_prompt_worker_mounts_provider_error_in_live_transcript() -> None:
+    error = AssistantMessage(stop_reason="error", error_message="provider failed")
+    app = TauTuiApp(
+        FakeSession(
+            events=[
+                AgentStartEvent(),
+                MessageStartEvent(message=error),
+                MessageEndEvent(message=error),
+                AgentEndEvent(),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await app._run_prompt("continue")
+        await pilot.pause()
+
+        errors = [
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "error"
+        ]
+        assert [widget.item.text for widget in errors] == ["Error: provider failed"]
+        assert app.state.running is False
+
+
+@pytest.mark.anyio
 async def test_tui_prompt_worker_shows_diagnostic_log_path_on_failure(tmp_path: Path) -> None:
     class EmptyMessageError(Exception):
         def __str__(self) -> str:

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -19,6 +19,11 @@ work continuing from another tab.
 Clicking anywhere in the window returns focus to the prompt, so you can scroll
 the transcript and keep typing without tabbing back.
 
+If a provider request fails after retries, Tau shows the failure as an explicit
+error block in the transcript. You can submit another prompt without starting a
+new session; empty failed provider turns are retained for diagnostics but are not
+replayed to the model as invalid conversation history.
+
 ## Cancelling and steering a run
 
 While the agent is working you don't have to wait:


### PR DESCRIPTION
## Brief description

Fix provider-error recovery across the portable agent loop and Textual frontend.

- Keep empty failed or aborted assistant messages in durable session history for diagnostics, but omit them from subsequent provider-facing context.
- Project failed assistant messages consistently when restoring TUI state, including partial text followed by the terminal error.
- Rebuild the mounted transcript at the terminal error boundary so live provider failures cannot disappear from the UI.
- Add harness, session, state, and mounted Textual regression coverage.
- Document the behavior in the TUI guide and a development note.

## How this improves user experience

A transient provider failure no longer poisons the next prompt with an invalid empty assistant turn. If a follow-up request also fails, Tau displays the error explicitly instead of stopping with no visible explanation. Users can continue working in the same session while retaining useful production diagnostics.

## Issue

Closes #394.

## How to manually validate

1. Start Tau in the TUI with an OpenAI-compatible provider.
2. Cause or simulate a provider request that ends in an empty `AssistantMessage` with `stop_reason="error"` (for example, exhaust retries on a 429 response).
3. Confirm that the transcript shows an explicit error block.
4. Submit another prompt such as `continue`.
5. Confirm that the provider payload does not include the previous empty assistant turn and that the session remains usable.
6. Resume the session and confirm that the persisted provider error is still visible.

The deterministic automated equivalent is:

```bash
uv run pytest tests/test_agent_loop.py tests/test_coding_session.py tests/test_tui_adapter.py tests/test_tui_app.py
```

## Validation performed

- `uv sync --dev --locked`
- `uv run pytest` — 973 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`
