### PR TITLE
Remove redundant tool-row spinner

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -140,11 +140,7 @@ from tau_coding.tui.config import (
     load_tui_settings,
     save_tui_settings,
 )
-from tau_coding.tui.state import (
-    TOOL_SPINNER_FRAMES,
-    TuiState,
-    format_terminal_command_result_block,
-)
+from tau_coding.tui.state import TuiState, format_terminal_command_result_block
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
@@ -4788,7 +4784,6 @@ class TauTuiApp(App[None]):
             self._apply_activity_indicator()
             return
         self._activity_frame = 0
-        self.state.tool_spinner = None
         if self._activity_timer is not None:
             self._activity_timer.pause()
         self._apply_activity_indicator()
@@ -4799,13 +4794,10 @@ class TauTuiApp(App[None]):
         self._activity_frame += 1
         self._apply_activity_indicator()
         self._sync_terminal_title()
-        self.state.tool_spinner = TOOL_SPINNER_FRAMES[
-            self._activity_frame % len(TOOL_SPINNER_FRAMES)
-        ]
-        self.call_later(self._respin_pending_tool)
+        self.call_later(self._refresh_pending_tool_timer)
 
-    async def _respin_pending_tool(self) -> None:
-        """Advance the spinner on the tool row that is currently executing."""
+    async def _refresh_pending_tool_timer(self) -> None:
+        """Refresh elapsed time on the tool row that is currently executing."""
         if not self.state.running:
             return
         item = next(

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -40,11 +40,8 @@ TOOL_RESULT_PREVIEW_LINES = 8
 TOOL_PATCH_PREVIEW_LINES = 32
 TOOL_RESULT_PREVIEW_CHARS = 2_000
 TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
-TOOL_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
-# Static invocation markers the spinner stands in for while a tool runs.
-_INVOCATION_MARKERS = ("→ ", "▸ ")
-# Show the live elapsed time on an executing tool row once it stops being
-# instant; quick reads/edits never flash a "(0s)".
+# Show live elapsed time on an executing tool row once it stops being instant;
+# quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
 
 
@@ -84,7 +81,6 @@ class TuiState:
     custom_renderer: CustomMessageMarkup | None = None
     tool_call_renderer: ToolCallMarkup | None = None
     tool_result_renderer: ToolResultMarkup | None = None
-    tool_spinner: str | None = None
 
     def add_item(
         self,
@@ -127,22 +123,17 @@ class TuiState:
         Resolved lazily at render time (like custom markup) so tool calls
         restored before the extension runtime connects still pick up their
         tool's `render_call` on the next redraw. ``None`` means "no renderer"
-        and the caller falls back to the generic ``item.text``. While a tool
-        is still executing and ``tool_spinner`` is set, the current spinner
-        frame stands in for the invocation's static marker.
+        and the caller falls back to the generic ``item.text``.
         """
         if item.role != "tool":
             return None
         line: str | None = None
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
-        if self.tool_spinner and item.tool_result_text is None:
-            line = apply_tool_spinner(line if line is not None else item.text, self.tool_spinner)
-            if item.started_at is not None:
-                elapsed = time.monotonic() - item.started_at
-                if elapsed >= TOOL_TIMER_MIN_SECONDS:
-                    line = f"{line} ({format_elapsed(elapsed)})"
-            return line
+        if item.tool_result_text is None and item.started_at is not None:
+            elapsed = time.monotonic() - item.started_at
+            if elapsed >= TOOL_TIMER_MIN_SECONDS:
+                return f"{line if line is not None else item.text} ({format_elapsed(elapsed)})"
         return line
 
     def resolve_tool_result(self, item: ChatItem, *, expanded: bool) -> str | None:
@@ -395,14 +386,6 @@ def format_elapsed(seconds: float) -> str:
         return f"{minutes}m {secs}s"
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h {minutes}m"
-
-
-def apply_tool_spinner(text: str, frame: str) -> str:
-    """Show the spinner frame in place of a static invocation marker."""
-    for marker in _INVOCATION_MARKERS:
-        if text.startswith(marker):
-            return f"{frame} {text[len(marker) :]}"
-    return f"{frame} {text}"
 
 
 def format_tool_call_block(tool_call: ToolCall) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1174,8 +1174,10 @@ def _chat_item_role_style(item: ChatItem, theme: TuiTheme) -> TuiRoleStyle:
 
 
 def _tool_accent_style(item: ChatItem, *, theme: TuiTheme) -> str | None:
-    if item.role != "tool" or not item.tool_result_text:
+    if item.role != "tool":
         return None
+    if item.tool_result_text is None:
+        return theme.role_styles["tool"].border
     if item.tool_result_text.startswith("✓"):
         return _tool_success_style(theme)
     if item.tool_result_text.startswith("✗"):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -100,7 +100,7 @@ from tau_coding.tui.config import (
     TuiTheme,
     tui_settings_path,
 )
-from tau_coding.tui.state import TOOL_SPINNER_FRAMES, ChatItem, TuiState
+from tau_coding.tui.state import ChatItem, TuiState
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
     LeftAlignedMarkdownHeading,
@@ -1110,6 +1110,25 @@ def test_light_theme_markdown_code_uses_aqua_without_background() -> None:
 
     assert "38;2;15;118;110" in output
     assert "38;2;15;118;110;48;2" not in output
+
+
+def test_pending_tool_invocation_uses_tool_accent_color() -> None:
+    console = Console(record=True, width=80)
+    item = ChatItem(role="tool", text="→ read README.md")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=item.text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
+        )
+    )
+
+    output = console.export_text(styles=True)
+
+    accent = "38;2;138;122;82;48;2;0;0;0m"
+    assert f"{accent}read" in output
+    assert f"{accent} README.md" in output
 
 
 def test_tool_chat_items_color_status_metadata_not_tool_name_or_results() -> None:
@@ -2938,7 +2957,7 @@ async def test_restored_tool_results_render_via_render_result() -> None:
 
 
 @pytest.mark.anyio
-async def test_pending_tool_row_shows_spinner_while_running() -> None:
+async def test_pending_tool_row_keeps_static_marker_while_running() -> None:
     session = FakeSession()
     session.extension_runtime = _RenderCallRuntime()
     app = TauTuiApp(session)  # type: ignore[arg-type]
@@ -2957,35 +2976,28 @@ async def test_pending_tool_row_shows_spinner_while_running() -> None:
                 args={"prompt": "x", "description": "Summarize codebase"},
             )
         )
-        app._tick_activity()
-        await pilot.pause()
 
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
-        # The spinner frame stands in for the static ▸ marker while running.
-        assert widget.selection_text[0] in TOOL_SPINNER_FRAMES
-        assert "▸" not in widget.selection_text
-        assert "Summarize codebase" in widget.selection_text
+        assert widget.selection_text == "▸ agent · Summarize codebase"
 
-        # Ticks must update the mounted widget in place — remounting every
-        # frame reads as transcript flicker.
-        first_frame = widget.selection_text[0]
+        # The run-wide activity indicator continues ticking without replacing
+        # the transcript marker with a second spinner.
+        app._tick_activity()
         app._tick_activity()
         await pilot.pause()
         same_widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert same_widget is widget
-        assert same_widget.selection_text[0] in TOOL_SPINNER_FRAMES
-        assert same_widget.selection_text[0] != first_frame
+        assert same_widget.selection_text == "▸ agent · Summarize codebase"
 
-        # Once the tool has been working for a while, the row shows a live
-        # elapsed timer after the description.
+        # Long-running tools retain useful elapsed-time feedback alongside the
+        # same static marker.
         tool_item = next(item for item in app.state.items if item.role == "tool")
         assert tool_item.started_at is not None
         tool_item.started_at -= 83
         app._tick_activity()
         await pilot.pause()
-        assert "(1m 23s)" in widget.selection_text
+        assert widget.selection_text == "▸ agent · Summarize codebase (1m 23s)"
 
-        # Once the result lands the static marker returns.
         await stream(
             ToolExecutionEndEvent(
                 tool_call_id="call-1",

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -71,6 +71,11 @@ a path like `@src/app.py`. Tau skips hidden and generated directories (`.git`,
 
 ## Tool output
 
+Tool calls keep a static marker in the transcript while they run: orange means
+in progress, green means success, and red means failure. The prompt-area activity
+indicator provides the run-wide animation without adding a second spinner to each
+tool row.
+
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Toggle full tool output with **Ctrl+O**.
 


### PR DESCRIPTION
## Summary

- remove the animated braille spinner from pending tool rows
- keep tool invocation markers static while preserving elapsed-time feedback for long-running tools
- style pending tool invocations with the theme's orange/yellow tool accent
- retain green and red completion styling and the prompt-area run activity indicator

## User experience

Tool rows no longer duplicate the run-wide animation already shown around the prompt. The transcript remains calmer and easier to scan while still communicating pending, successful, and failed states through color.

## Issue

No linked issue; addresses the redundant tool-row activity indicator reported during TUI review.

## Manual validation

1. Start `tau` and submit a prompt that invokes a tool.
2. Confirm the prompt-area activity indicator continues animating.
3. Confirm the pending tool row keeps its static `→` or extension-provided marker and uses the orange/yellow tool accent.
4. Let a tool run longer than one second and confirm elapsed time still appears without replacing the marker.
5. Confirm successful and failed tool rows transition to green and red respectively.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
