### PR TITLE
chore: prepare 0.2.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,26 @@
 [
   {
+    "version": "0.2.1",
+    "date": "2026-07-18",
+    "sections": {
+      "New": [
+        "Persist thinking/reasoning blocks and provider replay metadata across Tau's Pi-compatible event streams, session storage, exports, and TUI rendering.",
+        "Bundle Tau self-knowledge docs, examples, and skills so installed copies can answer Tau-specific questions without a source checkout."
+      ],
+      "Changed": [
+        "Discover Codex context and compaction limits at runtime from the authenticated model catalog, with conservative static fallbacks and a visible limit source in session diagnostics.",
+        "Remove the redundant animated tool-row spinner while keeping static status-colored markers and elapsed-time feedback."
+      ],
+      "Fixed": [
+        "Fix provider-error recovery so a failed or aborted assistant turn no longer poisons the next prompt, while keeping the error visible in the TUI and session history.",
+        "Fix tool-call labels in the session tree for assistant turns without visible text.",
+        "Fix light theme code block background in fenced code blocks.",
+        "Coerce the startup thinking level to a mode the remembered default model supports, preventing crashes on incompatible saved preferences.",
+        "Fix tests launching the real Anthropic OAuth browser during test runs."
+      ]
+    }
+  },
+  {
     "version": "0.2.0",
     "date": "2026-07-16",
     "sections": {

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Patch release preparing Tau 0.2.1 with all features and fixes merged since 0.2.0.

## New

- Persist thinking/reasoning blocks and provider replay metadata across Tau's Pi-compatible event streams, session storage, exports, and TUI rendering (#371).
- Bundle Tau self-knowledge docs, examples, and skills so installed copies can answer Tau-specific questions without a source checkout (#381).

## Changed

- Discover Codex context and compaction limits at runtime from the authenticated model catalog, with conservative static fallbacks and a visible limit source in session diagnostics (#390).
- Remove the redundant animated tool-row spinner while keeping static status-colored markers and elapsed-time feedback (#396).

## Fixed

- Fix provider-error recovery so a failed or aborted assistant turn no longer poisons the next prompt, while keeping the error visible in the TUI and session history (#395).
- Fix tool-call labels in the session tree for assistant turns without visible text (#387).
- Fix light theme code block background in fenced code blocks (#392).
- Coerce the startup thinking level to a mode the remembered default model supports, preventing crashes on incompatible saved preferences (#383).
- Fix tests launching the real Anthropic OAuth browser during test runs (#384).

## Release mechanics

- Bump `pyproject.toml` version to `0.2.1`.
- Add the `0.2.1` entry to `src/tau_coding/data/release-notes/releases.json`.
- Refresh `uv.lock`.

## Validation performed

- `uv run pytest -q` — 977 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
