### PR TITLE
Optimize long TUI transcript rendering

### DIFF
--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -58,6 +58,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Phase 21: Extensions](./phase-21-extensions.md)
 - [Phase 22: Compaction Replay Foundation](./phase-22-compaction-foundation.md)
 - [Phase 23: Advanced TUI and Product Polish](./phase-23-tui-polish.md)
+- [Bounded TUI Transcript Rendering](./tui-long-transcript-performance.md)
 - [Phase 24: Session Tree Branching](./phase-24-session-tree-branching.md)
 
 Phase 21 extensions are implemented; see the phase note and the user guide at

--- a/dev-notes/architecture/tui-long-transcript-performance.md
+++ b/dev-notes/architecture/tui-long-transcript-performance.md
@@ -1,0 +1,78 @@
+---
+title: "Bounded TUI Transcript Rendering"
+---
+
+Tau's Textual transcript now keeps a bounded window of message widgets mounted instead of
+letting the Textual DOM grow with every message in a session.
+
+## Why this exists
+
+The durable conversation and TUI display state were already separate, but the original
+`TranscriptView` mounted one Textual widget tree for every `ChatItem`. Long sessions therefore
+made unrelated interactions expensive: Textual had to visit thousands of message pumps during
+layout and refresh work even when the user was only typing in the prompt.
+
+A full transcript refresh was more expensive still because it removed and recreated every
+message widget. Tool completion, structured thinking responses, result visibility toggles, and
+terminal resize could all reach that path.
+
+## Architecture
+
+The complete display projection remains in `TuiState.items`. `TranscriptView` now mounts only a
+contiguous frontend window:
+
+```text
+CodingSession / durable messages
+              ↓
+TuiState.items (complete display history)
+              ↓
+TranscriptView window (bounded Textual DOM)
+```
+
+The latest 200 items are mounted initially. Small boundary rows indicate when earlier or later
+items are outside the window. Reaching a boundary moves the window by a smaller page while
+keeping an existing message as the scroll anchor. The state is never truncated, and session
+persistence is unchanged.
+
+This is deliberately a Textual adapter optimization. No windowing, rendering, or widget policy
+was added to `tau_agent` or `CodingSession`.
+
+## Incremental hot paths
+
+Common event paths no longer rebuild transcript history:
+
+- tool completion updates the existing tool row;
+- terminal commands append and complete one row;
+- final ordered thinking/text blocks replace only the provisional assistant tail;
+- thinking and tool-result visibility update only affected mounted rows;
+- terminal resize relies on native Textual reflow;
+- transcript item and tool-call lookup use frontend indexes rather than repeated scans.
+
+The prompt activity animation remains smooth, but fixed-size animation frames skip layout and
+tool elapsed-time rows update at most once per second.
+
+## Tradeoffs
+
+Native Textual Markdown, selection, streaming, and per-message rendering remain intact for the
+mounted window. Moving between windows clears widgets outside the viewport, so a mouse selection
+cannot span a paging boundary. The complete transcript remains available by continuing to scroll,
+and exports/session replay still use the full durable history.
+
+## Validation
+
+Automated tests cover:
+
+- a bounded mounted-widget count with complete state retained;
+- paging in both transcript directions;
+- scroll anchoring and streaming behavior;
+- incremental tool, structured assistant, result-toggle, and resize updates;
+- throttled activity/timer layout work.
+
+Run the project checks with:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2777,6 +2777,9 @@ class TauTuiApp(App[None]):
         self._completion_visible_line_budget: int | None = None
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
+        self._last_tool_timer_refresh_at = 0.0
+        self._last_activity_indicator_key: tuple[object, ...] | None = None
+        self._last_queue_render_key: tuple[object, ...] | None = None
         self._terminal_title = TerminalTitleController()
         self._active_notification_keys: set[tuple[str, str]] = set()
         self._supports_pyperclip: bool | None = None
@@ -3775,8 +3778,16 @@ class TauTuiApp(App[None]):
             f"$ {command.strip()}",
             always_show_tool_result=True,
         )
+        item = self.state.items[item_index]
         self._follow_transcript_output()
-        self._refresh()
+        transcript = self.query_one("#transcript", TranscriptView)
+        await transcript.append_item(
+            item,
+            theme=self.tui_settings.resolved_theme,
+            show_tool_results=True,
+            scroll_end=True,
+        )
+        self._refresh_chrome()
 
         try:
             result = await run_terminal_command(command, add_to_context=add_to_context)
@@ -3789,7 +3800,12 @@ class TauTuiApp(App[None]):
                     output=str(exc),
                 )
             self._notify(f"Could not run command: {exc}", severity="error")
-            self._refresh()
+            await transcript.update_item(
+                item,
+                theme=self.tui_settings.resolved_theme,
+                show_tool_results=True,
+            )
+            self._refresh_chrome()
             return
 
         if item_index >= len(self.state.items):
@@ -3802,7 +3818,12 @@ class TauTuiApp(App[None]):
             output=result.output,
         )
         self._follow_transcript_output()
-        self._refresh()
+        await transcript.update_item(
+            item,
+            theme=self.tui_settings.resolved_theme,
+            show_tool_results=True,
+        )
+        self._refresh_chrome()
 
     def _replace_tui_settings(self, *, theme: TuiThemeName) -> None:
         """Replace the current immutable TUI settings with a new theme."""
@@ -3832,7 +3853,7 @@ class TauTuiApp(App[None]):
         except Exception as exc:  # noqa: BLE001 - surface queueing failures in the TUI
             self._notify(f"Could not queue message: {exc}", severity="error")
             return
-        self._refresh()
+        self._refresh_chrome()
 
     async def _run_prompt(
         self,
@@ -3912,7 +3933,6 @@ class TauTuiApp(App[None]):
                     theme=theme,
                     show_thinking=self.state.show_thinking,
                 )
-            self._sync_activity_indicator()
             return
         if isinstance(event, MessageEndEvent):
             if isinstance(event.message, (UserMessage, CustomMessage)):
@@ -3929,18 +3949,32 @@ class TauTuiApp(App[None]):
                 visible_blocks = [
                     block
                     for block in event.message.content
-                    if isinstance(block, (TextContent, ThinkingContent))
+                    if (
+                        isinstance(block, TextContent)
+                        and bool(block.text)
+                        or isinstance(block, ThinkingContent)
+                        and bool(block.thinking)
+                    )
                 ]
+                canonical_items = self.state.items[-len(visible_blocks) :] if visible_blocks else []
                 if (
                     any(isinstance(block, ThinkingContent) for block in visible_blocks)
                     or len(visible_blocks) > 1
                 ):
-                    # The adapter replaced provisional rows with canonical ordered
-                    # blocks. Redraw through the normal extension-aware path.
-                    self._refresh()
+                    # Replace only this message's provisional streaming widgets;
+                    # unrelated history remains mounted and selectable.
+                    await transcript.finish_structured_assistant_message(
+                        canonical_items,
+                        theme=theme,
+                        show_thinking=self.state.show_thinking,
+                    )
                 else:
-                    await transcript.finish_assistant_message(event.message.text)
-                    self._refresh_chrome()
+                    canonical_item = canonical_items[-1] if canonical_items else None
+                    await transcript.finish_assistant_message(
+                        event.message.text,
+                        item=canonical_item,
+                    )
+                self._refresh_chrome()
                 return
             return
         if isinstance(event, ToolExecutionStartEvent):
@@ -3979,7 +4013,17 @@ class TauTuiApp(App[None]):
             self._refresh_chrome()
             return
         if isinstance(event, ToolExecutionEndEvent):
-            self._refresh()
+            updated_item = self.state.find_tool_item(event.tool_call_id)
+            if updated_item is not None:
+                expanded = self.state.show_tool_results or updated_item.always_show_tool_result
+                await transcript.update_item(
+                    updated_item,
+                    theme=theme,
+                    show_tool_results=expanded,
+                    invocation=self.state.resolve_tool_invocation(updated_item),
+                    result_markup=self.state.resolve_tool_result(updated_item, expanded=expanded),
+                )
+            self._refresh_chrome()
             return
         if isinstance(event, QueueUpdateEvent):
             self._refresh_chrome()
@@ -4196,10 +4240,17 @@ class TauTuiApp(App[None]):
         self.run_worker(self._cycle_scoped_model(), exclusive=False)
 
     def action_toggle_tool_results(self) -> None:
-        """Toggle inline tool result details in the transcript."""
+        """Toggle inline tool result details without rebuilding unrelated history."""
         expanded = self.state.toggle_tool_results()
-        self._refresh()
+        self.run_worker(self._update_tool_results_visibility(), exclusive=False)
         self._notify("Tool results expanded." if expanded else "Tool results collapsed.")
+
+    async def _update_tool_results_visibility(self) -> None:
+        transcript = self.query_one("#transcript", TranscriptView)
+        await transcript.update_tool_results_visibility(
+            self.state,
+            theme=self.tui_settings.resolved_theme,
+        )
 
     def action_toggle_thinking(self) -> None:
         """Toggle thinking-token display in the transcript."""
@@ -4765,8 +4816,16 @@ class TauTuiApp(App[None]):
         compact_info = self.query_one("#compact-session-info", CompactSessionInfo)
         compact_info.update_from_session(self.session, theme=theme)
         queued_messages = self.query_one("#queued-messages", Static)
-        queued_messages.display = self.state.queued_message_count > 0
-        queued_messages.update(_render_queued_messages(self.state, theme=theme))
+        queue_render_key = (
+            self.state.queued_steering,
+            self.state.queued_follow_up,
+            theme.name,
+            theme.muted_text,
+        )
+        if queue_render_key != self._last_queue_render_key:
+            self._last_queue_render_key = queue_render_key
+            queued_messages.display = self.state.queued_message_count > 0
+            queued_messages.update(_render_queued_messages(self.state, theme=theme))
         self._sync_activity_indicator()
         self._refresh_footer_bindings()
 
@@ -4800,7 +4859,10 @@ class TauTuiApp(App[None]):
         self._activity_frame += 1
         self._apply_activity_indicator()
         self._sync_terminal_title()
-        self.call_later(self._refresh_pending_tool_timer)
+        now = asyncio.get_running_loop().time()
+        if now - self._last_tool_timer_refresh_at >= 1.0:
+            self._last_tool_timer_refresh_at = now
+            self.call_later(self._refresh_pending_tool_timer)
 
     async def _refresh_pending_tool_timer(self) -> None:
         """Refresh elapsed time on the tool row that is currently executing."""
@@ -4836,13 +4898,26 @@ class TauTuiApp(App[None]):
             prompt_prefix = self.query_one("#prompt-prefix", Static)
         except NoMatches:
             return
+        shell_mode = _is_terminal_command_prompt(prompt.text)
+        render_key = (
+            theme.name,
+            theme.accent,
+            theme.screen_background,
+            theme.prompt_border,
+            self._activity_frame,
+            self.state.running,
+            shell_mode,
+        )
+        if render_key == self._last_activity_indicator_key:
+            return
+        self._last_activity_indicator_key = render_key
         prompt.styles.border = (
             "tall",
             _activity_prompt_border_color(
                 theme,
                 frame=self._activity_frame,
                 running=self.state.running,
-                shell_mode=_is_terminal_command_prompt(prompt.text),
+                shell_mode=shell_mode,
             ),
         )
         prompt_prefix.update(
@@ -4850,7 +4925,8 @@ class TauTuiApp(App[None]):
                 theme,
                 frame=self._activity_frame,
                 running=self.state.running,
-            )
+            ),
+            layout=False,
         )
 
     def _refresh_completions(self) -> None:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -81,6 +81,12 @@ class TuiState:
     custom_renderer: CustomMessageMarkup | None = None
     tool_call_renderer: ToolCallMarkup | None = None
     tool_result_renderer: ToolResultMarkup | None = None
+    _tool_items_by_call_id: dict[str, ChatItem] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def add_item(
         self,
@@ -94,17 +100,18 @@ class TuiState:
         details: dict[str, JSONValue] | None = None,
     ) -> None:
         """Append a transcript item."""
-        self.items.append(
-            ChatItem(
-                role=role,
-                text=text,
-                tool_call_id=tool_call_id,
-                tool_result_text=tool_result_text,
-                always_show_tool_result=always_show_tool_result,
-                custom_type=custom_type,
-                details=details,
-            )
+        item = ChatItem(
+            role=role,
+            text=text,
+            tool_call_id=tool_call_id,
+            tool_result_text=tool_result_text,
+            always_show_tool_result=always_show_tool_result,
+            custom_type=custom_type,
+            details=details,
         )
+        self.items.append(item)
+        if tool_call_id is not None and role in {"tool", "skill"}:
+            self._tool_items_by_call_id[tool_call_id] = item
 
     def resolve_custom_markup(self, item: ChatItem, *, expanded: bool) -> str | None:
         """Render a custom item's markup via the installed resolver, or ``None``.
@@ -160,16 +167,16 @@ class TuiState:
                 tool_call_id=tool_call.id,
             )
             return
-        self.items.append(
-            ChatItem(
-                role="tool",
-                text=format_tool_call_block(tool_call),
-                tool_call_id=tool_call.id,
-                tool_name=tool_call.name,
-                tool_arguments=tool_call.arguments,
-                started_at=time.monotonic(),
-            )
+        item = ChatItem(
+            role="tool",
+            text=format_tool_call_block(tool_call),
+            tool_call_id=tool_call.id,
+            tool_name=tool_call.name,
+            tool_arguments=tool_call.arguments,
+            started_at=time.monotonic(),
         )
+        self.items.append(item)
+        self._tool_items_by_call_id[tool_call.id] = item
 
     def add_user_message(
         self,
@@ -222,11 +229,8 @@ class TuiState:
         self.add_item("thinking", delta)
 
     def find_tool_item(self, tool_call_id: str) -> ChatItem | None:
-        """Return the transcript item for a tool call id, or ``None``."""
-        for item in reversed(self.items):
-            if item.role in {"tool", "skill"} and item.tool_call_id == tool_call_id:
-                return item
-        return None
+        """Return the transcript item for a tool call id in O(1)."""
+        return self._tool_items_by_call_id.get(tool_call_id)
 
     def record_tool_update(self, tool_call_id: str, message: str) -> ChatItem | None:
         """Attach live progress to its pending tool call; drop orphan updates."""
@@ -250,21 +254,21 @@ class TuiState:
             content=result.text,
             data=result.details if isinstance(result.details, dict) else None,
         )
-        for item in reversed(self.items):
-            if item.role in {"tool", "skill"} and item.tool_call_id == tool_call_id:
-                item.tool_result_text = result_text
-                item.tool_result = result
-                item.update_text = None
-                return
-        self.items.append(
-            ChatItem(
-                role="tool",
-                text=format_tool_result_summary(name=tool_name, ok=not is_error),
-                tool_call_id=tool_call_id,
-                tool_result_text=result_text,
-                tool_result=result,
-            )
+        item = self.find_tool_item(tool_call_id)
+        if item is not None:
+            item.tool_result_text = result_text
+            item.tool_result = result
+            item.update_text = None
+            return
+        item = ChatItem(
+            role="tool",
+            text=format_tool_result_summary(name=tool_name, ok=not is_error),
+            tool_call_id=tool_call_id,
+            tool_result_text=result_text,
+            tool_result=result,
         )
+        self.items.append(item)
+        self._tool_items_by_call_id[tool_call_id] = item
 
     def toggle_tool_results(self) -> bool:
         """Toggle expanded display for tool results and return the new state."""
@@ -289,6 +293,7 @@ class TuiState:
     def clear(self) -> None:
         """Clear visible transcript state without modifying durable session history."""
         self.items.clear()
+        self._tool_items_by_call_id.clear()
         self.assistant_buffer = ""
         self.error = None
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -23,7 +23,6 @@ from rich.theme import Theme
 from textual.containers import Horizontal, VerticalScroll
 from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.css.query import NoMatches
-from textual.events import Resize
 from textual.geometry import Offset
 from textual.selection import Selection
 from textual.widget import Widget
@@ -89,27 +88,60 @@ class SessionSummarySource(Protocol):
 class SessionSidebar(Static):
     """Compact sidebar with current session metadata."""
 
+    _summary_fingerprint: tuple[object, ...] | None = None
+
     def update_from_session(
         self,
         session: SessionSummarySource,
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Redraw the sidebar from current session metadata."""
-        self.update(render_session_sidebar(session, theme=theme))
+        """Redraw the sidebar only when displayed session metadata changed."""
+        fingerprint = _session_summary_fingerprint(session, theme=theme)
+        if fingerprint == self._summary_fingerprint:
+            return
+        self._summary_fingerprint = fingerprint
+        self.update(render_session_sidebar(session, theme=theme), layout=False)
 
 
 class CompactSessionInfo(Static):
     """Single-line session metadata for narrow TUI layouts."""
 
+    _summary_fingerprint: tuple[object, ...] | None = None
+
     def update_from_session(
         self,
         session: SessionSummarySource,
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Redraw compact session metadata."""
+        """Redraw compact session metadata only when its inputs changed."""
+        fingerprint = _session_summary_fingerprint(session, theme=theme)
+        if fingerprint == self._summary_fingerprint:
+            return
+        self._summary_fingerprint = fingerprint
         self.update(render_compact_session_info(session, theme=theme))
+
+
+def _session_summary_fingerprint(
+    session: SessionSummarySource,
+    *,
+    theme: TuiTheme,
+) -> tuple[object, ...]:
+    return (
+        theme.name,
+        session.cwd,
+        session.provider_name,
+        session.model,
+        session.thinking_level,
+        session.context_token_estimate,
+        session.auto_compact_token_threshold,
+        session.context_window_tokens,
+        tuple(tool.name for tool in session.tools),
+        tuple(skill.name for skill in session.skills),
+        tuple(template.name for template in session.prompt_templates),
+        tuple(context.path for context in session.context_files),
+    )
 
 
 class TauMarkdownBlock(MarkdownBlock):
@@ -205,6 +237,37 @@ class ThemedMarkdownWidget(TextualMarkdown):
 # matching how they appear while streaming.
 _BORDERLESS_TRANSCRIPT_ROLES = frozenset({"assistant", "thinking"})
 _HIDDEN_THINKING_PLACEHOLDER = "Thinking… Press Ctrl+T to show thinking tokens."
+TRANSCRIPT_WINDOW_ITEMS = 200
+TRANSCRIPT_WINDOW_PAGE_ITEMS = 80
+TRANSCRIPT_WINDOW_OVERSCAN_ITEMS = 40
+
+
+class TranscriptWindowBoundary(Static):
+    """Small paging sentinel shown when transcript items are outside the DOM window."""
+
+    ALLOW_SELECT = False
+    DEFAULT_CSS = """
+    TranscriptWindowBoundary {
+        width: 1fr;
+        height: 1;
+        margin: 0 1;
+        color: $tau-muted-text;
+        content-align: center middle;
+    }
+    """
+
+    def __init__(self, direction: Literal["earlier", "later"], count: int) -> None:
+        self.direction = direction
+        super().__init__(self._label(count), classes=f"transcript-window-{direction}")
+
+    def update_count(self, count: int) -> None:
+        """Update the hidden-item count without scheduling a layout pass."""
+        self.update(self._label(count), layout=False)
+
+    def _label(self, count: int) -> str:
+        noun = "message" if count == 1 else "messages"
+        arrow = "↑" if self.direction == "earlier" else "↓"
+        return f"{arrow} Scroll for {count} {self.direction} {noun}"
 
 
 class TranscriptMessageWidget(Horizontal):
@@ -257,6 +320,12 @@ class TranscriptMessageWidget(Horizontal):
         )
         self._theme = theme
         self._role_style = _chat_item_role_style(item, theme)
+        self._plain_render_key = (
+            self.selection_text,
+            self._role_style,
+            self._invocation,
+            self._result_markup,
+        )
         super().__init__(classes="transcript-message")
         foreground, background = _split_rich_style_colors(self._role_style.body)
         self._body_foreground = foreground
@@ -335,12 +404,30 @@ class TranscriptMessageWidget(Horizontal):
             return False
         self._invocation = invocation if self.item.role == "tool" else None
         self._result_markup = result_markup if self.item.role == "tool" else None
-        self.selection_text = transcript_item_selection_text(
+        next_role_style = _chat_item_role_style(self.item, self._theme)
+        next_selection_text = transcript_item_selection_text(
             self.item,
             show_tool_results=show_tool_results,
             invocation=self._invocation,
             result_markup=self._result_markup,
         )
+        next_render_key = (
+            next_selection_text,
+            next_role_style,
+            self._invocation,
+            self._result_markup,
+        )
+        if next_render_key == self._plain_render_key:
+            return True
+        self._plain_render_key = next_render_key
+        self.selection_text = next_selection_text
+        self._role_style = next_role_style
+        foreground, background = _split_rich_style_colors(self._role_style.body)
+        self._body_foreground = foreground
+        self._body_background = background
+        self.styles.border_left = ("tall", self._role_style.border)
+        if background:
+            self.styles.background = background
         self._markdown_text = _transcript_item_markdown(
             self.item,
             show_tool_results=show_tool_results,
@@ -360,6 +447,10 @@ class TranscriptMessageWidget(Horizontal):
                 result_markup=self._result_markup,
             )
         )
+        if foreground:
+            body.styles.color = foreground
+        if background:
+            body.styles.background = background
         return True
 
 
@@ -472,12 +563,20 @@ class TranscriptView(VerticalScroll):
             self.styles.min_width = min_width
         self._render_state: TuiState | None = None
         self._render_theme: TuiTheme = TAU_DARK_THEME
-        self._last_render_width = 0
         self._active_assistant_widget: StreamingTranscriptMessageWidget | None = None
         self._active_thinking_widget: StreamingTranscriptMessageWidget | None = None
+        self._active_message_widgets: list[Widget] = []
         self._hidden_thinking_placeholder_visible = False
         self._follow_output = True
         self._follow_scroll_pending = False
+        self._window_start = 0
+        self._window_end = 0
+        self._window_shift_pending = False
+        self._item_widgets: dict[
+            int, TranscriptMessageWidget | StreamingTranscriptMessageWidget
+        ] = {}
+        self._top_boundary: TranscriptWindowBoundary | None = None
+        self._bottom_boundary: TranscriptWindowBoundary | None = None
 
     def on_mount(self) -> None:
         """Follow new transcript content until the user scrolls away."""
@@ -508,12 +607,77 @@ class TranscriptView(VerticalScroll):
         return self._follow_output or self.is_vertical_scroll_end
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
-        """Track whether user scrollback has opted out of transcript following."""
+        """Track follow mode and page the bounded transcript window near its edges."""
         super().watch_scroll_y(old_value, new_value)
         if new_value < old_value:
             self._follow_output = False
-        elif new_value >= self.max_scroll_y:
+        elif new_value >= self.max_scroll_y and self._window_is_latest:
             self._follow_output = True
+
+        if new_value <= 1 and self._window_start > 0:
+            self._schedule_window_shift("earlier")
+        elif (
+            new_value >= max(0, self.max_scroll_y - 1)
+            and self._render_state is not None
+            and self._window_end < len(self._render_state.items)
+        ):
+            self._schedule_window_shift("later")
+
+    @property
+    def _window_is_latest(self) -> bool:
+        state = self._render_state
+        return state is None or self._window_end >= len(state.items)
+
+    def _schedule_window_shift(self, direction: Literal["earlier", "later"]) -> None:
+        if self._window_shift_pending:
+            return
+        self._window_shift_pending = True
+        self.call_later(self._shift_window, direction)
+
+    async def _shift_window(self, direction: Literal["earlier", "later"]) -> None:
+        """Move the mounted window while keeping one existing message as the anchor."""
+        state = self._render_state
+        if state is None or not state.items:
+            self._window_shift_pending = False
+            return
+        old_start = self._window_start
+        old_end = self._window_end
+        if direction == "earlier":
+            if old_start <= 0:
+                self._window_shift_pending = False
+                return
+            anchor_item = state.items[old_start] if old_start < len(state.items) else None
+            new_start = max(0, old_start - TRANSCRIPT_WINDOW_PAGE_ITEMS)
+            new_end = min(len(state.items), new_start + TRANSCRIPT_WINDOW_ITEMS)
+        else:
+            if old_end >= len(state.items):
+                self._window_shift_pending = False
+                return
+            anchor_item = state.items[old_end - 1] if old_end > old_start else None
+            new_end = min(len(state.items), old_end + TRANSCRIPT_WINDOW_PAGE_ITEMS)
+            new_start = max(0, new_end - TRANSCRIPT_WINDOW_ITEMS)
+
+        self._window_start = new_start
+        self._window_end = new_end
+        self._redraw(scroll_end=False, preserve_window=True)
+
+        def restore_anchor() -> None:
+            try:
+                if anchor_item is None:
+                    return
+                anchor = self._item_widgets.get(id(anchor_item))
+                if anchor is not None:
+                    self.scroll_to_widget(
+                        anchor,
+                        top=direction == "earlier",
+                        animate=False,
+                        immediate=True,
+                        force=True,
+                    )
+            finally:
+                self._window_shift_pending = False
+
+        self.call_after_refresh(restore_anchor)
 
     async def _finalize_active_thinking_message(self) -> None:
         """Stop streaming for a completed thinking block before another block starts."""
@@ -537,10 +701,21 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Redraw the transcript from display state."""
+        """Render display state while keeping the mounted transcript DOM bounded."""
+        same_state = self._render_state is state
+        retained_projection = same_state and any(
+            id(item) in self._item_widgets for item in state.items
+        )
+        should_follow = self._should_follow_output
+        if not retained_projection:
+            self._follow_output = True
+            should_follow = True
         self._render_state = state
         self._render_theme = theme
-        self._redraw(scroll_end=self._should_follow_output)
+        self._redraw(
+            scroll_end=should_follow,
+            preserve_window=retained_projection and not should_follow,
+        )
 
     def update_thinking_visibility(
         self,
@@ -548,89 +723,174 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
-        """Rebuild canonical transcript order after thinking visibility changes."""
+        """Update thinking rows in the mounted window without touching unrelated widgets."""
         self._render_state = state
         self._render_theme = theme
         should_follow = self._should_follow_output
         previous_scroll_y = self.scroll_y
+        window_items = state.items[self._window_start : self._window_end]
+        message_children = [
+            child
+            for child in self.children
+            if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
+        ]
+        thinking_children = [child for child in message_children if child.item.role == "thinking"]
+        non_thinking_children = [
+            child for child in message_children if child.item.role != "thinking"
+        ]
+        if thinking_children:
+            self.remove_children(thinking_children)
+        for item_id, widget in tuple(self._item_widgets.items()):
+            if widget in thinking_children:
+                del self._item_widgets[item_id]
 
-        self._redraw(scroll_end=should_follow)
-        if not should_follow:
+        non_thinking_index = 0
+        pending: list[tuple[ChatItem, TranscriptMessageWidget]] = []
+        hidden_run = False
+
+        def flush(before: Widget | None) -> None:
+            nonlocal pending
+            if not pending:
+                return
+            widgets = [widget for _, widget in pending]
+            self.mount(*widgets, before=before)
+            for item, widget in pending:
+                self._item_widgets[id(item)] = widget
+            pending = []
+
+        for item in window_items:
+            if item.role == "thinking":
+                if state.show_thinking:
+                    pending.append(
+                        (
+                            item,
+                            TranscriptMessageWidget(
+                                item,
+                                theme=theme,
+                                show_tool_results=state.show_tool_results,
+                            ),
+                        )
+                    )
+                elif not hidden_run:
+                    placeholder = TranscriptMessageWidget(
+                        ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                        theme=theme,
+                        show_tool_results=state.show_tool_results,
+                    )
+                    pending.append((item, placeholder))
+                    hidden_run = True
+                else:
+                    self._item_widgets[id(item)] = pending[-1][1]
+                continue
+
+            hidden_run = False
+            target = None
+            while non_thinking_index < len(non_thinking_children):
+                candidate = non_thinking_children[non_thinking_index]
+                non_thinking_index += 1
+                if candidate.item is item:
+                    target = candidate
+                    break
+            if target is not None:
+                flush(target)
+
+        flush(self._bottom_boundary)
+        self._active_thinking_widget = None
+        self._hidden_thinking_placeholder_visible = any(
+            widget.selection_text == _HIDDEN_THINKING_PLACEHOLDER for _, widget in pending
+        ) or _last_transcript_child_is_hidden_thinking_placeholder(self.children)
+        self.refresh(layout=True)
+        if should_follow:
+            self._request_follow_scroll()
+        else:
             self.call_after_refresh(
                 lambda: self.scroll_to(y=previous_scroll_y, animate=False, immediate=True)
             )
 
-    def on_resize(self, event: Resize) -> None:
-        """Re-render transcript entries when the terminal width changes."""
-        del event
-        if self._render_state is None:
-            return
-        width = self.scrollable_content_region.width
-        if width <= 0 or width == self._last_render_width:
-            return
-        was_at_end = self.is_vertical_scroll_end
-        self._redraw(scroll_end=was_at_end)
-        self.scroll_to(x=0, animate=False, immediate=True)
-
-    def _redraw(self, *, scroll_end: bool) -> None:
+    def _redraw(self, *, scroll_end: bool, preserve_window: bool = False) -> None:
         state = self._render_state
         if state is None:
             return
         theme = self._render_theme
-        self._last_render_width = self.scrollable_content_region.width
-        self.remove_children(
-            [
-                child
-                for child in self.children
-                if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget)
-            ]
-        )
+        total = len(state.items)
+        if not preserve_window or self._window_end <= self._window_start:
+            self._window_end = total
+            self._window_start = max(0, total - TRANSCRIPT_WINDOW_ITEMS)
+        else:
+            self._window_start = min(self._window_start, total)
+            self._window_end = min(max(self._window_end, self._window_start), total)
+            if self._window_end - self._window_start > TRANSCRIPT_WINDOW_ITEMS:
+                self._window_start = self._window_end - TRANSCRIPT_WINDOW_ITEMS
+
+        removable = [
+            child
+            for child in self.children
+            if isinstance(
+                child,
+                TranscriptMessageWidget
+                | StreamingTranscriptMessageWidget
+                | TranscriptWindowBoundary,
+            )
+        ]
+        if removable:
+            self.remove_children(removable)
         self._active_assistant_widget = None
         self._active_thinking_widget = None
+        self._active_message_widgets = []
         self._hidden_thinking_placeholder_visible = False
-        hidden_thinking_placeholder = False
-        for item in state.items:
+        self._item_widgets.clear()
+        self._top_boundary = None
+        self._bottom_boundary = None
+
+        widgets: list[Widget] = []
+        if self._window_start > 0:
+            self._top_boundary = TranscriptWindowBoundary("earlier", self._window_start)
+            widgets.append(self._top_boundary)
+
+        hidden_thinking_widget: TranscriptMessageWidget | None = None
+        for item in state.items[self._window_start : self._window_end]:
             if item.role == "thinking" and not state.show_thinking:
-                if not hidden_thinking_placeholder:
-                    self.mount(
-                        TranscriptMessageWidget(
-                            ChatItem(
-                                role="thinking",
-                                text=_HIDDEN_THINKING_PLACEHOLDER,
-                            ),
-                            theme=theme,
-                            show_tool_results=state.show_tool_results,
-                        )
+                if hidden_thinking_widget is None:
+                    hidden_thinking_widget = TranscriptMessageWidget(
+                        ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                        theme=theme,
+                        show_tool_results=state.show_tool_results,
                     )
-                    hidden_thinking_placeholder = True
+                    widgets.append(hidden_thinking_widget)
+                self._item_widgets[id(item)] = hidden_thinking_widget
                 continue
-            hidden_thinking_placeholder = False
-            custom_markup = (
-                state.resolve_custom_markup(item, expanded=state.show_tool_results)
-                if item.role == "custom"
-                else None
+            hidden_thinking_widget = None
+            expanded = state.show_tool_results or item.always_show_tool_result
+            widget = TranscriptMessageWidget(
+                item,
+                theme=theme,
+                show_tool_results=expanded,
+                custom_markup=(
+                    state.resolve_custom_markup(item, expanded=state.show_tool_results)
+                    if item.role == "custom"
+                    else None
+                ),
+                invocation=state.resolve_tool_invocation(item),
+                result_markup=state.resolve_tool_result(item, expanded=expanded),
             )
-            self.mount(
-                TranscriptMessageWidget(
-                    item,
-                    theme=theme,
-                    show_tool_results=state.show_tool_results or item.always_show_tool_result,
-                    custom_markup=custom_markup,
-                    invocation=state.resolve_tool_invocation(item),
-                    result_markup=state.resolve_tool_result(
-                        item,
-                        expanded=state.show_tool_results or item.always_show_tool_result,
-                    ),
-                )
-            )
-        if state.assistant_buffer:
+            self._item_widgets[id(item)] = widget
+            widgets.append(widget)
+
+        if self._window_end < total:
+            self._bottom_boundary = TranscriptWindowBoundary("later", total - self._window_end)
+            widgets.append(self._bottom_boundary)
+        elif state.assistant_buffer:
             self._active_assistant_widget = StreamingTranscriptMessageWidget(
                 ChatItem(role="assistant", text=state.assistant_buffer),
                 theme=theme,
             )
-            self.mount(self._active_assistant_widget)
+            self._active_message_widgets.append(self._active_assistant_widget)
+            widgets.append(self._active_assistant_widget)
+
+        if widgets:
+            self.mount(*widgets)
         self._hidden_thinking_placeholder_visible = (
-            _last_transcript_child_is_hidden_thinking_placeholder(self.children)
+            hidden_thinking_widget is not None and self._window_end == total
         )
         self.refresh(layout=True)
         if scroll_end:
@@ -647,11 +907,24 @@ class TranscriptView(VerticalScroll):
         invocation: str | None = None,
         result_markup: str | None = None,
     ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
-        """Append one transcript item without rebuilding previous blocks."""
+        """Append one item, paging to the latest window only for followed output."""
         should_follow = self._should_follow_output if not scroll_end else True
         await self._finalize_active_assistant_message()
         await self._finalize_active_thinking_message()
         self._render_theme = theme
+        state = self._render_state
+        item_index = _identity_index(state.items, item) if state is not None else None
+
+        if state is not None and item_index is not None and self._window_end < item_index:
+            if should_follow:
+                self._window_end = 0
+                self._redraw(scroll_end=True)
+                mounted = self._item_widgets.get(id(item))
+                if mounted is not None:
+                    return mounted
+            elif self._bottom_boundary is not None:
+                self._bottom_boundary.update_count(len(state.items) - self._window_end)
+
         widget = _transcript_widget(
             item,
             theme=theme,
@@ -660,15 +933,61 @@ class TranscriptView(VerticalScroll):
             invocation=invocation,
             result_markup=result_markup,
         )
-        await self.mount(widget)
+        if (
+            state is not None
+            and item_index is not None
+            and (
+                item_index < self._window_start
+                or (item_index > self._window_end and not should_follow)
+            )
+        ):
+            return widget
+        if state is not None and item_index is not None:
+            self._window_end = max(self._window_end, item_index + 1)
+        await self.mount(widget, before=self._bottom_boundary)
+        self._item_widgets[id(item)] = widget
         self._active_assistant_widget = None
         self._active_thinking_widget = None
+        self._active_message_widgets = []
         self._hidden_thinking_placeholder_visible = False
-        self._last_render_width = self.scrollable_content_region.width
+
+        if (
+            state is not None
+            and self._window_end - self._window_start
+            > TRANSCRIPT_WINDOW_ITEMS + TRANSCRIPT_WINDOW_OVERSCAN_ITEMS
+        ):
+            self._window_end = len(state.items)
+            self._window_start = max(0, self._window_end - TRANSCRIPT_WINDOW_ITEMS)
+            self._redraw(scroll_end=should_follow, preserve_window=True)
+            widget = self._item_widgets.get(id(item), widget)
+        elif self._top_boundary is not None:
+            self._top_boundary.update_count(self._window_start)
+
         self.refresh(layout=True)
         if should_follow:
             self._request_follow_scroll(force=scroll_end)
         return widget
+
+    async def update_tool_results_visibility(
+        self,
+        state: TuiState,
+        *,
+        theme: TuiTheme = TAU_DARK_THEME,
+    ) -> None:
+        """Update only mounted rows whose rendering depends on result visibility."""
+        self._render_state = state
+        self._render_theme = theme
+        for item in state.items[self._window_start : self._window_end]:
+            if item.role not in {"tool", "skill", "branch_summary", "compaction_summary"}:
+                continue
+            expanded = state.show_tool_results or item.always_show_tool_result
+            await self.update_item(
+                item,
+                theme=theme,
+                show_tool_results=expanded,
+                invocation=state.resolve_tool_invocation(item),
+                result_markup=state.resolve_tool_result(item, expanded=expanded),
+            )
 
     async def update_item(
         self,
@@ -679,32 +998,32 @@ class TranscriptView(VerticalScroll):
         invocation: str | None = None,
         result_markup: str | None = None,
     ) -> bool:
-        """Re-render one already-mounted transcript item in place."""
-        for child in self.children:
-            if isinstance(child, TranscriptMessageWidget) and child.item is item:
-                # Prefer updating the mounted widget's content: remounting
-                # forces a layout pass and follow-scroll on every call, which
-                # reads as transcript flicker at spinner-tick frequency.
-                if child.refresh_invocation(
-                    show_tool_results=show_tool_results,
-                    invocation=invocation,
-                    result_markup=result_markup,
-                ):
-                    return True
-                replacement = _transcript_widget(
-                    item,
-                    theme=theme,
-                    show_tool_results=show_tool_results,
-                    invocation=invocation,
-                    result_markup=result_markup,
-                )
-                await self.mount(replacement, after=child)
-                await child.remove()
-                self.refresh(layout=True)
-                if self._should_follow_output:
-                    self._request_follow_scroll()
-                return True
-        return False
+        """Update a mounted item in O(1); off-screen state is rendered when paged in."""
+        child = self._item_widgets.get(id(item))
+        if not isinstance(child, TranscriptMessageWidget) or child.item is not item:
+            return False
+        # Prefer updating the mounted widget's content: remounting forces a
+        # layout pass and visible flicker for live progress and elapsed timers.
+        if child.refresh_invocation(
+            show_tool_results=show_tool_results,
+            invocation=invocation,
+            result_markup=result_markup,
+        ):
+            return True
+        replacement = _transcript_widget(
+            item,
+            theme=theme,
+            show_tool_results=show_tool_results,
+            invocation=invocation,
+            result_markup=result_markup,
+        )
+        await self.mount(replacement, after=child)
+        await child.remove()
+        self._item_widgets[id(item)] = replacement
+        self.refresh(layout=True)
+        if self._should_follow_output:
+            self._request_follow_scroll()
+        return True
 
     async def start_assistant_message(
         self,
@@ -722,9 +1041,9 @@ class TranscriptView(VerticalScroll):
             theme=theme,
         )
         self._render_theme = theme
-        await self.mount(widget)
+        await self.mount(widget, before=self._bottom_boundary)
         self._active_assistant_widget = widget
-        self._last_render_width = self.scrollable_content_region.width
+        self._active_message_widgets.append(widget)
         if should_follow:
             self._request_follow_scroll(force=scroll_end)
         return widget
@@ -736,7 +1055,9 @@ class TranscriptView(VerticalScroll):
         theme: TuiTheme = TAU_DARK_THEME,
         scroll_end: bool = False,
     ) -> None:
-        """Append streamed assistant text to the active message widget."""
+        """Append streamed assistant text when the latest window is mounted."""
+        if not self._window_is_latest:
+            return
         should_follow = self._should_follow_output if not scroll_end else True
         widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
         await widget.append_fragment(delta)
@@ -752,6 +1073,16 @@ class TranscriptView(VerticalScroll):
         scroll_end: bool = False,
     ) -> None:
         """Append streamed thinking text or one hidden-thinking placeholder."""
+        state = self._render_state
+        if state is not None:
+            # The adapter adds provisional thinking items before this method runs.
+            was_latest = self._window_end >= max(0, len(state.items) - 1)
+            if was_latest:
+                self._window_end = len(state.items)
+            else:
+                if self._bottom_boundary is not None:
+                    self._bottom_boundary.update_count(len(state.items) - self._window_end)
+                return
         should_follow = self._should_follow_output if not scroll_end else True
         if not show_thinking:
             if self._hidden_thinking_placeholder_visible:
@@ -764,10 +1095,10 @@ class TranscriptView(VerticalScroll):
                 theme=theme,
                 show_tool_results=False,
             )
-            await self.mount(widget, before=self._active_assistant_widget)
+            await self.mount(widget, before=self._active_assistant_widget or self._bottom_boundary)
+            self._active_message_widgets.append(widget)
             self._active_thinking_widget = None
             self._hidden_thinking_placeholder_visible = True
-            self._last_render_width = self.scrollable_content_region.width
             self.refresh(layout=True)
             if should_follow:
                 self._request_follow_scroll(force=scroll_end)
@@ -780,25 +1111,97 @@ class TranscriptView(VerticalScroll):
             )
             await self.mount(
                 self._active_thinking_widget,
-                before=self._active_assistant_widget,
+                before=self._active_assistant_widget or self._bottom_boundary,
             )
+            self._active_message_widgets.append(self._active_thinking_widget)
         await self._active_thinking_widget.append_fragment(delta)
         if should_follow:
             self._request_follow_scroll(force=scroll_end)
 
-    async def finish_assistant_message(self, text: str | None = None) -> None:
+    async def finish_assistant_message(
+        self,
+        text: str | None = None,
+        *,
+        item: ChatItem | None = None,
+    ) -> None:
         """Finalize the active assistant widget after the provider sends the full message."""
         widget = self._active_assistant_widget
         if widget is None:
-            if text:
+            if item is not None:
+                await self.append_item(item, theme=self._render_theme)
+            elif text:
                 await self.append_item(
                     ChatItem(role="assistant", text=text),
                     theme=self._render_theme,
                 )
             return
         await widget.finalize(text)
+        if item is not None:
+            widget.item = item
+            self._item_widgets[id(item)] = widget
         self._active_assistant_widget = None
+        self._active_message_widgets = [
+            candidate for candidate in self._active_message_widgets if candidate is not widget
+        ]
         self._hidden_thinking_placeholder_visible = False
+
+    async def finish_structured_assistant_message(
+        self,
+        items: Sequence[ChatItem],
+        *,
+        theme: TuiTheme = TAU_DARK_THEME,
+        show_thinking: bool,
+    ) -> None:
+        """Replace only the provisional assistant tail with canonical ordered blocks."""
+        should_follow = self._should_follow_output
+        for widget in tuple(self._active_message_widgets):
+            if widget.parent is self:
+                await widget.remove()
+        self._active_message_widgets.clear()
+        self._active_assistant_widget = None
+        self._active_thinking_widget = None
+        self._hidden_thinking_placeholder_visible = False
+        for item_id, widget in tuple(self._item_widgets.items()):
+            if widget.parent is None:
+                del self._item_widgets[item_id]
+
+        state = self._render_state
+        if state is not None:
+            self._window_end = len(state.items)
+        hidden_widget: TranscriptMessageWidget | None = None
+        mounted: list[Widget] = []
+        for item in items:
+            if item.role == "thinking" and not show_thinking:
+                if hidden_widget is None:
+                    hidden_widget = TranscriptMessageWidget(
+                        ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                        theme=theme,
+                        show_tool_results=False,
+                    )
+                    mounted.append(hidden_widget)
+                self._item_widgets[id(item)] = hidden_widget
+                continue
+            hidden_widget = None
+            widget = TranscriptMessageWidget(
+                item,
+                theme=theme,
+                show_tool_results=False,
+            )
+            self._item_widgets[id(item)] = widget
+            mounted.append(widget)
+        if mounted:
+            await self.mount(*mounted, before=self._bottom_boundary)
+        self._hidden_thinking_placeholder_visible = hidden_widget is not None
+
+        if (
+            state is not None
+            and self._window_end - self._window_start
+            > TRANSCRIPT_WINDOW_ITEMS + TRANSCRIPT_WINDOW_OVERSCAN_ITEMS
+        ):
+            self._window_start = max(0, self._window_end - TRANSCRIPT_WINDOW_ITEMS)
+            self._redraw(scroll_end=should_follow, preserve_window=True)
+        elif should_follow:
+            self._request_follow_scroll()
 
     @property
     def lines(self) -> tuple[TranscriptLine, ...]:
@@ -813,6 +1216,16 @@ class TranscriptView(VerticalScroll):
             for message in messages
             for line in message.selection_text.splitlines()
         )
+
+
+def _identity_index(items: Sequence[ChatItem], target: ChatItem) -> int | None:
+    """Return an item's identity-based index with an O(1) append-path fast path."""
+    if items and items[-1] is target:
+        return len(items) - 1
+    for index in range(len(items) - 2, -1, -1):
+        if items[index] is target:
+            return index
+    return None
 
 
 def _last_transcript_child_is_hidden_thinking_placeholder(children: Sequence[Widget]) -> bool:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -103,12 +103,15 @@ from tau_coding.tui.config import (
 from tau_coding.tui.state import ChatItem, TuiState
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
+    TRANSCRIPT_WINDOW_ITEMS,
+    TRANSCRIPT_WINDOW_OVERSCAN_ITEMS,
     LeftAlignedMarkdownHeading,
     StreamingTranscriptMessageWidget,
     TauMarkdownBlock,
     ThemedMarkdownWidget,
     TranscriptMessageWidget,
     TranscriptView,
+    TranscriptWindowBoundary,
     _compact_token_count,
     _split_rich_style_colors,
     _syntax_language,
@@ -881,6 +884,18 @@ def test_compaction_summary_chat_items_expand_with_tool_results_toggle() -> None
     assert "Detailed compaction text" in expanded
 
 
+def test_tui_state_indexes_tool_items_and_clears_index() -> None:
+    state = TuiState()
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+
+    state.add_tool_call(tool_call)
+    item = state.items[-1]
+
+    assert state.find_tool_item("call-1") is item
+    state.clear()
+    assert state.find_tool_item("call-1") is None
+
+
 def test_tui_state_compacts_branch_summary_messages() -> None:
     state = tui_app.TuiState()
 
@@ -1362,6 +1377,51 @@ async def test_tool_execution_updates_render_in_place() -> None:
 
 
 @pytest.mark.anyio
+async def test_tool_completion_updates_row_without_redrawing_history() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="earlier")]))
+
+    async def stream(event: AgentEvent) -> None:
+        app.adapter.apply(event)
+        await app._apply_streaming_transcript_event(event)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_tool_results = True
+        history_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.text == "earlier"
+        )
+        await stream(
+            ToolExecutionStartEvent(
+                tool_call_id="call-1",
+                tool_name="read",
+                args={"path": "README.md"},
+            )
+        )
+        pending_tool_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "tool"
+        )
+        pending_border_color = pending_tool_widget.styles.border_left[1]
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-1",
+                tool_name="read",
+                result=AgentToolResult(content="contents"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+
+        assert history_widget.parent is app.query_one("#transcript", TranscriptView)
+        tool_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "tool"
+        )
+        assert tool_widget is pending_tool_widget
+        assert tool_widget.styles.border_left[1] != pending_border_color
+        assert "✓ read" in tool_widget.selection_text
+        assert "contents" in tool_widget.selection_text
+
+
+@pytest.mark.anyio
 async def test_assistant_message_renders_without_role_block() -> None:
     app = TauTuiApp(
         FakeSession([AssistantMessage(content="line one\nline two")]),
@@ -1378,6 +1438,83 @@ async def test_assistant_message_renders_without_role_block() -> None:
         assert not widget.styles.has_rule("border_left")
         assert widget.styles.background.a == 0
         assert body.styles.background.a == 0
+
+
+@pytest.mark.anyio
+async def test_long_transcript_mounts_bounded_latest_window_and_pages_earlier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tau_coding.tui import widgets as tui_widgets
+
+    monkeypatch.setattr(tui_widgets, "TRANSCRIPT_WINDOW_ITEMS", 6)
+    monkeypatch.setattr(tui_widgets, "TRANSCRIPT_WINDOW_PAGE_ITEMS", 2)
+    app = TauTuiApp(
+        FakeSession(messages=[UserMessage(content=f"message {index}") for index in range(12)])
+    )
+
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert transcript._window_start == 6
+        assert transcript._window_end == 12
+        assert [widget.item.text for widget in app.query(TranscriptMessageWidget)] == [
+            f"message {index}" for index in range(6, 12)
+        ]
+        [top_boundary] = list(app.query(TranscriptWindowBoundary))
+        assert top_boundary.direction == "earlier"
+
+        transcript.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+
+        assert transcript._window_start == 4
+        assert transcript._window_end == 10
+        assert [widget.item.text for widget in app.query(TranscriptMessageWidget)] == [
+            f"message {index}" for index in range(4, 10)
+        ]
+        assert {boundary.direction for boundary in app.query(TranscriptWindowBoundary)} == {
+            "earlier",
+            "later",
+        }
+        assert len(transcript._item_widgets) == 6
+
+
+@pytest.mark.anyio
+async def test_long_transcript_incremental_appends_keep_mounted_window_bounded() -> None:
+    initial_count = TRANSCRIPT_WINDOW_ITEMS + TRANSCRIPT_WINDOW_OVERSCAN_ITEMS
+    app = TauTuiApp(
+        FakeSession(
+            messages=[UserMessage(content=f"message {index}") for index in range(initial_count)]
+        )
+    )
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        for index in range(TRANSCRIPT_WINDOW_OVERSCAN_ITEMS + 1):
+            app.state.add_item("user", f"new message {index}")
+            await transcript.append_item(app.state.items[-1], scroll_end=True)
+        await pilot.pause()
+
+        mounted = list(app.query(TranscriptMessageWidget))
+        assert len(mounted) <= TRANSCRIPT_WINDOW_ITEMS + TRANSCRIPT_WINDOW_OVERSCAN_ITEMS
+        assert mounted[-1].item.text == f"new message {TRANSCRIPT_WINDOW_OVERSCAN_ITEMS}"
+        assert len(app.state.items) == initial_count + TRANSCRIPT_WINDOW_OVERSCAN_ITEMS + 1
+
+
+@pytest.mark.anyio
+async def test_transcript_resize_preserves_mounted_message_widgets() -> None:
+    app = TauTuiApp(
+        FakeSession(messages=[AssistantMessage(content=f"answer {index}") for index in range(20)])
+    )
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        before = tuple(app.query(TranscriptMessageWidget))
+
+        await pilot.resize_terminal(55, 24)
+        await pilot.pause()
+
+        assert tuple(app.query(TranscriptMessageWidget)) == before
 
 
 @pytest.mark.anyio
@@ -2994,7 +3131,7 @@ async def test_pending_tool_row_keeps_static_marker_while_running() -> None:
         tool_item = next(item for item in app.state.items if item.role == "tool")
         assert tool_item.started_at is not None
         tool_item.started_at -= 83
-        app._tick_activity()
+        await app._refresh_pending_tool_timer()
         await pilot.pause()
         assert widget.selection_text == "▸ agent · Summarize codebase (1m 23s)"
 
@@ -3009,6 +3146,29 @@ async def test_pending_tool_row_keeps_static_marker_while_running() -> None:
         await pilot.pause()
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert widget.selection_text.startswith("▸ agent · Summarize codebase")
+
+
+@pytest.mark.anyio
+async def test_activity_animation_throttles_tool_timer_layout_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = TauTuiApp(FakeSession())
+    scheduled: list[object] = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.state.running = True
+        app._last_tool_timer_refresh_at = asyncio.get_running_loop().time()
+        monkeypatch.setattr(app, "call_later", lambda callback, *args: scheduled.append(callback))
+
+        app._tick_activity()
+        app._tick_activity()
+        app._tick_activity()
+        assert scheduled == []
+
+        app._last_tool_timer_refresh_at -= 1.0
+        app._tick_activity()
+        assert scheduled == [app._refresh_pending_tool_timer]
 
 
 @pytest.mark.anyio
@@ -3516,6 +3676,94 @@ async def test_structured_assistant_redraw_preserves_extension_custom_card() -> 
         )
         assert "✓ Summarize codebase completed" in custom_widget.selection_text
         assert "<task-notification>" not in custom_widget.selection_text
+
+
+@pytest.mark.anyio
+async def test_structured_assistant_finalization_preserves_existing_widget_identity() -> None:
+    raw = "<task-notification>agent-1 completed</task-notification>"
+    partial = AssistantMessage()
+    session = FakeSession(
+        messages=[
+            CustomMessage(
+                content=raw,
+                custom_type="subagent-notification",
+                details={"description": "Summarize codebase"},
+            )
+        ],
+        events=[
+            AgentStartEvent(),
+            MessageStartEvent(message=partial),
+            MessageUpdateEvent(
+                message=partial,
+                assistant_message_event=ThinkingDeltaEvent(
+                    content_index=0,
+                    delta="plan",
+                    partial=partial,
+                ),
+            ),
+            MessageUpdateEvent(
+                message=partial,
+                assistant_message_event=TextDeltaEvent(
+                    content_index=1,
+                    delta="done",
+                    partial=partial,
+                ),
+            ),
+            MessageEndEvent(
+                message=AssistantMessage(
+                    content=[ThinkingContent(thinking="plan"), TextContent(text="done")]
+                )
+            ),
+            AgentEndEvent(),
+        ],
+    )
+    session.extension_runtime = _CustomMessageRuntime()
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        custom_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "custom"
+        )
+        await app._run_prompt("run")
+        await pilot.pause()
+
+        assert custom_widget.parent is app.query_one("#transcript", TranscriptView)
+        assert "✓ Summarize codebase completed" in custom_widget.selection_text
+
+
+@pytest.mark.anyio
+async def test_structured_assistant_ignores_empty_final_content_blocks() -> None:
+    partial = AssistantMessage()
+    session = FakeSession(
+        messages=[UserMessage(content="earlier")],
+        events=[
+            AgentStartEvent(),
+            MessageStartEvent(message=partial),
+            MessageUpdateEvent(
+                message=partial,
+                assistant_message_event=TextDeltaEvent(
+                    content_index=1,
+                    delta="done",
+                    partial=partial,
+                ),
+            ),
+            MessageEndEvent(
+                message=AssistantMessage(
+                    content=[ThinkingContent(thinking=""), TextContent(text="done")]
+                )
+            ),
+            AgentEndEvent(),
+        ],
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await app._run_prompt("run")
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == ["earlier", "done"]
 
 
 @pytest.mark.anyio
@@ -5533,6 +5781,40 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
 
     assert app.state.show_tool_results is False
     assert notifications == ["Tool results expanded.", "Tool results collapsed."]
+
+
+@pytest.mark.anyio
+async def test_tool_result_toggle_preserves_unrelated_message_widgets() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                UserMessage(content="earlier"),
+                AssistantMessage(
+                    content=[ToolCall(id="call-1", name="read", arguments={"path": "README.md"})]
+                ),
+                ToolResultMessage(
+                    tool_call_id="call-1",
+                    tool_name="read",
+                    content=[TextContent(text="contents")],
+                ),
+            ]
+        )
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        history_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.text == "earlier"
+        )
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+
+        assert history_widget.parent is app.query_one("#transcript", TranscriptView)
+        tool_widget = next(
+            widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "tool"
+        )
+        assert "contents" in tool_widget.selection_text
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -84,6 +84,17 @@ tool row.
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Toggle full tool output with **Ctrl+O**.
 
+## Long sessions
+
+Tau keeps long transcripts responsive by mounting only a window of messages in
+the terminal at once. Your complete session remains in display state and durable
+history. When older or newer messages are outside the current window, a small
+boundary row appears; keep scrolling toward it to page through the rest of the
+conversation.
+
+Paging does not summarize, delete, or compact context. Use `/compact` separately
+when you want to reduce what is sent to the model.
+
 ## Picking models and themes
 
 - **`/model`** opens the model picker. Selecting a model from another provider


### PR DESCRIPTION
## Summary

- keep the complete transcript in `TuiState` while mounting only a bounded 200-item Textual widget window
- page earlier and later history at scroll boundaries while preserving a visible message anchor
- update tool completion, terminal commands, structured assistant tails, thinking visibility, and tool-result visibility incrementally
- add O(1) mounted-item and tool-call lookup paths, cache unchanged session chrome, and reduce animation-related layout work
- document long-session behavior and the frontend-only architecture

## User experience

Long sessions no longer grow the Textual DOM without limit. Prompt typing, streaming, tool completion, and ordinary chrome updates remain responsive as transcript history grows. Users can continue scrolling through the complete conversation via lightweight earlier/later boundary rows; no durable history or model context is removed.

A local Textual test-harness comparison with 1,000 ordinary user/assistant messages showed the mounted descendant count stay near 529 rather than 2,528. Initial mount dropped from roughly 4.9s to 0.5s, a full bounded redraw from roughly 3.0s to 0.3s, and simulated typing returned close to the short-thread baseline. These are directional local measurements rather than CI performance thresholds.

## Related issues

Addresses the broader long-transcript follow-up identified in #271 and restores targeted thinking updates from #248 while preserving the ordered thinking/content behavior added for #368. No open issue is closed directly by this PR.

## Manual validation

1. Resume or create a session with several hundred transcript messages and run `uv run tau`.
2. Confirm the latest messages and prompt appear promptly.
3. Scroll to the top boundary and keep scrolling; earlier pages should load without losing the visible anchor. Scroll toward the later boundary to return.
4. Start a response that streams thinking and invokes tools. Scroll back while it runs and confirm the viewport is not pulled to the bottom.
5. Press `Ctrl+T` and `Ctrl+O`; only the relevant mounted rows should change.
6. Resize the terminal and confirm Markdown reflows without transcript flicker.

## Validation

- `uv sync --dev --locked`
- `uv run pytest` — 986 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npm_config_registry=https://registry.npmjs.org npx --yes pagefind@latest --site public`
