### PR TITLE
Add search field to the /resume session picker

### DIFF
--- a/dev-notes/architecture/resume-picker-search.md
+++ b/dev-notes/architecture/resume-picker-search.md
@@ -1,0 +1,66 @@
+# `/resume` picker searchbar
+
+## What changed
+
+The `/resume` modal (`SessionPickerScreen` in `src/tau_coding/tui/app.py`) now
+has a search field, matching the existing search UX in the model picker
+(`ModelPickerScreen`) and the login provider picker
+(`LoginProviderPickerScreen`).
+
+- Opening `/resume` (or pressing `Ctrl+R`) focuses a new
+  `#session-picker-search` input above the session list.
+- Typing filters the visible sessions by title, model, or working directory
+  (case-insensitive substring match), live as you type.
+- Arrow keys, Enter, and Escape keep working the same way, whether focus is on
+  the search field or the list — the search input forwards those keys to the
+  picker screen instead of editing its own text.
+- Submitting the search field (Enter) selects the currently highlighted
+  session, same as pressing Enter with the list focused.
+- When no sessions match, the help line switches to "No matching sessions -
+  Escape closes".
+
+## Why it exists
+
+Session lists grow over time, and finding a specific past session by scrolling
+through an unfiltered list becomes tedious. This brings `/resume` in line with
+the model and login pickers, which already offer this pattern.
+
+## How it maps to existing pickers
+
+The new `SessionPickerSearchInput` and the refresh/filter logic in
+`SessionPickerScreen` mirror `ModelPickerSearchInput` /
+`_filter_model_choices` and `LoginProviderSearchInput` /
+`_filter_login_providers`:
+
+- A dedicated `Input` subclass keeps navigation keys (`up`, `down`, `escape`)
+  local to the picker instead of letting the `Input` widget consume them.
+- A `_filter_session_records` module-level helper computes the visible
+  records from the full record list and the current search text.
+- `_refresh_session_list` rebuilds the `ListView` children and the help text
+  whenever the search text or record set changes.
+
+No changes were needed to `tau_agent` or `tau_ai` — this is purely a
+`tau_coding` TUI/frontend change, consistent with keeping the reusable agent
+harness free of Textual-specific code.
+
+## Testing
+
+- `test_tui_app_session_picker_search_filters_sessions` — typing a query
+  narrows the list and Enter still resumes the highlighted (filtered) session.
+- `test_tui_app_session_picker_search_with_no_matches_shows_help_text` —
+  typing a query with no matches empties the list and updates the help text.
+- Existing `/resume` picker tests (arrow-key navigation, Enter-to-resume,
+  human-readable metadata) continue to pass unchanged.
+
+## Manual verification
+
+1. Create a few sessions with different titles/models (or resume real
+   history) so `/resume` has more than one row.
+2. Run `tau`, then press `Ctrl+R` (or type `/resume` and press Enter).
+3. Confirm the search field is focused and type part of a session title or
+   model name — the list should narrow live.
+4. Press Enter to resume the highlighted session.
+5. Try a query that matches nothing and confirm the help text changes to
+   "No matching sessions - Escape closes".
+6. Press Escape at any point to confirm the picker still closes without
+   resuming.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -914,8 +914,48 @@ class ExtensionInputScreen(ModalScreen[str | None]):
         self.dismiss(None)
 
 
+class SessionPickerSearchInput(Input):
+    """Search input that keeps session-picker navigation local to the picker."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("escape", "cancel", "Cancel", show=False, priority=True),
+        Binding("up", "cursor_up", "Up", show=False, priority=True),
+        Binding("down", "cursor_down", "Down", show=False, priority=True),
+    ]
+
+    def _picker(self) -> SessionPickerScreen:
+        return cast(SessionPickerScreen, self.screen)
+
+    def on_key(self, event: Key) -> None:
+        """Route picker control keys before the input edits its text."""
+        if event.key == "up":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_up()
+        elif event.key == "down":
+            event.stop()
+            event.prevent_default()
+            self.action_cursor_down()
+        elif event.key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.action_cancel()
+
+    def action_cursor_up(self) -> None:
+        """Move the session picker selection up."""
+        self._picker().action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        """Move the session picker selection down."""
+        self._picker().action_cursor_down()
+
+    def action_cancel(self) -> None:
+        """Close the session picker."""
+        self._picker().action_cancel()
+
+
 class SessionPickerScreen(ModalScreen[str | None]):
-    """Minimal modal picker for indexed sessions."""
+    """Minimal modal picker for indexed sessions, with a search field."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = [
         Binding("escape", "cancel", "Cancel"),
@@ -932,12 +972,18 @@ class SessionPickerScreen(ModalScreen[str | None]):
     ) -> None:
         super().__init__()
         self.records = tuple(records)
+        self.visible_records = self.records
         self.theme = theme
+        self.search_value = ""
 
     def compose(self) -> ComposeResult:
         """Compose the session picker."""
         with Vertical(id="session-picker"):
             yield Static("Sessions", id="session-picker-title")
+            yield SessionPickerSearchInput(
+                placeholder="Search sessions",
+                id="session-picker-search",
+            )
             yield ListView(
                 *[
                     ListItem(Label(_session_picker_label(record), markup=False))
@@ -948,10 +994,25 @@ class SessionPickerScreen(ModalScreen[str | None]):
             yield Static("Enter selects - Escape closes", id="session-picker-help")
 
     def on_mount(self) -> None:
-        """Focus the session list for keyboard navigation."""
-        session_list = self.query_one("#session-picker-list", ListView)
-        session_list.index = 0
-        session_list.focus()
+        """Focus the search field for keyboard navigation."""
+        search = self.query_one("#session-picker-search", Input)
+        search.focus()
+        self._refresh_session_list()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter session choices as the search value changes."""
+        if event.input.id != "session-picker-search":
+            return
+        event.stop()
+        self.search_value = event.value
+        self._refresh_session_list()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Select the highlighted session from the search field."""
+        if event.input.id != "session-picker-search":
+            return
+        event.stop()
+        self._select_visible_record()
 
     def on_key(self, event: Key) -> None:
         """Route session picker keys to the list."""
@@ -967,7 +1028,8 @@ class SessionPickerScreen(ModalScreen[str | None]):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Dismiss with the selected session id."""
-        self.dismiss(self.records[event.index].id)
+        event.stop()
+        self._select_visible_record()
 
     def action_cursor_up(self) -> None:
         """Move to the previous session."""
@@ -979,11 +1041,38 @@ class SessionPickerScreen(ModalScreen[str | None]):
 
     def action_select_cursor(self) -> None:
         """Select the highlighted session."""
-        self.query_one("#session-picker-list", ListView).action_select_cursor()
+        self._select_visible_record()
 
     def action_cancel(self) -> None:
         """Close the picker without selecting a session."""
         self.dismiss(None)
+
+    def _select_visible_record(self) -> None:
+        if not self.visible_records:
+            return
+        session_list = self.query_one("#session-picker-list", ListView)
+        index = session_list.index
+        if index is None:
+            return
+        self.dismiss(self.visible_records[index].id)
+
+    def _refresh_session_list(self) -> None:
+        self.visible_records = _filter_session_records(self.records, self.search_value)
+        session_list = self.query_one("#session-picker-list", ListView)
+        session_list.clear()
+        session_list.extend(
+            [
+                ListItem(Label(_session_picker_label(record), markup=False))
+                for record in self.visible_records
+            ]
+        )
+        session_list.index = 0 if self.visible_records else None
+        help_text = (
+            "Enter selects - Escape closes"
+            if self.visible_records
+            else "No matching sessions - Escape closes"
+        )
+        self.query_one("#session-picker-help", Static).update(help_text)
 
 
 @dataclass(frozen=True, slots=True)
@@ -2464,6 +2553,14 @@ class TauTuiApp(App[None]):
         color: $tau-chrome-text;
         text-style: bold;
         margin-bottom: 1;
+    }
+
+    #session-picker-search {
+        height: 3;
+        margin-bottom: 1;
+        background: $tau-prompt-background;
+        color: $tau-prompt-text;
+        border: tall $tau-prompt-border;
     }
 
     #session-picker-list,
@@ -5229,6 +5326,22 @@ def _session_picker_label(record: SessionCompletionRecord) -> str:
     if title is not None:
         parts.append(title)
     return " - ".join(parts)
+
+
+def _filter_session_records(
+    records: Sequence[SessionCompletionRecord],
+    query: str,
+) -> tuple[SessionCompletionRecord, ...]:
+    normalized = query.strip().casefold()
+    if not normalized:
+        return tuple(records)
+    return tuple(
+        record
+        for record in records
+        if normalized in (record.title or "").casefold()
+        or normalized in record.model.casefold()
+        or normalized in _short_path(record.cwd).casefold()
+    )
 
 
 def _tree_picker_label(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3811,6 +3811,86 @@ async def test_tui_app_session_picker_arrow_keys_select_session() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_session_picker_search_filters_sessions() -> None:
+    updated_at = datetime(2026, 6, 19, 14, 30).timestamp()
+    session = FakeSession(messages=[UserMessage(content="Earlier")])
+    session.session_manager = _FakeSessionManager(
+        [
+            CodingSessionRecord(
+                id="session-1",
+                path=Path("/tmp/session-1.jsonl"),
+                cwd=Path("/workspace/project"),
+                model="fake-model",
+                title="Refactor auth",
+                created_at=1.0,
+                updated_at=updated_at,
+            ),
+            CodingSessionRecord(
+                id="session-2",
+                path=Path("/tmp/session-2.jsonl"),
+                cwd=Path("/workspace/project"),
+                model="other-model",
+                title="Add search bar",
+                created_at=1.0,
+                updated_at=updated_at,
+            ),
+        ]
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+r")
+        assert isinstance(app.screen, SessionPickerScreen)
+
+        search = app.screen.query_one("#session-picker-search", Input)
+        assert search.has_focus
+
+        search.value = "search bar"
+        await pilot.pause()
+
+        session_list = app.screen.query_one("#session-picker-list", ListView)
+        labels = [str(item.query_one(Label).render()) for item in session_list.children]
+        assert labels == ["2026-06-19 14:30 - other-model - Add search bar"]
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.resumed_session_ids == ["session-2"]
+
+
+@pytest.mark.anyio
+async def test_tui_app_session_picker_search_with_no_matches_shows_help_text() -> None:
+    session = FakeSession()
+    session.session_manager = _FakeSessionManager(
+        [
+            CodingSessionRecord(
+                id="session-1",
+                path=Path("/tmp/session-1.jsonl"),
+                cwd=Path("/workspace/project"),
+                model="fake-model",
+                title="Refactor auth",
+                created_at=1.0,
+                updated_at=2.0,
+            ),
+        ]
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+r")
+        assert isinstance(app.screen, SessionPickerScreen)
+
+        search = app.screen.query_one("#session-picker-search", Input)
+        search.value = "nonexistent"
+        await pilot.pause()
+
+        session_list = app.screen.query_one("#session-picker-list", ListView)
+        assert list(session_list.children) == []
+        help_text = app.screen.query_one("#session-picker-help", Static)
+        assert str(help_text.render()) == "No matching sessions - Escape closes"
+
+
+@pytest.mark.anyio
 async def test_tui_app_blocks_tree_picker_while_agent_is_running() -> None:
     session = FakeSession()
     app = TauTuiApp(session)

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -30,6 +30,10 @@ From inside the TUI:
 /resume <id>       # resume a specific session
 ```
 
+The `/resume` picker has a search field so you can filter by title, model, or
+working directory. Start typing to narrow the list, then use the arrow keys
+and Enter (or click) to pick a session.
+
 To deliberately start fresh instead of resuming, use `tau --new-session` (or
 `/new` in the TUI).
 


### PR DESCRIPTION
## Summary

Adds a search field to the `/resume` session picker in the Textual TUI, so you
can filter sessions by title, model, or working directory instead of scrolling
through the full list.

This mirrors the search UX that already exists in the `/model` picker
(`ModelPickerScreen`) and the login provider picker
(`LoginProviderPickerScreen`): a dedicated search `Input` is focused when the
modal opens, arrow keys / Enter / Escape keep working the same whether focus
is on the search field or the list, and the help line updates to
"No matching sessions - Escape closes" when a query has no matches.

## User experience

- Opening `/resume` (or pressing `Ctrl+R`) now focuses a search box above the
  session list instead of the list itself.
- Typing filters sessions live, case-insensitively, by title, model name, or
  working directory.
- Enter still resumes the highlighted (filtered) session; Escape still closes
  the picker without resuming.
- As history grows, finding a specific past session no longer requires
  scrolling through everything — this brings `/resume` in line with the
  existing `/model` and login pickers.

## Issue

No specific tracked issue; implements the requested "add a searchbar to the
`/resume` modal" enhancement.

## How to validate manually

1. From this branch, run `uv run tau` (or `tau` if installed) in a directory
   with a few prior sessions, or create a couple by running short prompts
   with different models/titles.
2. Press `Ctrl+R` (or type `/resume` and press Enter) to open the session
   picker.
3. Confirm the search field is focused, then type part of a session title or
   model name — the list should narrow live as you type.
4. Press Enter to resume the highlighted session.
5. Reopen `/resume` and type a query that matches nothing — confirm the list
   empties and the help text reads "No matching sessions - Escape closes".
6. Press Escape at any point and confirm the picker closes without resuming.

## Checks run locally

- `uv run pytest` — 979 passed
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — all files already formatted
- `uv run mypy` — no issues found in 91 source files
