### PR TITLE
Improve TUI sidebar session insights

### DIFF
--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -5,9 +5,9 @@ title: "TUI sidebar session insights"
 ## What changed
 
 Tau's interactive TUI now uses the sidebar as the detailed session summary and
-removes Textual's top header. The terminal tab title still follows the generated
-or user-assigned session name, so removing the header recovers a row without
-losing session identity.
+removes Textual's top header and shortcut footer. The terminal tab title still
+follows the generated or user-assigned session name, so removing the chrome
+recovers two rows without losing session identity or keyboard functionality.
 
 The sidebar now shows:
 
@@ -24,14 +24,17 @@ model state.
 
 ## Display choices
 
-Tools, skills, prompts, and extensions are short names, so they render as wrapping
-comma-separated lists. Context files remain bullets because paths are longer and
-need clear boundaries. Paths inside the working directory are project-relative;
-paths outside it are absolute so user-level instructions are unambiguous.
+Tools, prompts, and extensions are short names, so they render as wrapping
+comma-separated lists. Skills and context files remain bullets so each loaded
+instruction source has a clear row. Paths inside the working directory are
+project-relative; paths outside it are absolute so user-level instructions are
+unambiguous.
 
-A compact divider separates each section without adding blank padding. This keeps
-the expanded set of useful facts visually distinct while still fitting typical
-terminal heights.
+Spaced dividers separate each section. The sidebar is slightly wider, uses the
+same theme variable as the prompt field for its background, and hides on shorter
+terminals rather than clipping the expanded content. The versioned `τ = 2π` brand
+is a separate bottom-aligned widget, so it stays at the lower edge regardless of
+content height.
 
 ## Activity and usage semantics
 
@@ -70,4 +73,6 @@ For manual verification, open a named TUI session in a wide terminal, run severa
 prompts that call tools, and confirm that activity, usage, and cost update. Run
 `/compact` and verify that lifetime totals remain unchanged while the current
 context indicator shrinks. Resize the terminal until the sidebar disappears and
-confirm there is no top header and the terminal tab retains the session name.
+confirm there is no top header or shortcut footer and the terminal tab retains
+the session name. In a tall window, confirm the versioned Tau mark stays at the
+bottom of the wider sidebar.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -47,8 +47,7 @@ Input totals include fresh input, cache reads, and cache writes. Output totals u
 the provider's reported output count. Cost is calculated per assistant response
 from that response's provider/model metadata, including tiered rates and separate
 input, output, cache-read, and cache-write prices. If any billed response lacks
-pricing, Tau labels the branch cost unavailable rather than showing a misleading
-partial estimate.
+pricing, Tau displays `$N/A` rather than showing a misleading partial estimate.
 
 ## Architecture
 
@@ -75,4 +74,9 @@ prompts that call tools, and confirm that activity, usage, and cost update. Run
 context indicator shrinks. Resize the terminal until the sidebar disappears and
 confirm there is no top header or shortcut footer and the terminal tab retains
 the session name. In a tall window, confirm the versioned Tau mark stays at the
-bottom of the wider sidebar.
+bottom of the wider sidebar. The session name is bold so it stands apart from
+other values.
+
+The compact status line below the prompt omits the redundant word `context`,
+showing only `used/limit`. It styles the parent portion of the working-directory
+path and Git branch as metadata while keeping the directory basename prominent.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -80,3 +80,5 @@ other values.
 The compact status line below the prompt omits the redundant word `context`,
 showing only `used/limit`. It styles the parent portion of the working-directory
 path and Git branch as metadata while keeping the directory basename prominent.
+The prompt editor keeps only its left border; focus, shell-mode, and activity
+colors update that edge without surrounding the input on all four sides.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -83,4 +83,5 @@ path and Git branch as metadata while keeping the directory basename prominent.
 The prompt editor keeps only its left border; focus, shell-mode, and activity
 colors update that edge without surrounding the input on all four sides. Vertical
 padding replaces the removed top and bottom border space, preserving the original
-block height and full background area.
+block height and full background area. User transcript blocks share that prompt
+background in every built-in theme, matching both the composer and sidebar.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -89,4 +89,6 @@ padding replaces the removed top and bottom border space, preserving the origina
 block height and full background area. User transcript blocks share that prompt
 background in every built-in theme, matching both the composer and sidebar. A
 small vertical inset gives each submitted message a block silhouette instead of
-making only its text line appear highlighted.
+making only its text line appear highlighted. Markdown blocks disable the default
+resting underline and apply underline as a link-hover style; clickable spans remain
+bounded to their exact link text so the decoration cannot run across the row.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -30,9 +30,10 @@ instruction source has a clear row. Paths inside the working directory are
 project-relative; paths outside it are absolute so user-level instructions are
 unambiguous.
 
-Spaced dividers separate each section. The sidebar is slightly wider, uses the
-same theme variable as the prompt field for its background, and hides on shorter
-terminals rather than clipping the expanded content. The versioned `τ = 2π` brand
+Spaced dividers separate each section. Section headings use the bright prompt
+text color while values use the quieter metadata gray. The sidebar is slightly
+wider, uses the same theme variable as the prompt field for its background, and
+hides on shorter terminals rather than clipping the expanded content. The versioned `τ = 2π` brand
 is a separate bottom-aligned widget, so it stays at the lower edge regardless of
 content height.
 

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -74,11 +74,13 @@ prompts that call tools, and confirm that activity, usage, and cost update. Run
 context indicator shrinks. Resize the terminal until the sidebar disappears and
 confirm there is no top header or shortcut footer and the terminal tab retains
 the session name. In a tall window, confirm the versioned Tau mark stays at the
-bottom of the wider sidebar. The session name is bold so it stands apart from
-other values.
+bottom of the wider sidebar. The session name uses bold accent styling without a
+redundant `session` section heading, so it stands apart from other values.
 
 The compact status line below the prompt omits the redundant word `context`,
 showing only `used/limit`. It styles the parent portion of the working-directory
 path and Git branch as metadata while keeping the directory basename prominent.
 The prompt editor keeps only its left border; focus, shell-mode, and activity
-colors update that edge without surrounding the input on all four sides.
+colors update that edge without surrounding the input on all four sides. Vertical
+padding replaces the removed top and bottom border space, preserving the original
+block height and full background area.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -29,8 +29,9 @@ comma-separated lists. Context files remain bullets because paths are longer and
 need clear boundaries. Paths inside the working directory are project-relative;
 paths outside it are absolute so user-level instructions are unambiguous.
 
-The sidebar sections no longer use a divider between every section. This keeps the
-larger set of useful facts readable in shorter terminals.
+A compact divider separates each section without adding blank padding. This keeps
+the expanded set of useful facts visually distinct while still fitting typical
+terminal heights.
 
 ## Activity and usage semantics
 

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -86,4 +86,6 @@ The prompt editor keeps only its left border; focus, shell-mode, and activity
 colors update that edge without surrounding the input on all four sides. Vertical
 padding replaces the removed top and bottom border space, preserving the original
 block height and full background area. User transcript blocks share that prompt
-background in every built-in theme, matching both the composer and sidebar.
+background in every built-in theme, matching both the composer and sidebar. A
+small vertical inset gives each submitted message a block silhouette instead of
+making only its text line appear highlighted.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -32,8 +32,9 @@ unambiguous.
 
 Spaced dividers separate each section. Section headings use the bright prompt
 text color while values use the quieter metadata gray. The sidebar is wider and
-borderless, uses the same theme variable as the prompt field for its background,
-and hides on shorter terminals rather than clipping the expanded content. The
+borderless, uses a comfortable left content inset and the same theme variable as
+the prompt field for its background, and hides on shorter terminals rather than
+clipping the expanded content. The
 versioned `τ = 2π` brand is a separate bottom-aligned widget, so it stays at the
 lower edge regardless of content height.
 

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -1,0 +1,72 @@
+---
+title: "TUI sidebar session insights"
+---
+
+## What changed
+
+Tau's interactive TUI now uses the sidebar as the detailed session summary and
+removes Textual's top header. The terminal tab title still follows the generated
+or user-assigned session name, so removing the header recovers a row without
+losing session identity.
+
+The sidebar now shows:
+
+- the session name
+- user turns and assistant tool calls on the active branch
+- cumulative provider-reported input and output tokens
+- estimated cost when complete pricing is available
+- automatic-compaction status and threshold
+- context files, tools, skills, prompt templates, and loaded extensions
+
+Provider, model, thinking level, and duplicate resource counts were removed from
+the sidebar because the compact line below the prompt already presents the active
+model state.
+
+## Display choices
+
+Tools, skills, prompts, and extensions are short names, so they render as wrapping
+comma-separated lists. Context files remain bullets because paths are longer and
+need clear boundaries. Paths inside the working directory are project-relative;
+paths outside it are absolute so user-level instructions are unambiguous.
+
+The sidebar sections no longer use a divider between every section. This keeps the
+larger set of useful facts readable in shorter terminals.
+
+## Activity and usage semantics
+
+Statistics come from original message entries on the active root-to-leaf branch,
+not only from the compacted model context. Consequently, compaction does not erase
+activity or billed usage. A turn is a user or extension-authored custom message.
+A tool call is each tool-call block requested by an assistant message.
+
+Input totals include fresh input, cache reads, and cache writes. Output totals use
+the provider's reported output count. Cost is calculated per assistant response
+from that response's provider/model metadata, including tiered rates and separate
+input, output, cache-read, and cache-write prices. If any billed response lacks
+pricing, Tau labels the branch cost unavailable rather than showing a misleading
+partial estimate.
+
+## Architecture
+
+Lifetime aggregation lives in `tau_coding.session_stats`; it consumes durable
+session entries and remains independent of Textual. `CodingSession` supplies the
+active branch and resolves configured pricing. The TUI widget only formats the
+result. This preserves Tau's boundary between session behavior and frontend
+rendering.
+
+## Verification
+
+Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+For manual verification, open a named TUI session in a wide terminal, run several
+prompts that call tools, and confirm that activity, usage, and cost update. Run
+`/compact` and verify that lifetime totals remain unchanged while the current
+context indicator shrinks. Resize the terminal until the sidebar disappears and
+confirm there is no top header and the terminal tab retains the session name.

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -31,11 +31,11 @@ project-relative; paths outside it are absolute so user-level instructions are
 unambiguous.
 
 Spaced dividers separate each section. Section headings use the bright prompt
-text color while values use the quieter metadata gray. The sidebar is slightly
-wider, uses the same theme variable as the prompt field for its background, and
-hides on shorter terminals rather than clipping the expanded content. The versioned `τ = 2π` brand
-is a separate bottom-aligned widget, so it stays at the lower edge regardless of
-content height.
+text color while values use the quieter metadata gray. The sidebar is wider and
+borderless, uses the same theme variable as the prompt field for its background,
+and hides on shorter terminals rather than clipping the expanded content. The
+versioned `τ = 2π` brand is a separate bottom-aligned widget, so it stays at the
+lower edge regardless of content height.
 
 ## Activity and usage semantics
 
@@ -78,9 +78,10 @@ the session name. In a tall window, confirm the versioned Tau mark stays at the
 bottom of the wider sidebar. The session name uses bold accent styling without a
 redundant `session` section heading, so it stands apart from other values.
 
-The compact status line below the prompt omits the redundant word `context`,
-showing only `used/limit`. It styles the parent portion of the working-directory
-path and Git branch as metadata while keeping the directory basename prominent.
+The compact status block below the prompt places `provider:model (thinking)` on
+its first line and context consumption as only `used/limit` on its second. It
+styles the parent portion of the working-directory path and Git branch as metadata
+while keeping the directory basename prominent.
 The prompt editor keeps only its left border; focus, shell-mode, and activity
 colors update that edge without surrounding the input on all four sides. Vertical
 padding replaces the removed top and bottom border space, preserving the original

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -92,3 +92,10 @@ small vertical inset gives each submitted message a block silhouette instead of
 making only its text line appear highlighted. Markdown blocks disable the default
 resting underline and apply underline as a link-hover style; clickable spans remain
 bounded to their exact link text so the decoration cannot run across the row.
+
+Theme selection colors now have one source of truth: autocomplete derives its
+selected-row foreground and background from the same `highlight_text` and
+`highlight_background` values used by picker `ListView`s such as `/resume`. The
+dark theme promotes its existing aqua highlight (`#a7f3f0`) to the global accent,
+replacing the previous orange across headings, bullets, prompt activity, and other
+accent-driven UI.

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -106,6 +106,7 @@ from tau_coding.session_export import (
     normalize_export_format,
 )
 from tau_coding.session_manager import SessionManager
+from tau_coding.session_stats import SessionStats, calculate_session_stats
 from tau_coding.skills import Skill, expand_skill_command, load_skills_with_diagnostics
 from tau_coding.system_prompt import (
     BuildSystemPromptOptions,
@@ -706,6 +707,40 @@ class CodingSession:
     def extension_runtime(self) -> ExtensionRuntime:
         """Return the extension runtime bound to this session."""
         return self._extension_runtime
+
+    @property
+    def extension_names(self) -> tuple[str, ...]:
+        """Return loaded extension names in load order."""
+        return self._extension_runtime.extension_names
+
+    @property
+    def session_stats(self) -> SessionStats:
+        """Return cumulative activity and billed usage for the active branch."""
+        return calculate_session_stats(
+            self._state.entries,
+            pricing=self._pricing_for_response,
+        )
+
+    def _pricing_for_response(
+        self,
+        provider_name: str,
+        model: str,
+        input_tokens: int,
+    ) -> dict[str, float] | None:
+        provider = _provider_config_for_name(self._config, provider_name)
+        if (
+            provider is None
+            or provider.name != provider_name
+            or not hasattr(provider, "model_metadata")
+        ):
+            return None
+        metadata = provider.model_metadata.get(model)
+        if metadata is None:
+            return None
+        for tier in metadata.cost_tiers:
+            if tier.max_input_tokens is None or input_tokens <= tier.max_input_tokens:
+                return dict(tier.cost)
+        return dict(metadata.cost) if metadata.cost else None
 
     async def emit_pending_session_start(self) -> None:
         """Emit the `session_start` deferred by `load`, once per session.

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -1,0 +1,98 @@
+"""Lifetime activity and usage totals for an active session branch."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from tau_agent.messages import AssistantMessage, CustomMessage, UserMessage
+from tau_agent.session import MessageEntry
+from tau_agent.session.entries import SessionEntry
+
+PricingResolver = Callable[[str, str, int], Mapping[str, float] | None]
+_TOKENS_PER_MILLION = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class SessionStats:
+    """Cumulative activity and billed usage for one active branch."""
+
+    turn_count: int = 0
+    tool_call_count: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    estimated_cost: float | None = None
+
+
+def calculate_session_stats(
+    entries: Sequence[SessionEntry],
+    *,
+    pricing: PricingResolver,
+) -> SessionStats:
+    """Aggregate original branch messages, including messages replaced by compaction."""
+    turn_count = 0
+    tool_call_count = 0
+    input_tokens = 0
+    output_tokens = 0
+    estimated_cost = 0.0
+    has_billable_usage = False
+    has_complete_pricing = True
+
+    for entry in entries:
+        if not isinstance(entry, MessageEntry):
+            continue
+        message = entry.message
+        if isinstance(message, (UserMessage, CustomMessage)):
+            turn_count += 1
+            continue
+        if not isinstance(message, AssistantMessage):
+            continue
+
+        tool_call_count += len(message.tool_calls)
+        usage = message.usage
+        prompt_tokens = usage.input + usage.cache_read + usage.cache_write
+        input_tokens += prompt_tokens
+        output_tokens += usage.output
+        if prompt_tokens == 0 and usage.output == 0:
+            continue
+
+        has_billable_usage = True
+        rates = pricing(message.provider, message.model, prompt_tokens)
+        if rates is None:
+            if usage.cost.total > 0:
+                estimated_cost += usage.cost.total
+            else:
+                has_complete_pricing = False
+            continue
+        estimated_cost += _response_cost(
+            input_tokens=usage.input,
+            output_tokens=usage.output,
+            cache_read_tokens=usage.cache_read,
+            cache_write_tokens=usage.cache_write,
+            rates=rates,
+        )
+
+    return SessionStats(
+        turn_count=turn_count,
+        tool_call_count=tool_call_count,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
+    )
+
+
+def _response_cost(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+    rates: Mapping[str, float],
+) -> float:
+    """Calculate one response's estimated USD cost from per-million-token rates."""
+    return (
+        input_tokens * rates.get("input", 0.0)
+        + output_tokens * rates.get("output", 0.0)
+        + cache_read_tokens * rates.get("cacheRead", 0.0)
+        + cache_write_tokens * rates.get("cacheWrite", 0.0)
+    ) / _TOKENS_PER_MILLION

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2477,18 +2477,19 @@ class TauTuiApp(App[None]):
         height: auto;
         background: $tau-prompt-background;
         color: $tau-prompt-text;
-        border: tall transparent;
+        border: none;
+        border-left: tall transparent;
         margin: 0;
         padding: 0 1;
-        max-height: 8;
+        max-height: 6;
     }
 
     #prompt:focus {
-        border: tall $tau-prompt-border;
+        border-left: tall $tau-prompt-border;
     }
 
     #prompt.-shell-mode {
-        border: tall $tau-accent;
+        border-left: tall $tau-accent;
     }
 
     #compact-session-info {
@@ -4984,7 +4985,7 @@ class TauTuiApp(App[None]):
         if render_key == self._last_activity_indicator_key:
             return
         self._last_activity_indicator_key = render_key
-        prompt.styles.border = (
+        prompt.styles.border_left = (
             "tall",
             _activity_prompt_border_color(
                 theme,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -28,7 +28,6 @@ from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import (
     Button,
-    Footer,
     Input,
     Label,
     ListItem,
@@ -151,7 +150,7 @@ from tau_coding.tui.widgets import (
 
 type BindingEntry = Binding | tuple[str, str] | tuple[str, str, str]
 SIDEBAR_MIN_WIDTH = 96
-SIDEBAR_MIN_HEIGHT = 24
+SIDEBAR_MIN_HEIGHT = 38
 ACTIVITY_TICK_SECONDS = 0.15
 ACTIVITY_COLOR_FADE_STEPS = 24
 ACTIVITY_INDICATOR_HEIGHT = 3
@@ -2272,27 +2271,6 @@ class TauTuiApp(App[None]):
         color: $tau-screen-text;
     }
 
-    Footer {
-        background: $tau-chrome-background;
-        color: $tau-chrome-text;
-    }
-
-    Footer FooterKey {
-        background: $tau-chrome-background;
-        color: $tau-chrome-text;
-    }
-
-    Footer FooterKey .footer-key--key {
-        background: $tau-chrome-background;
-        color: $tau-accent;
-    }
-
-    Footer FooterKey .footer-key--description,
-    Footer FooterLabel {
-        background: $tau-chrome-background;
-        color: $tau-chrome-text;
-    }
-
     Toast {
         background: $tau-chrome-background;
         color: $tau-chrome-text;
@@ -2307,12 +2285,21 @@ class TauTuiApp(App[None]):
     }
 
     #sidebar {
-        width: 32;
-        min-width: 28;
+        width: 36;
+        min-width: 32;
         height: 1fr;
-        padding: 1 1 0 0;
-        background: $tau-sidebar-background;
+        padding: 1 1 1 0;
+        background: $tau-prompt-background;
         border-right: tall $tau-border;
+    }
+
+    #sidebar-content {
+        height: 1fr;
+    }
+
+    #sidebar-brand {
+        height: auto;
+        color: $tau-prompt-text;
     }
 
     TauTuiApp.-hide-sidebar #sidebar {
@@ -2864,7 +2851,6 @@ class TauTuiApp(App[None]):
                 yield CompactSessionInfo(id="compact-session-info")
                 yield Static("", id="autocomplete")
                 yield Container(id="below-prompt-slot")
-        yield Footer()
 
     async def on_mount(self) -> None:
         """Focus the prompt when the app starts."""
@@ -4897,7 +4883,6 @@ class TauTuiApp(App[None]):
             return COMPLETION_MAX_VISIBLE_LINES
 
         reserved_rows = COMPLETION_MIN_TRANSCRIPT_LINES + COMPLETION_WIDGET_CHROME_LINES
-        reserved_rows += 1  # Footer.
         for selector in ("#prompt-row", "#compact-session-info", "#queued-messages"):
             with suppress(NoMatches):
                 widget = self.query_one(selector)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2374,12 +2374,12 @@ class TauTuiApp(App[None]):
     }
 
     #sidebar {
-        width: 36;
-        min-width: 32;
+        width: 40;
+        min-width: 36;
         height: 1fr;
         padding: 1 1 1 0;
         background: $tau-prompt-background;
-        border-right: tall $tau-border;
+        border: none;
     }
 
     #sidebar-content {
@@ -2401,8 +2401,6 @@ class TauTuiApp(App[None]):
 
     TauTuiApp.-sidebar-right #sidebar {
         dock: right;
-        border-right: none;
-        border-left: tall $tau-border;
     }
 
     #main-pane {

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2377,7 +2377,7 @@ class TauTuiApp(App[None]):
         width: 40;
         min-width: 36;
         height: 1fr;
-        padding: 1 1 1 0;
+        padding: 1 1 1 2;
         background: $tau-prompt-background;
         border: none;
     }

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -29,7 +29,6 @@ from textual.widget import Widget
 from textual.widgets import (
     Button,
     Footer,
-    Header,
     Input,
     Label,
     ListItem,
@@ -2273,12 +2272,6 @@ class TauTuiApp(App[None]):
         color: $tau-screen-text;
     }
 
-    Header {
-        background: $tau-chrome-background;
-        color: $tau-muted-text;
-        dock: top;
-    }
-
     Footer {
         background: $tau-chrome-background;
         color: $tau-chrome-text;
@@ -2780,12 +2773,10 @@ class TauTuiApp(App[None]):
         self._terminal_title = TerminalTitleController()
         self._active_notification_keys: set[tuple[str, str]] = set()
         self._supports_pyperclip: bool | None = None
-        self._sync_header_title()
+        self._sync_session_title()
 
-    def _sync_header_title(self) -> None:
-        """Reflect the active session name in Textual's header state."""
-        self.title = "Tau"
-        self.sub_title = _session_header_sub_title(self.session)
+    def _sync_session_title(self) -> None:
+        """Reflect the active session name in the terminal tab title."""
         self._sync_terminal_title()
 
     def _sync_terminal_title(self) -> None:
@@ -2848,7 +2839,6 @@ class TauTuiApp(App[None]):
 
     def compose(self) -> ComposeResult:
         """Compose the TUI widgets."""
-        yield Header()
         with Horizontal(id="workspace"):
             yield SessionSidebar(id="sidebar")
             with Vertical(id="main-pane"):
@@ -3276,7 +3266,7 @@ class TauTuiApp(App[None]):
                     item.text = event.message.text
                     break
             self._refresh()
-            self._sync_header_title()
+            self._sync_session_title()
             return True
         return False
 
@@ -3917,7 +3907,7 @@ class TauTuiApp(App[None]):
         if isinstance(event, MessageEndEvent):
             if isinstance(event.message, (UserMessage, CustomMessage)):
                 await self._append_confirmed_user_message(event.message)
-                self._sync_header_title()
+                self._sync_session_title()
                 return
             if isinstance(event.message, AssistantMessage):
                 if event.message.stop_reason in {"error", "aborted"}:
@@ -4757,7 +4747,7 @@ class TauTuiApp(App[None]):
     def _refresh_chrome(self, *, theme: TuiTheme | None = None) -> None:
         """Refresh non-transcript chrome without remounting transcript blocks."""
         theme = theme or self.tui_settings.resolved_theme
-        self._sync_header_title()
+        self._sync_session_title()
         self._sync_text_selection_state()
         self._sync_queue_state()
         sidebar = self.query_one("#sidebar", SessionSidebar)
@@ -4907,7 +4897,7 @@ class TauTuiApp(App[None]):
             return COMPLETION_MAX_VISIBLE_LINES
 
         reserved_rows = COMPLETION_MIN_TRANSCRIPT_LINES + COMPLETION_WIDGET_CHROME_LINES
-        reserved_rows += 2  # Header and footer.
+        reserved_rows += 1  # Footer.
         for selector in ("#prompt-row", "#compact-session-info", "#queued-messages"):
             with suppress(NoMatches):
                 widget = self.query_one(selector)
@@ -5279,12 +5269,6 @@ def _named_session_title(title: str | None) -> str | None:
     if not stripped or stripped.lower() == "untitled session":
         return None
     return stripped
-
-
-def _session_header_sub_title(session: CodingSession) -> str:
-    """Return the session label shown beside Tau in the TUI header."""
-    title = _named_session_title(getattr(session, "session_title", None))
-    return title or "Untitled session"
 
 
 def _login_provider_label(provider: ProviderCatalogEntry) -> str:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2480,8 +2480,8 @@ class TauTuiApp(App[None]):
         border: none;
         border-left: tall transparent;
         margin: 0;
-        padding: 0 1;
-        max-height: 6;
+        padding: 1 1;
+        max-height: 8;
     }
 
     #prompt:focus {

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -89,11 +89,19 @@ class TuiTheme:
     markdown_code_block_background: str
     markdown_link: str
     markdown_bullet: str
-    completion_selected: str
-    completion_selected_description: str
     completion_description: str
     syntax_theme: str
     role_styles: dict[str, TuiRoleStyle]
+
+    @property
+    def completion_selected(self) -> str:
+        """Return the shared highlighted-row style used by autocomplete."""
+        return f"bold {self.highlight_text} on {self.highlight_background}"
+
+    @property
+    def completion_selected_description(self) -> str:
+        """Return the shared highlighted-row description style."""
+        return f"{self.highlight_text} on {self.highlight_background}"
 
 
 TAU_DARK_THEME = TuiTheme(
@@ -110,18 +118,16 @@ TAU_DARK_THEME = TuiTheme(
     prompt_text="#e5e7eb",
     prompt_border="#2d3748",
     autocomplete_background="#000000",
-    accent="#db945a",
+    accent="#a7f3f0",
     highlight_background="#a7f3f0",
     highlight_text="#061a1a",
-    markdown_heading="#db945a",
+    markdown_heading="#a7f3f0",
     markdown_table_header="#7b7b7b",
     markdown_table_border="#7b7b7b",
     markdown_inline_code="#759e95",
     markdown_code_block_background="#161b21",
     markdown_link="#93c5fd",
-    markdown_bullet="#db945a",
-    completion_selected="bold #061a1a on #a7f3f0",
-    completion_selected_description="#123333 on #a7f3f0",
+    markdown_bullet="#a7f3f0",
     completion_description="#667085",
     syntax_theme="ansi_dark",
     role_styles={
@@ -163,8 +169,6 @@ HIGH_CONTRAST_THEME = TuiTheme(
     markdown_code_block_background="#161b21",
     markdown_link="#80d8ff",
     markdown_bullet="#ffb454",
-    completion_selected="bold black on #7fffd4",
-    completion_selected_description="black on #7fffd4",
     completion_description="white",
     syntax_theme="ansi_dark",
     role_styles={
@@ -206,8 +210,6 @@ TAU_LIGHT_THEME = TuiTheme(
     markdown_code_block_background="#f1f5f9",
     markdown_link="#2563eb",
     markdown_bullet="#b45309",
-    completion_selected="bold #0f172a on #dbeafe",
-    completion_selected_description="#334155 on #dbeafe",
     completion_description="#667085",
     syntax_theme="ansi_light",
     role_styles={

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -125,7 +125,7 @@ TAU_DARK_THEME = TuiTheme(
     completion_description="#667085",
     syntax_theme="ansi_dark",
     role_styles={
-        "user": TuiRoleStyle(border="#7c8ea6", body="#d8dee9 on #000000"),
+        "user": TuiRoleStyle(border="#7c8ea6", body="#d8dee9 on #101419"),
         "assistant": TuiRoleStyle(border="#6ea6a0", body="#d8dee9 on #000000"),
         "tool": TuiRoleStyle(border="#8a7a52", body="#cbd5e1 on #000000"),
         "error": TuiRoleStyle(border="#ff4f4f", body="#ffb4b4 on #000000"),
@@ -168,7 +168,7 @@ HIGH_CONTRAST_THEME = TuiTheme(
     completion_description="white",
     syntax_theme="ansi_dark",
     role_styles={
-        "user": TuiRoleStyle(border="#00b7ff", body="white on #001626"),
+        "user": TuiRoleStyle(border="#00b7ff", body="white on #1a1a1a"),
         "assistant": TuiRoleStyle(border="#00ff66", body="white on #001a0b"),
         "tool": TuiRoleStyle(border="#ffd000", body="white on #211900"),
         "error": TuiRoleStyle(border="#ff4f4f", body="white on #260000"),
@@ -211,7 +211,7 @@ TAU_LIGHT_THEME = TuiTheme(
     completion_description="#667085",
     syntax_theme="ansi_light",
     role_styles={
-        "user": TuiRoleStyle(border="#2563eb", body="#111827"),
+        "user": TuiRoleStyle(border="#2563eb", body="#111827 on #f8fafc"),
         "assistant": TuiRoleStyle(border="#0f766e", body="#111827"),
         "tool": TuiRoleStyle(border="#a16207", body="#1f2937"),
         "error": TuiRoleStyle(border="#b91c1c", body="#7f1d1d"),

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1477,9 +1477,9 @@ def render_session_sidebar(
     activity = Text(
         f"{stats.turn_count} {_plural(stats.turn_count, 'turn')}, "
         f"{stats.tool_call_count} tool {_plural(stats.tool_call_count, 'call')}",
-        style=theme.prompt_text,
+        style=theme.completion_description,
     )
-    usage = Text(style=theme.prompt_text)
+    usage = Text(style=theme.completion_description)
     usage.append(f"{_compact_usage_count(stats.input_tokens)} in, ")
     usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
     usage.append(" · ", style=theme.completion_description)
@@ -1491,7 +1491,7 @@ def render_session_sidebar(
     threshold = session.auto_compact_token_threshold
     compaction = Text(
         "off" if threshold is None else f"auto at {_compact_token_count(threshold)}",
-        style=theme.prompt_text,
+        style=theme.completion_description,
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
     skills = _bullet_list(
@@ -1541,7 +1541,7 @@ def _sidebar_section(
     theme: TuiTheme,
 ) -> RenderableType:
     """Render one sidebar section without a surrounding border."""
-    header = Text(title, style=f"bold {theme.accent}")
+    header = Text(title, style=f"bold {theme.prompt_text}")
     return Group(Padding(header, (0, 0, 0, 1)), Padding(body, (0, 0, 0, 1)))
 
 
@@ -2137,7 +2137,12 @@ def _comma_list(
 ) -> Text:
     if not items:
         return Text(empty, style=theme.completion_description)
-    return Text(", ".join(items), style=theme.prompt_text, overflow="fold", no_wrap=False)
+    return Text(
+        ", ".join(items),
+        style=theme.completion_description,
+        overflow="fold",
+        no_wrap=False,
+    )
 
 
 def _compact_usage_count(value: int) -> str:
@@ -2173,7 +2178,7 @@ def _bullet_list(
         if index:
             text.append("\n")
         text.append("• ", style=theme.completion_description)
-        text.append(item, style=theme.prompt_text)
+        text.append(item, style=theme.completion_description)
     return text
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -20,7 +20,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from textual.containers import Horizontal, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.css.query import NoMatches
 from textual.events import Resize
@@ -39,6 +39,7 @@ from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import ChatItem, TuiState
+from tau_coding.version import current_version
 
 TAU_SIDEBAR_LOGO = "τ = 2π"
 
@@ -96,8 +97,12 @@ class SessionSummarySource(Protocol):
     def session_stats(self) -> SessionStats: ...
 
 
-class SessionSidebar(Static):
-    """Compact sidebar with current session metadata."""
+class SessionSidebar(Vertical):
+    """Compact sidebar with session metadata and bottom-aligned branding."""
+
+    def compose(self) -> Any:
+        yield Static("", id="sidebar-content")
+        yield Static("", id="sidebar-brand")
 
     def update_from_session(
         self,
@@ -106,7 +111,10 @@ class SessionSidebar(Static):
         theme: TuiTheme = TAU_DARK_THEME,
     ) -> None:
         """Redraw the sidebar from current session metadata."""
-        self.update(render_session_sidebar(session, theme=theme))
+        self.query_one("#sidebar-content", Static).update(
+            render_session_sidebar(session, theme=theme)
+        )
+        self.query_one("#sidebar-brand", Static).update(_sidebar_brand(theme=theme))
 
 
 class CompactSessionInfo(Static):
@@ -1066,7 +1074,7 @@ def render_session_sidebar(
         style=theme.prompt_text,
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _comma_list(
+    skills = _bullet_list(
         [skill.name for skill in session.skills],
         empty="No skills loaded",
         theme=theme,
@@ -1086,8 +1094,6 @@ def render_session_sidebar(
         empty="No context files",
         theme=theme,
     )
-    equation = Text(TAU_SIDEBAR_LOGO, style=f"bold {theme.prompt_text}")
-
     sections = (
         _sidebar_section("session", title, theme=theme),
         _sidebar_section("activity", activity, theme=theme),
@@ -1105,10 +1111,7 @@ def render_session_sidebar(
             separated_sections.append(_sidebar_separator(theme=theme))
         separated_sections.append(section)
 
-    return Group(
-        Padding(Align.center(equation), (0, 0, 1, 0)),
-        *separated_sections,
-    )
+    return Group(*separated_sections)
 
 
 def _sidebar_section(
@@ -1123,8 +1126,15 @@ def _sidebar_section(
 
 
 def _sidebar_separator(*, theme: TuiTheme) -> RenderableType:
-    """Render a compact divider between adjacent sidebar sections."""
-    return Rule(style=theme.border)
+    """Render a spaced divider between adjacent sidebar sections."""
+    return Padding(Rule(style=theme.border), (0, 0, 1, 0))
+
+
+def _sidebar_brand(*, theme: TuiTheme) -> RenderableType:
+    brand = Text(style=f"bold {theme.prompt_text}")
+    brand.append(TAU_SIDEBAR_LOGO)
+    brand.append(f"  {current_version()}", style=theme.completion_description)
+    return Align.center(brand)
 
 
 def render_compact_session_info(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -14,7 +14,6 @@ from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.markdown import CodeBlock, Heading, Markdown
 from rich.padding import Padding
-from rich.rule import Rule
 from rich.style import Style
 from rich.syntax import Syntax
 from rich.table import Table
@@ -33,6 +32,7 @@ from textual.widgets.markdown import MarkdownBlock, MarkdownStream
 
 from tau_agent.tools import AgentTool
 from tau_coding.prompt_templates import PromptTemplate
+from tau_coding.session_stats import SessionStats
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
@@ -84,6 +84,15 @@ class SessionSummarySource(Protocol):
 
     @property
     def thinking_level(self) -> str: ...
+
+    @property
+    def session_title(self) -> str | None: ...
+
+    @property
+    def extension_names(self) -> Sequence[str]: ...
+
+    @property
+    def session_stats(self) -> SessionStats: ...
 
 
 class SessionSidebar(Static):
@@ -1034,24 +1043,41 @@ def render_session_sidebar(
     theme: TuiTheme = TAU_DARK_THEME,
 ) -> RenderableType:
     """Render a dark, minimalist summary of the active coding session."""
-    metadata = Table.grid(padding=(0, 1))
-    metadata.add_column(style=theme.completion_description, no_wrap=True)
-    metadata.add_column(style=theme.prompt_text)
-    metadata.add_row("provider", session.provider_name)
-    metadata.add_row("model", session.model)
-    metadata.add_row("thinking", _thinking_level(session))
-    metadata.add_row("tools", str(len(session.tools)))
-    metadata.add_row("skills", str(len(session.skills)))
+    title = Text(session.session_title or "Untitled session", style=theme.prompt_text)
+    stats = session.session_stats
+    activity = Text(
+        f"{stats.turn_count} {_plural(stats.turn_count, 'turn')}, "
+        f"{stats.tool_call_count} tool {_plural(stats.tool_call_count, 'call')}",
+        style=theme.prompt_text,
+    )
+    usage = Text(style=theme.prompt_text)
+    usage.append(f"{_compact_usage_count(stats.input_tokens)} in, ")
+    usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
+    usage.append("\n")
+    if stats.estimated_cost is None:
+        usage.append("cost unavailable", style=theme.completion_description)
+    else:
+        usage.append(f"~{_format_cost(stats.estimated_cost)} estimated")
 
-    tools = _bullet_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _bullet_list(
+    threshold = session.auto_compact_token_threshold
+    compaction = Text(
+        "off" if threshold is None else f"auto at {_compact_token_count(threshold)}",
+        style=theme.prompt_text,
+    )
+    tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
+    skills = _comma_list(
         [skill.name for skill in session.skills],
-        empty="No skills loaded yet",
+        empty="No skills loaded",
         theme=theme,
     )
-    prompts = _bullet_list(
+    prompts = _comma_list(
         [template.name for template in session.prompt_templates],
         empty="No prompt templates",
+        theme=theme,
+    )
+    extensions = _comma_list(
+        list(session.extension_names),
+        empty="No extensions",
         theme=theme,
     )
     context = _bullet_list(
@@ -1063,15 +1089,15 @@ def render_session_sidebar(
 
     return Group(
         Padding(Align.center(equation), (0, 0, 1, 0)),
-        _sidebar_section("session", metadata, theme=theme),
-        _sidebar_separator(theme=theme),
+        _sidebar_section("session", title, theme=theme),
+        _sidebar_section("activity", activity, theme=theme),
+        _sidebar_section("usage", usage, theme=theme),
+        _sidebar_section("compaction", compaction, theme=theme),
         _sidebar_section("context", context, theme=theme),
-        _sidebar_separator(theme=theme),
         _sidebar_section("tools", tools, theme=theme),
-        _sidebar_separator(theme=theme),
         _sidebar_section("skills", skills, theme=theme),
-        _sidebar_separator(theme=theme),
         _sidebar_section("prompts", prompts, theme=theme),
+        _sidebar_section("extensions", extensions, theme=theme),
     )
 
 
@@ -1083,12 +1109,7 @@ def _sidebar_section(
 ) -> RenderableType:
     """Render one sidebar section without a surrounding border."""
     header = Text(title, style=f"bold {theme.accent}")
-    return Group(Padding(header, (0, 0, 0, 1)), Padding(body, (0, 0, 1, 1)))
-
-
-def _sidebar_separator(*, theme: TuiTheme) -> RenderableType:
-    """Render a subtle divider between sidebar sections."""
-    return Padding(Rule(style=theme.border), (0, 0, 1, 0))
+    return Group(Padding(header, (0, 0, 0, 1)), Padding(body, (0, 0, 0, 1)))
 
 
 def render_compact_session_info(
@@ -1571,7 +1592,10 @@ def _context_file_label(path: Path, *, cwd: Path) -> str:
     try:
         return str(expanded_path.resolve().relative_to(cwd.expanduser().resolve()))
     except (OSError, ValueError):
-        return _short_path(expanded_path)
+        try:
+            return str(expanded_path.resolve())
+        except OSError:
+            return str(expanded_path.absolute())
 
 
 def _thinking_level(session: SessionSummarySource) -> str:
@@ -1656,6 +1680,35 @@ def render_completion_suggestions(
         command.append("  ", style=style)
         table.add_row(command, Text(item.description or "", style=description_style))
     return table
+
+
+def _comma_list(
+    items: Sequence[str],
+    *,
+    empty: str,
+    theme: TuiTheme,
+) -> Text:
+    if not items:
+        return Text(empty, style=theme.completion_description)
+    return Text(", ".join(items), style=theme.prompt_text, overflow="fold", no_wrap=False)
+
+
+def _compact_usage_count(value: int) -> str:
+    if value < 1_000:
+        return str(value)
+    if value < 1_000_000:
+        return f"{value / 1_000:.1f}".rstrip("0").rstrip(".") + "k"
+    return f"{value / 1_000_000:.1f}".rstrip("0").rstrip(".") + "m"
+
+
+def _format_cost(value: float) -> str:
+    if 0 < value < 0.01:
+        return f"${value:.3f}"
+    return f"${value:.2f}"
+
+
+def _plural(count: int, singular: str) -> str:
+    return singular if count == 1 else f"{singular}s"
 
 
 def _bullet_list(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -172,6 +172,14 @@ def _session_summary_fingerprint(
 class TauMarkdownBlock(MarkdownBlock):
     """Markdown block that applies Tau's themed inline link color."""
 
+    DEFAULT_CSS = """
+    TauMarkdownBlock {
+        link-style: none;
+        link-style-hover: underline;
+        link-background-hover: transparent;
+    }
+    """
+
     @property
     def allow_select(self) -> bool:
         """Only allow native selection once Textual has mounted the block.

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -352,6 +352,8 @@ class TranscriptMessageWidget(Horizontal):
             self._result_markup,
         )
         super().__init__(classes="transcript-message")
+        if item.role == "user":
+            self.styles.padding = (1, 0)
         foreground, background = _split_rich_style_colors(self._role_style.body)
         self._body_foreground = foreground
         if item.role in _BORDERLESS_TRANSCRIPT_ROLES:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1472,7 +1472,7 @@ def render_session_sidebar(
     theme: TuiTheme = TAU_DARK_THEME,
 ) -> RenderableType:
     """Render a dark, minimalist summary of the active coding session."""
-    title = Text(session.session_title or "Untitled session", style=f"bold {theme.prompt_text}")
+    title = Text(session.session_title or "Untitled session", style=f"bold {theme.accent}")
     stats = session.session_stats
     activity = Text(
         f"{stats.turn_count} {_plural(stats.turn_count, 'turn')}, "
@@ -1515,7 +1515,7 @@ def render_session_sidebar(
         theme=theme,
     )
     sections = (
-        _sidebar_section("session", title, theme=theme),
+        Padding(title, (0, 0, 0, 1)),
         _sidebar_section("activity", activity, theme=theme),
         _sidebar_section("usage", usage, theme=theme),
         _sidebar_section("compaction", compaction, theme=theme),

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1565,11 +1565,11 @@ def render_compact_session_info(
     """Render the session facts below the prompt."""
     left = _styled_cwd(session.cwd, theme=theme)
     right = Text(style=theme.muted_text, overflow="fold", no_wrap=False, justify="right")
-    right.append(_context_usage(session), style=theme.completion_description)
-    right.append("  ")
     right.append(f"{session.provider_name}:{session.model}", style=theme.prompt_text)
     right.append(" ")
     right.append(f"({_thinking_level(session)})", style=theme.completion_description)
+    right.append("\n")
+    right.append(_context_usage(session), style=theme.completion_description)
 
     table = Table.grid(expand=True)
     table.add_column(ratio=1)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1472,7 +1472,7 @@ def render_session_sidebar(
     theme: TuiTheme = TAU_DARK_THEME,
 ) -> RenderableType:
     """Render a dark, minimalist summary of the active coding session."""
-    title = Text(session.session_title or "Untitled session", style=theme.prompt_text)
+    title = Text(session.session_title or "Untitled session", style=f"bold {theme.prompt_text}")
     stats = session.session_stats
     activity = Text(
         f"{stats.turn_count} {_plural(stats.turn_count, 'turn')}, "
@@ -1484,7 +1484,7 @@ def render_session_sidebar(
     usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
     usage.append(" · ", style=theme.completion_description)
     if stats.estimated_cost is None:
-        usage.append("cost unavailable", style=theme.completion_description)
+        usage.append("$N/A", style=theme.completion_description)
     else:
         usage.append(f"~{_format_cost(stats.estimated_cost)}")
 
@@ -1563,12 +1563,7 @@ def render_compact_session_info(
     theme: TuiTheme = TAU_DARK_THEME,
 ) -> RenderableType:
     """Render the session facts below the prompt."""
-    left = Text(
-        f"{_short_path(session.cwd)} ({_git_branch(session.cwd)})",
-        style=theme.prompt_text,
-        overflow="fold",
-        no_wrap=False,
-    )
+    left = _styled_cwd(session.cwd, theme=theme)
     right = Text(style=theme.muted_text, overflow="fold", no_wrap=False, justify="right")
     right.append(_context_usage(session), style=theme.completion_description)
     right.append("  ")
@@ -2003,15 +1998,22 @@ def _plain_text(text: str, *, body_style: str) -> Text:
 
 def _context_usage(session: SessionSummarySource) -> str:
     threshold = session.auto_compact_token_threshold
-    if threshold is None or threshold <= 0:
-        return (
-            f"{_compact_token_count(session.context_token_estimate)}"
-            f"/{_compact_token_count(session.context_window_tokens)} context"
-        )
-    return (
-        f"{_compact_token_count(session.context_token_estimate)}"
-        f"/{_compact_token_count(threshold)} context"
-    )
+    limit = session.context_window_tokens if threshold is None or threshold <= 0 else threshold
+    return f"{_compact_token_count(session.context_token_estimate)}/{_compact_token_count(limit)}"
+
+
+def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:
+    """Style the parent path as metadata while emphasizing the working directory."""
+    short_path = _short_path(cwd)
+    parent, separator, name = short_path.rpartition("/")
+    text = Text(overflow="fold", no_wrap=False)
+    if separator and name:
+        text.append(f"{parent}{separator}", style=theme.completion_description)
+        text.append(name, style=theme.prompt_text)
+    else:
+        text.append(short_path, style=theme.prompt_text)
+    text.append(f" ({_git_branch(cwd)})", style=theme.completion_description)
+    return text
 
 
 def _compact_token_count(value: int) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -14,6 +14,7 @@ from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.markdown import CodeBlock, Heading, Markdown
 from rich.padding import Padding
+from rich.rule import Rule
 from rich.style import Style
 from rich.syntax import Syntax
 from rich.table import Table
@@ -1053,11 +1054,11 @@ def render_session_sidebar(
     usage = Text(style=theme.prompt_text)
     usage.append(f"{_compact_usage_count(stats.input_tokens)} in, ")
     usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
-    usage.append("\n")
+    usage.append(" · ", style=theme.completion_description)
     if stats.estimated_cost is None:
         usage.append("cost unavailable", style=theme.completion_description)
     else:
-        usage.append(f"~{_format_cost(stats.estimated_cost)} estimated")
+        usage.append(f"~{_format_cost(stats.estimated_cost)}")
 
     threshold = session.auto_compact_token_threshold
     compaction = Text(
@@ -1087,8 +1088,7 @@ def render_session_sidebar(
     )
     equation = Text(TAU_SIDEBAR_LOGO, style=f"bold {theme.prompt_text}")
 
-    return Group(
-        Padding(Align.center(equation), (0, 0, 1, 0)),
+    sections = (
         _sidebar_section("session", title, theme=theme),
         _sidebar_section("activity", activity, theme=theme),
         _sidebar_section("usage", usage, theme=theme),
@@ -1098,6 +1098,16 @@ def render_session_sidebar(
         _sidebar_section("skills", skills, theme=theme),
         _sidebar_section("prompts", prompts, theme=theme),
         _sidebar_section("extensions", extensions, theme=theme),
+    )
+    separated_sections: list[RenderableType] = []
+    for index, section in enumerate(sections):
+        if index:
+            separated_sections.append(_sidebar_separator(theme=theme))
+        separated_sections.append(section)
+
+    return Group(
+        Padding(Align.center(equation), (0, 0, 1, 0)),
+        *separated_sections,
     )
 
 
@@ -1110,6 +1120,11 @@ def _sidebar_section(
     """Render one sidebar section without a surrounding border."""
     header = Text(title, style=f"bold {theme.accent}")
     return Group(Padding(header, (0, 0, 0, 1)), Padding(body, (0, 0, 0, 1)))
+
+
+def _sidebar_separator(*, theme: TuiTheme) -> RenderableType:
+    """Render a compact divider between adjacent sidebar sections."""
+    return Rule(style=theme.border)
 
 
 def render_compact_session_info(

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -1,0 +1,68 @@
+from tau_agent.messages import (
+    AssistantMessage,
+    CustomMessage,
+    TextContent,
+    ToolCall,
+    Usage,
+    UserMessage,
+)
+from tau_agent.session import CompactionEntry, MessageEntry
+from tau_coding.session_stats import calculate_session_stats
+
+
+def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:
+    user = MessageEntry(message=UserMessage(content="Fix it"))
+    assistant = MessageEntry(
+        parent_id=user.id,
+        message=AssistantMessage(
+            provider="openai",
+            model="gpt-test",
+            content=[
+                TextContent(text="Working"),
+                ToolCall(id="call-1", name="read", arguments={}),
+                ToolCall(id="call-2", name="edit", arguments={}),
+            ],
+            usage=Usage(input=1_000_000, output=100_000, cache_read=500_000),
+        ),
+    )
+    extension_turn = MessageEntry(
+        parent_id=assistant.id,
+        message=CustomMessage(custom_type="test:status", content="Continue"),
+    )
+    compaction = CompactionEntry(
+        parent_id=extension_turn.id,
+        summary="Earlier work",
+        replaces_entry_ids=[user.id, assistant.id],
+    )
+
+    stats = calculate_session_stats(
+        [user, assistant, extension_turn, compaction],
+        pricing=lambda provider, model, input_tokens: {
+            "input": 2.0,
+            "output": 8.0,
+            "cacheRead": 0.5,
+            "cacheWrite": 0.0,
+        },
+    )
+
+    assert stats.turn_count == 2
+    assert stats.tool_call_count == 2
+    assert stats.input_tokens == 1_500_000
+    assert stats.output_tokens == 100_000
+    assert stats.estimated_cost == 3.05
+
+
+def test_calculate_session_stats_marks_cost_unavailable_when_pricing_is_missing() -> None:
+    entry = MessageEntry(
+        message=AssistantMessage(
+            provider="custom",
+            model="unknown",
+            usage=Usage(input=100, output=20),
+        )
+    )
+
+    stats = calculate_session_stats([entry], pricing=lambda _provider, _model, _input: None)
+
+    assert stats.input_tokens == 100
+    assert stats.output_tokens == 20
+    assert stats.estimated_cost is None

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -13,7 +13,7 @@ from textual.color import Color
 from textual.containers import Container, VerticalScroll
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
-from textual.widgets import Footer, Input, Label, ListItem, ListView, Static, TextArea
+from textual.widgets import Input, Label, ListItem, ListView, Static, TextArea
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets.markdown import MarkdownStream
 
@@ -112,6 +112,7 @@ from tau_coding.tui.widgets import (
     TranscriptMessageWidget,
     TranscriptView,
     _compact_token_count,
+    _sidebar_brand,
     _split_rich_style_colors,
     _syntax_language,
     _transcript_plain_body_text,
@@ -458,7 +459,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
 
     output = console.export_text()
     assert "████████" not in output
-    assert "τ = 2π" in output
+    assert "τ = 2π" not in output
     assert "session" in output
     assert "context" in output
     assert "AGENTS.md" in output
@@ -475,15 +476,23 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "1.2m in, 48k out · ~$1.24" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
-    assert "review" in output
+    assert "• review" in output
     assert "permission-gate, subagents" in output
+
+
+def test_session_sidebar_brand_includes_current_version() -> None:
+    console = Console(record=True, width=80)
+
+    console.print(_sidebar_brand(theme=TAU_DARK_THEME))
+
+    assert "τ = 2π  0.2.1" in console.export_text()
 
 
 def test_session_sidebar_uses_accented_aligned_headers_without_section_borders() -> None:
     console = Console(record=True, width=80)
     sidebar = render_session_sidebar(FakeSession())
     panels = [renderable for renderable in sidebar.renderables if isinstance(renderable, Panel)]
-    session_section = sidebar.renderables[1]
+    session_section = sidebar.renderables[0]
     header = session_section.renderables[0]
 
     console.print(sidebar)
@@ -2110,11 +2119,11 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_uses_textual_footer_for_shortcut_hints() -> None:
+async def test_tui_app_omits_footer_but_keeps_shortcuts_active() -> None:
     app = TauTuiApp(FakeSession())
 
-    async with app.run_test(size=(120, 30)):
-        assert app.query_one(Footer) is not None
+    async with app.run_test(size=(120, 40)):
+        assert not app.query("Footer")
         assert len(app.query("#shortcut-hints")) == 0
         assert _visible_footer_bindings(app) == {
             "Quit": "ctrl+d",
@@ -2164,15 +2173,6 @@ async def test_tui_app_footer_hints_update_while_running() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_keeps_textual_footer_on_short_windows() -> None:
-    app = TauTuiApp(FakeSession())
-
-    async with app.run_test(size=(120, 18)):
-        assert app.query_one(Footer).display is True
-        assert len(app.query("#shortcut-hints")) == 0
-
-
-@pytest.mark.anyio
 async def test_tui_prompt_grows_to_six_lines_then_scrolls() -> None:
     app = TauTuiApp(FakeSession())
 
@@ -2180,7 +2180,7 @@ async def test_tui_prompt_grows_to_six_lines_then_scrolls() -> None:
         prompt = app.query_one("#prompt", TextArea)
         assert prompt.size.height == 1
 
-        prompt.text = "x" * 500
+        prompt.text = "x" * 700
         await pilot.pause()
         assert prompt.size.height == 6
 
@@ -2194,10 +2194,14 @@ async def test_tui_prompt_grows_to_six_lines_then_scrolls() -> None:
 async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
     app = TauTuiApp(FakeSession())
 
-    async with app.run_test(size=(120, 30)):
+    async with app.run_test(size=(120, 40)):
         sidebar = app.query_one("#sidebar")
+        sidebar_brand = app.query_one("#sidebar-brand", Static)
         compact_info = app.query_one("#compact-session-info")
         assert sidebar.display is True
+        assert sidebar.region.width == 36
+        assert sidebar_brand.region.bottom == sidebar.content_region.bottom
+        assert sidebar.styles.background == Color.parse(TAU_DARK_THEME.prompt_background)
         assert compact_info.display is True
         assert not app.has_class("-hide-sidebar")
 
@@ -2206,7 +2210,7 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
 async def test_tui_sidebar_fills_workspace_height() -> None:
     app = TauTuiApp(FakeSession())
 
-    async with app.run_test(size=(120, 30)):
+    async with app.run_test(size=(120, 40)):
         workspace = app.query_one("#workspace")
         sidebar = app.query_one("#sidebar")
 
@@ -2230,7 +2234,7 @@ async def test_tui_sidebar_hides_on_narrow_windows() -> None:
 async def test_tui_sidebar_hides_on_short_windows() -> None:
     app = TauTuiApp(FakeSession())
 
-    async with app.run_test(size=(120, 18)):
+    async with app.run_test(size=(120, 30)):
         sidebar = app.query_one("#sidebar")
         compact_info = app.query_one("#compact-session-info")
         assert sidebar.display is False
@@ -2242,23 +2246,23 @@ async def test_tui_sidebar_hides_on_short_windows() -> None:
 async def test_tui_sidebar_visibility_updates_on_resize() -> None:
     app = TauTuiApp(FakeSession())
 
-    async with app.run_test(size=(120, 30)) as pilot:
+    async with app.run_test(size=(120, 40)) as pilot:
         sidebar = app.query_one("#sidebar")
         compact_info = app.query_one("#compact-session-info")
         assert sidebar.display is True
         assert compact_info.display is True
 
-        await pilot.resize_terminal(width=80, height=30)
-        await pilot.pause()
-        assert sidebar.display is False
-        assert compact_info.display is True
-
-        await pilot.resize_terminal(width=120, height=18)
+        await pilot.resize_terminal(width=80, height=40)
         await pilot.pause()
         assert sidebar.display is False
         assert compact_info.display is True
 
         await pilot.resize_terminal(width=120, height=30)
+        await pilot.pause()
+        assert sidebar.display is False
+        assert compact_info.display is True
+
+        await pilot.resize_terminal(width=120, height=40)
         await pilot.pause()
         assert sidebar.display is True
         assert compact_info.display is True
@@ -2268,7 +2272,7 @@ async def test_tui_sidebar_visibility_updates_on_resize() -> None:
 async def test_tui_sidebar_shows_on_right_when_configured() -> None:
     app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="right"))
 
-    async with app.run_test(size=(120, 30)):
+    async with app.run_test(size=(120, 40)):
         sidebar = app.query_one("#sidebar")
         assert sidebar.display is True
         assert app.has_class("-sidebar-right")
@@ -2612,9 +2616,9 @@ async def test_tui_app_updates_terminal_title_after_auto_session_naming() -> Non
         await app._run_prompt("debug the login flow")
 
         assert "\x1b]0;τ | Debug login\x07" in writes
-        sidebar = app.query_one("#sidebar", Static)
+        sidebar_content = app.query_one("#sidebar-content", Static)
         console = Console(record=True, width=80, file=StringIO())
-        console.print(sidebar.content)
+        console.print(sidebar_content.content)
         assert "Debug login" in console.export_text()
         assert writes[-1] == "\x1b]0;τ | Debug login\x07"
 
@@ -4433,9 +4437,9 @@ async def test_tui_app_name_updates_sidebar() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
-        sidebar = app.query_one("#sidebar", Static)
+        sidebar_content = app.query_one("#sidebar-content", Static)
         console = Console(record=True, width=80, file=StringIO())
-        console.print(sidebar.content)
+        console.print(sidebar_content.content)
         assert "Customer bugfix" in console.export_text()
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -117,6 +117,7 @@ from tau_coding.tui.widgets import (
     _compact_token_count,
     _sidebar_brand,
     _split_rich_style_colors,
+    _styled_cwd,
     _syntax_language,
     _transcript_plain_body_text,
     render_chat_item,
@@ -447,7 +448,7 @@ class FakeSession:
 
 
 def _visible_footer_bindings(app: TauTuiApp) -> dict[str, str]:
-    """Return visible bindings that Textual's built-in Footer will render."""
+    """Return active bindings that a Textual Footer would render if mounted."""
     return {
         binding.description: binding.key_display or binding.key
         for _, binding, _enabled, _tooltip in app.screen.active_bindings.values()
@@ -483,6 +484,18 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "permission-gate, subagents" in output
 
 
+def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:
+    session = FakeSession()
+    session.session_stats = SessionStats(input_tokens=1200, output_tokens=300)
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "$N/A" in output
+    assert "cost unavailable" not in output
+
+
 def test_session_sidebar_brand_includes_current_version() -> None:
     console = Console(record=True, width=80)
 
@@ -497,6 +510,7 @@ def test_session_sidebar_uses_accented_aligned_headers_without_section_borders()
     panels = [renderable for renderable in sidebar.renderables if isinstance(renderable, Panel)]
     session_section = sidebar.renderables[0]
     header = session_section.renderables[0]
+    session_name = session_section.renderables[1]
 
     console.print(sidebar)
 
@@ -504,6 +518,7 @@ def test_session_sidebar_uses_accented_aligned_headers_without_section_borders()
     assert panels == []
     assert header.left == 1
     assert str(header.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
+    assert str(session_name.renderable.style) == f"bold {TAU_DARK_THEME.prompt_text}"
     assert " session" in output
     assert " context" in output
     assert " tools" in output
@@ -541,9 +556,19 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
 
     output = console.export_text()
     assert "/workspace/project (--)" in output
-    assert "12k/200k context" in output
+    assert "12k/200k" in output
+    assert "12k/200k context" not in output
     assert "openai:fake-model" in output
     assert "(medium)" in output
+
+
+def test_compact_session_info_styles_parent_path_as_metadata() -> None:
+    cwd = _styled_cwd(Path("/workspace/project"), theme=TAU_DARK_THEME)
+
+    assert cwd.plain == "/workspace/project (--)"
+    assert str(cwd.spans[0].style) == TAU_DARK_THEME.completion_description
+    assert str(cwd.spans[1].style) == TAU_DARK_THEME.prompt_text
+    assert str(cwd.spans[2].style) == TAU_DARK_THEME.completion_description
 
 
 def test_compact_token_count_uses_thousands_suffix() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -504,22 +504,25 @@ def test_session_sidebar_brand_includes_current_version() -> None:
     assert "τ = 2π  0.2.1" in console.export_text()
 
 
-def test_session_sidebar_uses_accented_aligned_headers_without_section_borders() -> None:
+def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:
     console = Console(record=True, width=80)
-    sidebar = render_session_sidebar(FakeSession())
+    session = FakeSession()
+    session._session_title = "Customer bugfix"
+    sidebar = render_session_sidebar(session)
     panels = [renderable for renderable in sidebar.renderables if isinstance(renderable, Panel)]
-    session_section = sidebar.renderables[0]
-    header = session_section.renderables[0]
-    session_name = session_section.renderables[1]
+    session_name = sidebar.renderables[0]
+    activity_section = sidebar.renderables[2]
+    activity_header = activity_section.renderables[0]
 
     console.print(sidebar)
 
     output = console.export_text()
     assert panels == []
-    assert header.left == 1
-    assert str(header.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
-    assert str(session_name.renderable.style) == f"bold {TAU_DARK_THEME.prompt_text}"
-    assert " session" in output
+    assert session_name.left == 1
+    assert str(session_name.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
+    assert activity_header.left == 1
+    assert str(activity_header.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
+    assert " session" not in output
     assert " context" in output
     assert " tools" in output
     assert "─" in output
@@ -2341,10 +2344,12 @@ async def test_tui_prompt_grows_to_six_lines_then_scrolls() -> None:
     async with app.run_test(size=(120, 30)) as pilot:
         prompt = app.query_one("#prompt", TextArea)
         assert prompt.size.height == 1
+        assert prompt.outer_size.height == 3
 
         prompt.text = "x" * 700
         await pilot.pause()
         assert prompt.size.height == 6
+        assert prompt.outer_size.height == 8
 
         prompt.text = "x" * 1000
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2375,6 +2375,7 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
         compact_info = app.query_one("#compact-session-info")
         assert sidebar.display is True
         assert sidebar.region.width == 40
+        assert sidebar.styles.padding.left == 2
         assert sidebar.styles.border_left[0] == ""
         assert sidebar.styles.border_right[0] == ""
         assert sidebar.styles.border_top[0] == ""

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -11,6 +11,7 @@ from rich.panel import Panel
 from textual import events
 from textual.color import Color
 from textual.containers import Container, VerticalScroll
+from textual.content import Style as TextualStyle
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
 from textual.widgets import Input, Label, ListItem, ListView, Static, TextArea
@@ -1151,8 +1152,18 @@ async def test_textual_markdown_widget_uses_theme_link_style() -> None:
         await pilot.pause()
 
         markdown = app.query_one(ThemedMarkdownWidget)
+        block = app.query_one(TauMarkdownBlock)
 
+    link_spans = [
+        span
+        for span in block.content.spans
+        if isinstance(span.style, TextualStyle) and "@click" in span.style.meta
+    ]
     assert markdown.tau_link_style == TAU_DARK_THEME.markdown_link
+    assert not block.styles.link_style
+    assert block.styles.link_style_hover.underline is True
+    assert [(span.start, span.end) for span in link_spans] == [(5, 9)]
+    assert block.content.plain[5:9] == "docs"
 
 
 def test_textual_markdown_uses_theme_highlight_and_aqua_inline_code() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1338,6 +1338,8 @@ async def test_transcript_message_widget_renders_full_height_role_block() -> Non
         # block is rectangular and the accent spans every wrapped line.
         assert widget.styles.background == background
         assert body.styles.background == background
+        assert widget.styles.padding.top == 1
+        assert widget.styles.padding.bottom == 1
         edge_type, edge_color = widget.styles.border_left
         assert edge_type != "none"
         assert edge_color == border

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -560,11 +560,14 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
     console.print(render_compact_session_info(FakeSession()))
 
     output = console.export_text()
+    lines = output.splitlines()
+    provider_line = next(index for index, line in enumerate(lines) if "openai:fake-model" in line)
+    context_line = next(index for index, line in enumerate(lines) if "12k/200k" in line)
     assert "/workspace/project (--)" in output
-    assert "12k/200k" in output
     assert "12k/200k context" not in output
-    assert "openai:fake-model" in output
-    assert "(medium)" in output
+    assert "openai:fake-model" in lines[provider_line]
+    assert "(medium)" in lines[provider_line]
+    assert context_line == provider_line + 1
 
 
 def test_compact_session_info_styles_parent_path_as_metadata() -> None:
@@ -2369,7 +2372,11 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
         sidebar_brand = app.query_one("#sidebar-brand", Static)
         compact_info = app.query_one("#compact-session-info")
         assert sidebar.display is True
-        assert sidebar.region.width == 36
+        assert sidebar.region.width == 40
+        assert sidebar.styles.border_left[0] == ""
+        assert sidebar.styles.border_right[0] == ""
+        assert sidebar.styles.border_top[0] == ""
+        assert sidebar.styles.border_bottom[0] == ""
         assert sidebar_brand.region.bottom == sidebar.content_region.bottom
         assert sidebar.styles.background == Color.parse(TAU_DARK_THEME.prompt_background)
         assert compact_info.display is True

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2696,7 +2696,10 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
 
         assert not app.query("#status")
         assert not app.query("#activity-status")
-        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_left[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_top[0] == ""
+        assert prompt.styles.border_right[0] == ""
+        assert prompt.styles.border_bottom[0] == ""
         assert indicator.render().plain == "τ"
 
         app.adapter.apply(AgentStartEvent())
@@ -2704,19 +2707,19 @@ async def test_tui_app_shows_activity_indicator_while_running() -> None:
 
         assert pytest.approx(tui_app.ACTIVITY_TICK_SECONDS) == 0.15
         assert tui_app.ACTIVITY_COLOR_FADE_STEPS == 24
-        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_left[1].hex.lower() == "#2d3748"
         assert indicator.render().plain.startswith("■")
 
         app._tick_activity()
 
-        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_left[1].hex.lower() == "#2d3748"
         assert indicator.render().plain.splitlines()[1] == "■"
 
         app.adapter.apply(AgentEndEvent())
         app._refresh()
 
         assert not app.query("#status")
-        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_left[1].hex.lower() == "#2d3748"
         assert indicator.render().plain == "τ"
 
 
@@ -2803,7 +2806,10 @@ async def test_tui_app_clears_activity_status_on_error() -> None:
 
         assert not app.query("#status")
         assert not app.query("#activity-status")
-        assert prompt.styles.border.top[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_left[1].hex.lower() == "#2d3748"
+        assert prompt.styles.border_top[0] == ""
+        assert prompt.styles.border_right[0] == ""
+        assert prompt.styles.border_bottom[0] == ""
         assert indicator.render().plain == "τ"
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 from collections.abc import AsyncIterator
 from datetime import datetime
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -58,6 +59,7 @@ from tau_coding.session import (
     TerminalCommandResult,
 )
 from tau_coding.session_manager import CodingSessionRecord
+from tau_coding.session_stats import SessionStats
 from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tools import create_coding_tools
@@ -170,6 +172,14 @@ class FakeSession:
         self.available_thinking_levels = ("off", "minimal", "low", "medium", "high", "xhigh")
         self.state = FakeSessionState()
         self.resource_diagnostics = ()
+        self.extension_names = ("permission-gate", "subagents")
+        self.session_stats = SessionStats(
+            turn_count=14,
+            tool_call_count=23,
+            input_tokens=1_200_000,
+            output_tokens=48_000,
+            estimated_cost=1.24,
+        )
         self.system_prompt = "You are Tau."
         self.session_manager = None
         self._session_title: str | None = None
@@ -453,17 +463,20 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "context" in output
     assert "AGENTS.md" in output
     assert "12k" not in output
-    assert "provider" in output
-    assert "openai" in output
-    assert "fake-model" in output
-    assert "thinking" in output
-    assert "medium" in output
+    assert "Untitled session" in output
+    assert "provider" not in output
+    assert "openai" not in output
+    assert "fake-model" not in output
+    assert "thinking" not in output
     assert "location" not in output
     assert "branch" not in output
-    assert "tools" in output
-    assert "read" in output
-    assert "skills" in output
+    assert "14 turns, 23 tool calls" in output
+    assert "1.2m in, 48k out" in output
+    assert "~$1.24 estimated" in output
+    assert "auto at 200k" in output
+    assert "read, write, edit, bash" in output
     assert "review" in output
+    assert "permission-gate, subagents" in output
 
 
 def test_session_sidebar_uses_accented_aligned_headers_without_section_borders() -> None:
@@ -481,7 +494,7 @@ def test_session_sidebar_uses_accented_aligned_headers_without_section_borders()
     assert str(header.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
     assert " session" in output
     assert " context" in output
-    assert "─" in output
+    assert " tools" in output
     assert "┌" not in output
     assert "│" not in output
 
@@ -495,6 +508,7 @@ def test_session_sidebar_lists_multiple_context_files() -> None:
             content="Agent rules.",
         ),
         ProjectContextFile(path="docs/AGENTS.md", content="Docs rules."),
+        ProjectContextFile(path="/Users/alex/.agents/AGENTS.md", content="User rules."),
     )
     console = Console(record=True, width=100)
 
@@ -504,6 +518,7 @@ def test_session_sidebar_lists_multiple_context_files() -> None:
     assert "AGENTS.md" in output
     assert ".agents/AGENTS.md" in output
     assert "docs/AGENTS.md" in output
+    assert "/Users/alex/.agents/AGENTS.md" in output
 
 
 def test_compact_session_info_renders_sidebar_facts() -> None:
@@ -2596,7 +2611,10 @@ async def test_tui_app_updates_terminal_title_after_auto_session_naming() -> Non
         await app._run_prompt("debug the login flow")
 
         assert "\x1b]0;τ | Debug login\x07" in writes
-        assert app.sub_title == "Debug login"
+        sidebar = app.query_one("#sidebar", Static)
+        console = Console(record=True, width=80, file=StringIO())
+        console.print(sidebar.content)
+        assert "Debug login" in console.export_text()
         assert writes[-1] == "\x1b]0;τ | Debug login\x07"
 
 
@@ -4397,27 +4415,15 @@ async def test_tui_app_system_appends_command_output_to_transcript() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_uses_session_name_in_header() -> None:
-    session = FakeSession()
-    session._session_title = "Customer bugfix"
-    app = TauTuiApp(session)
-
-    async with app.run_test():
-        assert app.title == "Tau"
-        assert app.sub_title == "Customer bugfix"
-
-
-@pytest.mark.anyio
-async def test_tui_app_uses_default_header_for_unnamed_session() -> None:
+async def test_tui_app_omits_textual_header() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test():
-        assert app.title == "Tau"
-        assert app.sub_title == "Untitled session"
+        assert not app.query("Header")
 
 
 @pytest.mark.anyio
-async def test_tui_app_name_updates_header() -> None:
+async def test_tui_app_name_updates_sidebar() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -4426,7 +4432,10 @@ async def test_tui_app_name_updates_header() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
-        assert app.sub_title == "Customer bugfix"
+        sidebar = app.query_one("#sidebar", Static)
+        console = Console(record=True, width=80, file=StringIO())
+        console.print(sidebar.content)
+        assert "Customer bugfix" in console.export_text()
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1316,6 +1316,7 @@ async def test_transcript_message_widget_renders_full_height_role_block() -> Non
 
     role_style = HIGH_CONTRAST_THEME.role_styles["user"]
     _, expected_background = _split_rich_style_colors(role_style.body)
+    assert expected_background == HIGH_CONTRAST_THEME.prompt_background
     background = Color.parse(expected_background)
     border = Color.parse(role_style.border)
 
@@ -2628,13 +2629,13 @@ def test_textual_theme_mapping_uses_tau_theme_values() -> None:
     assert textual_theme.variables["tau-screen-background"] == TAU_LIGHT_THEME.screen_background
 
 
-def test_tau_dark_theme_uses_black_chat_backgrounds() -> None:
+def test_tau_dark_theme_matches_user_and_prompt_backgrounds() -> None:
     theme = TuiSettings().resolved_theme
 
     assert theme.screen_background == "#000000"
     assert theme.transcript_background == "#000000"
     assert theme.prompt_background == "#101419"
-    assert theme.role_styles["user"].body.endswith("on #000000")
+    assert theme.role_styles["user"].body.endswith(f"on {theme.prompt_background}")
     assert theme.role_styles["assistant"].body.endswith("on #000000")
 
 
@@ -2645,7 +2646,7 @@ def test_tau_light_theme_uses_light_chat_backgrounds() -> None:
     assert theme.transcript_background == "#ffffff"
     assert theme.prompt_text == "#111827"
     assert theme.syntax_theme == "ansi_light"
-    assert theme.role_styles["user"].body == "#111827"
+    assert theme.role_styles["user"].body == f"#111827 on {theme.prompt_background}"
     assert theme.role_styles["assistant"].body == "#111827"
     assert theme.role_styles["tool"].body == "#1f2937"
     assert theme.role_styles["error"].border == "#b91c1c"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -472,7 +472,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "branch" not in output
     assert "14 turns, 23 tool calls" in output
     assert "1.2m in, 48k out" in output
-    assert "~$1.24 estimated" in output
+    assert "1.2m in, 48k out · ~$1.24" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert "review" in output
@@ -495,6 +495,7 @@ def test_session_sidebar_uses_accented_aligned_headers_without_section_borders()
     assert " session" in output
     assert " context" in output
     assert " tools" in output
+    assert "─" in output
     assert "┌" not in output
     assert "│" not in output
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1138,7 +1138,7 @@ def test_markdown_tables_use_highlight_color_for_headers() -> None:
 
     output = console.export_text(styles=True)
 
-    assert "38;2;219;148;90" in output
+    assert _style_color_escape(TAU_DARK_THEME.accent) in output
     assert "\x1b[36" not in output
 
 
@@ -2652,14 +2652,37 @@ def test_textual_theme_mapping_uses_tau_theme_values() -> None:
     assert textual_theme.variables["tau-screen-background"] == TAU_LIGHT_THEME.screen_background
 
 
-def test_tau_dark_theme_matches_user_and_prompt_backgrounds() -> None:
+def test_tau_dark_theme_uses_aqua_as_its_shared_accent() -> None:
     theme = TuiSettings().resolved_theme
 
+    assert theme.accent == "#a7f3f0"
+    assert theme.highlight_background == theme.accent
+    assert theme.markdown_heading == theme.accent
+    assert theme.markdown_bullet == theme.accent
     assert theme.screen_background == "#000000"
     assert theme.transcript_background == "#000000"
     assert theme.prompt_background == "#101419"
     assert theme.role_styles["user"].body.endswith(f"on {theme.prompt_background}")
     assert theme.role_styles["assistant"].body.endswith("on #000000")
+
+
+@pytest.mark.parametrize(
+    "theme",
+    [TAU_DARK_THEME, TAU_LIGHT_THEME, HIGH_CONTRAST_THEME],
+)
+def test_autocomplete_and_picker_share_theme_highlight(theme: TuiTheme) -> None:
+    completion_text, completion_background = _split_rich_style_colors(theme.completion_selected)
+    description_text, description_background = _split_rich_style_colors(
+        theme.completion_selected_description
+    )
+    variables = _theme_css_variables(theme)
+
+    assert completion_text == theme.highlight_text
+    assert completion_background == theme.highlight_background
+    assert description_text == theme.highlight_text
+    assert description_background == theme.highlight_background
+    assert variables["tau-highlight-background"] == theme.highlight_background
+    assert variables["tau-highlight-text"] == theme.highlight_text
 
 
 def test_tau_light_theme_uses_light_chat_backgrounds() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -513,6 +513,7 @@ def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> 
     session_name = sidebar.renderables[0]
     activity_section = sidebar.renderables[2]
     activity_header = activity_section.renderables[0]
+    activity_content = activity_section.renderables[1]
 
     console.print(sidebar)
 
@@ -521,7 +522,8 @@ def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> 
     assert session_name.left == 1
     assert str(session_name.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
     assert activity_header.left == 1
-    assert str(activity_header.renderable.style) == f"bold {TAU_DARK_THEME.accent}"
+    assert str(activity_header.renderable.style) == f"bold {TAU_DARK_THEME.prompt_text}"
+    assert str(activity_content.renderable.style) == TAU_DARK_THEME.completion_description
     assert " session" not in output
     assert " context" in output
     assert " tools" in output

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -119,8 +119,9 @@ names use compact comma-separated lists. Skills and context files use bullet
 lists, with one item or path per line. Project context paths are relative to the
 working directory; context loaded from outside the project uses its full path.
 
-The wider sidebar uses the prompt field's background color and keeps Tau's
-versioned `τ = 2π` mark pinned to its bottom edge. Tau does not render separate
+The wider sidebar uses the prompt field's background color, bright section
+headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark pinned to
+its bottom edge. Tau does not render separate
 top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
 and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
 automatically when the terminal is small, while the tab title continues to

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -84,7 +84,9 @@ indicator provides the run-wide animation without adding a second spinner to eac
 tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
-the transcript stays readable. Toggle full tool output with **Ctrl+O**.
+the transcript stays readable. Toggle full tool output with **Ctrl+O**. User
+message blocks use the same theme background as the prompt field and sidebar,
+visually tying submitted prompts to the composer.
 
 ## Long sessions
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -9,7 +9,9 @@ see [Keyboard shortcuts]({{< relref "../reference/keybindings.md" >}}).
 
 ## Sending a prompt
 
-Type into the prompt box at the bottom and press **Enter** to submit.
+Type into the prompt box at the bottom and press **Enter** to submit. Its single
+left border changes color to reflect focus, shell mode, and active runs without
+boxing in the editor.
 **Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
 assistant's reply above the prompt, showing tool calls as they run. In supported
 terminal emulators, Tau also updates the tab title: named sessions show as

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -119,9 +119,9 @@ names use compact comma-separated lists. Skills and context files use bullet
 lists, with one item or path per line. Project context paths are relative to the
 working directory; context loaded from outside the project uses its full path.
 
-The wider sidebar uses the prompt field's background color, bright section
-headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark pinned to
-its bottom edge. Tau does not render separate
+The wider, borderless sidebar uses the prompt field's background color, bright
+section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark
+pinned to its bottom edge. Tau does not render separate
 top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
 and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
 automatically when the terminal is small, while the tab title continues to
@@ -131,9 +131,10 @@ Usage and cost cover the active branch, including history replaced by compaction
 Cost is an estimate based on provider-reported usage and configured catalog rates;
 the sidebar shows `$N/A` when Tau lacks complete pricing data.
 
-The compact status line below the prompt shows context consumption as just
-`used/limit`. Its working-directory name is emphasized while the parent path and
-Git branch use the quieter metadata color.
+The compact status block below the prompt puts `provider:model (thinking)` on its
+first line and context consumption as just `used/limit` on the second. Its
+working-directory name is emphasized while the parent path and Git branch use the
+quieter metadata color.
 
 The sidebar can be moved to the **right** or turned **off** entirely by setting
 `sidebar_position` in `~/.tau/tui.json` — see

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -9,9 +9,9 @@ see [Keyboard shortcuts]({{< relref "../reference/keybindings.md" >}}).
 
 ## Sending a prompt
 
-Type into the prompt box at the bottom and press **Enter** to submit. Its single
-left border changes color to reflect focus, shell mode, and active runs without
-boxing in the editor.
+Type into the prompt box at the bottom and press **Enter** to submit. The editor
+keeps its padded block size and background, while a single left border changes
+color to reflect focus, shell mode, and active runs without boxing it in.
 **Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
 assistant's reply above the prompt, showing tool calls as they run. In supported
 terminal emulators, Tau also updates the tab title: named sessions show as
@@ -108,7 +108,8 @@ when you want to reduce what is sent to the model.
 
 ## The sidebar
 
-On wide-enough terminals Tau shows a sidebar with the session name, active-branch
+On wide-enough terminals Tau shows the session name prominently without a
+redundant section label, followed by active-branch
 turn and tool-call totals, provider-reported token usage, estimated cost,
 automatic-compaction threshold, and loaded tools, skills, prompt templates,
 extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -84,7 +84,8 @@ indicator provides the run-wide animation without adding a second spinner to eac
 tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
-the transcript stays readable. Toggle full tool output with **Ctrl+O**. User
+the transcript stays readable. Toggle full tool output with **Ctrl+O**. Markdown
+link hover styling underlines only the linked text, never the rest of its row. User
 message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.
 This visually ties submitted prompts to the composer.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -109,6 +109,9 @@ when you want to reduce what is sent to the model.
   opening the picker. Manage that list with `/scoped-models` or by pressing
   `Space` on a model in the `/model` picker.
 - **`/theme`** switches between `tau-dark`, `tau-light`, and `high-contrast`.
+  Each theme uses one shared selection palette for prompt autocomplete and modal
+  lists such as `/resume`. In `tau-dark`, the aqua selection color is also the
+  global accent used for headings, prompt activity, and other emphasized UI.
 
 ## The sidebar
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -98,14 +98,17 @@ the transcript stays readable. Toggle full tool output with **Ctrl+O**.
 On wide-enough terminals Tau shows a sidebar with the session name, active-branch
 turn and tool-call totals, provider-reported token usage, estimated cost,
 automatic-compaction threshold, and loaded tools, skills, prompt templates,
-extensions, and context files such as `AGENTS.md`. Resource names use compact
-comma-separated lists, while context files remain one path per line. Project
-context paths are relative to the working directory; context loaded from outside
-the project uses its full path.
+extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
+names use compact comma-separated lists. Skills and context files use bullet
+lists, with one item or path per line. Project context paths are relative to the
+working directory; context loaded from outside the project uses its full path.
 
-Tau does not render a separate top header. Named sessions remain visible in the
-sidebar and in the terminal tab title. The sidebar hides automatically when the
-terminal is small, while the tab title continues to identify the session.
+The wider sidebar uses the prompt field's background color and keeps Tau's
+versioned `τ = 2π` mark pinned to its bottom edge. Tau does not render separate
+top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
+and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
+automatically when the terminal is small, while the tab title continues to
+identify the session.
 
 Usage and cost cover the active branch, including history replaced by compaction.
 Cost is an estimate based on provider-reported usage and configured catalog rates;

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -86,7 +86,8 @@ tool row.
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Toggle full tool output with **Ctrl+O**. User
 message blocks use the same theme background as the prompt field and sidebar,
-visually tying submitted prompts to the composer.
+with light vertical padding so they read as blocks rather than highlighted lines.
+This visually ties submitted prompts to the composer.
 
 ## Long sessions
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -95,9 +95,21 @@ the transcript stays readable. Toggle full tool output with **Ctrl+O**.
 
 ## The sidebar
 
-On wide-enough terminals Tau shows a sidebar with the active provider/model,
-thinking mode, loaded tools, skills, prompt templates, and context files such as
-`AGENTS.md`. It hides automatically when the terminal is small.
+On wide-enough terminals Tau shows a sidebar with the session name, active-branch
+turn and tool-call totals, provider-reported token usage, estimated cost,
+automatic-compaction threshold, and loaded tools, skills, prompt templates,
+extensions, and context files such as `AGENTS.md`. Resource names use compact
+comma-separated lists, while context files remain one path per line. Project
+context paths are relative to the working directory; context loaded from outside
+the project uses its full path.
+
+Tau does not render a separate top header. Named sessions remain visible in the
+sidebar and in the terminal tab title. The sidebar hides automatically when the
+terminal is small, while the tab title continues to identify the session.
+
+Usage and cost cover the active branch, including history replaced by compaction.
+Cost is an estimate based on provider-reported usage and configured catalog rates;
+it is shown as unavailable when Tau lacks complete pricing data.
 
 The sidebar can be moved to the **right** or turned **off** entirely by setting
 `sidebar_position` in `~/.tau/tui.json` — see

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -123,7 +123,11 @@ identify the session.
 
 Usage and cost cover the active branch, including history replaced by compaction.
 Cost is an estimate based on provider-reported usage and configured catalog rates;
-it is shown as unavailable when Tau lacks complete pricing data.
+the sidebar shows `$N/A` when Tau lacks complete pricing data.
+
+The compact status line below the prompt shows context consumption as just
+`used/limit`. Its working-directory name is emphasized while the parent path and
+Git branch use the quieter metadata color.
 
 The sidebar can be moved to the **right** or turned **off** entirely by setting
 `sidebar_position` in `~/.tau/tui.json` — see


### PR DESCRIPTION
## Summary

- replace redundant provider/model/thinking sidebar metadata with the session name and active-branch activity totals
- show cumulative input/output usage, estimated model cost (`$N/A` when unavailable), automatic-compaction status, and loaded extensions
- render tools, prompts, and extensions as compact comma-separated lists while keeping skills and context paths as bullets
- widen and space the borderless sidebar, use bright headings with muted values, match the prompt background across themes, and pin the Tau version mark to the bottom
- remove Textual's top header and shortcut footer to recover vertical space while retaining dynamic terminal titles and keyboard shortcuts
- emphasize the unlabeled session name and working-directory basename, and place `provider:model (thinking)` above `used/limit` in the compact status block
- simplify the prompt editor to a single state-aware left border while preserving its original padded size and background block
- use the prompt/sidebar background with light vertical padding for user transcript messages in every built-in theme
- constrain Markdown hover underlines to the exact linked text
- promote the dark aqua highlight to the global accent and derive autocomplete selection styles from the same palette used by modal lists

## User experience

The sidebar now focuses on durable session identity, capabilities, and lifetime branch usage instead of repeating the compact model status line. Its wider, more clearly separated sections expose useful cost and activity information, preserve full external context paths, and retain Tau's identity and version without consuming global header or footer rows.

## Issue

No linked issue. This addresses the agreed TUI sidebar improvements from design discussion.

## Manual validation

1. Start `tau` in a wide, tall terminal and confirm there is no top header or shortcut footer.
2. Confirm the sidebar is wider, matches the prompt background, and shows `τ = 2π` with the current Tau version at its bottom edge.
3. Name a session and confirm the name appears in the sidebar and terminal tab.
4. Run several prompts that invoke tools and confirm turns, tool calls, tokens, and estimated cost update.
5. Run `/compact` and confirm lifetime activity/usage totals remain while current context usage shrinks.
6. Confirm skills and context files use bullets while tools, prompts, and extensions use comma-separated lists.
7. Resize the terminal until the sidebar hides and confirm the terminal tab still identifies the session.

## Validation

- `uv run pytest` (991 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`

The optional local Pagefind build could not download `pagefind` because the configured npm registry timed out; GitHub CI installs it independently.










