### PR TITLE
Release Tau 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.2.2",
+    "date": "2026-07-18",
+    "sections": {
+      "New": [
+        "Add data-driven JSON themes with built-in palettes plus user and project theme discovery.",
+        "Add live search to the resume session picker across session titles, models, and working directories."
+      ],
+      "Changed": [
+        "Keep long TUI sessions responsive by mounting a bounded transcript window while preserving access to the complete conversation.",
+        "Redesign the TUI sidebar around session identity, lifetime activity, token usage, estimated cost, compaction status, and loaded capabilities."
+      ]
+    }
+  },
+  {
     "version": "0.2.1",
     "date": "2026-07-18",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -502,7 +502,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.2.1" in console.export_text()
+    assert "τ = 2π  0.2.2" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.2.1 to 0.2.2
- add bundled release notes for custom themes, resume search, long-transcript performance, and sidebar session insights
- refresh the lockfile and versioned sidebar assertion

## Validation

- `uv run pytest` — 1037 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-release-dist`
- confirmed 0.2.2 is not already published on PyPI
