### PR TITLE
Fix picker highlight text contrast

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2563,12 +2563,12 @@ class TauTuiApp(App[None]):
         border: tall $tau-border;
     }
 
-    ListView > ListItem.--highlight {
+    ListView > ListItem.-highlight {
         background: $tau-highlight-background;
         color: $tau-highlight-text;
     }
 
-    ListView > ListItem.--highlight Label {
+    ListView > ListItem.-highlight Label {
         background: $tau-highlight-background;
         color: $tau-highlight-text;
     }
@@ -2723,6 +2723,14 @@ class TauTuiApp(App[None]):
     #theme-picker-list ListItem Label,
     #model-picker-list ListItem Label {
         color: $tau-screen-text;
+    }
+
+    #login-method-list ListItem.-highlight Label,
+    #login-provider-list ListItem.-highlight Label,
+    #theme-picker-list ListItem.-highlight Label,
+    #model-picker-list ListItem.-highlight Label {
+        background: $tau-highlight-background;
+        color: $tau-highlight-text;
     }
 
     #login-method-intro {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2955,6 +2955,30 @@ async def test_tui_app_theme_command_opens_picker_and_persists_selection(
         assert app.get_theme_variable_defaults()["tau-screen-background"] == "#ffffff"
 
 
+@pytest.mark.parametrize(
+    "theme",
+    [TAU_DARK_THEME, TAU_LIGHT_THEME, HIGH_CONTRAST_THEME],
+)
+@pytest.mark.anyio
+async def test_theme_picker_highlight_uses_theme_selection_palette(theme: TuiTheme) -> None:
+    theme_names = (TAU_DARK_THEME.name, TAU_LIGHT_THEME.name, HIGH_CONTRAST_THEME.name)
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme=theme.name))
+
+    async with app.run_test() as pilot:
+        picker = ThemePickerScreen(
+            current_theme=theme.name,
+            theme=theme,
+            theme_names=theme_names,
+        )
+        app.push_screen(picker)
+        await pilot.pause()
+
+        highlighted_item = picker.query_one("ListItem.-highlight", ListItem)
+        highlighted_label = highlighted_item.query_one(Label)
+        assert highlighted_label.styles.background == Color.parse(theme.highlight_background)
+        assert highlighted_label.styles.color == Color.parse(theme.highlight_text)
+
+
 @pytest.mark.anyio
 async def test_extension_select_dialog_returns_choice() -> None:
     app = TauTuiApp(FakeSession())  # type: ignore[arg-type]


### PR DESCRIPTION
## Description

Fix picker selection styling so focused labels use each active theme's configured highlight foreground and background colors.

This corrects the Textual highlight class selector from `.--highlight` to `.-highlight` and adds sufficiently specific rules for picker labels whose normal text-color selectors would otherwise win the cascade. The fix covers the theme, model, login-method, and login-provider pickers. A parameterized regression test verifies the theme picker against all three built-in themes.

## User experience

Focused theme names are now legible in dark mode: Tau renders dark text over the light aqua selection background instead of white text with insufficient contrast. Picker selections also consistently follow the shared theme palette across built-in themes.

Closes #401.

## Manual validation

1. Start Tau's interactive TUI with the `tau-dark` theme.
2. Run `/theme`.
3. Move the focused row with the Up and Down arrow keys.
4. Confirm the focused theme name is dark and readable on the light aqua background.
5. Select `tau-light` and `high-contrast`, reopen `/theme`, and confirm each focused row uses that theme's configured selection colors.
6. Optionally open the model and login pickers and verify their focused labels remain readable too.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` (from `website/`)
