### PR TITLE
fix: clarify TUI sidebar usage and footer context token labels (#403)

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1527,7 +1527,7 @@ def render_session_sidebar(
     sections = (
         Padding(title, (0, 0, 0, 1)),
         _sidebar_section("activity", activity, theme=theme),
-        _sidebar_section("usage", usage, theme=theme),
+        _sidebar_section("session totals", usage, theme=theme),
         _sidebar_section("compaction", compaction, theme=theme),
         _sidebar_section("context", context, theme=theme),
         _sidebar_section("tools", tools, theme=theme),
@@ -1989,7 +1989,9 @@ def _plain_text(text: str, *, body_style: str) -> Text:
 def _context_usage(session: SessionSummarySource) -> str:
     threshold = session.auto_compact_token_threshold
     limit = session.context_window_tokens if threshold is None or threshold <= 0 else threshold
-    return f"{_compact_token_count(session.context_token_estimate)}/{_compact_token_count(limit)}"
+    current_str = _compact_token_count(session.context_token_estimate)
+    limit_str = _compact_token_count(limit)
+    return f"context -> {current_str}/{limit_str}"
 
 
 def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -525,7 +525,7 @@ def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> 
     assert activity_header.left == 1
     assert str(activity_header.renderable.style) == f"bold {TAU_DARK_THEME.prompt_text}"
     assert str(activity_content.renderable.style) == TAU_DARK_THEME.completion_description
-    assert " session" not in output
+    assert "session totals" in output
     assert " context" in output
     assert " tools" in output
     assert "─" in output
@@ -563,7 +563,7 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
     output = console.export_text()
     lines = output.splitlines()
     provider_line = next(index for index, line in enumerate(lines) if "openai:fake-model" in line)
-    context_line = next(index for index, line in enumerate(lines) if "12k/200k" in line)
+    context_line = next(index for index, line in enumerate(lines) if "context -> 12k/200k" in line)
     assert "/workspace/project (--)" in output
     assert "12k/200k context" not in output
     assert "openai:fake-model" in lines[provider_line]

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -7,7 +7,7 @@ A model can only read so much text at once — its **context window**. Long codi
 sessions fill it up. Tau handles this with **compaction** (summarizing older
 history) and lets you tune how hard the model works with **thinking modes**.
 
-## Seeing context usage
+## Seeing context session totals
 
 Run `/session` in the TUI to see a rough estimate:
 


### PR DESCRIPTION
Fixes #403. This PR explicitly updates the TUI sidebar section header to "session totals" and prefixes the compact footer value with "context -> " to clearly differentiate between lifetime session usage and active context consumption. It also updates the TUI application tests and documentation to align with these labels.