### PR TITLE
feat: normalize file paths dropped into the TUI prompt

### DIFF
--- a/dev-notes/tui-file-drop.md
+++ b/dev-notes/tui-file-drop.md
@@ -1,0 +1,47 @@
+# TUI file drop (drag-and-drop paths into the prompt)
+
+Tracks issue #170: users can drag files onto the terminal window and Tau inserts
+the filesystem paths into the prompt.
+
+## How it works
+
+Terminals do not send OS drag-and-drop as a dedicated event. When a file is
+dropped onto the terminal window, the emulator *types* the file's path into the
+running program. Because Textual enables bracketed-paste mode, that typed path
+arrives as a single `textual.events.Paste` message — so file-drop support is
+implemented as a special case of paste handling.
+
+The exact dropped text varies by terminal:
+
+- most shell-escape paths (`/tmp/my\ file.png`) and space-separate multiple
+  files;
+- some quote paths that contain spaces (`"/tmp/my file.png"`);
+- some VTE-based terminals emit `file://` URIs;
+- a few emit the bare path, even with spaces.
+
+## Pieces
+
+- `src/tau_coding/tui/file_drop.py` — `normalize_dropped_paths(text)` decides
+  whether pasted text is *only* one or more absolute paths that exist on disk
+  (parsing escaped/quoted forms with `shlex`, and converting `file://` URIs).
+  If so it returns clean, space-separated paths, double-quoting any path with
+  whitespace. Anything else returns `None`. Requiring absolute, existing paths
+  keeps false positives (ordinary pasted prose) effectively impossible.
+- `PromptInput.on_paste` in `src/tau_coding/tui/app.py` — tries
+  `normalize_dropped_paths` first; on a match it inserts the normalized text at
+  the cursor with smart spacing (a separating space is added before/after only
+  when the neighboring character is not whitespace). Otherwise paste handling
+  falls through to the existing large-paste placeholder logic untouched.
+
+## Tests
+
+`tests/test_tui_file_drop.py` covers the detection/normalization matrix
+(escaped, quoted, bare, URI, multi-file, newline-separated, directories, and
+non-drop text) and the prompt insertion behavior (empty prompt, existing text,
+mid-text cursor, default paste passthrough).
+
+## Manual validation
+
+Run `tau` in a terminal, drag a file from Finder/your file manager onto the
+window, and confirm the prompt shows the file's path (quoted if it contains
+spaces), preserving anything already typed.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -138,6 +138,7 @@ from tau_coding.tui.config import (
     load_tui_settings,
     save_tui_settings,
 )
+from tau_coding.tui.file_drop import normalize_dropped_paths
 from tau_coding.tui.state import TuiState, format_terminal_command_result_block
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.themes import (
@@ -616,12 +617,34 @@ class PromptInput(TextArea):
         self.action_completion_previous()
 
     def on_paste(self, event: events.Paste) -> None:
-        """Show a compact placeholder instead of rendering very large pasted text."""
+        """Handle file drops and collapse very large pastes to a placeholder.
+
+        Terminals deliver OS drag-and-drop as typed text, which Textual reports
+        as a paste; when the pasted text is only existing file paths, insert the
+        normalized paths instead of the raw (possibly escaped) drop text.
+        """
+        dropped_paths = normalize_dropped_paths(event.text)
+        if dropped_paths is not None:
+            event.stop()
+            event.prevent_default()
+            self._insert_dropped_paths(dropped_paths)
+            return
         if len(event.text) <= PASTE_DISPLAY_THRESHOLD:
             return
         event.stop()
         event.prevent_default()
         self._show_large_paste_placeholder(event.text)
+
+    def _insert_dropped_paths(self, insertion: str) -> None:
+        """Insert dropped paths at the cursor, separated from surrounding text."""
+        position = self.cursor_position
+        before = self.text[:position]
+        after = self.text[position:]
+        if before and not before[-1].isspace():
+            insertion = f" {insertion}"
+        if not after or not after[0].isspace():
+            insertion = f"{insertion} "
+        self.insert(insertion)
 
     def _show_large_paste_placeholder(self, content: str) -> None:
         """Store large pasted text and render a compact placeholder."""

--- a/src/tau_coding/tui/file_drop.py
+++ b/src/tau_coding/tui/file_drop.py
@@ -1,0 +1,83 @@
+"""Detect and normalize files dragged into the terminal.
+
+Terminals do not deliver OS drag-and-drop as a dedicated event. When a file is
+dropped onto the terminal window, the terminal emulator types the file's path
+into the running program instead. Because Textual enables bracketed-paste mode,
+that typed path usually arrives as a single :class:`textual.events.Paste`
+message.
+
+The exact text depends on the terminal:
+
+- most terminals shell-escape paths (``/tmp/my\\ file.png``) and separate
+  multiple dropped files with spaces;
+- some quote paths with spaces (``"/tmp/my file.png"``);
+- some VTE-based terminals emit ``file://`` URIs;
+- a few emit the bare path, even when it contains spaces.
+
+This module recognizes pasted text that consists solely of one or more existing
+absolute paths and normalizes it to clean, space-separated filesystem paths,
+quoting any path that contains whitespace.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+__all__ = ["normalize_dropped_paths"]
+
+
+def normalize_dropped_paths(text: str) -> str | None:
+    """Return normalized prompt text when *text* looks like a file drop.
+
+    The pasted text is treated as a drop only when it consists exclusively of
+    one or more absolute paths that exist on disk (shell-escaped, quoted, or
+    ``file://`` URI forms are accepted). Anything else returns ``None`` so the
+    paste falls through to default handling.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return None
+
+    # A single dropped file may arrive as a bare path with unescaped spaces.
+    whole = _token_to_path(stripped)
+    if whole is not None:
+        return _quote_path(whole)
+
+    try:
+        tokens = shlex.split(stripped, posix=True)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+
+    paths: list[str] = []
+    for token in tokens:
+        path = _token_to_path(token)
+        if path is None:
+            return None
+        paths.append(path)
+    return " ".join(_quote_path(path) for path in paths)
+
+
+def _token_to_path(token: str) -> str | None:
+    """Resolve one dropped token to an existing absolute path, if possible."""
+    candidate = token
+    if candidate.startswith("file://"):
+        parsed = urlparse(candidate)
+        if parsed.netloc not in ("", "localhost"):
+            return None
+        candidate = unquote(parsed.path)
+    path = Path(candidate)
+    if not path.is_absolute() or not path.exists():
+        return None
+    return candidate
+
+
+def _quote_path(path: str) -> str:
+    """Quote *path* with double quotes when it contains whitespace."""
+    if not any(char.isspace() for char in path):
+        return path
+    escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'

--- a/tests/test_tui_file_drop.py
+++ b/tests/test_tui_file_drop.py
@@ -1,0 +1,149 @@
+"""Tests for drag-and-drop file insertion in the TUI prompt."""
+
+from pathlib import Path
+
+from textual import events
+
+from tau_coding.tui.app import PromptInput
+from tau_coding.tui.file_drop import normalize_dropped_paths
+
+
+def _escaped(path: Path) -> str:
+    """Render a path the way terminals do when a file is dropped."""
+    return str(path).replace(" ", "\\ ")
+
+
+class TestNormalizeDroppedPaths:
+    def test_plain_absolute_path_passes_through(self, tmp_path: Path) -> None:
+        file = tmp_path / "notes.txt"
+        file.touch()
+
+        assert normalize_dropped_paths(str(file)) == str(file)
+
+    def test_escaped_spaces_are_unescaped_and_quoted(self, tmp_path: Path) -> None:
+        file = tmp_path / "my file.png"
+        file.touch()
+
+        assert normalize_dropped_paths(_escaped(file)) == f'"{file}"'
+
+    def test_bare_path_with_spaces_is_quoted(self, tmp_path: Path) -> None:
+        file = tmp_path / "my file.png"
+        file.touch()
+
+        assert normalize_dropped_paths(str(file)) == f'"{file}"'
+
+    def test_double_quoted_path_is_normalized(self, tmp_path: Path) -> None:
+        file = tmp_path / "my file.png"
+        file.touch()
+
+        assert normalize_dropped_paths(f'"{file}"') == f'"{file}"'
+
+    def test_multiple_dropped_files_join_with_spaces(self, tmp_path: Path) -> None:
+        first = tmp_path / "first.txt"
+        second = tmp_path / "second file.txt"
+        first.touch()
+        second.touch()
+
+        dropped = f"{first} {_escaped(second)}"
+
+        assert normalize_dropped_paths(dropped) == f'{first} "{second}"'
+
+    def test_newline_separated_paths_join_with_spaces(self, tmp_path: Path) -> None:
+        first = tmp_path / "first.txt"
+        second = tmp_path / "second.txt"
+        first.touch()
+        second.touch()
+
+        assert normalize_dropped_paths(f"{first}\n{second}\n") == f"{first} {second}"
+
+    def test_directory_path_is_accepted(self, tmp_path: Path) -> None:
+        directory = tmp_path / "some dir"
+        directory.mkdir()
+
+        assert normalize_dropped_paths(_escaped(directory)) == f'"{directory}"'
+
+    def test_file_uri_is_converted_to_local_path(self, tmp_path: Path) -> None:
+        file = tmp_path / "my file.png"
+        file.touch()
+        uri = "file://" + str(file).replace(" ", "%20")
+
+        assert normalize_dropped_paths(uri) == f'"{file}"'
+
+    def test_missing_path_is_not_a_drop(self, tmp_path: Path) -> None:
+        assert normalize_dropped_paths(str(tmp_path / "missing.txt")) is None
+
+    def test_relative_path_is_not_a_drop(self) -> None:
+        assert normalize_dropped_paths("pyproject.toml") is None
+
+    def test_prose_is_not_a_drop(self) -> None:
+        assert normalize_dropped_paths("please summarize /tmp") is None
+
+    def test_blank_text_is_not_a_drop(self) -> None:
+        assert normalize_dropped_paths("   \n ") is None
+
+    def test_unbalanced_quotes_are_not_a_drop(self, tmp_path: Path) -> None:
+        file = tmp_path / "notes.txt"
+        file.touch()
+
+        assert normalize_dropped_paths(f'"{file}') is None
+
+
+class TestPromptInputFileDrop:
+    def test_drop_inserts_path_into_empty_prompt(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "notes.txt"
+        file.touch()
+
+        prompt.on_paste(events.Paste(str(file)))
+
+        assert prompt.text == f"{file} "
+
+    def test_drop_quotes_path_with_spaces(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "my file.png"
+        file.touch()
+
+        prompt.on_paste(events.Paste(_escaped(file)))
+
+        assert prompt.text == f'"{file}" '
+
+    def test_drop_preserves_existing_text(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "notes.txt"
+        file.touch()
+        prompt.text = "summarize "
+        prompt.move_cursor((0, len(prompt.text)))
+
+        prompt.on_paste(events.Paste(str(file)))
+
+        assert prompt.text == f"summarize {file} "
+
+    def test_drop_separates_from_preceding_text(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "notes.txt"
+        file.touch()
+        prompt.text = "summarize"
+        prompt.move_cursor((0, len(prompt.text)))
+
+        prompt.on_paste(events.Paste(str(file)))
+
+        assert prompt.text == f"summarize {file} "
+
+    def test_drop_mid_text_separates_both_sides(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "notes.txt"
+        file.touch()
+        prompt.text = "comparethese"
+        prompt.cursor_position = len("compare")
+
+        prompt.on_paste(events.Paste(str(file)))
+
+        assert prompt.text == f"compare {file} these"
+
+    def test_non_path_paste_keeps_default_behavior(self) -> None:
+        prompt = PromptInput()
+        event = events.Paste("just some regular text")
+
+        prompt.on_paste(event)
+
+        assert prompt.text == ""

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -76,6 +76,14 @@ Type `@` in the prompt to open file suggestions from the project tree, and inser
 a path like `@src/app.py`. Tau skips hidden and generated directories (`.git`,
 `.venv`, `node_modules`, `__pycache__`, `build`, `dist`).
 
+## Dropping files into the prompt
+
+Drag one or more files from your file manager onto the terminal window and Tau
+inserts their filesystem paths into the prompt at the cursor, separated by
+spaces. Paths that contain spaces are quoted automatically, and any text you
+already typed is preserved. This works anywhere over the TUI, not just above
+the input box, because the terminal delivers the drop as text input.
+
 ## Tool output
 
 Tool calls keep a static marker in the transcript while they run: orange means


### PR DESCRIPTION
## Summary

Normalizes and cleans up the file paths inserted when files are dragged into the TUI, closing #170.

**Note on what already worked:** basic drop-to-insert was already functional before this PR. Terminals don't deliver OS drag-and-drop as an event — dropping a file onto the terminal window makes the emulator *type* the file's path, and Textual's default `TextArea` paste handling inserts it. What didn't work well was the *formatting* of what got inserted. Verified empirically by posting a `Paste` event through the running app on `main`:

- Shell escapes are left in the prompt: you get `/tmp/my\ file.png` with backslashes (iTerm2, Terminal.app, most terminals).
- `file://` URIs dropped by some VTE-based terminals stay as URIs instead of paths.
- Multiple dropped files arrive as space-separated escape soup, unquoted.
- No spacing separates the dropped path from text you already typed.

This PR makes `PromptInput.on_paste` recognize pasted text that consists solely of one or more existing absolute paths and insert clean, normalized paths instead:

- Shell-escaped (`/tmp/my\ file.png`), quoted (`"/tmp/my file.png"`), bare paths with spaces, and `file://` URIs are all recognized.
- Multiple dropped files (space- or newline-separated) are inserted space-separated.
- Paths containing whitespace are automatically double-quoted.
- Insertion happens at the cursor with smart spacing, so existing typed input is preserved.
- Detection requires every token to be an absolute path that exists on disk, so ordinary pasted prose always falls through to the default paste behavior (and large pastes still collapse to the `[Pasted content #N: ...]` placeholder).

Same simulation after this PR produces `summarize "/private/.../my file.png" ` — a single, clean, quoted insertion.

## How it improves user experience

Dropped file references land in the prompt as clean, quoted paths ready to send — no backslash-escaped text to clean up by hand, no `file://` URIs, and multiple files are neatly separated.

## Issue

Closes #170

## How to manually validate

1. Run `tau` to open the interactive TUI.
2. Drag a file (ideally one whose path contains spaces) from your file manager onto the terminal window — over the input box or anywhere else in the TUI.
3. Confirm the file's filesystem path is inserted at the cursor, quoted if it contains spaces, with anything you already typed preserved.
4. Drag multiple files at once and confirm the paths are inserted space-separated.
5. Paste ordinary (non-path) text and confirm paste behavior is unchanged.

## Tests

- New `tests/test_tui_file_drop.py`: 19 tests covering the detection/normalization matrix and prompt insertion behavior.
- `src/tau_coding/tui/file_drop.py`: new `normalize_dropped_paths` helper, documented in `dev-notes/tui-file-drop.md`.
- Local checks: `uv run pytest` (1066 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean.
