### PR TITLE
Default the TUI sidebar to the right

### DIFF
--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -86,7 +86,7 @@ class TuiSettings:
     keybindings: TuiKeybindings = field(default_factory=TuiKeybindings)
     theme: TuiThemeName = "tau-dark"
     auto_copy_selection: bool = False
-    sidebar_position: Literal["left", "right", "off"] = "left"
+    sidebar_position: Literal["left", "right", "off"] = "right"
 
     def to_json(self) -> dict[str, Any]:
         """Serialize these settings to JSON-compatible data."""
@@ -140,7 +140,7 @@ def tui_settings_from_json(data: dict[str, Any]) -> TuiSettings:
     keybindings_data = data.get("keybindings", {})
     if not isinstance(keybindings_data, dict):
         raise TuiConfigError("TUI keybindings must be a JSON object")
-    raw_sidebar = data.get("sidebar_position", "left")
+    raw_sidebar = data.get("sidebar_position", "right")
     if not isinstance(raw_sidebar, str) or raw_sidebar not in {"left", "right", "off"}:
         raise TuiConfigError("sidebar_position must be 'left', 'right', or 'off'")
     return TuiSettings(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2460,13 +2460,24 @@ async def test_tui_sidebar_visibility_updates_on_resize() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_sidebar_shows_on_right_when_configured() -> None:
-    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="right"))
+async def test_tui_sidebar_shows_on_right_by_default() -> None:
+    app = TauTuiApp(FakeSession())
 
     async with app.run_test(size=(120, 40)):
         sidebar = app.query_one("#sidebar")
         assert sidebar.display is True
         assert app.has_class("-sidebar-right")
+        assert not app.has_class("-sidebar-off")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_shows_on_left_when_configured() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="left"))
+
+    async with app.run_test(size=(120, 40)):
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is True
+        assert not app.has_class("-sidebar-right")
         assert not app.has_class("-sidebar-off")
 
 

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -175,8 +175,9 @@ def test_get_tui_theme_returns_builtin_theme() -> None:
     assert get_tui_theme("tau-dark").screen_background == "#000000"
 
 
-def test_tui_sidebar_position_defaults_to_left() -> None:
-    assert TuiSettings().sidebar_position == "left"
+def test_tui_sidebar_position_defaults_to_right() -> None:
+    assert TuiSettings().sidebar_position == "right"
+    assert tui_settings_from_json({}).sidebar_position == "right"
 
 
 def test_tui_sidebar_position_roundtrips() -> None:

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -148,9 +148,9 @@ after compaction while cumulative usage continues to increase. The
 working-directory name is emphasized while the parent path and Git branch use
 the quieter metadata color.
 
-The sidebar can be moved to the **right** or turned **off** entirely by setting
-`sidebar_position` in `~/.tau/tui.json` — see
-[Configuration]({{< relref "../reference/configuration.md#tui-settings" >}}).
+The sidebar appears on the **right** by default. It can be moved to the **left**
+or turned **off** entirely by setting `sidebar_position` in `~/.tau/tui.json` —
+see [Configuration]({{< relref "../reference/configuration.md#tui-settings" >}}).
 
 ## Next
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -15,7 +15,7 @@ those locations and file formats.
 ├── providers.json      # provider/model preferences
 ├── credentials.json    # saved API keys / OAuth tokens (0600, atomic writes)
 ├── settings.json       # general settings (e.g. shell command prefix)
-├── tui.json            # TUI theme + keybindings
+├── tui.json            # TUI theme, keybindings, and layout
 ├── sessions/           # saved sessions, per project
 ├── skills/             # user-level skills
 ├── prompts/            # user-level prompt templates
@@ -223,6 +223,7 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
 ```json
 {
   "theme": "high-contrast",
+  "sidebar_position": "right",
   "keybindings": {
     "cancel": "escape",
     "command_palette": "ctrl+k",
@@ -250,7 +251,7 @@ to `tau-dark` with a startup notice, without overwriting the setting. Keys use
 Textual syntax; omitted keys keep their defaults. Tau rejects unknown
 keybinding names, empty keys, and duplicate assignments.
 
-- `sidebar_position`: `"left"` (default), `"right"`, or `"off"`. Controls
+- `sidebar_position`: `"right"` (default), `"left"`, or `"off"`. Controls
   placement of the session metadata sidebar. `"off"` hides the sidebar entirely;
   the compact session info row below the prompt still works.
 


### PR DESCRIPTION
## Brief description

Change the TUI's default `sidebar_position` from `"left"` to `"right"` when `~/.tau/tui.json` does not set a preference. Explicit `"left"`, `"right"`, and `"off"` preferences continue to work.

The configuration reference and TUI guide now document the new default.

## User experience

New and existing users without an explicit sidebar preference see session metadata on the right by default, while users who prefer the previous layout can keep it by setting:

```json
{
  "sidebar_position": "left"
}
```

## Issue

No linked issue.

## Manual validation

1. Remove `sidebar_position` from `~/.tau/tui.json` (or use a temporary Tau home without that setting).
2. Launch `tau` in a terminal at least 120 columns wide and 40 rows tall; confirm the sidebar appears on the right.
3. Set `"sidebar_position": "left"`, restart Tau, and confirm the sidebar moves to the left.
4. Set `"sidebar_position": "off"`, restart Tau, and confirm the sidebar is hidden.

## Validation performed

- `uv run pytest` (1048 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
