### PR TITLE
chore: prepare 0.2.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.2.3",
+    "date": "2026-07-20",
+    "sections": {
+      "Changed": [
+        "Default the TUI sidebar to the right side while preserving explicit left, right, and off preferences.",
+        "Label TUI sidebar token totals as cumulative session usage and document why cumulative provider usage can exceed the active context estimate.",
+        "Keep Tau's internal extension and model-catalog maintenance guidance in packaged self-documentation so it no longer appears in or competes with user skills."
+      ],
+      "Fixed": [
+        "Fix session JSONL reads splitting records on Unicode line separators (U+2028, U+2029, U+0085), which made affected sessions and the session index fail to load; the read-side fix also repairs already-affected session files.",
+        "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors."
+      ]
+    }
+  },
+  {
     "version": "0.2.2",
     "date": "2026-07-18",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -503,7 +503,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.2.2" in console.export_text()
+    assert "τ = 2π  0.2.3" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the Tau 0.2.3 patch release.

- Bump `pyproject.toml` and `uv.lock` to `0.2.3`
- Add 0.2.3 bundled release notes
- Update the sidebar brand version assertion in `tests/test_tui_app.py`

## Release notes (0.2.3)

### Changed

- Default the TUI sidebar to the right side while preserving explicit left, right, and off preferences. (#409)
- Label TUI sidebar token totals as cumulative session usage and document why cumulative provider usage can exceed the active context estimate. (#407)
- Keep Tau's internal extension and model-catalog maintenance guidance in packaged self-documentation so it no longer appears in or competes with user skills. (#406)

### Fixed

- Fix session JSONL reads splitting records on Unicode line separators (U+2028, U+2029, U+0085), which made affected sessions and the session index fail to load; the read-side fix also repairs already-affected session files. (#354)
- Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors. (#404)

## Validation

- `uv run pytest` — 1048 passed
- `uv run ruff check .` and `uv run ruff format --check .` — clean
- `uv run mypy` — no issues
- `uv run tau --version` — reports `tau 0.2.3`

## After merge

Publish a GitHub Release from `main` with tag `v0.2.3` to trigger the PyPI publish workflow, per `dev-notes/release-process.md`.
