### PR TITLE
Fix resume picker search to exclude workspace paths

### DIFF
--- a/dev-notes/architecture/resume-picker-search.md
+++ b/dev-notes/architecture/resume-picker-search.md
@@ -9,9 +9,9 @@ has a search field, matching the existing search UX in the model picker
 
 - Opening `/resume` (or pressing `Ctrl+R`) focuses a new
   `#session-picker-search` input above the session list.
-- Typing filters the visible sessions only by session name (case-insensitive
-  substring match), live as you type. Metadata such as model and working
-  directory does not affect search results.
+- Typing filters the visible sessions by session name or model (case-insensitive
+  substring match), live as you type. The working directory does not affect
+  search results.
 - Arrow keys, Enter, and Escape keep working the same way, whether focus is on
   the search field or the list — the search input forwards those keys to the
   picker screen instead of editing its own text.
@@ -48,8 +48,8 @@ harness free of Textual-specific code.
 
 - `test_tui_app_session_picker_search_filters_sessions` — typing a query
   narrows the list and Enter still resumes the highlighted (filtered) session.
-- `test_tui_app_session_picker_search_filters_only_by_session_name` — model
-  and working-directory matches are ignored while session names still match.
+- `test_tui_app_session_picker_search_does_not_match_workspace_path` — session
+  names and models match while working-directory matches are ignored.
 - `test_tui_app_session_picker_search_with_no_matches_shows_help_text` —
   typing a query with no matches empties the list and updates the help text.
 - Existing `/resume` picker tests (arrow-key navigation, Enter-to-resume,
@@ -60,9 +60,9 @@ harness free of Textual-specific code.
 1. Create a few sessions with different titles/models (or resume real
    history) so `/resume` has more than one row.
 2. Run `tau`, then press `Ctrl+R` (or type `/resume` and press Enter).
-3. Confirm the search field is focused and type part of a session name — the
-   list should narrow live. Model names and workspace path fragments should
-   not produce matches.
+3. Confirm the search field is focused and type part of a session name or model
+   name — the list should narrow live. Workspace path fragments should not
+   produce matches.
 4. Press Enter to resume the highlighted session.
 5. Try a query that matches nothing and confirm the help text changes to
    "No matching sessions - Escape closes".

--- a/dev-notes/architecture/resume-picker-search.md
+++ b/dev-notes/architecture/resume-picker-search.md
@@ -9,8 +9,9 @@ has a search field, matching the existing search UX in the model picker
 
 - Opening `/resume` (or pressing `Ctrl+R`) focuses a new
   `#session-picker-search` input above the session list.
-- Typing filters the visible sessions by title, model, or working directory
-  (case-insensitive substring match), live as you type.
+- Typing filters the visible sessions only by session name (case-insensitive
+  substring match), live as you type. Metadata such as model and working
+  directory does not affect search results.
 - Arrow keys, Enter, and Escape keep working the same way, whether focus is on
   the search field or the list — the search input forwards those keys to the
   picker screen instead of editing its own text.
@@ -47,6 +48,8 @@ harness free of Textual-specific code.
 
 - `test_tui_app_session_picker_search_filters_sessions` — typing a query
   narrows the list and Enter still resumes the highlighted (filtered) session.
+- `test_tui_app_session_picker_search_filters_only_by_session_name` — model
+  and working-directory matches are ignored while session names still match.
 - `test_tui_app_session_picker_search_with_no_matches_shows_help_text` —
   typing a query with no matches empties the list and updates the help text.
 - Existing `/resume` picker tests (arrow-key navigation, Enter-to-resume,
@@ -57,8 +60,9 @@ harness free of Textual-specific code.
 1. Create a few sessions with different titles/models (or resume real
    history) so `/resume` has more than one row.
 2. Run `tau`, then press `Ctrl+R` (or type `/resume` and press Enter).
-3. Confirm the search field is focused and type part of a session title or
-   model name — the list should narrow live.
+3. Confirm the search field is focused and type part of a session name — the
+   list should narrow live. Model names and workspace path fragments should
+   not produce matches.
 4. Press Enter to resume the highlighted session.
 5. Try a query that matches nothing and confirm the help text changes to
    "No matching sessions - Escape closes".

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -11,7 +11,7 @@
       "Fixed": [
         "Fix session JSONL reads splitting records on Unicode line separators (U+2028, U+2029, U+0085), which made affected sessions and the session index fail to load; the read-side fix also repairs already-affected session files.",
         "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors.",
-        "Fix the resume picker search to filter only by session name instead of matching model names or workspace paths."
+        "Fix the resume picker search to avoid matching workspace paths while retaining session-name and model matches."
       ]
     }
   },

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -10,7 +10,8 @@
       ],
       "Fixed": [
         "Fix session JSONL reads splitting records on Unicode line separators (U+2028, U+2029, U+0085), which made affected sessions and the session index fail to load; the read-side fix also repairs already-affected session files.",
-        "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors."
+        "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors.",
+        "Fix the resume picker search to filter only by session name instead of matching model names or workspace paths."
       ]
     }
   },

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5424,13 +5424,7 @@ def _filter_session_records(
     normalized = query.strip().casefold()
     if not normalized:
         return tuple(records)
-    return tuple(
-        record
-        for record in records
-        if normalized in (record.title or "").casefold()
-        or normalized in record.model.casefold()
-        or normalized in _short_path(record.cwd).casefold()
-    )
+    return tuple(record for record in records if normalized in (record.title or "").casefold())
 
 
 def _tree_picker_label(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5424,7 +5424,11 @@ def _filter_session_records(
     normalized = query.strip().casefold()
     if not normalized:
         return tuple(records)
-    return tuple(record for record in records if normalized in (record.title or "").casefold())
+    return tuple(
+        record
+        for record in records
+        if normalized in (record.title or "").casefold() or normalized in record.model.casefold()
+    )
 
 
 def _tree_picker_label(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4285,7 +4285,7 @@ async def test_tui_app_session_picker_search_filters_sessions() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_session_picker_search_filters_only_by_session_name() -> None:
+async def test_tui_app_session_picker_search_does_not_match_workspace_path() -> None:
     session = FakeSession()
     session.session_manager = _FakeSessionManager(
         [
@@ -4309,14 +4309,14 @@ async def test_tui_app_session_picker_search_filters_only_by_session_name() -> N
         search = app.screen.query_one("#session-picker-search", Input)
         session_list = app.screen.query_one("#session-picker-list", ListView)
 
-        for query in ("path-query", "model-query"):
+        search.value = "path-query"
+        await pilot.pause()
+        assert list(session_list.children) == []
+
+        for query in ("model-query", "named"):
             search.value = query
             await pilot.pause()
-            assert list(session_list.children) == []
-
-        search.value = "named"
-        await pilot.pause()
-        assert len(session_list.children) == 1
+            assert len(session_list.children) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4285,6 +4285,41 @@ async def test_tui_app_session_picker_search_filters_sessions() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_session_picker_search_filters_only_by_session_name() -> None:
+    session = FakeSession()
+    session.session_manager = _FakeSessionManager(
+        [
+            CodingSessionRecord(
+                id="session-1",
+                path=Path("/tmp/session-1.jsonl"),
+                cwd=Path("/workspace/path-query"),
+                model="model-query",
+                title="Named session",
+                created_at=1.0,
+                updated_at=2.0,
+            ),
+        ]
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+r")
+        assert isinstance(app.screen, SessionPickerScreen)
+
+        search = app.screen.query_one("#session-picker-search", Input)
+        session_list = app.screen.query_one("#session-picker-list", ListView)
+
+        for query in ("path-query", "model-query"):
+            search.value = query
+            await pilot.pause()
+            assert list(session_list.children) == []
+
+        search.value = "named"
+        await pilot.pause()
+        assert len(session_list.children) == 1
+
+
+@pytest.mark.anyio
 async def test_tui_app_session_picker_search_with_no_matches_shows_help_text() -> None:
     session = FakeSession()
     session.session_manager = _FakeSessionManager(

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -30,9 +30,9 @@ From inside the TUI:
 /resume <id>       # resume a specific session
 ```
 
-The `/resume` picker has a search field that filters by session name. Start
-typing to narrow the list, then use the arrow keys and Enter (or click) to pick
-a session.
+The `/resume` picker has a search field that filters by session name or model.
+Start typing to narrow the list, then use the arrow keys and Enter (or click) to
+pick a session.
 
 To deliberately start fresh instead of resuming, use `tau --new-session` (or
 `/new` in the TUI).

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -30,9 +30,9 @@ From inside the TUI:
 /resume <id>       # resume a specific session
 ```
 
-The `/resume` picker has a search field so you can filter by title, model, or
-working directory. Start typing to narrow the list, then use the arrow keys
-and Enter (or click) to pick a session.
+The `/resume` picker has a search field that filters by session name. Start
+typing to narrow the list, then use the arrow keys and Enter (or click) to pick
+a session.
 
 To deliberately start fresh instead of resuming, use `tau --new-session` (or
 `/new` in the TUI).


### PR DESCRIPTION
## Summary

- remove workspace paths from `/resume` picker search matching
- retain matching by session name and model name
- add regression coverage and update user/developer documentation

## User experience

Users can find sessions by their names or models without unrelated results caused by text in the workspace path.

## Issue

Addresses the reported `/resume` modal search-filter bug. No issue number was provided.

## Manual validation

1. Create sessions with different names or models in a workspace whose path contains a distinctive query string.
2. Open Tau and press `Ctrl+R` or run `/resume`.
3. Search for the workspace path string and verify no session appears solely because of its path.
4. Search for part of a session name and verify the matching session appears.
5. Search for a model name and verify the matching session appears.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-fix-resume-dist`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
