### PR TITLE
Fix custom prompt auto-naming order

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1570,11 +1570,12 @@ class CodingSession:
             events = self._harness.prompt_message(prompt_message)
             self._invalidate_context_usage_cache()
             async for event in events:
+                auto_name_message: str | None = None
                 if isinstance(event, MessageEndEvent):
                     persisted_count = await self._persist_messages_since(persisted_count)
                     if not auto_name_attempted and isinstance(event.message, UserMessage):
                         auto_name_attempted = True
-                        await self._try_auto_name_session(event.message.text, context=context)
+                        auto_name_message = event.message.text
                 if isinstance(event, ToolExecutionEndEvent):
                     self._invalidate_context_usage_cache()
                 if (
@@ -1593,6 +1594,10 @@ class CodingSession:
                     yield SessionAgentEndEvent(messages=event.messages, will_retry=False)
                 else:
                     yield event
+                # Let frontends render the confirmed, expanded prompt before
+                # session naming performs its separate provider request.
+                if auto_name_message is not None:
+                    await self._try_auto_name_session(auto_name_message, context=context)
             persisted_count = await self._persist_messages_since(persisted_count)
             if overflow_message is not None:
                 session_event_1 = CompactionStartEvent(reason="overflow")

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -12,6 +12,7 @@ from tau_agent import (
     AgentMessage,
     AgentTool,
     AssistantMessage,
+    MessageEndEvent,
     TextContent,
     ThinkingContent,
     ToolCall,
@@ -1834,6 +1835,56 @@ async def test_session_auto_names_first_unnamed_managed_session(tmp_path: Path) 
     _assert_messages(
         provider.calls[1][2], [UserMessage(content="Please fix the broken CLI output.")]
     )
+
+
+@pytest.mark.anyio
+async def test_session_yields_expanded_custom_prompt_before_auto_naming(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    resources_root = tmp_path / "resources"
+    prompts_dir = resources_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    (prompts_dir / "review.md").write_text("Review this target:\n{{ arguments }}")
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                assistant_done(message=AssistantMessage(content="Review target")),
+            ],
+            [
+                assistant_start(model="fake"),
+                assistant_done(message=AssistantMessage(content="Done")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+            resource_paths=TauResourcePaths(root=resources_root, agents_root=None),
+        )
+    )
+
+    stream = session.prompt("/review src/app.py")
+    for _ in range(3):
+        await anext(stream)
+    prompt_event = await asyncio.wait_for(anext(stream), timeout=1)
+
+    assert isinstance(prompt_event, MessageEndEvent)
+    assert isinstance(prompt_event.message, UserMessage)
+    assert prompt_event.message.text == "Review this target:\nsrc/app.py"
+    assert provider.calls == []
+
+    await _collect_session_events(stream)
+    renamed = manager.get_session(record.id)
+    assert renamed is not None
+    assert renamed.title == "Review target"
 
 
 @pytest.mark.anyio

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -54,9 +54,16 @@ If a summary request fails, Tau falls back to a deterministic summary.
 ## Renaming
 
 New sessions are automatically given a short name from the first message when
-Tau can generate one. The name appears anywhere session names are already shown,
-including the `/resume` picker and id completions. If naming fails, the session
-continues normally and Tau falls back to a short local name when possible.
+Tau can generate one. Tau shows the confirmed message first—including the
+expanded text from a prompt-template slash command—then performs naming without
+holding up that transcript update. The name appears anywhere session names are
+already shown, including the `/resume` picker and id completions.
+
+Auto-naming makes one high-level provider request. The provider adapter may retry
+transient failures according to its configured `max_retries`. If those attempts
+are exhausted, or the response is not a usable title, Tau does not start another
+naming request: the session continues normally and uses a short local fallback
+when possible.
 
 ```text
 /name My refactor session


### PR DESCRIPTION
## Summary

- yield the confirmed, expanded first user message before starting session auto-naming
- add regression coverage for prompt-template slash commands
- document auto-naming fallback and provider-level retry behavior

## User experience

Prompt-template slash commands now show their expanded prompt in the transcript immediately, matching ordinary prompts, instead of leaving the transcript blank while auto-naming runs.

## Issue

Addresses the reported custom-prompt auto-naming ordering problem. No linked issue.

## Manual validation

1. Add a prompt template such as `~/.agents/prompts/review.md`.
2. Start a new managed TUI session.
3. Submit `/review src/app.py`.
4. Confirm the expanded template appears in the transcript before the generated session title arrives.
5. Simulate an exhausted naming failure and confirm the turn continues with a local fallback title.

## Checks

- `uv sync --dev --locked`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
