### PR TITLE
Shorten home context paths in sidebar

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -2030,9 +2030,10 @@ def _context_file_label(path: Path, *, cwd: Path) -> str:
         return str(expanded_path.resolve().relative_to(cwd.expanduser().resolve()))
     except (OSError, ValueError):
         try:
-            return str(expanded_path.resolve())
+            absolute_path = expanded_path.resolve()
         except OSError:
-            return str(expanded_path.absolute())
+            absolute_path = expanded_path.absolute()
+        return _short_path(absolute_path)
 
 
 def _thinking_level(session: SessionSummarySource) -> str:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -542,7 +542,11 @@ def test_session_sidebar_lists_multiple_context_files() -> None:
             content="Agent rules.",
         ),
         ProjectContextFile(path="docs/AGENTS.md", content="Docs rules."),
-        ProjectContextFile(path="/Users/alex/.agents/AGENTS.md", content="User rules."),
+        ProjectContextFile(
+            path=str(Path.home() / ".agents" / "AGENTS.md"),
+            content="User rules.",
+        ),
+        ProjectContextFile(path="/Users/alex/.agents/AGENTS.md", content="External rules."),
     )
     console = Console(record=True, width=100)
 
@@ -552,6 +556,8 @@ def test_session_sidebar_lists_multiple_context_files() -> None:
     assert "AGENTS.md" in output
     assert ".agents/AGENTS.md" in output
     assert "docs/AGENTS.md" in output
+    assert "~/.agents/AGENTS.md" in output
+    assert str(Path.home() / ".agents" / "AGENTS.md") not in output
     assert "/Users/alex/.agents/AGENTS.md" in output
 
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -124,7 +124,8 @@ estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
 templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists. Skills and context files use bullet
 lists, with one item or path per line. Project context paths are relative to the
-working directory; context loaded from outside the project uses its full path.
+working directory; context loaded from the home directory starts with `~/`, while
+other context loaded from outside the project uses its full path.
 
 The wider, borderless sidebar uses the prompt field's background color, bright
 section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark


### PR DESCRIPTION
## Description

Shorten context-file paths under the user's home directory in the TUI sidebar by rendering the home prefix as `~/`. Project paths remain relative to the working directory, and paths elsewhere remain absolute.

## User experience

Global context files now appear as concise paths such as `~/.agents/AGENTS.md` instead of `/Users/name/.agents/AGENTS.md`, reducing unnecessary sidebar wrapping and visual noise.

## Issue

No linked issue; addresses the reported sidebar path readability problem.

## Manual validation

1. Ensure `~/.agents/AGENTS.md` exists.
2. Start `tau` in a project with a wide enough terminal to display the sidebar.
3. Confirm the context section shows `~/.agents/AGENTS.md` rather than the full absolute home path.
4. Confirm project context files still use paths relative to the working directory.
