### PR TITLE
Fix duplicate transcript rows during redraw

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -932,15 +932,19 @@ class TranscriptView(VerticalScroll):
             self._request_follow_scroll()
 
     def _hide_and_remove_children(self, children: Sequence[Widget]) -> None:
-        """Hide stale rows before Textual removes them on its next message cycle.
+        """Hide the trailing visible row before scheduling asynchronous pruning.
 
-        ``remove_children`` schedules asynchronous pruning. Replacement rows are
-        mounted immediately, so leaving the old rows visible can paint both
-        projections for a frame, which is especially noticeable for a final
-        assistant response. Hiding first keeps the transition visually atomic.
+        Replacement rows mount before Textual finishes ``remove_children``. The
+        boundary between those projections can therefore paint the final row
+        twice for a frame. Hide only that boundary row to avoid adding work
+        proportional to the full transcript window.
         """
-        for child in children:
-            child.display = False
+        viewport = self.scrollable_content_region
+        visible_children = [child for child in children if child.region.overlaps(viewport)]
+        if visible_children:
+            # The bottom-most stale row borders the replacement projection and
+            # is the one that can appear duplicated while pruning catches up.
+            visible_children[-1].styles.visibility = "hidden"
         self.remove_children(children)
 
     async def append_item(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -774,7 +774,7 @@ class TranscriptView(VerticalScroll):
             child for child in message_children if child.item.role != "thinking"
         ]
         if thinking_children:
-            self.remove_children(thinking_children)
+            self._hide_and_remove_children(thinking_children)
         for item_id, widget in tuple(self._item_widgets.items()):
             if widget in thinking_children:
                 del self._item_widgets[item_id]
@@ -868,7 +868,7 @@ class TranscriptView(VerticalScroll):
             )
         ]
         if removable:
-            self.remove_children(removable)
+            self._hide_and_remove_children(removable)
         self._active_assistant_widget = None
         self._active_thinking_widget = None
         self._active_message_widgets = []
@@ -930,6 +930,18 @@ class TranscriptView(VerticalScroll):
         self.refresh(layout=True)
         if scroll_end:
             self._request_follow_scroll()
+
+    def _hide_and_remove_children(self, children: Sequence[Widget]) -> None:
+        """Hide stale rows before Textual removes them on its next message cycle.
+
+        ``remove_children`` schedules asynchronous pruning. Replacement rows are
+        mounted immediately, so leaving the old rows visible can paint both
+        projections for a frame, which is especially noticeable for a final
+        assistant response. Hiding first keeps the transition visually atomic.
+        """
+        for child in children:
+            child.display = False
+        self.remove_children(children)
 
     async def append_item(
         self,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1597,8 +1597,8 @@ async def test_transcript_redraw_hides_stale_assistant_before_mounting_replaceme
             if widget.selection_text == "final answer"
         ]
         assert len(matching) == 2
-        assert original.display is False
-        assert sum(widget.display for widget in matching) == 1
+        assert original.visible is False
+        assert sum(widget.visible for widget in matching) == 1
 
         await pilot.pause()
         assert [widget.selection_text for widget in app.query(TranscriptMessageWidget)] == [

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1580,6 +1580,33 @@ async def test_long_transcript_incremental_appends_keep_mounted_window_bounded()
 
 
 @pytest.mark.anyio
+async def test_transcript_redraw_hides_stale_assistant_before_mounting_replacement() -> None:
+    app = TauTuiApp(FakeSession(messages=[AssistantMessage(content="final answer")]))
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        original = app.query_one(TranscriptMessageWidget)
+
+        # A full refresh schedules Textual's child removal asynchronously, so
+        # inspect the transition before the next message cycle drains it.
+        app._refresh()
+
+        matching = [
+            widget
+            for widget in app.query(TranscriptMessageWidget)
+            if widget.selection_text == "final answer"
+        ]
+        assert len(matching) == 2
+        assert original.display is False
+        assert sum(widget.display for widget in matching) == 1
+
+        await pilot.pause()
+        assert [widget.selection_text for widget in app.query(TranscriptMessageWidget)] == [
+            "final answer"
+        ]
+
+
+@pytest.mark.anyio
 async def test_transcript_resize_preserves_mounted_message_widgets() -> None:
     app = TauTuiApp(
         FakeSession(messages=[AssistantMessage(content=f"answer {index}") for index in range(20)])


### PR DESCRIPTION
## Summary

Fix a transient duplicate rendering of transcript rows during full TUI redraws. Textual removes children asynchronously, so Tau now hides only the trailing visible boundary row before scheduling removal and mounting replacements. Limiting suppression to one visible row avoids adding work proportional to a long transcript window.

A regression test covers the intermediate redraw frame, not only the settled DOM.

## User experience

Completed assistant responses no longer briefly appear twice, stacked one above the other, when the transcript redraws. This is especially noticeable in long sessions and around structured assistant finalization.

## Issue

Addresses a reported duplicate assistant response in session `daf7e5f695fb4c0ca3dd25ac52cff3ac`. No GitHub issue is currently linked.

## Manual validation

1. Open or resume a long TUI session.
2. Submit a prompt that produces an assistant response with thinking and text.
3. Trigger a full transcript refresh while observing the final response.
4. Confirm only one visible copy is painted throughout the redraw.

Automated regression coverage invokes a full refresh and inspects the transition before Textual's asynchronous removal cycle completes.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`
