### PR TITLE
Style footer provider as metadata

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1575,7 +1575,8 @@ def render_compact_session_info(
     """Render the session facts below the prompt."""
     left = _styled_cwd(session.cwd, theme=theme)
     right = Text(style=theme.muted_text, overflow="fold", no_wrap=False, justify="right")
-    right.append(f"{session.provider_name}:{session.model}", style=theme.prompt_text)
+    right.append(session.provider_name, style=theme.completion_description)
+    right.append(f":{session.model}", style=theme.prompt_text)
     right.append(" ")
     right.append(f"({_thinking_level(session)})", style=theme.completion_description)
     right.append("\n")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -577,6 +577,16 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
     assert context_line == provider_line + 1
 
 
+def test_compact_session_info_styles_provider_as_metadata() -> None:
+    console = Console(record=True, width=120, color_system="truecolor")
+
+    console.print(render_compact_session_info(FakeSession()))
+
+    output = console.export_text(styles=True)
+    assert f"\x1b[{_style_color_escape(TAU_DARK_THEME.completion_description)}mopenai" in output
+    assert f"\x1b[{_style_color_escape(TAU_DARK_THEME.prompt_text)}m:fake-model" in output
+
+
 def test_compact_session_info_styles_parent_path_as_metadata() -> None:
     cwd = _styled_cwd(Path("/workspace/project"), theme=TAU_DARK_THEME)
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -146,8 +146,8 @@ first line and the approximate active context as `used/limit` on the second.
 Unlike cumulative usage, this estimate describes the system prompt, tools,
 and active messages Tau expects to send on the next request. It can decrease
 after compaction while cumulative usage continues to increase. The
-working-directory name is emphasized while the parent path and Git branch use
-the quieter metadata color.
+working-directory name and model are emphasized while the parent path, Git
+branch, and provider use the quieter metadata color.
 
 The sidebar appears on the **right** by default. It can be moved to the **left**
 or turned **off** entirely by setting `sidebar_position` in `~/.tau/tui.json` —


### PR DESCRIPTION
## Description

Style the compact footer's provider name with the quieter metadata gray while keeping the model name bright. Add regression coverage and update the TUI guide.

## User experience

The footer now has a clearer visual hierarchy consistent with the working-directory path, thinking level, and context usage: `provider:model` renders as gray provider text followed by light model text.

## Issue

No linked issue.

## Manual validation

1. Start Tau's interactive TUI.
2. Inspect the compact status block below the prompt.
3. Confirm the provider is gray, the model remains bright, and thinking/context values use the same gray as the provider.
