### PR TITLE
Render user messages as Markdown

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1353,7 +1353,7 @@ def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
 
 def _use_plain_transcript_body(item: ChatItem) -> bool:
     """Return whether a transcript item can use fast selectable plain text."""
-    return item.role in {"user", "tool", "skill", "error"}
+    return item.role in {"tool", "skill", "error"}
 
 
 def _transcript_plain_body_text(
@@ -1433,7 +1433,14 @@ def _transcript_item_markdown(
     visible_text = _visible_chat_text(
         item, show_tool_results=show_tool_results, invocation=invocation
     )
-    if item.role in {"assistant", "thinking", "status", "branch_summary", "compaction_summary"}:
+    if item.role in {
+        "user",
+        "assistant",
+        "thinking",
+        "status",
+        "branch_summary",
+        "compaction_summary",
+    }:
         return visible_text
     return _plain_markdown(visible_text)
 
@@ -1740,7 +1747,7 @@ def _render_chat_body(
     )
     if patch_body is not None:
         return patch_body
-    if role in {"assistant", "thinking", "status"}:
+    if role in {"user", "assistant", "thinking", "status"}:
         if _has_unclosed_fence(text):
             return _plain_text(text, body_style=body_style)
         return ThemedMarkdown(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1296,15 +1296,15 @@ def test_assistant_chat_items_render_markdown_tables() -> None:
     assert "---" not in output
 
 
-def test_user_chat_items_keep_markdown_literal() -> None:
+def test_user_chat_items_render_markdown() -> None:
     console = Console(record=True, width=60)
-    item = ChatItem(role="user", text="- keep this literal")
+    item = ChatItem(role="user", text="- render this item")
 
     console.print(render_chat_item(item))
     output = console.export_text()
 
-    assert "- keep this literal" in output
-    assert "• keep this literal" not in output
+    assert "• render this item" in output
+    assert "- render this item" not in output
 
 
 def test_chat_items_preserve_malformed_fenced_code() -> None:
@@ -1340,7 +1340,7 @@ async def test_transcript_message_widget_extracts_plain_text_selection() -> None
 
 @pytest.mark.anyio
 async def test_transcript_message_widget_renders_full_height_role_block() -> None:
-    plain_text = "alpha beta gamma\nsecond line\nthird line"
+    plain_text = "alpha beta gamma\n\nsecond paragraph\n\nthird paragraph"
     app = TauTuiApp(
         FakeSession(messages=[UserMessage(content=plain_text)]),
         tui_settings=TuiSettings(theme="high-contrast"),
@@ -2554,6 +2554,21 @@ async def test_tui_transcript_reflows_when_terminal_resizes() -> None:
 
         assert transcript.virtual_size.width <= transcript.scrollable_content_region.width
         assert transcript.scroll_offset.x == 0
+
+
+@pytest.mark.anyio
+async def test_user_message_code_block_uses_syntax_highlighting() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content='```python\nprint("hello")\n```')]))
+
+    async with app.run_test(size=(64, 30)) as pilot:
+        await pilot.pause()
+        markdown = app.query_one(ThemedMarkdownWidget)
+        fence = app.query_one("MarkdownFence")
+
+        assert markdown.parent is not None
+        assert fence.lexer == "python"
+        assert fence.code == 'print("hello")'
+        assert fence._highlighted_code.spans
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -12,8 +12,9 @@ see [Keyboard shortcuts]({{< relref "../reference/keybindings.md" >}}).
 Type into the prompt box at the bottom and press **Enter** to submit. The editor
 keeps its padded block size and background, while a single left border changes
 color to reflect focus, shell mode, and active runs without boxing it in.
-**Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
-assistant's reply above the prompt, showing tool calls as they run. In supported
+**Shift+Enter** inserts a newline for multi-line prompts. Submitted prompts render
+as Markdown, including fenced code blocks with syntax highlighting. Tau streams
+the assistant's reply above the prompt, showing tool calls as they run. In supported
 terminal emulators, Tau also updates the tab title: named sessions show as
 `τ | <name>`, and active runs add an animated running indicator so you can see
 work continuing from another tab.


### PR DESCRIPTION
## Description

Render user transcript messages through Tau's themed Markdown renderers in both the Textual TUI and Rich compatibility output. This enables Markdown formatting and syntax-highlighted fenced code blocks in submitted prompts.

Tests cover user Markdown lists and syntax-highlighted Python fences. The TUI guide now documents the behavior.

## User experience

Users can include readable Markdown and fenced code examples directly in prompts. Language-tagged code blocks receive syntax highlighting, matching assistant messages.

## Issue

No linked issue.

## Manual validation

1. Start `tau`.
2. Submit a prompt containing:

   ~~~markdown
   Please review this code:

   ```python
   def greet(name: str) -> str:
       return f"Hello, {name}!"
   ```
   ~~~

3. Confirm the submitted user message renders as Markdown and the Python block is syntax highlighted.
