### PR TITLE
feat: expand Hugging Face model catalog

### DIFF
--- a/dev-notes/hugging-face-model-parity.md
+++ b/dev-notes/hugging-face-model-parity.md
@@ -2,7 +2,7 @@
 
 ## What changed
 
-Tau's built-in Hugging Face Inference Providers catalog now contains all 49 models in Pi's generated Hugging Face catalog. This adds 31 models across DeepSeek, Gemma, GLM, GPT OSS, Kimi, Llama, MiniMax, MiMo, Qwen, and Step families.
+Tau's built-in Hugging Face Inference Providers catalog now contains 46 models. This adds 28 live-routable models from Pi's generated Hugging Face catalog across DeepSeek, Gemma, GLM, GPT OSS, Kimi, Llama, MiniMax, MiMo, Qwen, and Step families. Live testing excluded three Pi entries that no enabled Hugging Face inference provider could serve: `Qwen/Qwen3-Next-80B-A3B-Thinking`, `XiaomiMiMo/MiMo-V2-Flash`, and `moonshotai/Kimi-K2-Thinking`.
 
 Each addition includes the provider model ID, display name, reasoning and input capabilities, context window, output limit, compatibility metadata, and token pricing. The existing `moonshotai/Kimi-K2.6` default remains unchanged.
 

--- a/dev-notes/hugging-face-model-parity.md
+++ b/dev-notes/hugging-face-model-parity.md
@@ -1,0 +1,35 @@
+# Hugging Face model catalog parity
+
+## What changed
+
+Tau's built-in Hugging Face Inference Providers catalog now contains all 49 models in Pi's generated Hugging Face catalog. This adds 31 models across DeepSeek, Gemma, GLM, GPT OSS, Kimi, Llama, MiniMax, MiMo, Qwen, and Step families.
+
+Each addition includes the provider model ID, display name, reasoning and input capabilities, context window, output limit, compatibility metadata, and token pricing. The existing `moonshotai/Kimi-K2.6` default remains unchanged.
+
+## Why it exists
+
+Tau and Pi use the same Hugging Face OpenAI-compatible router. Keeping their built-in model choices aligned means Tau users can select the broader set directly through `/model` instead of maintaining a personal catalog overlay.
+
+This remains application configuration in `tau_coding`; no Hugging Face assumptions were added to the portable `tau_agent` harness.
+
+## How to test
+
+Run the catalog and provider configuration tests:
+
+```bash
+uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py -q
+```
+
+With a saved Hugging Face credential, validate the packaged catalog against the live router:
+
+```bash
+uv run python ~/.tau/provider-validation/validate_provider_catalog.py run \
+  --builtins-only \
+  --provider huggingface \
+  --concurrency 2 \
+  --provider-concurrency 1 \
+  --timeout-seconds 30 \
+  --max-retries 0
+```
+
+The helper stops at `response_start` by default to verify model and payload acceptance while minimizing token usage. Keep detailed live-validation artifacts outside the repository.

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3997,7 +3997,7 @@ kind = "openai-compatible"
 base_url = "https://router.huggingface.co/v1"
 api_key_env = "HF_TOKEN"
 credential_name = "huggingface"
-models = ["MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3.5-397B-A17B", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1"]
+models = ["MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "MiniMaxAI/MiniMax-M3", "Qwen/Qwen3-235B-A22B", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-30B-A3B-Instruct", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3-Next-80B-A3B-Thinking", "Qwen/Qwen3.5-122B-A10B", "Qwen/Qwen3.5-27B", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.5-9B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "XiaomiMiMo/MiMo-V2-Flash", "XiaomiMiMo/MiMo-V2.5-Pro", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro", "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2-Thinking", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "moonshotai/Kimi-K2.7-Code", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "stepfun-ai/Step-3.5-Flash", "stepfun-ai/Step-3.7-Flash", "zai-org/GLM-4.5", "zai-org/GLM-4.5-Air", "zai-org/GLM-4.5V", "zai-org/GLM-4.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1", "zai-org/GLM-5.2"]
 default_model = "moonshotai/Kimi-K2.6"
 docs_url = "https://huggingface.co/docs/inference-providers"
 api = "openai-completions"
@@ -4006,24 +4006,55 @@ thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
+"MiniMaxAI/MiniMax-M2" = 204800
 "MiniMaxAI/MiniMax-M2.1" = 204800
 "MiniMaxAI/MiniMax-M2.5" = 204800
 "MiniMaxAI/MiniMax-M2.7" = 204800
+"MiniMaxAI/MiniMax-M3" = 524288
+"Qwen/Qwen3-235B-A22B" = 40960
 "Qwen/Qwen3-235B-A22B-Thinking-2507" = 262144
+"Qwen/Qwen3-32B" = 131072
+"Qwen/Qwen3-Coder-30B-A3B-Instruct" = 262144
 "Qwen/Qwen3-Coder-480B-A35B-Instruct" = 262144
 "Qwen/Qwen3-Coder-Next" = 262144
 "Qwen/Qwen3-Next-80B-A3B-Instruct" = 262144
+"Qwen/Qwen3-Next-80B-A3B-Thinking" = 262144
+"Qwen/Qwen3.5-122B-A10B" = 262144
+"Qwen/Qwen3.5-27B" = 262144
+"Qwen/Qwen3.5-35B-A3B" = 262144
 "Qwen/Qwen3.5-397B-A17B" = 262144
+"Qwen/Qwen3.5-9B" = 262144
+"Qwen/Qwen3.6-27B" = 262144
+"Qwen/Qwen3.6-35B-A3B" = 262144
+"XiaomiMiMo/MiMo-V2-Flash" = 262144
+"XiaomiMiMo/MiMo-V2.5-Pro" = 1048576
+"deepseek-ai/DeepSeek-R1" = 64000
 "deepseek-ai/DeepSeek-R1-0528" = 163840
 "deepseek-ai/DeepSeek-V3.2" = 163840
+"deepseek-ai/DeepSeek-V4-Flash" = 1048576
+"deepseek-ai/DeepSeek-V4-Pro" = 1048576
+"google/gemma-4-26B-A4B-it" = 262144
+"google/gemma-4-31B-it" = 262144
+"meta-llama/Llama-3.3-70B-Instruct" = 131072
 "moonshotai/Kimi-K2-Instruct" = 131072
 "moonshotai/Kimi-K2-Instruct-0905" = 262144
+"moonshotai/Kimi-K2-Thinking" = 262144
 "moonshotai/Kimi-K2.5" = 262144
 "moonshotai/Kimi-K2.6" = 262144
+"moonshotai/Kimi-K2.7-Code" = 262144
+"openai/gpt-oss-120b" = 131072
+"openai/gpt-oss-20b" = 131072
+"stepfun-ai/Step-3.5-Flash" = 262144
+"stepfun-ai/Step-3.7-Flash" = 262144
+"zai-org/GLM-4.5" = 131072
+"zai-org/GLM-4.5-Air" = 131072
+"zai-org/GLM-4.5V" = 65536
+"zai-org/GLM-4.6" = 204800
 "zai-org/GLM-4.7" = 204800
 "zai-org/GLM-4.7-Flash" = 200000
 "zai-org/GLM-5" = 202752
 "zai-org/GLM-5.1" = 202752
+"zai-org/GLM-5.2" = 262144
 
 [providers.model_metadata."MiniMaxAI/MiniMax-M2.1"]
 name = "MiniMax-M2.1"
@@ -4186,6 +4217,285 @@ context_window = 202752
 max_tokens = 131072
 compat = { supportsDeveloperRole = false }
 cost = { input = 1, output = 3.2, cacheRead = 0.2, cacheWrite = 0 }
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M2"]
+name = "MiniMax-M2"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 128000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."MiniMaxAI/MiniMax-M3"]
+name = "MiniMax-M3"
+reasoning = true
+input = ["text", "image"]
+context_window = 524288
+max_tokens = 128000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-235B-A22B"]
+name = "Qwen3 235B-A22B"
+reasoning = true
+input = ["text"]
+context_window = 40960
+max_tokens = 16384
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.2, output = 0.8, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-32B"]
+name = "Qwen3 32B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 16384
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.29, output = 0.59, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Coder-30B-A3B-Instruct"]
+name = "Qwen3-Coder 30B-A3B Instruct"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.07, output = 0.26, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3-Next-80B-A3B-Thinking"]
+name = "Qwen3-Next-80B-A3B-Thinking"
+reasoning = false
+input = ["text"]
+context_window = 262144
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.5-122B-A10B"]
+name = "Qwen3.5 122B-A10B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.4, output = 3.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.5-27B"]
+name = "Qwen3.5 27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.3, output = 2.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.5-35B-A3B"]
+name = "Qwen3.5 35B-A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.25, output = 2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.5-9B"]
+name = "Qwen3.5 9B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.17, output = 0.25, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.6-27B"]
+name = "Qwen3.6 27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.47, output = 3.19, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."Qwen/Qwen3.6-35B-A3B"]
+name = "Qwen3.6 35B-A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.15, output = 0.95, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."XiaomiMiMo/MiMo-V2-Flash"]
+name = "MiMo-V2-Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 4096
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."XiaomiMiMo/MiMo-V2.5-Pro"]
+name = "MiMo-V2.5-Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 1, output = 3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-R1"]
+name = "DeepSeek-R1"
+reasoning = true
+input = ["text"]
+context_window = 64000
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.7, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V4-Flash"]
+name = "DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.14, output = 0.28, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 393216
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.435, output = 0.87, cacheRead = 0.003625, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-26B-A4B-it"]
+name = "Gemma 4 26B A4B IT"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.13, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemma-4-31B-it"]
+name = "Gemma 4 31B IT"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.14, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."meta-llama/Llama-3.3-70B-Instruct"]
+name = "Llama-3.3-70B-Instruct"
+reasoning = false
+input = ["text"]
+context_window = 131072
+max_tokens = 4096
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2-Thinking"]
+name = "Kimi-K2-Thinking"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K2.7-Code"]
+name = "Kimi K2.7 Code"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.95, output = 4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-120b"]
+name = "GPT OSS 120B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.25, output = 0.69, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-oss-20b"]
+name = "GPT OSS 20B"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 32768
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.1, output = 0.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."stepfun-ai/Step-3.5-Flash"]
+name = "Step 3.5 Flash"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 256000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."stepfun-ai/Step-3.7-Flash"]
+name = "Step 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 256000
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.2, output = 1.15, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.5"]
+name = "GLM-4.5"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 98304
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.5-Air"]
+name = "GLM-4.5-Air"
+reasoning = true
+input = ["text"]
+context_window = 131072
+max_tokens = 98304
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.13, output = 0.85, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.5V"]
+name = "GLM-4.5V"
+reasoning = true
+input = ["text", "image"]
+context_window = 65536
+max_tokens = 16384
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.6, output = 1.8, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-4.6"]
+name = "GLM-4.6"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 0.55, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."zai-org/GLM-5.2"]
+name = "GLM-5.2"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 131072
+compat = { supportsDeveloperRole = false }
+cost = { input = 1.4, output = 4.4, cacheRead = 0, cacheWrite = 0 }
 
 [[providers]]
 name = "fireworks"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3997,7 +3997,7 @@ kind = "openai-compatible"
 base_url = "https://router.huggingface.co/v1"
 api_key_env = "HF_TOKEN"
 credential_name = "huggingface"
-models = ["MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "MiniMaxAI/MiniMax-M3", "Qwen/Qwen3-235B-A22B", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-30B-A3B-Instruct", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3-Next-80B-A3B-Thinking", "Qwen/Qwen3.5-122B-A10B", "Qwen/Qwen3.5-27B", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.5-9B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "XiaomiMiMo/MiMo-V2-Flash", "XiaomiMiMo/MiMo-V2.5-Pro", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro", "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2-Thinking", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "moonshotai/Kimi-K2.7-Code", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "stepfun-ai/Step-3.5-Flash", "stepfun-ai/Step-3.7-Flash", "zai-org/GLM-4.5", "zai-org/GLM-4.5-Air", "zai-org/GLM-4.5V", "zai-org/GLM-4.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1", "zai-org/GLM-5.2"]
+models = ["MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "MiniMaxAI/MiniMax-M3", "Qwen/Qwen3-235B-A22B", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-30B-A3B-Instruct", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3.5-122B-A10B", "Qwen/Qwen3.5-27B", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.5-9B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "XiaomiMiMo/MiMo-V2.5-Pro", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro", "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "moonshotai/Kimi-K2.7-Code", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "stepfun-ai/Step-3.5-Flash", "stepfun-ai/Step-3.7-Flash", "zai-org/GLM-4.5", "zai-org/GLM-4.5-Air", "zai-org/GLM-4.5V", "zai-org/GLM-4.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1", "zai-org/GLM-5.2"]
 default_model = "moonshotai/Kimi-K2.6"
 docs_url = "https://huggingface.co/docs/inference-providers"
 api = "openai-completions"
@@ -4018,7 +4018,6 @@ thinking_parameter = "reasoning_effort"
 "Qwen/Qwen3-Coder-480B-A35B-Instruct" = 262144
 "Qwen/Qwen3-Coder-Next" = 262144
 "Qwen/Qwen3-Next-80B-A3B-Instruct" = 262144
-"Qwen/Qwen3-Next-80B-A3B-Thinking" = 262144
 "Qwen/Qwen3.5-122B-A10B" = 262144
 "Qwen/Qwen3.5-27B" = 262144
 "Qwen/Qwen3.5-35B-A3B" = 262144
@@ -4026,7 +4025,6 @@ thinking_parameter = "reasoning_effort"
 "Qwen/Qwen3.5-9B" = 262144
 "Qwen/Qwen3.6-27B" = 262144
 "Qwen/Qwen3.6-35B-A3B" = 262144
-"XiaomiMiMo/MiMo-V2-Flash" = 262144
 "XiaomiMiMo/MiMo-V2.5-Pro" = 1048576
 "deepseek-ai/DeepSeek-R1" = 64000
 "deepseek-ai/DeepSeek-R1-0528" = 163840
@@ -4038,7 +4036,6 @@ thinking_parameter = "reasoning_effort"
 "meta-llama/Llama-3.3-70B-Instruct" = 131072
 "moonshotai/Kimi-K2-Instruct" = 131072
 "moonshotai/Kimi-K2-Instruct-0905" = 262144
-"moonshotai/Kimi-K2-Thinking" = 262144
 "moonshotai/Kimi-K2.5" = 262144
 "moonshotai/Kimi-K2.6" = 262144
 "moonshotai/Kimi-K2.7-Code" = 262144
@@ -4263,15 +4260,6 @@ max_tokens = 65536
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.07, output = 0.26, cacheRead = 0, cacheWrite = 0 }
 
-[providers.model_metadata."Qwen/Qwen3-Next-80B-A3B-Thinking"]
-name = "Qwen3-Next-80B-A3B-Thinking"
-reasoning = false
-input = ["text"]
-context_window = 262144
-max_tokens = 131072
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.3, output = 2, cacheRead = 0, cacheWrite = 0 }
-
 [providers.model_metadata."Qwen/Qwen3.5-122B-A10B"]
 name = "Qwen3.5 122B-A10B"
 reasoning = true
@@ -4325,15 +4313,6 @@ context_window = 262144
 max_tokens = 65536
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.15, output = 0.95, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."XiaomiMiMo/MiMo-V2-Flash"]
-name = "MiMo-V2-Flash"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 4096
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.1, output = 0.3, cacheRead = 0, cacheWrite = 0 }
 
 [providers.model_metadata."XiaomiMiMo/MiMo-V2.5-Pro"]
 name = "MiMo-V2.5-Pro"
@@ -4397,15 +4376,6 @@ context_window = 131072
 max_tokens = 4096
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.59, output = 0.79, cacheRead = 0, cacheWrite = 0 }
-
-[providers.model_metadata."moonshotai/Kimi-K2-Thinking"]
-name = "Kimi-K2-Thinking"
-reasoning = true
-input = ["text"]
-context_window = 262144
-max_tokens = 262144
-compat = { supportsDeveloperRole = false }
-cost = { input = 0.6, output = 2.5, cacheRead = 0.15, cacheWrite = 0 }
 
 [providers.model_metadata."moonshotai/Kimi-K2.7-Code"]
 name = "Kimi K2.7 Code"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -3,6 +3,9 @@
     "version": "0.2.3",
     "date": "2026-07-20",
     "sections": {
+      "New": [
+        "Add 31 Hugging Face Inference Providers models for full parity with Pi's built-in Hugging Face catalog."
+      ],
       "Changed": [
         "Default the TUI sidebar to the right side while preserving explicit left, right, and off preferences.",
         "Label TUI sidebar token totals as cumulative session usage and document why cumulative provider usage can exceed the active context estimate.",

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -4,7 +4,7 @@
     "date": "2026-07-20",
     "sections": {
       "New": [
-        "Add 31 Hugging Face Inference Providers models for full parity with Pi's built-in Hugging Face catalog."
+        "Add 28 live-routable Hugging Face Inference Providers models from Pi's built-in catalog."
       ],
       "Changed": [
         "Default the TUI sidebar to the right side while preserving explicit left, right, and off preferences.",

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -210,6 +210,59 @@ def test_builtin_catalog_golden_nvidia_entry() -> None:
     assert gpt_oss_metadata.max_tokens == 65_536
 
 
+def test_builtin_catalog_huggingface_model_parity() -> None:
+    entry = builtin_provider_entry("huggingface")
+    assert entry is not None
+    added_models = {
+        "MiniMaxAI/MiniMax-M2",
+        "MiniMaxAI/MiniMax-M3",
+        "Qwen/Qwen3-235B-A22B",
+        "Qwen/Qwen3-32B",
+        "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "Qwen/Qwen3-Next-80B-A3B-Thinking",
+        "Qwen/Qwen3.5-122B-A10B",
+        "Qwen/Qwen3.5-27B",
+        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.5-9B",
+        "Qwen/Qwen3.6-27B",
+        "Qwen/Qwen3.6-35B-A3B",
+        "XiaomiMiMo/MiMo-V2-Flash",
+        "XiaomiMiMo/MiMo-V2.5-Pro",
+        "deepseek-ai/DeepSeek-R1",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "google/gemma-4-26B-A4B-it",
+        "google/gemma-4-31B-it",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "moonshotai/Kimi-K2-Thinking",
+        "moonshotai/Kimi-K2.7-Code",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+        "stepfun-ai/Step-3.5-Flash",
+        "stepfun-ai/Step-3.7-Flash",
+        "zai-org/GLM-4.5",
+        "zai-org/GLM-4.5-Air",
+        "zai-org/GLM-4.5V",
+        "zai-org/GLM-4.6",
+        "zai-org/GLM-5.2",
+    }
+
+    assert len(entry.models) == 49
+    assert added_models <= set(entry.models)
+    assert set(entry.context_windows or {}) == set(entry.models)
+    assert set(entry.model_metadata) == set(entry.models)
+    assert entry.default_model == "moonshotai/Kimi-K2.6"
+
+    minimax_m3 = entry.model_metadata["MiniMaxAI/MiniMax-M3"]
+    assert minimax_m3.input == ("text", "image")
+    assert minimax_m3.context_window == 524_288
+    assert minimax_m3.max_tokens == 128_000
+
+    llama = entry.model_metadata["meta-llama/Llama-3.3-70B-Instruct"]
+    assert llama.reasoning is False
+    assert llama.context_window == 131_072
+
+
 def test_builtin_catalog_golden_kimi_entries() -> None:
     moonshot = builtin_provider_entry("moonshotai")
     assert moonshot is not None

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -210,7 +210,7 @@ def test_builtin_catalog_golden_nvidia_entry() -> None:
     assert gpt_oss_metadata.max_tokens == 65_536
 
 
-def test_builtin_catalog_huggingface_model_parity() -> None:
+def test_builtin_catalog_huggingface_model_expansion() -> None:
     entry = builtin_provider_entry("huggingface")
     assert entry is not None
     added_models = {
@@ -219,14 +219,12 @@ def test_builtin_catalog_huggingface_model_parity() -> None:
         "Qwen/Qwen3-235B-A22B",
         "Qwen/Qwen3-32B",
         "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "Qwen/Qwen3-Next-80B-A3B-Thinking",
         "Qwen/Qwen3.5-122B-A10B",
         "Qwen/Qwen3.5-27B",
         "Qwen/Qwen3.5-35B-A3B",
         "Qwen/Qwen3.5-9B",
         "Qwen/Qwen3.6-27B",
         "Qwen/Qwen3.6-35B-A3B",
-        "XiaomiMiMo/MiMo-V2-Flash",
         "XiaomiMiMo/MiMo-V2.5-Pro",
         "deepseek-ai/DeepSeek-R1",
         "deepseek-ai/DeepSeek-V4-Flash",
@@ -234,7 +232,6 @@ def test_builtin_catalog_huggingface_model_parity() -> None:
         "google/gemma-4-26B-A4B-it",
         "google/gemma-4-31B-it",
         "meta-llama/Llama-3.3-70B-Instruct",
-        "moonshotai/Kimi-K2-Thinking",
         "moonshotai/Kimi-K2.7-Code",
         "openai/gpt-oss-120b",
         "openai/gpt-oss-20b",
@@ -247,7 +244,7 @@ def test_builtin_catalog_huggingface_model_parity() -> None:
         "zai-org/GLM-5.2",
     }
 
-    assert len(entry.models) == 49
+    assert len(entry.models) == 46
     assert added_models <= set(entry.models)
     assert set(entry.context_windows or {}) == set(entry.models)
     assert set(entry.model_metadata) == set(entry.models)

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -100,7 +100,7 @@ needed. Available models and plan limits change over time; consult the
 ### Hugging Face Inference Providers
 
 Log in with `/login huggingface` or set `HF_TOKEN`. Tau's built-in Hugging Face
-catalog includes 49 coding-capable models routed through
+catalog includes 46 coding-capable models routed through
 `https://router.huggingface.co/v1`, including DeepSeek, Gemma, GLM, GPT OSS,
 Kimi, Llama, MiniMax, MiMo, Qwen, and Step families. Use `/model` to search the
 full list; model availability and the inference provider selected by Hugging

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -97,6 +97,15 @@ needed. Available models and plan limits change over time; consult the
 [OpenCode Go](https://opencode.ai/docs/go) and
 [OpenCode Zen](https://opencode.ai/docs/zen) pages for the current list.
 
+### Hugging Face Inference Providers
+
+Log in with `/login huggingface` or set `HF_TOKEN`. Tau's built-in Hugging Face
+catalog includes 49 coding-capable models routed through
+`https://router.huggingface.co/v1`, including DeepSeek, Gemma, GLM, GPT OSS,
+Kimi, Llama, MiniMax, MiMo, Qwen, and Step families. Use `/model` to search the
+full list; model availability and the inference provider selected by Hugging
+Face can vary over time and by account.
+
 ### Moonshot AI API vs. Kimi Code
 
 Both Kimi providers authenticate requests with Bearer API keys; neither uses


### PR DESCRIPTION
## Description

Add 28 live-routable Hugging Face Inference Providers models from Pi's catalog, bringing Tau's built-in Hugging Face catalog to 46 models. Each model includes context limits, output limits, capabilities, compatibility flags, and pricing metadata. The existing default remains unchanged.

Three Pi entries that failed live routing were deliberately excluded: `Qwen/Qwen3-Next-80B-A3B-Thinking`, `XiaomiMiMo/MiMo-V2-Flash`, and `moonshotai/Kimi-K2-Thinking`.

Also add catalog coverage, user documentation, a development note, and a release note.

## User experience

Hugging Face users can select the expanded, live-validated model set directly in `/model`, without maintaining a custom `~/.tau/catalog.toml` overlay or seeing models that currently have no available inference provider.

## Issue

No linked issue; addresses the reported Hugging Face model catalog gap.

## Manual validation

1. Save a Hugging Face token with `/login huggingface` or set `HF_TOKEN`.
2. Open `/model`, filter to Hugging Face, and confirm the expanded model list appears.
3. Select a newly added model and send a short prompt.

Live validation used Tau's packaged catalog, saved Hugging Face credentials, and the prompt `Reply with exactly: OK`. All retained additions streamed content successfully except `XiaomiMiMo/MiMo-V2.5-Pro`, which reached the router but returned transient `429 Model busy` responses.

## Checks

- `uv run pytest` (1053 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
