### PR TITLE
Make Tau updates prominent and add tau update

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Tau is also available on [conda-forge](https://conda-forge.org), and can be inst
 pixi global install tau-ai
 ```
 
+Upgrade a normal installation with:
+
+```bash
+tau update
+```
+
 For local development:
 
 ```bash

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -26,7 +26,7 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
 
 `tau update` inspects the active environment before running anything:
 
-- `uv-receipt.toml` means uv owns the tool, so Tau runs `uv tool upgrade tau-ai`.
+- `uv-receipt.toml` means uv owns the tool. Tau fetches the latest stable PyPI version and runs `uv tool install tau-ai@<latest-version>`, explicitly replacing any version pin recorded when the tool was installed.
 - `pipx_metadata.json` means pipx owns it, so Tau runs `pipx upgrade tau-ai`.
 - The distribution's standard `INSTALLER` metadata identifies ordinary uv and pip installs. Tau runs either `uv pip install --python <current-python> --upgrade tau-ai` or `<current-python> -m pip install --upgrade tau-ai`, targeting the environment that is running Tau.
 

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -9,6 +9,7 @@ Tau now performs a small, best-effort update check in CLI startup paths that lau
 - The result is cached under `~/.tau/cache/update-check.json` and refreshed at most once per day.
 - Failures are quiet no-ops: network errors, malformed JSON, missing fields, and invalid versions do not stop startup.
 - `TAU_NO_UPDATE_CHECK=1` disables the check, and the check is skipped automatically when `CI` is set.
+- `tau update` upgrades `tau-ai`, trying uv, pipx, and then the current Python interpreter's pip.
 
 ## Where it belongs
 
@@ -16,15 +17,25 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
 
 ## Output policy
 
-- TUI startup passes the notice through the existing startup notification path.
+- TUI startup renders the update notice as the first transcript item in fixed bright-yellow, bold styling, before release notes, provider errors, theme diagnostics, or session history.
 - Print mode writes the notice to stderr for normal text output.
 - Structured print output (`--output json`) suppresses the notice to avoid corrupting scripted output.
-- Utility commands (`tau --version`, `tau sessions`, `tau export`, `tau providers`, `tau setup`) do not run the update check.
+- Utility commands (`tau --version`, `tau update`, `tau sessions`, `tau export`, `tau providers`, `tau setup`) do not run the update check.
+
+## Update command
+
+`tau update` tries installers in this order:
+
+1. `uv tool upgrade tau-ai`
+2. `pipx upgrade tau-ai`
+3. `<current-python> -m pip install --upgrade tau-ai`
+
+Unavailable or failed installers fall through without cluttering successful output. If every installer fails, Tau exits nonzero and prints each diagnostic. Editable checkout installs should still be refreshed explicitly with `uv tool install --editable --force .`.
 
 ## Testing
 
 Run:
 
 ```bash
-uv run pytest tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
+uv run pytest tests/test_updater.py tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
 ```

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -9,7 +9,7 @@ Tau now performs a small, best-effort update check in CLI startup paths that lau
 - The result is cached under `~/.tau/cache/update-check.json` and refreshed at most once per day.
 - Failures are quiet no-ops: network errors, malformed JSON, missing fields, and invalid versions do not stop startup.
 - `TAU_NO_UPDATE_CHECK=1` disables the check, and the check is skipped automatically when `CI` is set.
-- `tau update` upgrades `tau-ai`, trying uv, pipx, and then the current Python interpreter's pip.
+- `tau update` upgrades `tau-ai` with the package manager that owns the active Tau environment.
 
 ## Where it belongs
 
@@ -24,13 +24,13 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
 
 ## Update command
 
-`tau update` tries installers in this order:
+`tau update` inspects the active environment before running anything:
 
-1. `uv tool upgrade tau-ai`
-2. `pipx upgrade tau-ai`
-3. `<current-python> -m pip install --upgrade tau-ai`
+- `uv-receipt.toml` means uv owns the tool, so Tau runs `uv tool upgrade tau-ai`.
+- `pipx_metadata.json` means pipx owns it, so Tau runs `pipx upgrade tau-ai`.
+- The distribution's standard `INSTALLER` metadata identifies ordinary uv and pip installs. Tau runs either `uv pip install --python <current-python> --upgrade tau-ai` or `<current-python> -m pip install --upgrade tau-ai`, targeting the environment that is running Tau.
 
-Unavailable or failed installers fall through without cluttering successful output. If every installer fails, Tau exits nonzero and prints each diagnostic. Editable checkout installs should still be refreshed explicitly with `uv tool install --editable --force .`.
+Tau does not fall through to another installer when the selected command fails. Direct-URL and editable installs are sent back to their original source; Conda/Pixi-managed and unrecognized environments get manual instructions rather than being modified with pip. Editable checkout installs can be refreshed with `uv tool install --editable --force .`.
 
 ## Testing
 

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -60,6 +60,7 @@ from tau_coding.update_check import (
     startup_release_notes_notice,
     startup_update_notice,
 )
+from tau_coding.updater import update_tau
 from tau_coding.version import current_version as _current_version
 
 
@@ -246,6 +247,12 @@ def main(
     command = positional_args[0] if positional_args else None
     initial_prompt = " ".join(positional_args) if positional_args else None
 
+    if prompt_option is None and command == "update":
+        if len(positional_args) != 1:
+            raise typer.BadParameter("Usage: tau update")
+        update_command()
+        raise typer.Exit()
+
     if prompt_option is None and command == "sessions" and len(positional_args) == 1:
         render_session_list(SessionManager().list_sessions())
         raise typer.Exit()
@@ -349,14 +356,7 @@ async def run_openai_tui(
 ) -> None:
     """Run the Textual TUI with the default OpenAI-compatible provider."""
     release_notes_notice = startup_release_notes_notice(_current_version())
-    startup_notices = [
-        notice
-        for notice in (
-            release_notes_notice.message if release_notes_notice is not None else None,
-            update_notice.message if update_notice is not None else None,
-        )
-        if notice is not None
-    ]
+    startup_notices = (release_notes_notice.message,) if release_notes_notice is not None else ()
     await run_tui_app(
         model=model,
         cwd=cwd,
@@ -365,7 +365,8 @@ async def run_openai_tui(
         provider_name=provider_name,
         auto_compact_token_threshold=auto_compact_token_threshold,
         initial_prompt=initial_prompt,
-        startup_notices=tuple(startup_notices),
+        startup_update_notice=update_notice.message if update_notice is not None else None,
+        startup_notices=startup_notices,
         extension_paths=extension_paths,
         extensions_enabled=extensions_enabled,
         project_extensions_enabled=project_extensions_enabled,
@@ -374,6 +375,21 @@ async def run_openai_tui(
 
 def _startup_update_notice() -> UpdateNotice | None:
     return startup_update_notice(_current_version())
+
+
+def update_command() -> None:
+    """Upgrade Tau using the installer that manages the current environment."""
+    result = update_tau()
+    if not result.succeeded:
+        typer.echo("Could not update Tau with uv, pipx, or pip:", err=True)
+        for failure in result.failures:
+            typer.echo(f"- {failure}", err=True)
+        raise typer.Exit(1)
+    if result.stdout:
+        typer.echo(result.stdout)
+    if result.stderr:
+        typer.echo(result.stderr, err=True)
+    typer.echo(f"Tau update completed with: {' '.join(result.command or ())}")
 
 
 def render_session_list(records: list[CodingSessionRecord]) -> None:

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -381,7 +381,7 @@ def update_command() -> None:
     """Upgrade Tau using the installer that manages the current environment."""
     result = update_tau()
     if not result.succeeded:
-        typer.echo("Could not update Tau with uv, pipx, or pip:", err=True)
+        typer.echo("Could not safely update Tau:", err=True)
         for failure in result.failures:
             typer.echo(f"- {failure}", err=True)
         raise typer.Exit(1)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2827,6 +2827,7 @@ class TauTuiApp(App[None]):
         tui_settings: TuiSettings | None = None,
         startup_message: str | None = None,
         startup_notice: str | None = None,
+        startup_update_notice: str | None = None,
         startup_notices: Sequence[str] = (),
         initial_prompt: str | None = None,
     ) -> None:
@@ -2847,6 +2848,8 @@ class TauTuiApp(App[None]):
         self._bindings = BindingsMap(_app_bindings(self.tui_settings.keybindings))
         self.session = session
         self.state = TuiState(skills=session.skills)
+        if startup_update_notice is not None:
+            self.state.add_item("status", startup_update_notice, highlight="update")
         for notice in self.startup_notices:
             self.state.add_item("status", notice)
         if self.tui_settings.theme != self.tui_settings.resolved_theme.name:
@@ -5963,6 +5966,7 @@ async def run_tui_app(
     initial_prompt: str | None = None,
     session_manager: SessionManager | None = None,
     startup_notice: str | None = None,
+    startup_update_notice: str | None = None,
     startup_notices: Sequence[str] = (),
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
@@ -6056,6 +6060,7 @@ async def run_tui_app(
             session,
             tui_settings=load_tui_settings(),
             startup_message=startup_message,
+            startup_update_notice=startup_update_notice,
             startup_notices=all_startup_notices,
             initial_prompt=initial_prompt,
         )

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from tau_agent.messages import (
     AgentMessage,
@@ -52,6 +53,7 @@ class ChatItem:
     always_show_tool_result: bool = False
     custom_type: str | None = None
     details: dict[str, JSONValue] | None = None
+    highlight: Literal["update"] | None = None
 
 
 @dataclass(slots=True)
@@ -87,6 +89,7 @@ class TuiState:
         always_show_tool_result: bool = False,
         custom_type: str | None = None,
         details: dict[str, JSONValue] | None = None,
+        highlight: Literal["update"] | None = None,
     ) -> None:
         """Append a transcript item."""
         item = ChatItem(
@@ -97,6 +100,7 @@ class TuiState:
             always_show_tool_result=always_show_tool_result,
             custom_type=custom_type,
             details=details,
+            highlight=highlight,
         )
         self.items.append(item)
         if tool_call_id is not None and role in {"tool", "skill"}:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1353,7 +1353,7 @@ def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
 
 def _use_plain_transcript_body(item: ChatItem) -> bool:
     """Return whether a transcript item can use fast selectable plain text."""
-    return item.role in {"user", "tool", "skill", "error"}
+    return item.highlight == "update" or item.role in {"user", "tool", "skill", "error"}
 
 
 def _transcript_plain_body_text(
@@ -1634,6 +1634,8 @@ def render_chat_item(
 
 
 def _chat_item_role_style(item: ChatItem, theme: TuiTheme) -> TuiRoleStyle:
+    if item.highlight == "update":
+        return TuiRoleStyle(border="#ffff00", body="bold #ffff00")
     if item.role == "tool" and item.tool_result_text:
         if item.tool_result_text.startswith("✓"):
             return TuiRoleStyle(border=theme.success, body=theme.role_styles["tool"].body)

--- a/src/tau_coding/update_check.py
+++ b/src/tau_coding/update_check.py
@@ -40,7 +40,7 @@ class UpdateNotice:
         """Return concise update guidance."""
         return (
             f"Tau {self.latest_version} is available (installed: {self.current_version}). "
-            f"Update with: uv tool upgrade {self.package_name}"
+            "Run `tau update` to upgrade."
         )
 
 

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -1,15 +1,20 @@
-"""Upgrade the installed Tau CLI with common Python tool managers."""
+"""Upgrade Tau with the package manager that owns its environment."""
 
 from __future__ import annotations
 
+import json
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
 from subprocess import CompletedProcess, run
+from typing import Literal
 
 from tau_coding.update_check import PYPI_PACKAGE_NAME
 
 CommandRunner = Callable[..., CompletedProcess[str]]
+InstallMethod = Literal["uv-tool", "uv-pip", "pipx", "pip"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,41 +35,123 @@ def update_tau(
     *,
     runner: CommandRunner = run,
     python_executable: str | None = None,
-    commands: Sequence[Sequence[str]] | None = None,
+    environment_prefix: Path | None = None,
+    direct_url: str | None = None,
+    installer: str | None = None,
+    inspect_distribution: bool = True,
 ) -> UpdateResult:
-    """Upgrade Tau, trying uv, pipx, then the current interpreter's pip.
+    """Upgrade Tau with the installer that owns the active environment.
 
-    A failed or unavailable installer falls through to the next option. Output from
-    unsuccessful attempts is kept for the final diagnostic instead of cluttering the
-    successful update path.
+    Python distributions record their installer in ``INSTALLER``. uv and pipx
+    tool environments also leave ownership receipts. Managed, editable,
+    direct-URL, and unrecognized installations stop with instructions instead
+    of trying unrelated package managers.
     """
-    candidates = commands or (
-        ("uv", "tool", "upgrade", PYPI_PACKAGE_NAME),
-        ("pipx", "upgrade", PYPI_PACKAGE_NAME),
-        (
-            python_executable or sys.executable,
-            "-m",
+    prefix = (environment_prefix or Path(sys.prefix)).resolve()
+    if inspect_distribution:
+        direct_url = _installed_direct_url()
+        installer = _installed_installer()
+    if direct_url:
+        return _failure(
+            "Tau was installed from a local or direct URL, so it cannot be safely "
+            f"updated from PyPI. Reinstall it from its original source: {direct_url}"
+        )
+
+    method = detect_install_method(prefix, installer=installer)
+    if method is None:
+        if (prefix / "conda-meta").is_dir():
+            return _failure(
+                "Tau is installed in a Conda/Pixi-managed environment. "
+                "Update it with the manager that created that environment."
+            )
+        installed_by = installer or "unknown"
+        return _failure(
+            "Could not identify a supported installer for this Tau environment "
+            f"({prefix}). Package metadata reports: {installed_by}."
+        )
+
+    executable = python_executable or sys.executable
+    command = _update_command(method, executable)
+    completed = _run(runner, command)
+    if isinstance(completed, str):
+        return _failure(f"{' '.join(command)}: {completed}")
+    if completed.returncode != 0:
+        return _failure(f"{' '.join(command)}: {_result_detail(completed)}")
+    return UpdateResult(
+        command=command,
+        stdout=completed.stdout.strip(),
+        stderr=completed.stderr.strip(),
+    )
+
+
+def detect_install_method(prefix: Path, *, installer: str | None = None) -> InstallMethod | None:
+    """Detect installer ownership from receipts and distribution metadata."""
+    if (prefix / "uv-receipt.toml").is_file():
+        return "uv-tool"
+    if (prefix / "pipx_metadata.json").is_file():
+        return "pipx"
+    normalized_installer = installer.strip().lower() if installer else None
+    if normalized_installer == "uv":
+        return "uv-pip"
+    if normalized_installer == "pip":
+        return "pip"
+    return None
+
+
+def _update_command(method: InstallMethod, python_executable: str) -> tuple[str, ...]:
+    if method == "uv-tool":
+        return ("uv", "tool", "upgrade", PYPI_PACKAGE_NAME)
+    if method == "uv-pip":
+        return (
+            "uv",
             "pip",
             "install",
+            "--python",
+            python_executable,
             "--upgrade",
             PYPI_PACKAGE_NAME,
-        ),
-    )
-    failures: list[str] = []
-    for candidate in candidates:
-        command = tuple(candidate)
-        try:
-            result = runner(command, capture_output=True, text=True, check=False)
-        except OSError as exc:
-            failures.append(f"{' '.join(command)}: {exc}")
-            continue
-        if result.returncode == 0:
-            return UpdateResult(
-                command=command,
-                stdout=result.stdout.strip(),
-                stderr=result.stderr.strip(),
-                failures=tuple(failures),
-            )
-        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
-        failures.append(f"{' '.join(command)}: {detail}")
-    return UpdateResult(command=None, failures=tuple(failures))
+        )
+    if method == "pipx":
+        return ("pipx", "upgrade", PYPI_PACKAGE_NAME)
+    return (python_executable, "-m", "pip", "install", "--upgrade", PYPI_PACKAGE_NAME)
+
+
+def _installed_direct_url() -> str | None:
+    raw = _distribution_file("direct_url.json")
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return "an unrecognized direct source"
+    url = data.get("url") if isinstance(data, dict) else None
+    return url if isinstance(url, str) and url else "an unrecognized direct source"
+
+
+def _installed_installer() -> str | None:
+    raw = _distribution_file("INSTALLER")
+    if not raw:
+        return None
+    return raw.strip() or None
+
+
+def _distribution_file(filename: str) -> str | None:
+    try:
+        return distribution(PYPI_PACKAGE_NAME).read_text(filename)
+    except PackageNotFoundError:
+        return None
+
+
+def _run(runner: CommandRunner, command: tuple[str, ...]) -> CompletedProcess[str] | str:
+    try:
+        return runner(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        return str(exc)
+
+
+def _result_detail(result: CompletedProcess[str]) -> str:
+    return result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+
+
+def _failure(message: str) -> UpdateResult:
+    return UpdateResult(command=None, failures=(message,))

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -11,9 +11,10 @@ from pathlib import Path
 from subprocess import CompletedProcess, run
 from typing import Literal
 
-from tau_coding.update_check import PYPI_PACKAGE_NAME
+from tau_coding.update_check import PYPI_PACKAGE_NAME, fetch_latest_pypi_version
 
 CommandRunner = Callable[..., CompletedProcess[str]]
+LatestVersionFetcher = Callable[[], str | None]
 InstallMethod = Literal["uv-tool", "uv-pip", "pipx", "pip"]
 
 
@@ -39,6 +40,7 @@ def update_tau(
     direct_url: str | None = None,
     installer: str | None = None,
     inspect_distribution: bool = True,
+    latest_version_fetcher: LatestVersionFetcher = fetch_latest_pypi_version,
 ) -> UpdateResult:
     """Upgrade Tau with the installer that owns the active environment.
 
@@ -70,8 +72,17 @@ def update_tau(
             f"({prefix}). Package metadata reports: {installed_by}."
         )
 
+    latest_version: str | None = None
+    if method == "uv-tool":
+        try:
+            latest_version = latest_version_fetcher()
+        except Exception as exc:  # noqa: BLE001 - report update lookup failures to the user
+            return _failure(f"Could not determine the latest Tau version from PyPI: {exc}")
+        if latest_version is None:
+            return _failure("Could not determine the latest Tau version from PyPI.")
+
     executable = python_executable or sys.executable
-    command = _update_command(method, executable)
+    command = _update_command(method, executable, latest_version=latest_version)
     completed = _run(runner, command)
     if isinstance(completed, str):
         return _failure(f"{' '.join(command)}: {completed}")
@@ -98,9 +109,16 @@ def detect_install_method(prefix: Path, *, installer: str | None = None) -> Inst
     return None
 
 
-def _update_command(method: InstallMethod, python_executable: str) -> tuple[str, ...]:
+def _update_command(
+    method: InstallMethod,
+    python_executable: str,
+    *,
+    latest_version: str | None = None,
+) -> tuple[str, ...]:
     if method == "uv-tool":
-        return ("uv", "tool", "upgrade", PYPI_PACKAGE_NAME)
+        if latest_version is None:
+            raise ValueError("latest_version is required for uv tool updates")
+        return ("uv", "tool", "install", f"{PYPI_PACKAGE_NAME}@{latest_version}")
     if method == "uv-pip":
         return (
             "uv",

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -1,0 +1,70 @@
+"""Upgrade the installed Tau CLI with common Python tool managers."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from subprocess import CompletedProcess, run
+
+from tau_coding.update_check import PYPI_PACKAGE_NAME
+
+CommandRunner = Callable[..., CompletedProcess[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateResult:
+    """Result of trying to upgrade Tau."""
+
+    command: tuple[str, ...] | None
+    stdout: str = ""
+    stderr: str = ""
+    failures: tuple[str, ...] = ()
+
+    @property
+    def succeeded(self) -> bool:
+        return self.command is not None
+
+
+def update_tau(
+    *,
+    runner: CommandRunner = run,
+    python_executable: str | None = None,
+    commands: Sequence[Sequence[str]] | None = None,
+) -> UpdateResult:
+    """Upgrade Tau, trying uv, pipx, then the current interpreter's pip.
+
+    A failed or unavailable installer falls through to the next option. Output from
+    unsuccessful attempts is kept for the final diagnostic instead of cluttering the
+    successful update path.
+    """
+    candidates = commands or (
+        ("uv", "tool", "upgrade", PYPI_PACKAGE_NAME),
+        ("pipx", "upgrade", PYPI_PACKAGE_NAME),
+        (
+            python_executable or sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            PYPI_PACKAGE_NAME,
+        ),
+    )
+    failures: list[str] = []
+    for candidate in candidates:
+        command = tuple(candidate)
+        try:
+            result = runner(command, capture_output=True, text=True, check=False)
+        except OSError as exc:
+            failures.append(f"{' '.join(command)}: {exc}")
+            continue
+        if result.returncode == 0:
+            return UpdateResult(
+                command=command,
+                stdout=result.stdout.strip(),
+                stderr=result.stderr.strip(),
+                failures=tuple(failures),
+            )
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        failures.append(f"{' '.join(command)}: {detail}")
+    return UpdateResult(command=None, failures=tuple(failures))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from tau_coding.update_check import (
     ReleaseNotesNotice,
     UpdateNotice,
 )
+from tau_coding.updater import UpdateResult
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
@@ -123,6 +124,42 @@ def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPa
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "tau 1.2.3"
+
+
+def test_update_command_upgrades_without_startup_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_startup_update_notice",
+        lambda: (_ for _ in ()).throw(AssertionError("no update check")),
+    )
+    monkeypatch.setattr(
+        cli,
+        "update_tau",
+        lambda: UpdateResult(
+            command=("uv", "tool", "upgrade", "tau-ai"),
+            stdout="Updated tau-ai",
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["update"])
+
+    assert result.exit_code == 0
+    assert "Updated tau-ai" in result.stdout
+    assert "Tau update completed with: uv tool upgrade tau-ai" in result.stdout
+
+
+def test_update_command_reports_installer_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "update_tau",
+        lambda: UpdateResult(command=None, failures=("uv: not found", "pipx: not found")),
+    )
+
+    result = CliRunner().invoke(app, ["update"])
+
+    assert result.exit_code == 1
+    assert "Could not update Tau with uv, pipx, or pip" in result.stderr
+    assert "uv: not found" in result.stderr
 
 
 def test_print_mode_writes_update_notice_to_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -271,10 +308,12 @@ def test_cli_positional_prompt_invokes_tui_runner(
 async def test_run_openai_tui_combines_release_notes_and_update_notice(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str, ...]] = []
+    calls: list[tuple[str | None, tuple[str, ...]]] = []
 
     async def fake_run_tui_app(**kwargs: object) -> None:
-        calls.append(kwargs["startup_notices"])  # type: ignore[arg-type]
+        calls.append(  # type: ignore[arg-type]
+            (kwargs["startup_update_notice"], kwargs["startup_notices"])
+        )
 
     monkeypatch.setattr(cli, "run_tui_app", fake_run_tui_app)
     monkeypatch.setattr(cli, "_current_version", lambda: "0.1.2")
@@ -302,8 +341,8 @@ async def test_run_openai_tui_combines_release_notes_and_update_notice(
 
     assert calls == [
         (
-            "Tau updated to 0.1.2\n\n**New**\n- Release note",
-            "Tau 0.1.3 is available (installed: 0.1.2). Update with: uv tool upgrade tau-ai",
+            "Tau 0.1.3 is available (installed: 0.1.2). Run `tau update` to upgrade.",
+            ("Tau updated to 0.1.2\n\n**New**\n- Release note",),
         )
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,7 +136,7 @@ def test_update_command_upgrades_without_startup_check(monkeypatch: pytest.Monke
         cli,
         "update_tau",
         lambda: UpdateResult(
-            command=("uv", "tool", "upgrade", "tau-ai"),
+            command=("uv", "tool", "install", "tau-ai@0.2.4"),
             stdout="Updated tau-ai",
         ),
     )
@@ -145,7 +145,7 @@ def test_update_command_upgrades_without_startup_check(monkeypatch: pytest.Monke
 
     assert result.exit_code == 0
     assert "Updated tau-ai" in result.stdout
-    assert "Tau update completed with: uv tool upgrade tau-ai" in result.stdout
+    assert "Tau update completed with: uv tool install tau-ai@0.2.4" in result.stdout
 
 
 def test_update_command_reports_installer_failures(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,7 +158,7 @@ def test_update_command_reports_installer_failures(monkeypatch: pytest.MonkeyPat
     result = CliRunner().invoke(app, ["update"])
 
     assert result.exit_code == 1
-    assert "Could not update Tau with uv, pipx, or pip" in result.stderr
+    assert "Could not safely update Tau" in result.stderr
     assert "uv: not found" in result.stderr
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6798,9 +6798,13 @@ async def test_tui_resume_refreshes_context_after_session_swap() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_shows_startup_update_notice_in_transcript_only() -> None:
+async def test_tui_app_shows_startup_update_notice_first_in_bright_yellow() -> None:
     session = FakeSession(messages=[UserMessage(content="Earlier prompt")])
-    app = TauTuiApp(session, startup_notices=("Tau updated to 0.2.0", "Tau 0.2.0 is available"))
+    app = TauTuiApp(
+        session,
+        startup_update_notice="Tau 0.2.0 is available",
+        startup_notices=("Tau updated to 0.2.0",),
+    )
     notifications: list[tuple[str, str | None]] = []
 
     def fake_notify(message: str, **kwargs: object) -> None:
@@ -6813,10 +6817,14 @@ async def test_tui_app_shows_startup_update_notice_in_transcript_only() -> None:
         await pilot.pause()
         transcript = app.query_one("#transcript", TranscriptView)
         assert [line.text for line in transcript.lines] == [
-            "Tau updated to 0.2.0",
             "Tau 0.2.0 is available",
+            "Tau updated to 0.2.0",
             "Earlier prompt",
         ]
+        update_widget = transcript.query(TranscriptMessageWidget).first()
+        assert update_widget.item.highlight == "update"
+        assert update_widget._role_style.border == "#ffff00"
+        assert update_widget._role_style.body == "bold #ffff00"
 
     assert notifications == []
     assert [message.text for message in session.messages] == ["Earlier prompt"]

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -32,7 +32,7 @@ def test_startup_update_notice_reports_newer_stable_release(tmp_path) -> None:
     assert notice.current_version == "0.1.0"
     assert notice.latest_version == "0.2.0"
     assert "Tau 0.2.0 is available (installed: 0.1.0)" in notice.message
-    assert "uv tool upgrade tau-ai" in notice.message
+    assert "Run `tau update` to upgrade" in notice.message
     assert calls == [(PYPI_JSON_URL, UPDATE_CHECK_TIMEOUT_SECONDS)]
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,45 @@
+from subprocess import CompletedProcess
+
+from tau_coding.updater import update_tau
+
+
+def test_update_tau_falls_back_to_next_installer() -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def runner(command: tuple[str, ...], **kwargs: object) -> CompletedProcess[str]:
+        assert kwargs == {"capture_output": True, "text": True, "check": False}
+        calls.append(command)
+        if command[0] == "uv":
+            return CompletedProcess(command, 1, stdout="", stderr="not a uv tool")
+        return CompletedProcess(command, 0, stdout="upgraded", stderr="")
+
+    result = update_tau(
+        runner=runner,
+        commands=(("uv", "tool", "upgrade", "tau-ai"), ("pipx", "upgrade", "tau-ai")),
+    )
+
+    assert result.succeeded is True
+    assert result.command == ("pipx", "upgrade", "tau-ai")
+    assert result.stdout == "upgraded"
+    assert result.failures == ("uv tool upgrade tau-ai: not a uv tool",)
+    assert calls == [
+        ("uv", "tool", "upgrade", "tau-ai"),
+        ("pipx", "upgrade", "tau-ai"),
+    ]
+
+
+def test_update_tau_reports_unavailable_and_failed_installers() -> None:
+    def runner(command: tuple[str, ...], **kwargs: object) -> CompletedProcess[str]:
+        del kwargs
+        if command[0] == "uv":
+            raise FileNotFoundError("uv not found")
+        return CompletedProcess(command, 2, stdout="failed", stderr="")
+
+    result = update_tau(
+        runner=runner,
+        commands=(("uv",), ("pipx",)),
+    )
+
+    assert result.succeeded is False
+    assert result.command is None
+    assert result.failures == ("uv: uv not found", "pipx: failed")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -34,11 +34,26 @@ def test_update_tau_uses_uv_tool_for_uv_owned_tool_environment(tmp_path: Path) -
         runner=runner,
         environment_prefix=tmp_path,
         inspect_distribution=False,
+        latest_version_fetcher=lambda: "0.2.4",
     )
 
     assert result.succeeded is True
-    assert result.command == ("uv", "tool", "upgrade", "tau-ai")
-    assert calls == [("uv", "tool", "upgrade", "tau-ai")]
+    assert result.command == ("uv", "tool", "install", "tau-ai@0.2.4")
+    assert calls == [("uv", "tool", "install", "tau-ai@0.2.4")]
+
+
+def test_update_tau_reports_uv_latest_version_lookup_failure(tmp_path: Path) -> None:
+    (tmp_path / "uv-receipt.toml").touch()
+
+    result = update_tau(
+        runner=_success,
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
+        latest_version_fetcher=lambda: None,
+    )
+
+    assert result.succeeded is False
+    assert result.failures == ("Could not determine the latest Tau version from PyPI.",)
 
 
 def test_update_tau_uses_pipx_for_pipx_owned_environment(tmp_path: Path) -> None:
@@ -105,11 +120,12 @@ def test_update_tau_does_not_fall_back_when_owner_update_fails(tmp_path: Path) -
         runner=runner,
         environment_prefix=tmp_path,
         inspect_distribution=False,
+        latest_version_fetcher=lambda: "0.2.4",
     )
 
     assert result.succeeded is False
-    assert result.failures == ("uv tool upgrade tau-ai: uv failed",)
-    assert calls == [("uv", "tool", "upgrade", "tau-ai")]
+    assert result.failures == ("uv tool install tau-ai@0.2.4: uv failed",)
+    assert calls == [("uv", "tool", "install", "tau-ai@0.2.4")]
 
 
 def test_update_tau_refuses_direct_url_install(tmp_path: Path) -> None:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,45 +1,150 @@
+from pathlib import Path
 from subprocess import CompletedProcess
 
-from tau_coding.updater import update_tau
+from tau_coding.updater import detect_install_method, update_tau
 
 
-def test_update_tau_falls_back_to_next_installer() -> None:
+def _success(command: tuple[str, ...], **kwargs: object) -> CompletedProcess[str]:
+    assert kwargs == {"capture_output": True, "text": True, "check": False}
+    return CompletedProcess(command, 0, stdout="upgraded", stderr="")
+
+
+def test_detect_install_method_uses_receipts_before_installer_metadata(tmp_path: Path) -> None:
+    assert detect_install_method(tmp_path) is None
+    assert detect_install_method(tmp_path, installer="uv") == "uv-pip"
+    assert detect_install_method(tmp_path, installer="pip") == "pip"
+
+    (tmp_path / "uv-receipt.toml").touch()
+    assert detect_install_method(tmp_path, installer="pip") == "uv-tool"
+
+    (tmp_path / "uv-receipt.toml").unlink()
+    (tmp_path / "pipx_metadata.json").touch()
+    assert detect_install_method(tmp_path, installer="pip") == "pipx"
+
+
+def test_update_tau_uses_uv_tool_for_uv_owned_tool_environment(tmp_path: Path) -> None:
+    (tmp_path / "uv-receipt.toml").touch()
     calls: list[tuple[str, ...]] = []
 
     def runner(command: tuple[str, ...], **kwargs: object) -> CompletedProcess[str]:
-        assert kwargs == {"capture_output": True, "text": True, "check": False}
         calls.append(command)
-        if command[0] == "uv":
-            return CompletedProcess(command, 1, stdout="", stderr="not a uv tool")
-        return CompletedProcess(command, 0, stdout="upgraded", stderr="")
+        return _success(command, **kwargs)
 
     result = update_tau(
         runner=runner,
-        commands=(("uv", "tool", "upgrade", "tau-ai"), ("pipx", "upgrade", "tau-ai")),
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
     )
 
     assert result.succeeded is True
+    assert result.command == ("uv", "tool", "upgrade", "tau-ai")
+    assert calls == [("uv", "tool", "upgrade", "tau-ai")]
+
+
+def test_update_tau_uses_pipx_for_pipx_owned_environment(tmp_path: Path) -> None:
+    (tmp_path / "pipx_metadata.json").touch()
+
+    result = update_tau(
+        runner=_success,
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
+    )
+
     assert result.command == ("pipx", "upgrade", "tau-ai")
-    assert result.stdout == "upgraded"
-    assert result.failures == ("uv tool upgrade tau-ai: not a uv tool",)
-    assert calls == [
-        ("uv", "tool", "upgrade", "tau-ai"),
-        ("pipx", "upgrade", "tau-ai"),
-    ]
 
 
-def test_update_tau_reports_unavailable_and_failed_installers() -> None:
+def test_update_tau_reuses_uv_pip_for_uv_installed_distribution(tmp_path: Path) -> None:
+    result = update_tau(
+        runner=_success,
+        python_executable="/env/bin/python",
+        environment_prefix=tmp_path,
+        installer="uv",
+        inspect_distribution=False,
+    )
+
+    assert result.command == (
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "/env/bin/python",
+        "--upgrade",
+        "tau-ai",
+    )
+
+
+def test_update_tau_uses_current_environment_pip_for_pip_install(tmp_path: Path) -> None:
+    result = update_tau(
+        runner=_success,
+        python_executable="/env/bin/python",
+        environment_prefix=tmp_path,
+        installer="pip",
+        inspect_distribution=False,
+    )
+
+    assert result.command == (
+        "/env/bin/python",
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "tau-ai",
+    )
+
+
+def test_update_tau_does_not_fall_back_when_owner_update_fails(tmp_path: Path) -> None:
+    (tmp_path / "uv-receipt.toml").touch()
+    calls: list[tuple[str, ...]] = []
+
     def runner(command: tuple[str, ...], **kwargs: object) -> CompletedProcess[str]:
         del kwargs
-        if command[0] == "uv":
-            raise FileNotFoundError("uv not found")
-        return CompletedProcess(command, 2, stdout="failed", stderr="")
+        calls.append(command)
+        return CompletedProcess(command, 2, stdout="", stderr="uv failed")
 
     result = update_tau(
         runner=runner,
-        commands=(("uv",), ("pipx",)),
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
     )
 
     assert result.succeeded is False
-    assert result.command is None
-    assert result.failures == ("uv: uv not found", "pipx: failed")
+    assert result.failures == ("uv tool upgrade tau-ai: uv failed",)
+    assert calls == [("uv", "tool", "upgrade", "tau-ai")]
+
+
+def test_update_tau_refuses_direct_url_install(tmp_path: Path) -> None:
+    result = update_tau(
+        runner=_success,
+        environment_prefix=tmp_path,
+        direct_url="file:///checkout/tau",
+        installer="uv",
+        inspect_distribution=False,
+    )
+
+    assert result.succeeded is False
+    assert "original source: file:///checkout/tau" in result.failures[0]
+
+
+def test_update_tau_refuses_conda_or_pixi_environment(tmp_path: Path) -> None:
+    (tmp_path / "conda-meta").mkdir()
+
+    result = update_tau(
+        runner=_success,
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
+    )
+
+    assert result.succeeded is False
+    assert "Conda/Pixi-managed" in result.failures[0]
+
+
+def test_update_tau_refuses_unknown_installer(tmp_path: Path) -> None:
+    result = update_tau(
+        runner=_success,
+        environment_prefix=tmp_path,
+        installer="custom-manager",
+        inspect_distribution=False,
+    )
+
+    assert result.succeeded is False
+    assert "Package metadata reports: custom-manager" in result.failures[0]

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -33,11 +33,17 @@ You can install Tau with `pipx install tau-ai` or
 
 ### Upgrade Tau
 
-For a normal install, let Tau use uv, pipx, or pip to upgrade itself:
+For a normal install, let Tau detect and reuse the installer that owns its environment:
 
 ```bash
 tau update
 ```
+
+Tau reuses uv or pipx when their environment receipt is present. For ordinary
+Python installs, standard package metadata tells Tau whether to use uv or pip,
+and Tau targets the exact Python environment running it. It stops instead of
+switching installers for editable, direct-URL, Conda/Pixi, or unrecognized
+installations.
 
 If you installed a local checkout with `uv tool install --editable .`, run the
 install command again after pulling changes:

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -33,10 +33,10 @@ You can install Tau with `pipx install tau-ai` or
 
 ### Upgrade Tau
 
-For a normal tool install, upgrade with:
+For a normal install, let Tau use uv, pipx, or pip to upgrade itself:
 
 ```bash
-uv tool upgrade tau-ai
+tau update
 ```
 
 If you installed a local checkout with `uv tool install --editable .`, run the

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -39,9 +39,11 @@ For a normal install, let Tau detect and reuse the installer that owns its envir
 tau update
 ```
 
-Tau reuses uv or pipx when their environment receipt is present. For ordinary
-Python installs, standard package metadata tells Tau whether to use uv or pip,
-and Tau targets the exact Python environment running it. It stops instead of
+Tau reuses uv or pipx when their environment receipt is present. For uv tools,
+it installs the latest stable version explicitly so an older version pin cannot
+block the update. For ordinary Python installs, standard package metadata tells
+Tau whether to use uv or pip, and Tau targets the exact Python environment
+running it. It stops instead of
 switching installers for editable, direct-URL, Conda/Pixi, or unrecognized
 installations.
 

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -28,7 +28,7 @@ features and fixes.
 | --- | --- |
 | `tau` | Open the interactive TUI |
 | `tau "<prompt>"` | Open the TUI with an initial prompt |
-| `tau update` | Upgrade Tau with uv, pipx, or pip |
+| `tau update` | Upgrade Tau with the installer that owns its environment |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |
 | `tau providers` | List configured providers and how each authenticates |

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -15,10 +15,12 @@ tau [OPTIONS] [PROMPT] [COMMAND] [ARGS]
 - `-p/--prompt` runs a single prompt in [print mode]({{< relref "../guides/print-mode.md" >}}).
 
 On TUI and text print-mode startup, Tau may show a non-blocking notice when a
-newer `tau-ai` release is available on PyPI. Disable it with
-`TAU_NO_UPDATE_CHECK=1`; utility commands such as `tau --version`, `tau sessions`,
-and `tau export` do not run the check. After an upgrade, the TUI also adds a
-one-time release-notes message to the transcript with the new features and fixes.
+newer `tau-ai` release is available on PyPI. In the TUI, this notice is the first
+transcript item and appears in bright yellow. Run `tau update` to upgrade. Disable
+the check with `TAU_NO_UPDATE_CHECK=1`; utility commands such as `tau --version`,
+`tau update`, `tau sessions`, and `tau export` do not run it. After an upgrade,
+the TUI also adds a one-time release-notes message to the transcript with the new
+features and fixes.
 
 ## Commands
 
@@ -26,6 +28,7 @@ one-time release-notes message to the transcript with the new features and fixes
 | --- | --- |
 | `tau` | Open the interactive TUI |
 | `tau "<prompt>"` | Open the TUI with an initial prompt |
+| `tau update` | Upgrade Tau with uv, pipx, or pip |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |
 | `tau providers` | List configured providers and how each authenticates |


### PR DESCRIPTION
## Summary

- render available-version notices as the first TUI transcript item in bright yellow
- add `tau update`, which detects and reuses the installer that owns Tau's active environment
- make uv-tool updates install the explicit latest stable version so an old receipt pin cannot block upgrades
- point startup guidance and installation docs to the new command

## User experience

Outdated Tau installations are now difficult to miss, without interrupting startup. Users can upgrade directly with one memorable command. Tau respects the existing installation: uv tool, uv pip, pipx, and pip installs are updated with that same manager, while direct-source, Conda/Pixi, and unknown installs stop with safe instructions instead of trying unrelated tools.

## Issue

No linked issue.

## Manual validation

1. Seed `~/.tau/cache/update-check.json` with a fresh `latest_version` newer than the installed version.
2. Run `tau` and confirm the bright-yellow update notice is the first transcript item, before release notes and session history.
3. Run `tau update` from a normal uv, pipx, or pip installation and confirm Tau invokes that installation's manager.
4. For a uv tool originally installed with an exact old version, confirm Tau runs `uv tool install tau-ai@<latest-version>` rather than preserving the old pin.
5. Confirm an editable checkout reports its original source instead of modifying another installation.
6. Run `tau --version` after updating.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-feature-dist`
- `hugo --minify --destination /tmp/tau-feature-site` (from `website/`)
