### PR TITLE
chore: prepare 0.2.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.2.3"
+version = "0.2.4"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,11 +1,26 @@
 [
   {
+    "version": "0.2.4",
+    "date": "2026-07-21",
+    "sections": {
+      "New": [
+        "Add 28 live-routable Hugging Face Inference Providers models from Pi's built-in catalog.",
+        "Insert files dragged onto the terminal as normalized prompt paths while preserving existing text and quoting paths that contain spaces."
+      ],
+      "Changed": [
+        "Shorten TUI sidebar context paths under the home directory with ~/ and give provider metadata quieter styling.",
+        "Raise the minimum supported Pydantic version to 2.11 for explicit wire-model alias validation and serialization behavior."
+      ],
+      "Fixed": [
+        "Show expanded prompt-template text before automatic session naming starts, and avoid redundant naming attempts after provider retries are exhausted.",
+        "Fix the resume picker search to avoid matching workspace paths while retaining session-name and model matches."
+      ]
+    }
+  },
+  {
     "version": "0.2.3",
     "date": "2026-07-20",
     "sections": {
-      "New": [
-        "Add 28 live-routable Hugging Face Inference Providers models from Pi's built-in catalog."
-      ],
       "Changed": [
         "Default the TUI sidebar to the right side while preserving explicit left, right, and off preferences.",
         "Label TUI sidebar token totals as cumulative session usage and document why cumulative provider usage can exceed the active context estimate.",
@@ -13,8 +28,7 @@
       ],
       "Fixed": [
         "Fix session JSONL reads splitting records on Unicode line separators (U+2028, U+2029, U+0085), which made affected sessions and the session index fail to load; the read-side fix also repairs already-affected session files.",
-        "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors.",
-        "Fix the resume picker search to avoid matching workspace paths while retaining session-name and model matches."
+        "Fix picker highlight text contrast so focused labels use each theme's configured highlight foreground and background colors."
       ]
     }
   },

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -503,7 +503,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.2.3" in console.export_text()
+    assert "τ = 2π  0.2.4" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the Tau 0.2.4 patch release.

- Bump `pyproject.toml` and `uv.lock` to `0.2.4`
- Add 0.2.4 bundled release notes and keep 0.2.3 notes aligned with its published tag
- Update the sidebar brand version assertion in `tests/test_tui_app.py`

## Release notes (0.2.4)

### New

- Add 28 live-routable Hugging Face Inference Providers models from Pi's built-in catalog. (#428)
- Insert files dragged onto the terminal as normalized prompt paths while preserving existing text and quoting paths that contain spaces. (#408)

### Changed

- Shorten TUI sidebar context paths under the home directory with `~/` and give provider metadata quieter styling. (#422, #425)
- Raise the minimum supported Pydantic version to 2.11 for explicit wire-model alias validation and serialization behavior. (#412)

### Fixed

- Show expanded prompt-template text before automatic session naming starts, and avoid redundant naming attempts after provider retries are exhausted. (#421)
- Fix the resume picker search to avoid matching workspace paths while retaining session-name and model matches. (#420)

## Validation

- `uv run pytest` — 1073 passed
- `uv run ruff check .` and `uv run ruff format --check .` — clean
- `uv run mypy` — no issues
- `uv build --out-dir /tmp/tau-0.2.4-dist` — sdist and wheel built
- `uv run tau --version` — reports `tau 0.2.4`
- PyPI version check — `tau-ai==0.2.4` is not published

## After merge

Publish a GitHub Release from `main` with tag `v0.2.4` to trigger the PyPI publish workflow, per `dev-notes/release-process.md`.
