### PR TITLE
fix(agent): honor AgentToolResult.terminate

### DIFF
--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -137,8 +137,8 @@ async def run_agent_loop(
                 return
 
             tool_results: list[ToolResultMessage] = []
+            final_tool_results: list[AgentToolResult] = []
             calls = list(assistant.tool_calls)
-            has_more_tools = bool(calls)
             for call in calls:
                 async for event in _execute_tool_call(
                     call,
@@ -148,13 +148,18 @@ async def run_agent_loop(
                     after_tool_call,
                 ):
                     yield event
-                    if isinstance(event, MessageEndEvent) and isinstance(
+                    if isinstance(event, ToolExecutionEndEvent):
+                        final_tool_results.append(event.result)
+                    elif isinstance(event, MessageEndEvent) and isinstance(
                         event.message, ToolResultMessage
                     ):
                         tool_results.append(event.message)
                         messages.append(event.message)
                         new_messages.append(event.message)
 
+            has_more_tools = bool(final_tool_results) and not all(
+                result.terminate is True for result in final_tool_results
+            )
             yield TurnEndEvent(message=assistant, tool_results=tool_results)
             turn += 1
             pending = tuple(get_steering_messages() if get_steering_messages else ())


### PR DESCRIPTION
## Summary

Honor `AgentToolResult.terminate` in the agent loop.

The loop now collects finalized results after the complete tool-call batch has run and skips the automatic follow-up model turn only when every result requests termination. Results modified by `after_tool_call` are respected, while mixed batches continue normally.

## Reproduction

Before this change, a custom terminal tool could return:

```python
return AgentToolResult(
    content=[TextContent(text="result accepted")],
    terminate=True,
)
```

The tool completed successfully, but the loop set `has_more_tools` from the presence of tool calls alone and made another provider request. With `max_turns=1`, the attempted follow-up also turned a successful run into `Agent stopped after max_turns=1`.

This is the same early-termination behavior fixed in Pi:

- https://github.com/earendil-works/pi/issues/3525
- https://github.com/earendil-works/pi/blob/v0.80.6/packages/agent/src/agent-loop.ts#L584-L600

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
