### PR TITLE
feat!: mirror Pi's non-interactive CLI flags

### DIFF
--- a/dev-notes/architecture/phase-21-extensions.md
+++ b/dev-notes/architecture/phase-21-extensions.md
@@ -65,7 +65,7 @@ skills/prompts, which use last-wins precedence):
 1. `<cwd>/.tau/extensions/` — project extensions (**off by default**, see
    Security)
 2. `~/.tau/extensions/` — user extensions
-3. Paths passed explicitly (`tau --extension/-x PATH`, repeatable; a file or
+3. Paths passed explicitly (`tau --extension/-e PATH`, repeatable; a file or
    a directory)
 
 Within a directory, one level deep, matching Pi:
@@ -73,7 +73,7 @@ Within a directory, one level deep, matching Pi:
 - `*.py` files are extension modules
 - a subdirectory containing `extension.py` is an extension (the analog of
   Pi's `index.ts` convention)
-- a directory (subdirectory or explicit `-x` path) whose `pyproject.toml`
+- a directory (subdirectory or explicit `-e` path) whose `pyproject.toml`
   declares `[tool.tau] extensions = ["src/pkg/extension.py", ...]` loads the
   declared entries instead — the analog of Pi's `package.json`
   `pi.extensions` manifest ("complex packages must use package.json
@@ -671,7 +671,7 @@ gates this behind a project-trust prompt; Tau does not have a trust store
 yet. **Ruling:** project-directory extensions are **disabled by default**
 in v1. `<cwd>/.tau/extensions/` loads only with the explicit
 `--project-extensions` CLI flag. User extensions (`~/.tau/extensions/`) and
-explicit `-x` paths load by default; `--no-extensions` turns directory
+explicit `-e` paths load by default; `--no-extensions` turns directory
 discovery off entirely. A per-project trust prompt is the immediate
 follow-up that can flip the project default.
 

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -19,7 +19,7 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
 
 - TUI startup renders the update notice as the first transcript item in fixed bright-yellow, bold styling, before release notes, provider errors, theme diagnostics, or session history.
 - Print mode writes the notice to stderr for normal text output.
-- Structured print output (`--output json`) suppresses the notice to avoid corrupting scripted output.
+- Structured print output (`--mode json`) suppresses the notice to avoid corrupting scripted output.
 - Utility commands (`tau --version`, `tau update`, `tau sessions`, `tau export`, `tau providers`, `tau setup`) do not run the update check.
 
 ## Update command

--- a/dev-notes/cli-mirror-pi-flags.md
+++ b/dev-notes/cli-mirror-pi-flags.md
@@ -1,0 +1,60 @@
+# Mirroring Pi's non-interactive CLI flags
+
+Issue: https://github.com/huggingface/tau/issues/439
+
+## What changed
+
+- `tau --resume <session-id>` is renamed to `tau --session <session-id>`,
+  matching Pi's `--session <path|id>` naming. This is a **breaking change**
+  for scripted use of Tau; the version was bumped `0.2.4` -> `0.3.0`.
+- `--resume` still exists as a hidden option so that using it produces a
+  clear migration error (`--resume was renamed to --session. Use
+  \`tau --session <id>\` instead.`) rather than Typer's generic "no such
+  option" message. It never resumes a session.
+- The `--session`/`--new-session` conflict check and validation message were
+  updated to reference `--session`.
+- Docs (`website/content/reference/cli.md`,
+  `website/content/guides/sessions.md`) and CLI help text now say
+  `--session`.
+- The in-TUI `/resume` slash command (`src/tau_coding/commands.py`,
+  `src/tau_coding/tui/autocomplete.py`) is unaffected: it is a distinct,
+  interactive picker/id command, not the process-startup CLI flag.
+
+## Audit of Tau vs Pi non-interactive flags
+
+Per the [Pi CLI reference](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md#cli-reference),
+the full audit and disposition for this change:
+
+| Tau (current) | Pi | Disposition |
+|---|---|---|
+| `--resume <id>` | `--session <path\|id>` | **Fixed here.** Renamed to `--session <id>`. Path support (Pi also accepts a JSONL file path) is left as a follow-up; Tau's `--session` accepts an indexed session id only for now. Pi's own `-r/--resume` (no value, opens a picker) is not adopted; Tau's picker already lives in the TUI's `/resume` slash command. |
+| `--prompt`, `-p <text>` | `-p`, `--print` (boolean, prompt is positional) | **Deferred.** Aligning `-p` to a boolean print-mode flag with a positional prompt is a bigger behavior change than a rename (Tau's print mode is currently keyed on `--prompt` being set). Left for a follow-up issue/PR so it can be scoped and tested on its own. |
+| `--output`, `-o <text\|json\|transcript>` | `--mode json\|rpc` | **Kept as-is, justified.** Tau's `text\|json\|transcript` output modes do not map 1:1 onto Pi's `json\|rpc` modes (Tau has no RPC mode; `transcript` has no Pi equivalent). Renaming the flag without renaming the values would be more confusing than the current divergence. |
+| `--extension`, `-x <path>` | `-e`, `--extension <source>` | **Kept as-is, justified.** `-x` does not collide with any Pi short flag Tau exposes, and repointing Tau's established `-x` shortcut for parity with Pi's `-e` would itself be a breaking, low-value rename. |
+| `tau export <id> [out]` (subcommand) | `--export <in> [out]` (flag) | **Kept as-is, justified.** Tau's `export` sits alongside its other subcommands (`sessions`, `providers`, `setup`, `update`); folding it into a flag on the root command would be a larger structural change than this issue's scope. |
+| `--version` | `-v`, `--version` | **Deferred.** Adding the `-v` short flag is low-risk and could land as a small follow-up; not required for this rename. |
+
+## Flag names reserved for future Pi parity
+
+Per the issue, Tau should not add new flags that squat on names Pi uses for
+different things. Known Pi flags Tau does not yet have: `-c/--continue`,
+`--fork`, `--no-session`, `--name/-n`, `--session-dir`. If Tau adds
+equivalent features later, prefer these names with matching semantics.
+
+## Exit resume hint (issue #438)
+
+Issue #438 (print a resume hint on exit) was still unimplemented at the time
+of this change, so there is no existing hint string to update. Whoever
+implements #438 should print:
+
+```text
+To resume this session: tau --session <session-id>
+```
+
+using the flag name from this change.
+
+## Testing
+
+```bash
+uv run pytest tests/test_cli.py tests/test_tui_app.py
+```

--- a/dev-notes/cli-mirror-pi-flags.md
+++ b/dev-notes/cli-mirror-pi-flags.md
@@ -17,7 +17,7 @@ just the original one.
 | `-x, --extension <path>` | `-e, --extension <path>` | Matches Pi's `-e, --extension`. |
 | `tau export <id> [out]` (subcommand only) | `tau export <id> [out]` **and** `tau --export <id> [out]` | Added `--export` as a top-level flag alias, matching Pi's `--export <in> [out]`, while keeping the subcommand for backward compatibility (it isn't deprecated — it fits Tau's other subcommands). |
 | `--version` | `--version`, `-v` | Added the `-v` short flag, matching Pi's `-v, --version`. |
-| (none) | piped stdin merges into the print-mode prompt | Mirrors Pi's `cat file \| pi -p "..."` behavior: when stdin is not a TTY, its contents are prepended to the prompt. |
+| (none) | piped stdin merges into the print-mode prompt | Mirrors Pi's `cat file \| pi -p "..."` behavior: when stdin is not a TTY, its contents are prepended to the prompt. A piped body can also be the *entire* prompt (`tau -p` with no positional text). |
 
 Every renamed/removed flag keeps a **hidden** option under its old name that
 raises a clear migration error instead of Typer's generic "no such option":
@@ -96,6 +96,7 @@ tau -p "hello"                                 # print mode, text output
 tau -p --mode json "hello"                     # print mode, JSON output
 tau --mode json "hello"                        # --mode alone also triggers print mode
 cat README.md | tau -p "summarize this"        # stdin merged into the prompt
+cat README.md | tau -p                          # stdin alone as the prompt
 tau -e ./my-extension.py "hello"               # load an extension
 tau --export <session-id> out.html             # export via the flag form
 tau --session <session-id>                     # resume a session

--- a/dev-notes/cli-mirror-pi-flags.md
+++ b/dev-notes/cli-mirror-pi-flags.md
@@ -43,15 +43,15 @@ equivalent features later, prefer these names with matching semantics.
 
 ## Exit resume hint (issue #438)
 
-Issue #438 (print a resume hint on exit) was still unimplemented at the time
-of this change, so there is no existing hint string to update. Whoever
-implements #438 should print:
+Issue #438 (print a resume hint on exit) landed in #441 while this PR was in
+flight, printing `To resume this session: tau --resume <session-id>`. This
+PR rebases onto that change and updates the printed hint (and the matching
+internal `--resume and --new-session cannot be used together` message in
+`src/tau_coding/tui/app.py`) to use `--session`:
 
 ```text
 To resume this session: tau --session <session-id>
 ```
-
-using the flag name from this change.
 
 ## Testing
 

--- a/dev-notes/cli-mirror-pi-flags.md
+++ b/dev-notes/cli-mirror-pi-flags.md
@@ -2,50 +2,80 @@
 
 Issue: https://github.com/huggingface/tau/issues/439
 
+This PR started as a single-flag rename (`--resume` -> `--session`) and grew,
+in place, into a full mirror of Pi's non-interactive CLI flag surface. The
+version bump `0.2.4` -> `0.3.0` covers all of the breaking renames below, not
+just the original one.
+
 ## What changed
 
-- `tau --resume <session-id>` is renamed to `tau --session <session-id>`,
-  matching Pi's `--session <path|id>` naming. This is a **breaking change**
-  for scripted use of Tau; the version was bumped `0.2.4` -> `0.3.0`.
-- `--resume` still exists as a hidden option so that using it produces a
-  clear migration error (`--resume was renamed to --session. Use
-  \`tau --session <id>\` instead.`) rather than Typer's generic "no such
-  option" message. It never resumes a session.
-- The `--session`/`--new-session` conflict check and validation message were
-  updated to reference `--session`.
-- Docs (`website/content/reference/cli.md`,
-  `website/content/guides/sessions.md`) and CLI help text now say
-  `--session`.
-- The in-TUI `/resume` slash command (`src/tau_coding/commands.py`,
-  `src/tau_coding/tui/autocomplete.py`) is unaffected: it is a distinct,
-  interactive picker/id command, not the process-startup CLI flag.
+| Tau (before) | Tau (now) | Notes |
+|---|---|---|
+| `--resume <id>` | `--session <id>` | Matches Pi's `--session <path\|id>`. Id only for now; JSONL path support is a possible follow-up. |
+| `-p, --prompt <text>` | `-p, --print` (boolean) + positional prompt | Matches Pi's `-p, --print`. The prompt is the same positional argument the TUI already uses for an initial prompt. |
+| `-o, --output <text\|json\|transcript>` | `--mode <text\|json\|transcript>` | Matches Pi's `--mode` flag name. Tau keeps its own value set (no RPC mode; Pi has no `transcript` mode) — see the audit table below. Passing `--mode` on its own also triggers non-interactive mode, mirroring `pi --mode json "prompt"` needing no separate `-p`. |
+| `-x, --extension <path>` | `-e, --extension <path>` | Matches Pi's `-e, --extension`. |
+| `tau export <id> [out]` (subcommand only) | `tau export <id> [out]` **and** `tau --export <id> [out]` | Added `--export` as a top-level flag alias, matching Pi's `--export <in> [out]`, while keeping the subcommand for backward compatibility (it isn't deprecated — it fits Tau's other subcommands). |
+| `--version` | `--version`, `-v` | Added the `-v` short flag, matching Pi's `-v, --version`. |
+| (none) | piped stdin merges into the print-mode prompt | Mirrors Pi's `cat file \| pi -p "..."` behavior: when stdin is not a TTY, its contents are prepended to the prompt. |
+
+Every renamed/removed flag keeps a **hidden** option under its old name that
+raises a clear migration error instead of Typer's generic "no such option":
+
+- `--resume <id>` -> `--resume was renamed to --session. Use \`tau --session <id>\` instead.`
+- `--prompt <text>` -> `--prompt was removed. Pass the prompt positionally and use --print, e.g. \`tau --print "<text>"\`.`
+- `-o/--output <mode>` -> `--output was renamed to --mode. Use \`tau --mode <mode>\` instead.`
+- `-x <path>` -> `-x was renamed to -e/--extension.`
+
+None of these old flags do anything anymore; they only exist to produce a
+friendly error.
+
+### Flag ordering
+
+Tau's CLI accepts an unquoted, multi-word prompt as trailing positional
+arguments (`tau fix the bug in main.py`, no quotes needed). To support that,
+the root command uses Click's `ignore_unknown_options` + a variadic
+`prompt_args` argument. One consequence: once positional-argument capture
+starts, everything after it — including tokens that look like flags — is
+absorbed into the prompt. Put flags **before** the prompt:
+
+```bash
+# Works: flags precede the prompt
+tau -p --mode json "summarize this"
+
+# Breaks: --mode is swallowed into the prompt text
+tau -p "summarize this" --mode json
+```
+
+This matches Pi's own documented examples, which always place flags before
+the trailing message (`pi --model gpt-4o "Help me refactor"`).
 
 ## Audit of Tau vs Pi non-interactive flags
 
 Per the [Pi CLI reference](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md#cli-reference),
-the full audit and disposition for this change:
+the full audit and disposition:
 
 | Tau (current) | Pi | Disposition |
 |---|---|---|
-| `--resume <id>` | `--session <path\|id>` | **Fixed here.** Renamed to `--session <id>`. Path support (Pi also accepts a JSONL file path) is left as a follow-up; Tau's `--session` accepts an indexed session id only for now. Pi's own `-r/--resume` (no value, opens a picker) is not adopted; Tau's picker already lives in the TUI's `/resume` slash command. |
-| `--prompt`, `-p <text>` | `-p`, `--print` (boolean, prompt is positional) | **Deferred.** Aligning `-p` to a boolean print-mode flag with a positional prompt is a bigger behavior change than a rename (Tau's print mode is currently keyed on `--prompt` being set). Left for a follow-up issue/PR so it can be scoped and tested on its own. |
-| `--output`, `-o <text\|json\|transcript>` | `--mode json\|rpc` | **Kept as-is, justified.** Tau's `text\|json\|transcript` output modes do not map 1:1 onto Pi's `json\|rpc` modes (Tau has no RPC mode; `transcript` has no Pi equivalent). Renaming the flag without renaming the values would be more confusing than the current divergence. |
-| `--extension`, `-x <path>` | `-e`, `--extension <source>` | **Kept as-is, justified.** `-x` does not collide with any Pi short flag Tau exposes, and repointing Tau's established `-x` shortcut for parity with Pi's `-e` would itself be a breaking, low-value rename. |
-| `tau export <id> [out]` (subcommand) | `--export <in> [out]` (flag) | **Kept as-is, justified.** Tau's `export` sits alongside its other subcommands (`sessions`, `providers`, `setup`, `update`); folding it into a flag on the root command would be a larger structural change than this issue's scope. |
-| `--version` | `-v`, `--version` | **Deferred.** Adding the `-v` short flag is low-risk and could land as a small follow-up; not required for this rename. |
+| `--session <id>` | `--session <path\|id>` | **Fixed.** Renamed from `--resume`. Id only for now; path support left as a follow-up. Pi's own `-r/--resume` (no value, opens a picker) is not adopted; Tau's picker already lives in the TUI's `/resume` slash command. |
+| `-p, --print` (boolean) | `-p, --print` (boolean) | **Fixed.** Prompt moved to a positional argument, matching Pi. |
+| `--mode <text\|json\|transcript>` | `--mode json\|rpc` | **Fixed the flag name; kept Tau's own value set, justified.** Tau's `text`/`json`/`transcript` output modes do not map 1:1 onto Pi's `json`/`rpc` (Tau has no RPC mode; `transcript` has no Pi equivalent). Adding an RPC mode is a much larger effort (a process-integration protocol) and is out of scope here. |
+| `-e, --extension <path>` | `-e, --extension <source>` | **Fixed.** |
+| `tau export`/`tau --export` | `--export <in> [out]` | **Fixed by addition.** Added the flag form; kept the subcommand form since it fits Tau's other subcommands (`sessions`, `providers`, `setup`, `update`), none of which Pi has an equivalent for either. |
+| `-v, --version` | `-v, --version` | **Fixed.** |
 
 ## Flag names reserved for future Pi parity
 
-Per the issue, Tau should not add new flags that squat on names Pi uses for
-different things. Known Pi flags Tau does not yet have: `-c/--continue`,
-`--fork`, `--no-session`, `--name/-n`, `--session-dir`. If Tau adds
+Tau should not add new flags that squat on names Pi uses for different
+things. Known Pi flags Tau does not yet have: `-c/--continue`, `--fork`,
+`--no-session`, `--name/-n`, `--session-dir`, `--mode rpc`. If Tau adds
 equivalent features later, prefer these names with matching semantics.
 
 ## Exit resume hint (issue #438)
 
 Issue #438 (print a resume hint on exit) landed in #441 while this PR was in
-flight, printing `To resume this session: tau --resume <session-id>`. This
-PR rebases onto that change and updates the printed hint (and the matching
+flight, printing `To resume this session: tau --resume <session-id>`. This PR
+rebased onto that change and updated the printed hint (and the matching
 internal `--resume and --new-session cannot be used together` message in
 `src/tau_coding/tui/app.py`) to use `--session`:
 
@@ -57,4 +87,18 @@ To resume this session: tau --session <session-id>
 
 ```bash
 uv run pytest tests/test_cli.py tests/test_tui_app.py
+```
+
+Manual smoke test:
+
+```bash
+tau -p "hello"                                 # print mode, text output
+tau -p --mode json "hello"                     # print mode, JSON output
+tau --mode json "hello"                        # --mode alone also triggers print mode
+cat README.md | tau -p "summarize this"        # stdin merged into the prompt
+tau -e ./my-extension.py "hello"               # load an extension
+tau --export <session-id> out.html             # export via the flag form
+tau --session <session-id>                     # resume a session
+tau -v                                          # short version flag
+tau --resume x / --prompt x / --output json / -x . # all error with a migration hint
 ```

--- a/dev-notes/exit-resume-hint.md
+++ b/dev-notes/exit-resume-hint.md
@@ -6,18 +6,19 @@ When the interactive TUI exits and the session was persisted, Tau now prints
 a one-line reminder of how to resume it:
 
 ```text
-To resume this session: tau --resume <session-id>
+To resume this session: tau --session <session-id>
 ```
 
 This mirrors Pi's exit-time hint (`To resume this session: pi --session
-[session id]`), adapted to Tau's actual resume flag (`tau --resume
-<session-id>` rather than `--session`).
+[session id]`) using Tau's `--session` flag, which was renamed from
+`--resume` in [issue #439](https://github.com/huggingface/tau/issues/439)
+to match Pi's naming (see `dev-notes/cli-mirror-pi-flags.md`).
 
 ## Why
 
 Closing the TUI previously gave no indication of how to pick the
 conversation back up. New users in particular had to already know about
-`tau --resume <id>` or `tau sessions`. A short, low-friction hint at exit
+`tau --session <id>` or `tau sessions`. A short, low-friction hint at exit
 closes that gap without adding new UI surface.
 
 See [issue #438](https://github.com/huggingface/tau/issues/438) for the

--- a/examples/extensions/hello_tool.py
+++ b/examples/extensions/hello_tool.py
@@ -2,7 +2,7 @@
 
 Install by copying into `~/.tau/extensions/`, or run:
 
-    tau -x examples/extensions/hello_tool.py
+    tau -e examples/extensions/hello_tool.py
 """
 
 from tau_agent.messages import TextContent

--- a/examples/extensions/permission_gate.py
+++ b/examples/extensions/permission_gate.py
@@ -5,7 +5,7 @@ never executes; the model sees the block reason instead.
 
 Install by copying into `~/.tau/extensions/`, or run:
 
-    tau -x examples/extensions/permission_gate.py
+    tau -e examples/extensions/permission_gate.py
 """
 
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.2.4"
+version = "0.3.0"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -139,9 +139,21 @@ def main(
         list[str] | None,
         typer.Argument(help="Initial prompt to run in interactive TUI mode."),
     ] = None,
+    print_mode: Annotated[
+        bool,
+        typer.Option(
+            "--print",
+            "-p",
+            help="Run the positional prompt in non-interactive print mode.",
+        ),
+    ] = False,
     prompt_option: Annotated[
         str | None,
-        typer.Option("--prompt", "-p", help="Prompt to run in non-interactive print mode."),
+        typer.Option(
+            "--prompt",
+            help="Removed; pass the prompt positionally and use --print instead.",
+            hidden=True,
+        ),
     ] = None,
     provider: Annotated[
         str | None,
@@ -185,10 +197,23 @@ def main(
         Path | None,
         typer.Option("--cwd", help="Working directory for built-in coding tools."),
     ] = None,
+    mode: Annotated[
+        PrintOutputMode | None,
+        typer.Option(
+            "--mode",
+            help="Run in non-interactive print mode with this output format "
+            "(text, json, or transcript).",
+        ),
+    ] = None,
     output: Annotated[
-        PrintOutputMode,
-        typer.Option("--output", "-o", help="Output mode for print mode."),
-    ] = PrintOutputMode.text,
+        PrintOutputMode | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Removed; use --mode instead.",
+            hidden=True,
+        ),
+    ] = None,
     session: Annotated[
         str | None,
         typer.Option("--session", help="Resume a session id in TUI mode."),
@@ -216,15 +241,30 @@ def main(
         list[Path] | None,
         typer.Option(
             "--extension",
-            "-x",
+            "-e",
             help="Load an extension file or directory (repeatable).",
         ),
     ] = None,
+    extension_legacy: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "-x",
+            help="Removed; use -e/--extension instead.",
+            hidden=True,
+        ),
+    ] = None,
+    export: Annotated[
+        bool,
+        typer.Option(
+            "--export",
+            help="Export the given session id or JSONL path (mirrors `tau export`).",
+        ),
+    ] = False,
     no_extensions: Annotated[
         bool,
         typer.Option(
             "--no-extensions",
-            help="Disable extension directory discovery (explicit -x paths still load).",
+            help="Disable extension directory discovery (explicit -e paths still load).",
         ),
     ] = False,
     project_extensions: Annotated[
@@ -236,7 +276,7 @@ def main(
     ] = False,
     version: Annotated[
         bool,
-        typer.Option("--version", help="Show Tau's version and exit."),
+        typer.Option("--version", "-v", help="Show Tau's version and exit."),
     ] = False,
 ) -> None:
     """Run the Tau CLI."""
@@ -256,42 +296,50 @@ def main(
     if session is not None and new_session:
         raise typer.BadParameter("--session and --new-session cannot be used together")
 
+    if prompt_option is not None:
+        raise typer.BadParameter(
+            "--prompt was removed. Pass the prompt positionally and use --print, e.g. "
+            f'`tau --print "{prompt_option}"`.'
+        )
+
+    if output is not None:
+        raise typer.BadParameter(
+            f"--output was renamed to --mode. Use `tau --mode {output.value}` instead."
+        )
+
+    if extension_legacy is not None:
+        raise typer.BadParameter("-x was renamed to -e/--extension.")
+
+    print_requested = print_mode or mode is not None
+    effective_output = mode or PrintOutputMode.text
+
     positional_args = prompt_args or []
     command = positional_args[0] if positional_args else None
     initial_prompt = " ".join(positional_args) if positional_args else None
 
-    if prompt_option is None and command == "update":
+    if not print_requested and not export and command == "update":
         if len(positional_args) != 1:
             raise typer.BadParameter("Usage: tau update")
         update_command()
         raise typer.Exit()
 
-    if prompt_option is None and command == "sessions" and len(positional_args) == 1:
+    if not print_requested and not export and command == "sessions" and len(positional_args) == 1:
         render_session_list(SessionManager().list_sessions())
         raise typer.Exit()
 
-    if prompt_option is None and command == "export":
-        try:
-            session_ref, output_path, export_format = _parse_export_cli_args(positional_args[1:])
-        except RuntimeError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        try:
-            exported_path = anyio.run(
-                export_session_command,
-                session_ref,
-                output_path,
-                export_format,
-            )
-        except (RuntimeError, ValueError) as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        typer.echo(f"Exported session to {exported_path}")
-        raise typer.Exit()
+    if not print_requested and not export and command == "export":
+        _run_export_cli(positional_args[1:])
 
-    if prompt_option is None and command == "providers" and len(positional_args) == 1:
+    if export:
+        if print_requested:
+            raise typer.BadParameter("--export cannot be combined with --print/--mode.")
+        _run_export_cli(positional_args)
+
+    if not print_requested and command == "providers" and len(positional_args) == 1:
         providers_command()
         raise typer.Exit()
 
-    if prompt_option is None and command == "setup" and len(positional_args) == 1:
+    if not print_requested and command == "setup" and len(positional_args) == 1:
         setup_command(
             provider_name=provider or DEFAULT_PROVIDER_NAME,
             base_url=setup_base_url,
@@ -306,7 +354,7 @@ def main(
 
     extension_paths = tuple(extension or ())
 
-    if prompt_option is None:
+    if not print_requested:
         notice = _startup_update_notice()
         try:
             resumable_session_id = anyio.run(
@@ -329,12 +377,14 @@ def main(
             typer.echo(f"To resume this session: tau --session {resumable_session_id}")
         raise typer.Exit()
 
-    prompt = prompt_option
-    if prompt is None:
-        raise AssertionError("prompt option should be set outside TUI mode")
+    if not positional_args:
+        raise typer.BadParameter(
+            'Usage: tau --print "<prompt>" (or --mode text|json|transcript "<prompt>")'
+        )
+    prompt = _merge_stdin_prompt(initial_prompt or "")
 
     notice = _startup_update_notice()
-    if notice is not None and output is PrintOutputMode.text:
+    if notice is not None and effective_output is PrintOutputMode.text:
         typer.echo(notice.message, err=True)
 
     try:
@@ -343,7 +393,7 @@ def main(
             prompt,
             model,
             cwd or Path.cwd(),
-            output,
+            effective_output,
             provider,
             None,
             extension_paths,
@@ -442,6 +492,50 @@ async def export_session_command(
         source=str(session_path),
         format=normalized_format,
     )
+
+
+def _run_export_cli(args: list[str]) -> None:
+    """Run `tau export`/`tau --export` and exit."""
+    try:
+        session_ref, output_path, export_format = _parse_export_cli_args(args)
+    except RuntimeError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    try:
+        exported_path = anyio.run(
+            export_session_command,
+            session_ref,
+            output_path,
+            export_format,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(f"Exported session to {exported_path}")
+    raise typer.Exit()
+
+
+def _merge_stdin_prompt(prompt: str) -> str:
+    """Merge piped stdin content into a print-mode prompt, mirroring Pi.
+
+    When stdin is not a terminal (e.g. `cat file | tau -p "..."`), its
+    contents are prepended to the prompt text.
+    """
+    stdin = sys.stdin
+    if stdin is None:
+        return prompt
+    try:
+        if stdin.isatty():
+            return prompt
+    except (AttributeError, ValueError):
+        return prompt
+    try:
+        piped = stdin.read()
+    except (OSError, ValueError):
+        return prompt
+    if not piped:
+        return prompt
+    if not prompt:
+        return piped
+    return f"{piped}\n\n{prompt}"
 
 
 def _parse_export_cli_args(args: list[str]) -> tuple[str, Path | None, str | None]:

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -189,9 +189,17 @@ def main(
         PrintOutputMode,
         typer.Option("--output", "-o", help="Output mode for print mode."),
     ] = PrintOutputMode.text,
+    session: Annotated[
+        str | None,
+        typer.Option("--session", help="Resume a session id in TUI mode."),
+    ] = None,
     resume: Annotated[
         str | None,
-        typer.Option("--resume", help="Resume a session id in TUI mode."),
+        typer.Option(
+            "--resume",
+            help="Removed; use --session <session-id> instead.",
+            hidden=True,
+        ),
     ] = None,
     new_session: Annotated[
         bool,
@@ -240,8 +248,13 @@ def main(
     if ctx.invoked_subcommand is not None:
         return
 
-    if resume is not None and new_session:
-        raise typer.BadParameter("--resume and --new-session cannot be used together")
+    if resume is not None:
+        raise typer.BadParameter(
+            f"--resume was renamed to --session. Use `tau --session {resume}` instead."
+        )
+
+    if session is not None and new_session:
+        raise typer.BadParameter("--session and --new-session cannot be used together")
 
     positional_args = prompt_args or []
     command = positional_args[0] if positional_args else None
@@ -300,7 +313,7 @@ def main(
                 run_openai_tui,
                 model,
                 cwd or Path.cwd(),
-                resume,
+                session,
                 new_session,
                 provider,
                 auto_compact_threshold,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -326,7 +326,7 @@ def main(
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
         if resumable_session_id is not None:
-            typer.echo(f"To resume this session: tau --resume {resumable_session_id}")
+            typer.echo(f"To resume this session: tau --session {resumable_session_id}")
         raise typer.Exit()
 
     prompt = prompt_option

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -377,11 +377,12 @@ def main(
             typer.echo(f"To resume this session: tau --session {resumable_session_id}")
         raise typer.Exit()
 
-    if not positional_args:
-        raise typer.BadParameter(
-            'Usage: tau --print "<prompt>" (or --mode text|json|transcript "<prompt>")'
-        )
     prompt = _merge_stdin_prompt(initial_prompt or "")
+    if not prompt:
+        raise typer.BadParameter(
+            'Usage: tau --print "<prompt>" (or --mode text|json|transcript "<prompt>"); '
+            "a prompt can also be piped in via stdin"
+        )
 
     notice = _startup_update_notice()
     if notice is not None and effective_output is PrintOutputMode.text:

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -15,7 +15,7 @@ Installed examples are under `examples/extensions/` next to these docs. Read the
 
 - `~/.tau/extensions/`: discovered by default.
 - `<project>/.tau/extensions/`: enabled explicitly with `--project-extensions`.
-- `tau -x PATH`: explicitly load a file or directory.
+- `tau -e PATH`: explicitly load a file or directory.
 
 An extension defines `setup(tau)`. Project extensions execute arbitrary Python and are disabled by default; enable only trusted repositories.
 
@@ -26,7 +26,7 @@ An extension defines `setup(tau)`. Project extensions execute arbitrary Python a
 3. Confirm the requested capability exists in the extension API before inventing a workaround.
 4. Define `setup(tau)` and use documented registration APIs; do not reach into private session or Textual internals.
 5. Keep extension behavior out of `tau_agent`; extensions belong to `tau_coding`. Use `tau_agent` types for portable messages and tools, and keep Textual behind Tau's UI adapter APIs.
-6. Put user extensions in `~/.tau/extensions/`. Project extensions require explicit trust through `--project-extensions`; never enable one from an untrusted repository. Use `tau -x PATH` for isolated testing.
+6. Put user extensions in `~/.tau/extensions/`. Project extensions require explicit trust through `--project-extensions`; never enable one from an untrusted repository. Use `tau -e PATH` for isolated testing.
 7. Test through the real extension runtime so discovery, imports, and `setup` registration are exercised. For Tau core changes, add deterministic tests with fake providers/tools and cover reload and lifecycle behavior when applicable.
 8. Run focused tests followed by the repository's full pytest, Ruff, formatting, and mypy checks.
 9. Update `website/content/guides/extensions.md` and add a development note for user-facing architectural changes.

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -4,7 +4,9 @@
     "date": "2026-07-22",
     "sections": {
       "Changed": [
-        "Breaking: rename the non-interactive `tau --resume <session-id>` flag to `tau --session <session-id>`, matching Pi's `--session` naming; `--resume` now errors with a migration hint instead of resuming."
+        "Breaking: mirror Pi's non-interactive CLI flags. `--resume` is now `--session`, `-p`/`--prompt <text>` is now `-p`/`--print` with a positional prompt, `-o`/`--output` is now `--mode`, and `-x` is now `-e` for `--extension`; the old flags now error with a migration hint instead of running.",
+        "Add a top-level `--export <session-id> [out]` flag alongside the existing `tau export` subcommand, and add `-v` as a short flag for `--version`, both matching Pi's flag names.",
+        "Merge piped stdin into the print-mode prompt (e.g. `cat file | tau -p \"...\"`), matching Pi's behavior."
       ]
     }
   },

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "0.3.0",
+    "date": "2026-07-22",
+    "sections": {
+      "Changed": [
+        "Breaking: rename the non-interactive `tau --resume <session-id>` flag to `tau --session <session-id>`, matching Pi's `--session` naming; `--resume` now errors with a migration hint instead of resuming."
+      ]
+    }
+  },
+  {
     "version": "0.2.4",
     "date": "2026-07-21",
     "sections": {

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6019,7 +6019,7 @@ async def run_tui_app(
 ) -> str | None:
     """Run the Textual app and return the active id when its session is persisted."""
     if new_session and session_id is not None:
-        raise RuntimeError("--resume and --new-session cannot be used together")
+        raise RuntimeError("--session and --new-session cannot be used together")
 
     provider_settings = load_provider_settings()
     shell_settings = load_shell_settings()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -738,7 +738,7 @@ def test_default_tui_invokes_tui_runner_with_flags(
             "fake",
             "--provider",
             "local",
-            "--resume",
+            "--session",
             "session-1",
             "--auto-compact-threshold",
             "1000",
@@ -749,7 +749,23 @@ def test_default_tui_invokes_tui_runner_with_flags(
     assert calls == [("fake", tmp_path, "session-1", False, "local", 1000, None)]
 
 
-def test_default_tui_rejects_resume_with_new_session(tmp_path: Path) -> None:
+def test_default_tui_rejects_session_with_new_session(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "--cwd",
+            str(tmp_path),
+            "--session",
+            "session-1",
+            "--new-session",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--session and --new-session cannot be used together" in _strip_ansi(result.output)
+
+
+def test_legacy_resume_flag_errors_with_migration_hint(tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app,
         [
@@ -757,12 +773,13 @@ def test_default_tui_rejects_resume_with_new_session(tmp_path: Path) -> None:
             str(tmp_path),
             "--resume",
             "session-1",
-            "--new-session",
         ],
     )
 
     assert result.exit_code != 0
-    assert "--resume and --new-session cannot be used together" in _strip_ansi(result.output)
+    output = _strip_ansi(result.output)
+    assert "--resume was renamed to --session" in output
+    assert "session-1" in output
 
 
 def _constrained_provider_settings() -> ProviderSettings:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,7 +279,7 @@ def test_cli_prints_resume_hint_after_tui_exit(
     result = CliRunner().invoke(app, [])
 
     assert result.exit_code == 0
-    assert result.stdout == "To resume this session: tau --resume session-123\n"
+    assert result.stdout == "To resume this session: tau --session session-123\n"
 
 
 def test_cli_suppresses_resume_hint_without_persisted_session(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -862,6 +862,30 @@ def test_print_mode_merges_piped_stdin_into_prompt(monkeypatch: pytest.MonkeyPat
     assert calls == ["piped content\n\n\nSummarize"]
 
 
+def test_print_mode_accepts_stdin_only_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        *extra: object,
+    ) -> bool:
+        del model, cwd, output, provider_name, extra
+        calls.append(prompt)
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["-p"], input="piped content\n")
+
+    assert result.exit_code == 0
+    assert calls == ["piped content\n"]
+
+
 def test_export_flag_invokes_exporter(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,7 +206,7 @@ def test_json_print_mode_suppresses_update_notice(monkeypatch: pytest.MonkeyPatc
     )
     monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
 
-    result = CliRunner().invoke(app, ["-p", "hello", "--output", "json"])
+    result = CliRunner().invoke(app, ["-p", "--mode", "json", "hello"])
 
     assert result.exit_code == 0
     assert result.stderr == ""
@@ -780,6 +780,124 @@ def test_legacy_resume_flag_errors_with_migration_hint(tmp_path: Path) -> None:
     output = _strip_ansi(result.output)
     assert "--resume was renamed to --session" in output
     assert "session-1" in output
+
+
+def test_legacy_prompt_flag_errors_with_migration_hint() -> None:
+    result = CliRunner().invoke(app, ["--prompt", "hello"])
+
+    assert result.exit_code != 0
+    output = _strip_ansi(result.output)
+    assert "--prompt was removed" in output
+    assert "--print" in output
+
+
+def test_legacy_output_flag_errors_with_migration_hint() -> None:
+    result = CliRunner().invoke(app, ["-p", "--output", "json", "hello"])
+
+    assert result.exit_code != 0
+    output = _strip_ansi(result.output)
+    assert "--output was renamed to --mode" in output
+
+
+def test_legacy_extension_short_flag_errors_with_migration_hint(tmp_path: Path) -> None:
+    result = CliRunner().invoke(app, ["-x", str(tmp_path)])
+
+    assert result.exit_code != 0
+    output = _strip_ansi(result.output)
+    assert "-x was renamed to -e/--extension" in output
+
+
+def test_mode_flag_alone_triggers_print_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, PrintOutputMode]] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        *extra: object,
+    ) -> bool:
+        del model, cwd, provider_name, extra
+        calls.append((prompt, output))
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["--mode", "json", "hello"])
+
+    assert result.exit_code == 0
+    assert calls == [("hello", PrintOutputMode.json)]
+
+
+def test_print_mode_requires_a_prompt() -> None:
+    result = CliRunner().invoke(app, ["-p"])
+
+    assert result.exit_code != 0
+    assert "Usage: tau --print" in _strip_ansi(result.output)
+
+
+def test_print_mode_merges_piped_stdin_into_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        *extra: object,
+    ) -> bool:
+        del model, cwd, output, provider_name, extra
+        calls.append(prompt)
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["-p", "Summarize"], input="piped content\n")
+
+    assert result.exit_code == 0
+    assert calls == ["piped content\n\n\nSummarize"]
+
+
+def test_export_flag_invokes_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, Path | None, str | None]] = []
+    output_path = tmp_path / "out.html"
+
+    async def fake_export_session_command(
+        session_ref: str,
+        requested_output_path: Path | None = None,
+        requested_export_format: str | None = None,
+    ) -> Path:
+        calls.append((session_ref, requested_output_path, requested_export_format))
+        return output_path
+
+    monkeypatch.setattr(cli, "export_session_command", fake_export_session_command)
+
+    result = CliRunner().invoke(app, ["--export", "session-1", str(output_path)])
+
+    assert result.exit_code == 0
+    assert calls == [("session-1", output_path, None)]
+    assert f"Exported session to {output_path}" in result.stdout
+
+
+def test_export_flag_rejects_combination_with_print() -> None:
+    result = CliRunner().invoke(app, ["--export", "-p", "session-1"])
+
+    assert result.exit_code != 0
+    assert "--export cannot be combined with --print/--mode" in _strip_ansi(result.output)
+
+
+def test_version_short_flag_prints_version() -> None:
+    result = CliRunner().invoke(app, ["-v"])
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("tau ")
 
 
 def _constrained_provider_settings() -> ProviderSettings:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -336,7 +336,7 @@ def test_manifest_empty_list_falls_back_to_extension_py(tmp_path: Path) -> None:
 
 
 def test_explicit_file_path_to_package_entry_cannot_reach_siblings(tmp_path: Path) -> None:
-    """`-x` on an entry *file* loads it standalone: relative imports fail.
+    """`-e` on an entry *file* loads it standalone: relative imports fail.
 
     Package extensions must be loaded through their directory (or a manifest);
     this pins the failure mode the docs warn about.

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -503,7 +503,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.2.4" in console.export_text()
+    assert "τ = 2π  0.3.0" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -48,7 +48,7 @@ defining `setup(tau)`, which runs once at startup with the extension API.
 |---|---|
 | `~/.tau/extensions/` | by default |
 | `<project>/.tau/extensions/` | only with `--project-extensions` |
-| any file or directory | with `tau -x PATH` (repeatable) |
+| any file or directory | with `tau -e PATH` (repeatable) |
 
 Within a directory, `*.py` files are extensions, and a subdirectory
 containing `extension.py` is a package-style extension — its sibling
@@ -70,14 +70,14 @@ directory, so sibling modules stay importable with relative imports. The
 extension is named after the entry's parent directory (or after the file
 itself when it isn't named `extension.py`).
 
-One caveat: `tau -x` on an entry **file** loads it standalone — no
+One caveat: `tau -e` on an entry **file** loads it standalone — no
 package, so relative imports fail. Once an extension has sibling
 modules, always pass a directory: the package directory itself, or the
 repo root when a manifest declares the entry.
 
 Extensions load project-first; on name conflicts (extension names, tool
 names, command names) the first registration wins. `--no-extensions`
-disables directory discovery entirely (explicit `-x` paths still load).
+disables directory discovery entirely (explicit `-e` paths still load).
 `/reload` awaits `session_shutdown(reason="reload")` on the outgoing
 extension generation, clears its UI, re-imports every extension and re-runs
 `setup`, then awaits `session_start(reason="reload")` on the new generation.
@@ -497,7 +497,7 @@ package that feature-detects newer API seams).
 
 ```bash
 git clone git@github.com:rian-dolphin/tau-subagents.git
-tau -x ./tau-subagents
+tau -e ./tau-subagents
 # then: "Use a subagent to summarize this repository's architecture."
 ```
 

--- a/website/content/guides/print-mode.md
+++ b/website/content/guides/print-mode.md
@@ -13,32 +13,49 @@ questions.
 tau -p "summarize the changes in the last commit"
 ```
 
-The `-p` / `--prompt` flag is what switches Tau into print mode. It still uses
-the full coding-session environment — the same tools, project context, and
-session storage as the TUI — so its turns are saved under `~/.tau/sessions/` too.
+The `-p` / `--print` flag switches Tau into print mode; the prompt itself is a
+plain positional argument, the same as an initial prompt for the TUI. Print
+mode still uses the full coding-session environment — the same tools, project
+context, and session storage as the TUI — so its turns are saved under
+`~/.tau/sessions/` too.
+
+Put flags **before** the prompt. Tau accepts multi-word prompts without
+quoting, so anything after the last recognized flag — including tokens that
+look like other flags — is treated as prompt text:
+
+```bash
+tau -p --mode json "list the public functions in src/app.py"
+```
 
 ## Output formats
 
-Choose how results are written with `-o` / `--output`:
+Choose how results are written with `--mode`. Passing `--mode` on its own also
+switches Tau into non-interactive mode, so `-p` is optional once `--mode` is set:
 
 ```bash
-tau -p "list the public functions in src/app.py" -o text        # default, human-readable
-tau -p "list the public functions in src/app.py" -o json        # JSON, for parsing
-tau -p "list the public functions in src/app.py" -o transcript  # structured transcript
+tau -p --mode text "list the public functions in src/app.py"        # default, human-readable
+tau --mode json "list the public functions in src/app.py"           # JSON, for parsing
+tau -p --mode transcript "list the public functions in src/app.py"  # structured transcript
 ```
 
 - **text** — plain text with ANSI styling, for reading.
 - **json** — machine-readable, for piping into other tools.
 - **transcript** — a structured record of the turn.
 
+Piped stdin is merged into the prompt, so you can feed file contents in:
+
+```bash
+cat README.md | tau -p "Summarize this text"
+```
+
 ## Choosing provider, model, and directory
 
 The same selection flags work in print mode:
 
 ```bash
-tau -p "explain this module" -m gpt-5.5
+tau -m gpt-5.5 -p "explain this module"
 tau --provider local -p "explain this module"
-tau -p "audit for secrets" --cwd ./services/api
+tau --cwd ./services/api -p "audit for secrets"
 ```
 
 ## Exit status
@@ -46,7 +63,7 @@ tau -p "audit for secrets" --cwd ./services/api
 Print mode exits non-zero if the run fails, so you can use it in scripts:
 
 ```bash
-if tau -p "do the tests pass? answer yes or no" -o text | grep -qi yes; then
+if tau --mode text -p "do the tests pass? answer yes or no" | grep -qi yes; then
   echo "looks good"
 fi
 ```

--- a/website/content/guides/print-mode.md
+++ b/website/content/guides/print-mode.md
@@ -48,6 +48,13 @@ Piped stdin is merged into the prompt, so you can feed file contents in:
 cat README.md | tau -p "Summarize this text"
 ```
 
+A piped body can also be the entire prompt — `tau -p` with no positional text
+and piped stdin is valid:
+
+```bash
+cat README.md | tau -p
+```
+
 ## Choosing provider, model, and directory
 
 The same selection flags work in print mode:

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -41,7 +41,7 @@ When you quit the TUI and the session was persisted, Tau prints a reminder of
 the exact command to resume it:
 
 ```text
-To resume this session: tau --resume <session-id>
+To resume this session: tau --session <session-id>
 ```
 
 ## Branching from history (`/tree`)

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -20,7 +20,7 @@ Each row shows the session id, title, model, and working directory.
 From the shell:
 
 ```bash
-tau --resume <session-id>
+tau --session <session-id>
 ```
 
 From inside the TUI:

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -120,7 +120,7 @@ tau sessions
 Resume the most recent one for this directory, or pick from a list:
 
 ```bash
-tau --resume <session-id>
+tau --session <session-id>
 ```
 
 …or open the picker inside the TUI with `/resume`. See

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -43,7 +43,7 @@ features and fixes.
 | `--provider TEXT` | Configured provider name to use |
 | `--cwd PATH` | Working directory for the built-in tools |
 | `-o, --output [text\|json\|transcript]` | Output mode for print mode (default `text`) |
-| `--resume TEXT` | Resume a session id in the TUI |
+| `--session TEXT` | Resume a session id in the TUI |
 | `--new-session` | Start a new session instead of resuming the default |
 | `--auto-compact-threshold INT` | Auto-compact above this rough token estimate |
 | `-x, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -12,7 +12,8 @@ tau [OPTIONS] [PROMPT] [COMMAND] [ARGS]
 
 - With no arguments, `tau` opens the interactive [TUI]({{< relref "../guides/tui.md" >}}).
 - A positional `PROMPT` opens the TUI and submits it as the first turn.
-- `-p/--prompt` runs a single prompt in [print mode]({{< relref "../guides/print-mode.md" >}}).
+- `-p/--print` (or `--mode`) runs that same positional prompt in [print mode]({{< relref "../guides/print-mode.md" >}}) instead of the TUI.
+- Put flags before the prompt — Tau treats everything after the last recognized flag as prompt text, including tokens that look like flags.
 
 On TUI and text print-mode startup, Tau may show a non-blocking notice when a
 newer `tau-ai` release is available on PyPI. In the TUI, this notice is the first
@@ -31,6 +32,7 @@ features and fixes.
 | `tau update` | Upgrade Tau with the installer that owns its environment |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |
+| `tau --export <ref> [dest]` | Same as `tau export`, as a top-level flag |
 | `tau providers` | List configured providers and how each authenticates |
 | `tau [setup options] setup` | Create/update an OpenAI-compatible provider |
 
@@ -38,18 +40,22 @@ features and fixes.
 
 | Flag | Description |
 | --- | --- |
-| `-p, --prompt TEXT` | Run this prompt in non-interactive print mode |
+| `-p, --print` | Run the positional prompt in non-interactive print mode |
 | `-m, --model TEXT` | Model to request from the provider |
 | `--provider TEXT` | Configured provider name to use |
 | `--cwd PATH` | Working directory for the built-in tools |
-| `-o, --output [text\|json\|transcript]` | Output mode for print mode (default `text`) |
+| `--mode [text\|json\|transcript]` | Output mode for print mode (default `text`); also triggers print mode on its own |
 | `--session TEXT` | Resume a session id in the TUI |
 | `--new-session` | Start a new session instead of resuming the default |
 | `--auto-compact-threshold INT` | Auto-compact above this rough token estimate |
-| `-x, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |
-| `--no-extensions` | Disable extension directory discovery (explicit `-x` paths still load) |
+| `-e, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |
+| `--no-extensions` | Disable extension directory discovery (explicit `-e` paths still load) |
 | `--project-extensions` | Also load `<project>/.tau/extensions` (runs project-supplied code at startup) |
-| `--version` | Print the version and exit |
+| `-v, --version` | Print the version and exit |
+
+`--resume`, `--prompt`, `-o/--output`, and `-x` are removed; each now exits
+with an error naming its replacement (`--session`, `--print`, `--mode`, and
+`-e/--extension`, respectively).
 
 ### Provider setup options
 


### PR DESCRIPTION
## Summary

Mirrors Pi's non-interactive CLI flag surface (see [Pi's CLI reference](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md#cli-reference)). This started as a single-flag rename and grew, in place, into a full audit-and-fix of every divergence called out in #439.

This is a **breaking change**, so the version is bumped `0.2.4` -> `0.3.0` with a release-notes entry.

Closes #439.

## What changed

| Tau (before) | Tau (now) | Notes |
|---|---|---|
| `--resume <id>` | `--session <id>` | Matches Pi's `--session <path\|id>`. Id only for now. |
| `-p, --prompt <text>` | `-p, --print` (boolean) + positional prompt | Matches Pi's `-p, --print`; prompt is the same positional the TUI already uses for an initial prompt. |
| `-o, --output <text\|json\|transcript>` | `--mode <text\|json\|transcript>` | Matches Pi's `--mode` name. Tau keeps its own value set (no RPC mode; Pi has no `transcript`) — see audit below. `--mode` alone also triggers print mode, like `pi --mode json "prompt"`. |
| `-x, --extension <path>` | `-e, --extension <path>` | Matches Pi's `-e`. |
| `tau export <id> [out]` (subcommand only) | subcommand **+** `tau --export <id> [out]` | Added the flag form to match Pi's `--export`; kept the subcommand since it fits Tau's other subcommands. |
| `--version` | `--version`, `-v` | Added Pi's `-v` short flag. |
| (none) | piped stdin merges into the print-mode prompt | Mirrors `cat file \| pi -p "..."`. |

Every renamed/removed flag keeps a **hidden** alias under the old name that raises a clear migration error (e.g. `--resume was renamed to --session. Use \`tau --session <id>\` instead.`) instead of Typer's generic "no such option".

**Flag ordering:** Tau accepts unquoted multi-word prompts as trailing positional args, which means everything after the last recognized flag — including flag-looking tokens — becomes prompt text. Put flags before the prompt (`tau -p --mode json "..."`, not `tau -p "..." --mode json`). This matches Pi's own documented usage.

## How it improves user experience

- Pi users get a consistent flag surface across the two tools for every non-interactive flag that has a real Tau equivalent.
- Users of the old flags get a friendly migration error instead of Typer's generic failure.
- `cat file | tau -p "..."` now works, matching a documented Pi workflow.

## Full flag audit (Tau vs Pi)

Full detail in [`dev-notes/cli-mirror-pi-flags.md`](https://github.com/huggingface/tau/blob/mirror-pi-cli-flags/dev-notes/cli-mirror-pi-flags.md):

| Tau (current) | Pi | Disposition |
|---|---|---|
| `--session <id>` | `--session <path\|id>` | **Fixed.** Id only for now; path support left as a follow-up. Pi's own no-argument `-r/--resume` picker is not adopted — Tau's picker lives in the TUI's `/resume` slash command. |
| `-p, --print` | `-p, --print` | **Fixed.** |
| `--mode <text\|json\|transcript>` | `--mode json\|rpc` | **Flag name fixed; value set intentionally kept.** No RPC mode in Tau (a process-integration protocol, out of scope here); no `transcript` mode in Pi. |
| `-e, --extension` | `-e, --extension` | **Fixed.** |
| `tau export` / `tau --export` | `--export <in> [out]` | **Fixed by addition**, subcommand form kept for consistency with `sessions`/`providers`/`setup`/`update`. |
| `-v, --version` | `-v, --version` | **Fixed.** |

Reserved for future Pi parity (not implemented, not to be squatted on with different semantics): `-c/--continue`, `--fork`, `--no-session`, `--name/-n`, `--session-dir`, `--mode rpc`.

## Notes

- Issue #438's exit resume hint (merged as #441) is updated in this branch to print `tau --session <id>` (see the earlier commit on this branch).
- The in-TUI `/resume` slash command is unaffected.

## How to validate manually

```bash
tau -p "hello"                                  # print mode, text output
tau -p --mode json "hello"                       # print mode, JSON output
tau --mode json "hello"                          # --mode alone also triggers print mode
cat README.md | tau -p "summarize this"          # stdin merged into the prompt
tau -e ./my-extension.py "hello"                 # load an extension
tau --export <session-id> out.html               # export via the flag form
tau --session <session-id>                        # resume a session
tau -v                                            # short version flag

# legacy flags all error with a migration hint:
tau --resume x
tau --prompt x
tau -o json -p x
tau -x .
```

## Checks run locally

```bash
uv run pytest         # 1098 passed
uv run ruff check .    # All checks passed
uv run ruff format --check .  # all formatted
uv run mypy            # Success: no issues found in 92 source files
```
