### PR TITLE
feat: print resume hint after TUI exit

### DIFF
--- a/dev-notes/exit-resume-hint.md
+++ b/dev-notes/exit-resume-hint.md
@@ -1,0 +1,57 @@
+# Exit resume hint
+
+## What
+
+When the interactive TUI exits and the session was persisted, Tau now prints
+a one-line reminder of how to resume it:
+
+```text
+To resume this session: tau --resume <session-id>
+```
+
+This mirrors Pi's exit-time hint (`To resume this session: pi --session
+[session id]`), adapted to Tau's actual resume flag (`tau --resume
+<session-id>` rather than `--session`).
+
+## Why
+
+Closing the TUI previously gave no indication of how to pick the
+conversation back up. New users in particular had to already know about
+`tau --resume <id>` or `tau sessions`. A short, low-friction hint at exit
+closes that gap without adding new UI surface.
+
+See [issue #438](https://github.com/huggingface/tau/issues/438) for the
+original request and discussion.
+
+## How it maps to the architecture
+
+Per `AGENTS.md`, `tau_agent` stays UI-agnostic; this hint is purely a
+`tau_coding` (CLI/TUI) concern:
+
+- `src/tau_coding/tui/app.py`: `run_tui_app` now returns `str | None` — the
+  active session id, but only if that session is actually persisted/indexed
+  (`manager.get_session(active_session_id) is not None`). Ephemeral or
+  never-persisted sessions return `None`, and the hint is suppressed.
+- `src/tau_coding/cli.py`: `run_openai_tui` forwards that return value.
+  `main()` captures it from `anyio.run(...)` as `resumable_session_id` and,
+  after the TUI has fully exited (session/provider cleanup complete), prints
+  the hint via `typer.echo` before raising `typer.Exit()`.
+
+No new state or side channel was introduced — the resumable session id is
+threaded back through existing return values.
+
+## Scope
+
+This only covers the interactive TUI exit path. Print mode
+(`tau -p`/`run_openai_print_mode`) is a single-shot, already-scripted
+invocation and was left out of scope — see the issue for that discussion.
+
+## How to test/use it
+
+- Automated: `tests/test_cli.py::test_cli_prints_resume_hint_after_tui_exit`
+  and `test_cli_suppresses_resume_hint_without_persisted_session` exercise
+  the CLI-level behavior with a fake `run_openai_tui`.
+- Manual: run `tau`, send at least one message (so the session persists),
+  then quit (`Ctrl+C` / `/quit`). The shell should print the resume hint
+  with the real session id. Starting `tau` and exiting immediately, before
+  any session-worthy activity, should print nothing.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -296,7 +296,7 @@ def main(
     if prompt_option is None:
         notice = _startup_update_notice()
         try:
-            anyio.run(
+            resumable_session_id = anyio.run(
                 run_openai_tui,
                 model,
                 cwd or Path.cwd(),
@@ -312,6 +312,8 @@ def main(
             )
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
+        if resumable_session_id is not None:
+            typer.echo(f"To resume this session: tau --resume {resumable_session_id}")
         raise typer.Exit()
 
     prompt = prompt_option
@@ -353,11 +355,11 @@ async def run_openai_tui(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
-) -> None:
-    """Run the Textual TUI with the default OpenAI-compatible provider."""
+) -> str | None:
+    """Run the Textual TUI and return its resumable session id, if any."""
     release_notes_notice = startup_release_notes_notice(_current_version())
     startup_notices = (release_notes_notice.message,) if release_notes_notice is not None else ()
-    await run_tui_app(
+    return await run_tui_app(
         model=model,
         cwd=cwd,
         session_id=session_id,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5994,8 +5994,8 @@ async def run_tui_app(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
-) -> None:
-    """Create the default provider/session and run the Textual app."""
+) -> str | None:
+    """Run the Textual app and return the active id when its session is persisted."""
     if new_session and session_id is not None:
         raise RuntimeError("--resume and --new-session cannot be used together")
 
@@ -6094,3 +6094,8 @@ async def run_tui_app(
             if close_session is not None:
                 await close_session()
         await provider.aclose()
+
+    active_session_id: str | None = getattr(session, "session_id", None)
+    if active_session_id is None or manager.get_session(active_session_id) is None:
+        return None
+    return active_session_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,39 @@ def test_cli_without_prompt_invokes_tui_runner(
     assert calls == [(None, tmp_path, None, False, None, None, None)]
 
 
+def test_cli_prints_resume_hint_after_tui_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> str:
+        del args, kwargs
+        return "session-123"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, [])
+
+    assert result.exit_code == 0
+    assert result.stdout == "To resume this session: tau --resume session-123\n"
+
+
+def test_cli_suppresses_resume_hint_without_persisted_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, [])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
 def test_cli_positional_prompt_invokes_tui_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7349,6 +7349,101 @@ async def test_run_tui_app_creates_new_session_by_default(
 
 
 @pytest.mark.anyio
+async def test_run_tui_app_returns_session_id_when_persisted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    record = CodingSessionRecord(
+        id="new-session",
+        path=tmp_path / "new-session.jsonl",
+        cwd=tmp_path,
+        model="fake-model",
+        title=None,
+        created_at=1.0,
+        updated_at=1.0,
+    )
+
+    class FakeProvider:
+        async def aclose(self) -> None:
+            return None
+
+    class FakeManager:
+        def __init__(self) -> None:
+            self.persisted = False
+
+        def prepare_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            return record
+
+        def get_session(self, session_id: str) -> CodingSessionRecord | None:
+            return record if self.persisted else None
+
+    class FakeSession:
+        session_id = "new-session"
+
+        async def aclose(self) -> None:
+            return None
+
+    class FakeCodingSession:
+        @classmethod
+        async def load(cls, config: object) -> FakeSession:
+            return FakeSession()
+
+    class FakeApp:
+        def __init__(self, session: FakeSession, **kwargs: object) -> None:
+            pass
+
+        async def run_async(self) -> None:
+            return None
+
+    settings = ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=("local-model",),
+                default_model="local-model",
+            ),
+        ),
+    )
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(
+        tui_app,
+        "create_model_provider",
+        lambda provider, **kwargs: FakeProvider(),
+    )
+    monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
+    monkeypatch.setattr(tui_app, "TauTuiApp", FakeApp)
+    monkeypatch.setattr(tui_app, "load_tui_settings", lambda: TuiSettings())
+
+    manager = FakeManager()
+    manager.persisted = False
+    result = await tui_app.run_tui_app(
+        model=None,
+        cwd=tmp_path,
+        provider_name="local",
+        session_manager=manager,
+    )
+    assert result is None
+
+    manager.persisted = True
+    result = await tui_app.run_tui_app(
+        model=None,
+        cwd=tmp_path,
+        provider_name="local",
+        session_manager=manager,
+    )
+    assert result == "new-session"
+
+
+@pytest.mark.anyio
 async def test_run_tui_app_opens_when_provider_login_is_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -37,6 +37,13 @@ pick a session.
 To deliberately start fresh instead of resuming, use `tau --new-session` (or
 `/new` in the TUI).
 
+When you quit the TUI and the session was persisted, Tau prints a reminder of
+the exact command to resume it:
+
+```text
+To resume this session: tau --resume <session-id>
+```
+
 ## Branching from history (`/tree`)
 
 A session is a *tree*, not just a line — so you can go back and try a different


### PR DESCRIPTION
## Summary

Print a one-line reminder of how to resume the session after the
interactive TUI exits, mirroring Pi's exit-time behavior but using Tau's
actual resume syntax.

```text
To resume this session: tau --resume <session-id>
```

## UX improvement

Previously, closing the TUI gave no indication of how to pick the
conversation back up — users had to already know about `tau --resume <id>`
or `tau sessions`. This hint closes that gap with a low-friction message
printed right after exit, only when there's actually something to resume.

The hint is suppressed for sessions that were never persisted/indexed (for
example, quitting immediately with no session-worthy activity), so it never
points at a dangling id.

## Scope

This covers the interactive TUI exit path only. Print mode (`tau -p`) is a
single-shot, already-scripted invocation, so it's left out of scope — see
the issue for that discussion.

## Implementation

Per `AGENTS.md`, `tau_agent` stays UI-agnostic; this lives entirely in
`tau_coding`:

- `src/tau_coding/tui/app.py`: `run_tui_app` now returns `str | None` — the
  active session id, but only if `SessionManager.get_session(...)` confirms
  it was actually persisted/indexed.
- `src/tau_coding/cli.py`: `run_openai_tui` forwards that value; `main()`
  captures it and prints the hint via `typer.echo` after the TUI has fully
  torn down (session/provider cleanup complete).

No new state or side channel — the resumable session id is threaded back
through existing return values.

## Closes

Closes #438

## Manual validation

1. `tau` in a project directory, send at least one message so the session
   persists, then quit (`Ctrl+C` / `/quit`).
   - Expect: `To resume this session: tau --resume <session-id>` printed to
     the shell after exit.
2. `tau`, then quit immediately before any session-worthy activity.
   - Expect: no resume hint printed.
3. `tau --resume <id>` an existing session, exit again.
   - Expect: the hint reprints the same session id.

## Checks run locally

- `uv run pytest` — 1088 passed
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 135 files already formatted
- `uv run mypy` — no issues found
