### PR TITLE
fix: surface and retry transient Codex in-stream errors

### DIFF
--- a/dev-notes/architecture/provider-retries.md
+++ b/dev-notes/architecture/provider-retries.md
@@ -22,6 +22,15 @@ transient status codes such as `408`, `409`, `429`, and `5xx` responses before
 surfacing a final provider error. The default is two retries, for three total
 request attempts.
 
+The OpenAI Codex adapter also retries transient *in-stream* failures. The Codex
+Responses endpoint can return HTTP 200 and then send an SSE `error` or
+`response.failed` event (for example `server_is_overloaded`). When such an event
+arrives before any content or thinking deltas, the adapter classifies it against
+transient markers (overloaded, service unavailable, rate limit, internal/server
+errors, timeouts), emits `ProviderRetryEvent`, and reissues the request under
+the same `max_retries` budget. Errors after partial content, and non-transient
+errors such as `invalid_api_key`, stay terminal.
+
 Backoff is short, exponential, and capped by `max_retry_delay_seconds`.
 Cancellation is checked during the backoff delay so Escape/TUI cancellation does
 not wait for the entire retry sleep to finish.

--- a/dev-notes/codex-stream-error-recovery.md
+++ b/dev-notes/codex-stream-error-recovery.md
@@ -1,0 +1,58 @@
+# Codex in-stream error recovery
+
+## What changed
+
+The OpenAI Codex provider now surfaces the real failure behind SSE `error`
+events, retries transient ones automatically, and records the provider's error
+classification in the diagnostic log. After a terminal provider error, the TUI
+also states that the run ended and can be retried by sending another message.
+
+## Why it exists
+
+A production Codex session failed twice with
+`Error: OpenAI Codex returned an error` and no further detail. The session file
+showed the provider had sent an HTTP 200 stream containing:
+
+```json
+{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null},"sequence_number":2}
+```
+
+Three gaps compounded:
+
+1. `_error_message()` only read top-level `message`/`code` fields, so nested
+   `error.message` text never reached the user — only the generic fallback did.
+2. In-stream errors on HTTP 200 were always terminal; the retry loop only
+   covered HTTP statuses and transport exceptions, so a brief overload window
+   ended the run immediately.
+3. `agent-calls.jsonl` recorded only the (generic) error message, dropping the
+   nested `type`/`code` that explain the failure.
+
+## Architecture
+
+The fix preserves Tau's layer boundaries:
+
+- `tau_ai.openai_codex` extracts `(code, message)` from all Codex error shapes
+  (top-level fields, nested `error`, and `response.error` for
+  `response.failed`). Transient in-stream errors that arrive before any content
+  or thinking deltas are retried under the existing `max_retries` budget, with
+  the usual backoff, `ProviderRetryEvent` progress, and cancellation checks.
+  Retry classification stays in the provider adapter; `tau_agent` only forwards
+  events.
+- `tau_coding.diagnostics` copies only non-secret scalar fields (`type`,
+  `code`, `message`, `sequence_number`, status code, attempt count) from the
+  provider event into `agent-calls.jsonl`. Bodies and full payloads stay out.
+- `tau_coding.tui.app` appends "Run ended before completion. Send a message to
+  retry." to terminal error blocks, except for context-overflow errors, which
+  Tau already auto-compacts and retries.
+
+## How to test
+
+```bash
+uv run pytest tests/test_tau_ai.py -k codex
+uv run pytest tests/test_coding_session.py -k stream_error
+uv run pytest tests/test_tui_app.py -k prompt_worker
+```
+
+Manual check: configure `openai-codex` with `max_retries: 2` and prompt during
+a Codex overload window. Tau retries quietly, and if the overload persists the
+error block shows the provider's own message plus the log path and retry hint.

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -167,6 +167,7 @@ class OpenAICodexProvider:
             attempt = 0
             while True:
                 emitted_content = False
+                emitted_thinking = False
                 try:
                     credentials = await self._config.credential_resolver()
                     headers = _build_codex_headers(
@@ -223,14 +224,43 @@ class OpenAICodexProvider:
                             return
 
                         yield ProviderResponseStartEvent(model=model)
+                        stream_error: dict[str, JSONValue] | None = None
                         async for event in _codex_provider_events(response, signal=signal):
                             if isinstance(
                                 event,
                                 ProviderTextDeltaEvent | ProviderToolCallEvent,
                             ):
                                 emitted_content = True
+                            elif isinstance(event, ProviderThinkingDeltaEvent):
+                                emitted_thinking = True
+                            if (
+                                isinstance(event, ProviderErrorEvent)
+                                and not emitted_content
+                                and not emitted_thinking
+                                and self._should_retry(attempt)
+                                and _retryable_stream_error_event(event)
+                            ):
+                                stream_error = _stream_error_event_data(event)
+                                break
                             yield event
-                        return
+                        if stream_error is None:
+                            return
+                        code, _message = _stream_error_details(stream_error)
+                        delay = retry_delay_seconds(
+                            attempt,
+                            max_delay_seconds=self._config.max_retry_delay_seconds,
+                        )
+                        yield provider_retry_event(
+                            attempt=attempt,
+                            max_retries=self._config.max_retries,
+                            delay_seconds=delay,
+                            reason=f"stream error ({code or 'unknown'})",
+                            data={"event": stream_error},
+                        )
+                        attempt += 1
+                        if not await wait_for_retry(delay, signal=signal):
+                            return
+                        continue
                 except httpx.HTTPError as exc:
                     if not emitted_content and self._should_retry(attempt):
                         delay = retry_delay_seconds(
@@ -790,27 +820,90 @@ def _usage_from_response(event: Mapping[str, Any]) -> Usage | None:
 
 
 def _response_error_message(event: Mapping[str, Any]) -> str:
-    response = event.get("response")
-    if isinstance(response, Mapping):
-        error = response.get("error")
-        if isinstance(error, Mapping):
-            message = error.get("message")
-            code = error.get("code")
-            if isinstance(message, str) and message:
-                return message
-            if isinstance(code, str) and code:
-                return f"OpenAI Codex response failed: {code}"
+    code, message = _stream_error_details(event)
+    if message:
+        return message
+    if code:
+        return f"OpenAI Codex response failed: {code}"
     return "OpenAI Codex response failed"
 
 
 def _error_message(event: Mapping[str, Any], *, fallback: str) -> str:
-    message = event.get("message")
-    if isinstance(message, str) and message:
+    code, message = _stream_error_details(event)
+    if message:
         return message
-    code = event.get("code")
-    if isinstance(code, str) and code:
+    if code:
         return code
     return fallback
+
+
+def _stream_error_details(event: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """Extract the machine code and human message from a Codex stream error.
+
+    Codex reports failures either as a top-level ``error`` SSE event with a
+    nested ``error`` object (``{"type":"error","error":{"code":...}}``) or
+    as ``response.failed`` with the failure under ``response.error``. Looking
+    only at top-level fields hides details such as ``server_is_overloaded``
+    behind a generic fallback message.
+    """
+    sources: list[Mapping[str, Any]] = [event]
+    nested = event.get("error")
+    if isinstance(nested, Mapping):
+        sources.append(nested)
+    response = event.get("response")
+    if isinstance(response, Mapping):
+        response_error = response.get("error")
+        if isinstance(response_error, Mapping):
+            sources.append(response_error)
+
+    message: str | None = None
+    code: str | None = None
+    for source in sources:
+        if message is None:
+            raw_message = source.get("message")
+            if isinstance(raw_message, str) and raw_message:
+                message = raw_message
+        if code is None:
+            raw_code = source.get("code")
+            if isinstance(raw_code, str) and raw_code:
+                code = raw_code
+    if code is None and isinstance(nested, Mapping):
+        nested_type = nested.get("type")
+        if isinstance(nested_type, str) and nested_type:
+            code = nested_type
+    return code, message
+
+
+_TRANSIENT_STREAM_ERROR_MARKERS = (
+    "overloaded",
+    "service_unavailable",
+    "temporarily_unavailable",
+    "rate_limit",
+    "internal_error",
+    "server_error",
+    "timeout",
+)
+
+
+def _stream_error_event_data(event: ProviderErrorEvent) -> dict[str, JSONValue] | None:
+    """Return the raw SSE event attached to a provider stream error."""
+    data = event.data
+    if not isinstance(data, dict):
+        return None
+    raw = data.get("event")
+    return raw if isinstance(raw, dict) else None
+
+
+def _retryable_stream_error_event(event: ProviderErrorEvent) -> bool:
+    """Return True when an in-stream Codex error looks transient and retryable."""
+    raw = _stream_error_event_data(event)
+    if raw is None:
+        return False
+    code, message = _stream_error_details(raw)
+    haystack = " ".join(part for part in (code, message) if part).lower()
+    if not haystack or _is_terminal_rate_limit(haystack):
+        return False
+    return any(marker in haystack for marker in _TRANSIENT_STREAM_ERROR_MARKERS)
 
 
 def _build_codex_headers(

--- a/src/tau_coding/diagnostics.py
+++ b/src/tau_coding/diagnostics.py
@@ -62,10 +62,14 @@ class AgentCallDiagnosticLogger:
     ) -> Path:
         """Log a terminal assistant error message with safe diagnostic details."""
         entry = _base_entry(context, phase=phase, kind="assistant_error")
-        entry["error"] = {
+        error: dict[str, Any] = {
             "message": message.error_message or "Error",
             "stop_reason": message.stop_reason,
         }
+        provider = _provider_error_details(message)
+        if provider:
+            error["provider"] = provider
+        entry["error"] = error
         self._append(entry)
         return self.path
 
@@ -78,6 +82,67 @@ class AgentCallDiagnosticLogger:
 def new_agent_call_run_id() -> str:
     """Return a stable id for one coding-session agent call."""
     return uuid4().hex
+
+
+_SAFE_ERROR_OBJECT_KEYS = ("type", "code", "message", "param")
+
+
+def _provider_error_details(message: AssistantMessage) -> dict[str, Any]:
+    """Extract non-secret provider failure details from message diagnostics.
+
+    Provider adapters attach the raw stream event to assistant diagnostics, but
+    that payload can be large. Only scalar classification fields (status codes,
+    attempt counts, and error type/code/message) are copied into the log so the
+    entry stays small and free of request or credential material.
+    """
+    for diagnostic in message.diagnostics or []:
+        if diagnostic.type != "provider_error" or not diagnostic.details:
+            continue
+        details: dict[str, Any] = {}
+        status_code = diagnostic.details.get("status_code")
+        if isinstance(status_code, int) and not isinstance(status_code, bool):
+            details["status_code"] = status_code
+        attempts = diagnostic.details.get("attempts")
+        if isinstance(attempts, int) and not isinstance(attempts, bool):
+            details["attempts"] = attempts
+        event = diagnostic.details.get("event")
+        if isinstance(event, dict):
+            event_details = _safe_stream_event_details(event)
+            if event_details:
+                details["event"] = event_details
+        return details
+    return {}
+
+
+def _safe_stream_event_details(event: dict[str, Any]) -> dict[str, Any]:
+    """Keep only non-secret scalar fields from a provider stream error event."""
+    details: dict[str, Any] = {}
+    event_type = event.get("type")
+    if isinstance(event_type, str) and event_type:
+        details["type"] = event_type
+    sequence_number = event.get("sequence_number")
+    if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
+        details["sequence_number"] = sequence_number
+    nested = _safe_error_object(event.get("error"))
+    if nested:
+        details["error"] = nested
+    response = event.get("response")
+    if isinstance(response, dict):
+        response_error = _safe_error_object(response.get("error"))
+        if response_error:
+            details["response_error"] = response_error
+    return details
+
+
+def _safe_error_object(value: object) -> dict[str, str]:
+    """Copy scalar classification fields from a provider error object."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: field
+        for key in _SAFE_ERROR_OBJECT_KEYS
+        if isinstance((field := value.get(key)), str) and field
+    }
 
 
 def _base_entry(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1588,7 +1588,7 @@ class CodingSession:
                         phase="agent_loop",
                         message=event.message,
                     )
-                    if _is_context_overflow_error(event.message):
+                    if is_context_overflow_error(event.message):
                         overflow_message = event.message
                 if isinstance(event, AgentEndEvent):
                     yield SessionAgentEndEvent(messages=event.messages, will_retry=False)
@@ -2125,7 +2125,8 @@ def _next_user_message_index(
     return None
 
 
-def _is_context_overflow_error(message: AssistantMessage) -> bool:
+def is_context_overflow_error(message: AssistantMessage) -> bool:
+    """Return True when an assistant error looks like a context overflow."""
     text = message.error_message or ""
     normalized = text.lower()
     markers = (

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -117,6 +117,7 @@ from tau_coding.session import (
     ModelChoice,
     SessionTreeBranchResult,
     SessionTreeChoice,
+    is_context_overflow_error,
     jsonl_session_storage,
     parse_terminal_command,
 )
@@ -4024,6 +4025,7 @@ class TauTuiApp(App[None]):
                     and event.message.stop_reason == "error"
                 ):
                     _attach_diagnostic_log_path_to_error(self.state, self.session)
+                    _attach_retry_hint_to_error(self.state, event.message)
                 await self._apply_streaming_transcript_event(event)
         except Exception as exc:  # noqa: BLE001 - surface unexpected worker errors in the TUI
             if active_run_id != self._prompt_run_id:
@@ -5847,6 +5849,26 @@ def _format_prompt_error(exc: BaseException, session: CodingSession) -> str:
     if isinstance(log_path, Path):
         return f"{message}\nLog: {log_path}"
     return message
+
+
+_TERMINAL_ERROR_RETRY_HINT = "Run ended before completion. Send a message to retry."
+
+
+def _attach_retry_hint_to_error(state: TuiState, message: AssistantMessage) -> None:
+    """Clarify that a terminal provider error ended the run and can be retried.
+
+    Context-overflow errors are auto-compacted and retried by the session, so
+    they are skipped to avoid asking the user to retry while Tau already is.
+    """
+    if is_context_overflow_error(message):
+        return
+    if state.error is not None and _TERMINAL_ERROR_RETRY_HINT not in state.error:
+        state.error = f"{state.error}\n{_TERMINAL_ERROR_RETRY_HINT}"
+    for item in reversed(state.items):
+        if item.role == "error":
+            if _TERMINAL_ERROR_RETRY_HINT not in item.text:
+                item.text = f"{item.text}\n{_TERMINAL_ERROR_RETRY_HINT}"
+            return
 
 
 def _attach_diagnostic_log_path_to_error(state: TuiState, session: CodingSession) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -19,7 +19,8 @@ from tau_agent import (
     ToolResultMessage,
     UserMessage,
 )
-from tau_agent.messages import assistant_content
+from tau_agent.messages import AssistantMessageDiagnostic, assistant_content
+from tau_agent.provider_events import AssistantErrorEvent
 from tau_agent.session import (
     CompactionEntry,
     JsonlSessionStorage,
@@ -315,6 +316,69 @@ async def test_prompt_logs_error_event_diagnostic_data(tmp_path: Path) -> None:
     assert entry["error"] == {
         "message": "provider failed",
         "stop_reason": "error",
+    }
+    assert "Hello" not in log_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_prompt_logs_safe_provider_stream_error_details(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    tau_paths = TauPaths(home=tmp_path / "tau-home", agents_home=tmp_path / "agents-home")
+    error = AssistantMessage(
+        stop_reason="error",
+        error_message="Our servers are currently overloaded. Please try again later.",
+        diagnostics=[
+            AssistantMessageDiagnostic(
+                type="provider_error",
+                details={
+                    "event": {
+                        "type": "error",
+                        "error": {
+                            "type": "service_unavailable_error",
+                            "code": "server_is_overloaded",
+                            "message": "Our servers are currently overloaded. "
+                            "Please try again later.",
+                            "param": None,
+                        },
+                        "sequence_number": 2,
+                    }
+                },
+            )
+        ],
+    )
+    provider = FakeProvider([[AssistantErrorEvent(reason="error", error=error)]])
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            session_id="session-1",
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    await _collect_session_events(session.prompt("Hello"))
+
+    log_path = tau_paths.agent_calls_log_path
+    entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert entry["kind"] == "assistant_error"
+    assert entry["error"] == {
+        "message": "Our servers are currently overloaded. Please try again later.",
+        "stop_reason": "error",
+        "provider": {
+            "event": {
+                "type": "error",
+                "sequence_number": 2,
+                "error": {
+                    "type": "service_unavailable_error",
+                    "code": "server_is_overloaded",
+                    "message": "Our servers are currently overloaded. Please try again later.",
+                },
+            }
+        },
     }
     assert "Hello" not in log_path.read_text(encoding="utf-8")
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -923,6 +923,256 @@ async def test_openai_codex_provider_includes_plain_http_error_body_in_message()
     }
 
 
+_CODEX_OVERLOAD_ERROR_SSE = (
+    'data: {"type":"error","error":{"type":"service_unavailable_error",'
+    '"code":"server_is_overloaded","message":"Our servers are currently '
+    'overloaded. Please try again later.","param":null},"sequence_number":2}\n\n'
+)
+
+_CODEX_TEXT_SSE = (
+    'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
+    'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+)
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_surfaces_nested_stream_error_message() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=_CODEX_OVERLOAD_ERROR_SSE,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == (
+        "Our servers are currently overloaded. Please try again later."
+    )
+    assert events[-1].error.diagnostics[0].details == {
+        "event": {
+            "type": "error",
+            "error": {
+                "type": "service_unavailable_error",
+                "code": "server_is_overloaded",
+                "message": "Our servers are currently overloaded. Please try again later.",
+                "param": None,
+            },
+            "sequence_number": 2,
+        }
+    }
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_retries_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = _CODEX_OVERLOAD_ERROR_SSE if len(requests) == 1 else _CODEX_TEXT_SSE
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert [event.type for event in events] == [
+        "start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "done",
+    ]
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_retries_transient_response_failed() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = (
+            'data: {"type":"response.failed","response":{"status":"failed",'
+            '"error":{"code":"server_is_overloaded",'
+            '"message":"The server is overloaded."}}}\n\n'
+            if len(requests) == 1
+            else _CODEX_TEXT_SSE
+        )
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert [event.type for event in events] == [
+        "start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "done",
+    ]
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_surfaces_stream_error_after_retry_exhaustion() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=_CODEX_OVERLOAD_ERROR_SSE,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == (
+        "Our servers are currently overloaded. Please try again later."
+    )
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_does_not_retry_non_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"error","error":{"type":"invalid_request_error",'
+                '"code":"invalid_api_key","message":"Invalid API key.","param":null},'
+                '"sequence_number":1}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                provider_name="openai-codex",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Invalid API key."
+
+
 @pytest.mark.anyio
 async def test_openai_codex_provider_formats_request_and_streams_text() -> None:
     requests: list[httpx.Request] = []

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6671,9 +6671,41 @@ async def test_tui_prompt_worker_shows_diagnostic_log_path_for_error_event(tmp_p
 
     await app._run_prompt("break")
 
-    assert app.state.error == f"Error: provider failed\nLog: {session.last_diagnostic_log_path}"
+    assert app.state.error == (
+        f"Error: provider failed\nLog: {session.last_diagnostic_log_path}\n"
+        "Run ended before completion. Send a message to retry."
+    )
     assert app.state.items[-1].role == "error"
     assert app.state.items[-1].text == app.state.error
+    assert app.state.running is False
+
+
+@pytest.mark.anyio
+async def test_tui_prompt_worker_skips_retry_hint_for_context_overflow() -> None:
+    class OverflowSession(FakeSession):
+        def __init__(self) -> None:
+            super().__init__(
+                events=[
+                    AgentStartEvent(),
+                    MessageEndEvent(
+                        message=AssistantMessage(
+                            stop_reason="error",
+                            error_message="prompt is too long: context window exceeded",
+                        )
+                    ),
+                    AgentEndEvent(),
+                ]
+            )
+
+    session = OverflowSession()
+    app = TauTuiApp(session)
+    app._refresh = lambda: None  # type: ignore[method-assign]
+
+    await app._run_prompt("break")
+
+    assert app.state.error == "prompt is too long: context window exceeded"
+    assert app.state.items[-1].role == "error"
+    assert app.state.items[-1].text == "Error: prompt is too long: context window exceeded"
     assert app.state.running is False
 
 
@@ -6698,7 +6730,9 @@ async def test_tui_prompt_worker_mounts_provider_error_in_live_transcript() -> N
         errors = [
             widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "error"
         ]
-        assert [widget.item.text for widget in errors] == ["Error: provider failed"]
+        assert [widget.item.text for widget in errors] == [
+            "Error: provider failed\nRun ended before completion. Send a message to retry."
+        ]
         assert app.state.running is False
 
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -22,9 +22,12 @@ Clicking anywhere in the window returns focus to the prompt, so you can scroll
 the transcript and keep typing without tabbing back.
 
 If a provider request fails after retries, Tau shows the failure as an explicit
-error block in the transcript. You can submit another prompt without starting a
-new session; empty failed provider turns are retained for diagnostics but are not
-replayed to the model as invalid conversation history.
+error block in the transcript, using the provider's own error message (for
+example `server_is_overloaded` details instead of a generic failure). The block
+includes a diagnostic log path and a reminder that the run ended. You can submit
+another prompt without starting a new session; empty failed provider turns are
+retained for diagnostics but are not replayed to the model as invalid
+conversation history.
 
 ## Cancelling and steering a run
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -161,6 +161,10 @@ Provider preferences live in `~/.tau/providers.json`:
   preferred thinking level per model for new sessions; resumed sessions still use
   their session history. `timeout_seconds` defaults to `60` (> 0); `max_retries`
   defaults to `2`; `max_retry_delay_seconds` defaults to `1` (both ≥ 0).
+  Retries cover transient HTTP statuses (`408`, `409`, `425`, `429`, `5xx`),
+  transport errors, and — for the OpenAI Codex provider — transient in-stream
+  SSE error events such as `server_is_overloaded` that arrive on an otherwise
+  successful HTTP 200 response.
 - API keys and OAuth credentials are **not** stored here — they live in
   `~/.tau/credentials.json` (private but not encrypted). OAuth objects may contain
   provider metadata such as a GitHub Enterprise domain and are refreshed


### PR DESCRIPTION
## Summary

Fixes vague, non-retried OpenAI Codex failures. Codex can return an HTTP 200 SSE stream that then carries an `error` event, e.g.:

```json
{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null},"sequence_number":2}
```

Before this PR, Tau displayed `Error: OpenAI Codex returned an error` (generic fallback) and ended the run immediately — twice in a row in the session that motivated this fix — even though the failure was transient.

Root causes addressed:

1. `tau_ai.openai_codex._error_message()` only read top-level `message`/`code`, missing the nested `error.message` / `error.code` (and `response.error` for `response.failed`).
2. The retry loop only covered HTTP status failures and transport exceptions; in-stream errors on HTTP 200 were always terminal.
3. `agent-calls.jsonl` recorded only the (generic) message, dropping the provider's error classification.
4. The TUI error block did not say the run had ended or that the user could simply retry.

## What changed

- **`src/tau_ai/openai_codex.py`**
  - New `_stream_error_details()` extracts `(code, message)` from all Codex error shapes (top-level fields, nested `error` object, `response.error`).
  - Transient in-stream errors (`overloaded`, `service_unavailable`, `rate_limit`, `internal_error`, `server_error`, `timeout`, …) are retried under the existing `max_retries` budget — but only when no content or thinking deltas were emitted yet, so a retry can never duplicate streamed output. Emits the usual `ProviderRetryEvent` with backoff and cancellation checks. Non-transient errors (e.g. `invalid_api_key`) and post-content errors stay terminal.
- **`src/tau_coding/diagnostics.py`** — `log_assistant_error` now copies non-secret scalar fields (`type`, `code`, `message`, `sequence_number`, status code, attempts) from provider diagnostics into `agent-calls.jsonl`; bodies and full payloads stay out.
- **`src/tau_coding/tui/app.py`** — terminal provider errors get a `Run ended before completion. Send a message to retry.` line in the transcript. Context-overflow errors are excluded because Tau already auto-compacts and retries those (`_is_context_overflow_error` was promoted to public `is_context_overflow_error` in `session.py` for this check).
- **Docs**: new `dev-notes/codex-stream-error-recovery.md`, updated `dev-notes/architecture/provider-retries.md`, `website/content/guides/tui.md`, and `website/content/reference/configuration.md`.

## How this improves UX

- Users see the provider's real message (`Our servers are currently overloaded…`) instead of a generic fallback.
- Brief Codex overload/rate-limit windows are absorbed by automatic retries instead of killing the run (default `max_retries: 2` = 3 attempts).
- When a run does fail, the error block states plainly that the run ended and can be retried, and the diagnostic log contains the provider's error code/type for debugging.

## Related

- No tracking issue; found by investigating a real session where Codex returned `server_is_overloaded` twice (zero usage, no output) and Tau surfaced only the generic message.
- Follows the nested-error extraction pattern already used by `_responses_error_message` in `src/tau_ai/openai_compatible.py`.
- Complements `dev-notes/provider-error-recovery.md` (empty failed turns are retained but not replayed, so sending another message after these errors is safe).

## How to validate

Automated:

```bash
uv run pytest            # 1092 passed
uv run ruff check .
uv run ruff format --check .
uv run mypy
```

New regression coverage:

- `tests/test_tau_ai.py` — nested `error` message extraction, retry on transient `error` and `response.failed` events (2 requests, clean event stream), retry exhaustion still surfaces detail, non-transient errors not retried.
- `tests/test_coding_session.py` — `agent-calls.jsonl` entries include safe provider error classification.
- `tests/test_tui_app.py` — retry hint appended to terminal errors, skipped for context overflow.

Manual:

1. Configure `openai-codex` in `~/.tau/providers.json` with `"max_retries": 2` and a short `"max_retry_delay_seconds"`.
2. Prompt during a Codex overload/rate-limit window (or point `base_url` at a mock that returns an SSE `error` event with `server_is_overloaded` once, then succeeds).
3. Observe: Tau retries quietly and completes; if the failure persists, the transcript shows the provider's own message, the diagnostic log path, and `Run ended before completion. Send a message to retry.`
