### PR TITLE
Add one-line installers for macOS, Linux, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,40 @@ or rendering. Frontends consume events.
 ## Install
 
 Tau is published on PyPI as `tau-ai` and installs a `tau` command.
-It requires Python 3.12 or newer.
+It requires Python 3.12 or newer. The recommended installers use
+[`uv`](https://docs.astral.sh/uv/) and install it first when necessary.
+
+macOS and Linux:
+
+```bash
+curl -LsSf https://twotimespi.dev/install.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://twotimespi.dev/install.ps1 | iex
+```
+
+The installers do not use `sudo`. They announce before installing `uv`, install
+Tau in an isolated tool environment, verify `tau --version`, and report if a
+shell restart is needed. You can [inspect the shell installer](https://twotimespi.dev/install.sh)
+or [PowerShell installer](https://twotimespi.dev/install.ps1) before running it.
+
+Already have a package manager? Install Tau directly:
 
 ```bash
 uv tool install tau-ai
-tau --version
-```
-
-Don't have `uv`? Install with `pipx` or `pip` instead:
-
-```bash
+# or
 pipx install tau-ai
 # or
 python -m pip install tau-ai
 ```
 
-If you prefer `uv`, install it with:
+Then check it worked:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
+tau --version
 ```
 
 Tau is also available on [conda-forge](https://conda-forge.org), and can be installed using [pixi](https://pixi.prefix.dev/latest/#installation):

--- a/dev-notes/install-scripts.md
+++ b/dev-notes/install-scripts.md
@@ -1,0 +1,31 @@
+# Tau install scripts
+
+Tau's website now serves small bootstrap installers for macOS/Linux and Windows:
+
+```text
+website/static/install.sh
+website/static/install.ps1
+```
+
+They remove the requirement that a new user already knows about or has `uv`.
+Each script looks for `uv`, announces and runs Astral's official installer when
+it is missing, installs `tau-ai` as an isolated uv tool, verifies the installed
+command, and explains when a shell restart may be needed. Neither script uses
+administrator privileges.
+
+The scripts intentionally remain thin wrappers around `uv tool install tau-ai`.
+Tau does not gain a second environment manager, and experienced users can still
+use uv, pipx, or pip directly. Both scripts are published as readable static
+files so users can inspect them before execution.
+
+## Validation
+
+Run the POSIX script syntax check and website build:
+
+```text
+sh -n website/static/install.sh
+hugo --source website --minify
+```
+
+The normal Python test, lint, format, type-check, and package-build commands are
+also expected to remain green.

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -9,14 +9,26 @@ minutes.
 
 ## 1. Install Tau
 
-Tau is a Python tool. The easiest way to install it is with
-[`uv`](https://docs.astral.sh/uv/):
+Tau is a Python tool requiring Python 3.12 or newer. Its installer uses
+[`uv`](https://docs.astral.sh/uv/) to create an isolated environment and installs
+`uv` first when it is not already available.
+
+On macOS or Linux, run:
 
 ```bash
-uv tool install tau-ai
+curl -LsSf https://twotimespi.dev/install.sh | sh
 ```
 
-Tau requires Python 3.12 or newer.
+On Windows, run in PowerShell:
+
+```powershell
+irm https://twotimespi.dev/install.ps1 | iex
+```
+
+The installer announces before installing `uv`, never uses `sudo`, verifies the
+installed `tau` command, and tells you if you need to restart your shell for a
+`PATH` update. To review code before executing it, download and inspect
+[`install.sh`](/install.sh) or [`install.ps1`](/install.ps1) first.
 
 Check it worked:
 
@@ -24,11 +36,9 @@ Check it worked:
 tau --version
 ```
 
-{{% tip title="Don't have uv?" %}}
-You can install Tau with `pipx install tau-ai` or
-`python -m pip install tau-ai`. If you prefer `uv`, install it with
-`curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux), or see the
-[uv install docs](https://docs.astral.sh/uv/getting-started/installation/).
+{{% tip title="Already have a package manager?" %}}
+Install Tau directly with `uv tool install tau-ai`, `pipx install tau-ai`, or
+`python -m pip install tau-ai`.
 {{% /tip %}}
 
 ### Upgrade Tau

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -15,7 +15,7 @@
         </p>
         <div class="cta-row">
           <span class="install">
-            <span><span class="dollar">$</span> uv tool install tau-ai</span>
+            <span><span class="dollar">$</span> curl -LsSf https://twotimespi.dev/install.sh | sh</span>
             <button class="copy" id="copyBtn" type="button" aria-label="Copy install command">copy</button>
           </span>
           <a class="ghost" href="{{ "/internals/architecture/" | relURL }}">Start with the architecture <span class="arr">&rarr;</span></a>
@@ -192,7 +192,7 @@
     <p>A map for building your own agent: start with events, add a loop, wrap it in a harness, then give it tools and a UI.</p>
     <div class="cta-row">
       <span class="install">
-        <span><span class="dollar">$</span> uv tool install tau-ai</span>
+        <span><span class="dollar">$</span> curl -LsSf https://twotimespi.dev/install.sh | sh</span>
         <button class="copy" id="copyBtn2" type="button" aria-label="Copy install command">copy</button>
       </span>
       <a class="ghost" href="{{ "/quickstart/" | relURL }}">Get started <span class="arr">&rarr;</span></a>

--- a/website/static/install.ps1
+++ b/website/static/install.ps1
@@ -1,0 +1,68 @@
+$ErrorActionPreference = "Stop"
+
+$UvInstallerUrl = "https://astral.sh/uv/install.ps1"
+
+function Find-Uv {
+    $command = Get-Command uv -ErrorAction SilentlyContinue
+    if ($null -ne $command) {
+        return $command.Source
+    }
+
+    $candidates = @()
+    if ($env:UV_INSTALL_DIR) {
+        $candidates += Join-Path $env:UV_INSTALL_DIR "uv.exe"
+    }
+    if ($env:XDG_BIN_HOME) {
+        $candidates += Join-Path $env:XDG_BIN_HOME "uv.exe"
+    }
+    $candidates += Join-Path $env:USERPROFILE ".local\bin\uv.exe"
+    $candidates += Join-Path $env:USERPROFILE ".cargo\bin\uv.exe"
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+$uv = Find-Uv
+if (-not $uv) {
+    Write-Host "Tau uses uv to manage its isolated Python environment."
+    Write-Host "uv was not found, so the official uv installer will be run now."
+
+    $installer = Invoke-RestMethod $UvInstallerUrl
+    Invoke-Expression $installer
+
+    $uv = Find-Uv
+    if (-not $uv) {
+        throw "uv was installed but its executable could not be found. Open a new terminal and run: uv tool install tau-ai"
+    }
+}
+
+Write-Host "Installing Tau with $uv ..."
+& $uv tool install tau-ai
+if ($LASTEXITCODE -ne 0) {
+    throw "uv could not install Tau."
+}
+
+$toolBin = (& $uv tool dir --bin | Select-Object -Last 1).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "uv could not locate its tool executable directory."
+}
+$tau = Join-Path $toolBin "tau.exe"
+if (-not (Test-Path -LiteralPath $tau -PathType Leaf)) {
+    throw "Tau was installed but $tau was not found."
+}
+
+& $tau --version
+if ($LASTEXITCODE -ne 0) {
+    throw "Tau was installed but could not be started."
+}
+Write-Host "Tau is installed. Run: tau"
+
+$pathEntries = $env:PATH -split ";"
+if ($toolBin -notin $pathEntries) {
+    Write-Host "Restart PowerShell if 'tau' is not found; $toolBin must be on PATH."
+}

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -eu
+
+UV_INSTALLER_URL="https://astral.sh/uv/install.sh"
+
+find_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        command -v uv
+        return
+    fi
+
+    if [ -n "${UV_INSTALL_DIR:-}" ] && [ -x "$UV_INSTALL_DIR/uv" ]; then
+        printf '%s\n' "$UV_INSTALL_DIR/uv"
+        return
+    fi
+    if [ -n "${XDG_BIN_HOME:-}" ] && [ -x "$XDG_BIN_HOME/uv" ]; then
+        printf '%s\n' "$XDG_BIN_HOME/uv"
+        return
+    fi
+
+    for candidate in "$HOME/.local/bin/uv" "$HOME/.cargo/bin/uv"; do
+        if [ -x "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+
+    return 1
+}
+
+uv_bin=$(find_uv || true)
+if [ -z "$uv_bin" ]; then
+    printf '%s\n' "Tau uses uv to manage its isolated Python environment."
+    printf '%s\n' "uv was not found, so the official uv installer will be run now."
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -LsSf "$UV_INSTALLER_URL" | sh
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- "$UV_INSTALLER_URL" | sh
+    else
+        printf '%s\n' "Error: installing uv requires curl or wget." >&2
+        exit 1
+    fi
+
+    uv_bin=$(find_uv || true)
+    if [ -z "$uv_bin" ]; then
+        printf '%s\n' "Error: uv was installed but its executable could not be found." >&2
+        printf '%s\n' "Open a new terminal and run: uv tool install tau-ai" >&2
+        exit 1
+    fi
+fi
+
+printf '%s\n' "Installing Tau with $uv_bin ..."
+"$uv_bin" tool install tau-ai
+
+tool_bin=$("$uv_bin" tool dir --bin)
+tau_bin="$tool_bin/tau"
+if [ ! -x "$tau_bin" ]; then
+    printf '%s\n' "Error: Tau was installed but $tau_bin was not found." >&2
+    exit 1
+fi
+
+"$tau_bin" --version
+printf '%s\n' "Tau is installed. Run: tau"
+
+case ":$PATH:" in
+    *":$tool_bin:"*) ;;
+    *)
+        printf '%s\n' "Restart your shell if 'tau' is not found; $tool_bin must be on PATH."
+        ;;
+esac

--- a/website/static/landing.js
+++ b/website/static/landing.js
@@ -4,7 +4,7 @@
     var b = document.getElementById(id);
     if(!b) return;
     b.addEventListener("click", function(){
-      navigator.clipboard && navigator.clipboard.writeText("uv tool install tau-ai");
+      navigator.clipboard && navigator.clipboard.writeText("curl -LsSf https://twotimespi.dev/install.sh | sh");
       var t = b.textContent; b.textContent = "copied";
       setTimeout(function(){ b.textContent = t; }, 1400);
     });


### PR DESCRIPTION
## Description

- add `https://twotimespi.dev/install.sh` for macOS and Linux
- add `https://twotimespi.dev/install.ps1` for Windows PowerShell
- detect and reuse `uv`, or clearly announce and run Astral's official installer when it is missing
- install Tau as an isolated uv tool, verify `tau --version`, and provide `PATH` guidance
- make the one-line installer the website default while retaining direct uv, pipx, and pip instructions

## User experience

New users no longer need to know what `uv` is or install it separately. Each platform gets one copyable command, no administrator privileges are used, and both scripts remain available for inspection before execution.

## Issue

No linked issue. Addresses installation onboarding friction.

## Manual validation

### macOS/Linux

```bash
curl -LsSf https://twotimespi.dev/install.sh | sh
```

Before deployment, serve `website/static/` locally or run the checked-out script directly:

```bash
sh website/static/install.sh
tau --version
```

### Windows PowerShell

```powershell
irm https://twotimespi.dev/install.ps1 | iex
```

Before deployment:

```powershell
& website/static/install.ps1
tau --version
```

### Checks run

```text
uv run pytest
uv run ruff check .
uv run ruff format --check .
uv run mypy
uv build
hugo --source website --minify
sh -n website/static/install.sh
```
