### PR TITLE
Limit dense content in the TUI sidebar

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2871,13 +2871,16 @@ class TauTuiApp(App[None]):
         padding: 1 1 1 2;
         background: $tau-prompt-background;
         border: none;
+        overflow-y: auto;
+        scrollbar-size-vertical: 0;
     }
 
     #sidebar-content {
-        height: 1fr;
+        height: auto;
     }
 
     #sidebar-brand {
+        dock: bottom;
         height: auto;
         color: $tau-prompt-text;
     }

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2871,16 +2871,13 @@ class TauTuiApp(App[None]):
         padding: 1 1 1 2;
         background: $tau-prompt-background;
         border: none;
-        overflow-y: auto;
-        scrollbar-size-vertical: 0;
     }
 
     #sidebar-content {
-        height: auto;
+        height: 1fr;
     }
 
     #sidebar-brand {
-        dock: bottom;
         height: auto;
         color: $tau-prompt-text;
     }

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -20,7 +20,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from textual.containers import Horizontal, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.css.query import NoMatches
 from textual.geometry import Offset
@@ -41,6 +41,7 @@ from tau_coding.tui.state import ChatItem, TuiState
 from tau_coding.version import current_version
 
 TAU_SIDEBAR_LOGO = "τ = 2π"
+SIDEBAR_SKILLS_LIMIT = 5
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,8 +97,8 @@ class SessionSummarySource(Protocol):
     def session_stats(self) -> SessionStats: ...
 
 
-class SessionSidebar(VerticalScroll):
-    """Scrollable sidebar with session metadata and bottom-aligned branding."""
+class SessionSidebar(Vertical):
+    """Compact sidebar with session metadata and bottom-aligned branding."""
 
     def compose(self) -> Any:
         yield Static("", id="sidebar-content")
@@ -1504,9 +1505,8 @@ def render_session_sidebar(
         style=theme.completion_description,
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _bullet_list(
+    skills = _limited_skill_list(
         [skill.name for skill in session.skills],
-        empty="No skills loaded",
         theme=theme,
     )
     prompts = _comma_list(
@@ -2155,6 +2155,18 @@ def _format_cost(value: float) -> str:
 
 def _plural(count: int, singular: str) -> str:
     return singular if count == 1 else f"{singular}s"
+
+
+def _limited_skill_list(items: Sequence[str], *, theme: TuiTheme) -> Text:
+    text = _bullet_list(
+        items[:SIDEBAR_SKILLS_LIMIT],
+        empty="No skills loaded",
+        theme=theme,
+    )
+    hidden_count = len(items) - SIDEBAR_SKILLS_LIMIT
+    if hidden_count > 0:
+        text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
+    return text
 
 
 def _bullet_list(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, Literal, Protocol
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 from rich.align import Align
-from rich.console import Console, Group, RenderableType
+from rich.console import Console, ConsoleOptions, Group, RenderableType, RenderResult
 from rich.markdown import CodeBlock, Heading, Markdown
 from rich.padding import Padding
 from rich.rule import Rule
@@ -41,7 +41,8 @@ from tau_coding.tui.state import ChatItem, TuiState
 from tau_coding.version import current_version
 
 TAU_SIDEBAR_LOGO = "τ = 2π"
-SIDEBAR_SKILLS_LIMIT = 5
+SIDEBAR_BULLET_LIST_LIMIT = 5
+SIDEBAR_COMMA_LIST_MAX_LINES = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -1505,8 +1506,9 @@ def render_session_sidebar(
         style=theme.completion_description,
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _limited_skill_list(
+    skills = _limited_bullet_list(
         [skill.name for skill in session.skills],
+        empty="No skills loaded",
         theme=theme,
     )
     prompts = _comma_list(
@@ -1519,7 +1521,7 @@ def render_session_sidebar(
         empty="No extensions",
         theme=theme,
     )
-    context = _bullet_list(
+    context = _limited_bullet_list(
         _context_file_labels(session.context_files, cwd=session.cwd),
         empty="No context files",
         theme=theme,
@@ -2123,19 +2125,55 @@ def render_completion_suggestions(
     return table
 
 
+@dataclass(frozen=True, slots=True)
+class _LineLimitedCommaList:
+    items: tuple[str, ...]
+    empty: str
+    style: str
+
+    def __rich_console__(
+        self,
+        console: Console,
+        options: ConsoleOptions,
+    ) -> RenderResult:
+        if not self.items:
+            yield Text(self.empty, style=self.style)
+            return
+
+        visible_count = 0
+        for count in range(1, len(self.items) + 1):
+            candidate = self._text(self.items[:count])
+            if len(candidate.wrap(console, options.max_width)) > SIDEBAR_COMMA_LIST_MAX_LINES:
+                break
+            visible_count = count
+
+        text = self._text(self.items[:visible_count])
+        hidden_count = len(self.items) - visible_count
+        if hidden_count:
+            if visible_count:
+                text.append("\n")
+            text.append(f"...({hidden_count} more)", style=self.style)
+        yield text
+
+    def _text(self, items: Sequence[str]) -> Text:
+        return Text(
+            ", ".join(items),
+            style=self.style,
+            overflow="fold",
+            no_wrap=False,
+        )
+
+
 def _comma_list(
     items: Sequence[str],
     *,
     empty: str,
     theme: TuiTheme,
-) -> Text:
-    if not items:
-        return Text(empty, style=theme.completion_description)
-    return Text(
-        ", ".join(items),
+) -> RenderableType:
+    return _LineLimitedCommaList(
+        items=tuple(items),
+        empty=empty,
         style=theme.completion_description,
-        overflow="fold",
-        no_wrap=False,
     )
 
 
@@ -2157,13 +2195,18 @@ def _plural(count: int, singular: str) -> str:
     return singular if count == 1 else f"{singular}s"
 
 
-def _limited_skill_list(items: Sequence[str], *, theme: TuiTheme) -> Text:
+def _limited_bullet_list(
+    items: Sequence[str],
+    *,
+    empty: str,
+    theme: TuiTheme,
+) -> Text:
     text = _bullet_list(
-        items[:SIDEBAR_SKILLS_LIMIT],
-        empty="No skills loaded",
+        items[:SIDEBAR_BULLET_LIST_LIMIT],
+        empty=empty,
         theme=theme,
     )
-    hidden_count = len(items) - SIDEBAR_SKILLS_LIMIT
+    hidden_count = len(items) - SIDEBAR_BULLET_LIST_LIMIT
     if hidden_count > 0:
         text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
     return text

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1505,15 +1505,22 @@ def render_session_sidebar(
         "off" if threshold is None else f"auto at {_compact_token_count(threshold)}",
         style=theme.completion_description,
     )
-    tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
+    tools = _comma_list(
+        [tool.name for tool in session.tools],
+        empty="No tools",
+        overflow_hint="Run /tools to see the full list.",
+        theme=theme,
+    )
     skills = _limited_bullet_list(
         [skill.name for skill in session.skills],
         empty="No skills loaded",
+        overflow_hint="Run /skills to see the full list.",
         theme=theme,
     )
     prompts = _comma_list(
         [template.name for template in session.prompt_templates],
         empty="No prompt templates",
+        overflow_hint="Run /prompts to see the full list.",
         theme=theme,
     )
     extensions = _comma_list(
@@ -2130,6 +2137,7 @@ class _LineLimitedCommaList:
     items: tuple[str, ...]
     empty: str
     style: str
+    overflow_hint: str | None
 
     def __rich_console__(
         self,
@@ -2153,6 +2161,8 @@ class _LineLimitedCommaList:
             if visible_count:
                 text.append("\n")
             text.append(f"...({hidden_count} more)", style=self.style)
+            if self.overflow_hint is not None:
+                text.append(f"\n{self.overflow_hint}", style=self.style)
         yield text
 
     def _text(self, items: Sequence[str]) -> Text:
@@ -2169,11 +2179,13 @@ def _comma_list(
     *,
     empty: str,
     theme: TuiTheme,
+    overflow_hint: str | None = None,
 ) -> RenderableType:
     return _LineLimitedCommaList(
         items=tuple(items),
         empty=empty,
         style=theme.completion_description,
+        overflow_hint=overflow_hint,
     )
 
 
@@ -2200,6 +2212,7 @@ def _limited_bullet_list(
     *,
     empty: str,
     theme: TuiTheme,
+    overflow_hint: str | None = None,
 ) -> Text:
     text = _bullet_list(
         items[:SIDEBAR_BULLET_LIST_LIMIT],
@@ -2209,6 +2222,8 @@ def _limited_bullet_list(
     hidden_count = len(items) - SIDEBAR_BULLET_LIST_LIMIT
     if hidden_count > 0:
         text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
+        if overflow_hint is not None:
+            text.append(f"\n{overflow_hint}", style=theme.completion_description)
     return text
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -2147,13 +2147,30 @@ class _LineLimitedCommaList:
                 break
             visible_count = count
 
-        text = self._text(self.items[:visible_count])
+        if visible_count:
+            text = self._text(self.items[:visible_count])
+        else:
+            visible_count = 1
+            text = self._truncate_to_line_budget(
+                self._text(self.items[:visible_count]),
+                console=console,
+                width=options.max_width,
+            )
+
         hidden_count = len(self.items) - visible_count
         if hidden_count:
-            if visible_count:
-                text.append("\n")
+            text.append("\n")
             text.append(f"...({hidden_count} more)", style=self.style)
         yield text
+
+    def _truncate_to_line_budget(self, text: Text, *, console: Console, width: int) -> Text:
+        wrapped_lines = list(text.wrap(console, width))
+        visible_lines = [line.copy() for line in wrapped_lines[:SIDEBAR_COMMA_LIST_MAX_LINES]]
+        if len(wrapped_lines) > SIDEBAR_COMMA_LIST_MAX_LINES:
+            last_line = visible_lines[-1]
+            last_line.truncate(max(0, width - 1), overflow="crop")
+            last_line.append("…", style=self.style)
+        return Text("\n").join(visible_lines)
 
     def _text(self, items: Sequence[str]) -> Text:
         return Text(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1505,22 +1505,15 @@ def render_session_sidebar(
         "off" if threshold is None else f"auto at {_compact_token_count(threshold)}",
         style=theme.completion_description,
     )
-    tools = _comma_list(
-        [tool.name for tool in session.tools],
-        empty="No tools",
-        overflow_hint="Run /tools to see the full list.",
-        theme=theme,
-    )
+    tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
     skills = _limited_bullet_list(
         [skill.name for skill in session.skills],
         empty="No skills loaded",
-        overflow_hint="Run /skills to see the full list.",
         theme=theme,
     )
     prompts = _comma_list(
         [template.name for template in session.prompt_templates],
         empty="No prompt templates",
-        overflow_hint="Run /prompts to see the full list.",
         theme=theme,
     )
     extensions = _comma_list(
@@ -2137,7 +2130,6 @@ class _LineLimitedCommaList:
     items: tuple[str, ...]
     empty: str
     style: str
-    overflow_hint: str | None
 
     def __rich_console__(
         self,
@@ -2161,8 +2153,6 @@ class _LineLimitedCommaList:
             if visible_count:
                 text.append("\n")
             text.append(f"...({hidden_count} more)", style=self.style)
-            if self.overflow_hint is not None:
-                text.append(f"\n{self.overflow_hint}", style=self.style)
         yield text
 
     def _text(self, items: Sequence[str]) -> Text:
@@ -2179,13 +2169,11 @@ def _comma_list(
     *,
     empty: str,
     theme: TuiTheme,
-    overflow_hint: str | None = None,
 ) -> RenderableType:
     return _LineLimitedCommaList(
         items=tuple(items),
         empty=empty,
         style=theme.completion_description,
-        overflow_hint=overflow_hint,
     )
 
 
@@ -2212,7 +2200,6 @@ def _limited_bullet_list(
     *,
     empty: str,
     theme: TuiTheme,
-    overflow_hint: str | None = None,
 ) -> Text:
     text = _bullet_list(
         items[:SIDEBAR_BULLET_LIST_LIMIT],
@@ -2222,8 +2209,6 @@ def _limited_bullet_list(
     hidden_count = len(items) - SIDEBAR_BULLET_LIST_LIMIT
     if hidden_count > 0:
         text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
-        if overflow_hint is not None:
-            text.append(f"\n{overflow_hint}", style=theme.completion_description)
     return text
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -20,7 +20,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.containers import Horizontal, VerticalScroll
 from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.css.query import NoMatches
 from textual.geometry import Offset
@@ -96,8 +96,8 @@ class SessionSummarySource(Protocol):
     def session_stats(self) -> SessionStats: ...
 
 
-class SessionSidebar(Vertical):
-    """Compact sidebar with session metadata and bottom-aligned branding."""
+class SessionSidebar(VerticalScroll):
+    """Scrollable sidebar with session metadata and bottom-aligned branding."""
 
     def compose(self) -> Any:
         yield Static("", id="sidebar-content")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -520,8 +520,10 @@ def test_session_sidebar_limits_skills_to_five(
     assert "skill-7" not in output
     if hidden_label is None:
         assert "more)" not in output
+        assert "Run /skills" not in output
     else:
         assert hidden_label in output
+        assert "Run /skills to see the full list." in output
 
 
 def test_session_sidebar_limits_context_files_to_five() -> None:
@@ -540,6 +542,7 @@ def test_session_sidebar_limits_context_files_to_five() -> None:
     assert "context-6.md" not in output
     assert "context-7.md" not in output
     assert "...(2 more)" in output
+    assert "Run /context" not in output
 
 
 def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
@@ -562,12 +565,17 @@ def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
 
 
 @pytest.mark.parametrize(
-    ("attribute", "prefix"),
-    [("tools", "tool"), ("prompt_templates", "prompt"), ("extension_names", "extension")],
+    ("attribute", "prefix", "command"),
+    [
+        ("tools", "tool", "/tools"),
+        ("prompt_templates", "prompt", "/prompts"),
+        ("extension_names", "extension", None),
+    ],
 )
 def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
     attribute: str,
     prefix: str,
+    command: str | None,
 ) -> None:
     session = FakeSession()
     names = tuple(f"{prefix}-item-{index}" for index in range(1, 20))
@@ -583,6 +591,10 @@ def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
     assert names[0] in output
     assert names[-1] not in output
     assert "...(" in output
+    if command is None:
+        assert "Run /extensions" not in output
+    else:
+        assert f"Run {command} to see the full list." in output
 
 
 def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2437,6 +2437,27 @@ async def test_tui_sidebar_fills_workspace_height() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_sidebar_scrolls_overflow_without_showing_a_scrollbar() -> None:
+    session = FakeSession()
+    session.context_files = tuple(
+        ProjectContextFile(path=str(session.cwd / f"rules/{index}/AGENTS.md"), content="Rules.")
+        for index in range(30)
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        sidebar = app.query_one("#sidebar", VerticalScroll)
+
+        assert sidebar.max_scroll_y > 0
+        assert sidebar.styles.overflow_y == "auto"
+        assert sidebar.styles.scrollbar_size_vertical == 0
+
+        sidebar.scroll_down(animate=False)
+        await pilot.pause()
+        assert sidebar.scroll_y > 0
+
+
+@pytest.mark.anyio
 async def test_tui_sidebar_hides_on_narrow_windows() -> None:
     app = TauTuiApp(FakeSession())
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -561,6 +561,33 @@ def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
     assert len(wide_output.splitlines()) == 3
 
 
+@pytest.mark.parametrize(("item_count", "hidden_label"), [(1, None), (2, "...(1 more)")])
+def test_comma_list_represents_an_oversized_first_item(
+    item_count: int,
+    hidden_label: str | None,
+) -> None:
+    oversized_name = "x" * 40
+    console = Console(record=True, width=12)
+
+    console.print(
+        _comma_list(
+            [oversized_name, "second-item"][:item_count],
+            empty="Empty",
+            theme=TAU_DARK_THEME,
+        )
+    )
+
+    output = console.export_text()
+    assert output.startswith("x" * 12)
+    assert "…" in output
+    if hidden_label is None:
+        assert len(output.splitlines()) == 3
+        assert "more)" not in output
+    else:
+        assert len(output.splitlines()) == 4
+        assert hidden_label in output
+
+
 @pytest.mark.parametrize(
     ("attribute", "prefix"),
     [("tools", "tool"), ("prompt_templates", "prompt"), ("extension_names", "extension")],

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -520,10 +520,8 @@ def test_session_sidebar_limits_skills_to_five(
     assert "skill-7" not in output
     if hidden_label is None:
         assert "more)" not in output
-        assert "Run /skills" not in output
     else:
         assert hidden_label in output
-        assert "Run /skills to see the full list." in output
 
 
 def test_session_sidebar_limits_context_files_to_five() -> None:
@@ -542,7 +540,6 @@ def test_session_sidebar_limits_context_files_to_five() -> None:
     assert "context-6.md" not in output
     assert "context-7.md" not in output
     assert "...(2 more)" in output
-    assert "Run /context" not in output
 
 
 def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
@@ -565,17 +562,12 @@ def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
 
 
 @pytest.mark.parametrize(
-    ("attribute", "prefix", "command"),
-    [
-        ("tools", "tool", "/tools"),
-        ("prompt_templates", "prompt", "/prompts"),
-        ("extension_names", "extension", None),
-    ],
+    ("attribute", "prefix"),
+    [("tools", "tool"), ("prompt_templates", "prompt"), ("extension_names", "extension")],
 )
 def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
     attribute: str,
     prefix: str,
-    command: str | None,
 ) -> None:
     session = FakeSession()
     names = tuple(f"{prefix}-item-{index}" for index in range(1, 20))
@@ -591,10 +583,6 @@ def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
     assert names[0] in output
     assert names[-1] not in output
     assert "...(" in output
-    if command is None:
-        assert "Run /extensions" not in output
-    else:
-        assert f"Run {command} to see the full list." in output
 
 
 def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from rich.console import Console
@@ -119,6 +120,7 @@ from tau_coding.tui.widgets import (
     TranscriptMessageWidget,
     TranscriptView,
     TranscriptWindowBoundary,
+    _comma_list,
     _compact_token_count,
     _sidebar_brand,
     _split_rich_style_colors,
@@ -520,6 +522,67 @@ def test_session_sidebar_limits_skills_to_five(
         assert "more)" not in output
     else:
         assert hidden_label in output
+
+
+def test_session_sidebar_limits_context_files_to_five() -> None:
+    session = FakeSession()
+    session.context_files = tuple(
+        ProjectContextFile(path=str(session.cwd / f"context-{index}.md"), content="Rules")
+        for index in range(1, 8)
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    for index in range(1, 6):
+        assert f"• context-{index}.md" in output
+    assert "context-6.md" not in output
+    assert "context-7.md" not in output
+    assert "...(2 more)" in output
+
+
+def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:
+    items = [f"i{index}" for index in range(1, 16)]
+
+    narrow_console = Console(record=True, width=12)
+    narrow_console.print(_comma_list(items, empty="Empty", theme=TAU_DARK_THEME))
+    narrow_output = narrow_console.export_text()
+    assert "i9" in narrow_output
+    assert "i10" not in narrow_output
+    assert "...(6 more)" in narrow_output
+    assert len(narrow_output.splitlines()) == 4
+
+    wide_console = Console(record=True, width=30)
+    wide_console.print(_comma_list(items, empty="Empty", theme=TAU_DARK_THEME))
+    wide_output = wide_console.export_text()
+    assert "i15" in wide_output
+    assert "more)" not in wide_output
+    assert len(wide_output.splitlines()) == 3
+
+
+@pytest.mark.parametrize(
+    ("attribute", "prefix"),
+    [("tools", "tool"), ("prompt_templates", "prompt"), ("extension_names", "extension")],
+)
+def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
+    attribute: str,
+    prefix: str,
+) -> None:
+    session = FakeSession()
+    names = tuple(f"{prefix}-item-{index}" for index in range(1, 20))
+    values: tuple[object, ...] = names
+    if attribute != "extension_names":
+        values = tuple(SimpleNamespace(name=name) for name in names)
+    setattr(session, attribute, values)
+    console = Console(record=True, width=40)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert names[0] in output
+    assert names[-1] not in output
+    assert "...(" in output
 
 
 def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -497,6 +497,31 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "permission-gate, subagents" in output
 
 
+@pytest.mark.parametrize(("skill_count", "hidden_label"), [(5, None), (7, "...(2 more)")])
+def test_session_sidebar_limits_skills_to_five(
+    skill_count: int,
+    hidden_label: str | None,
+) -> None:
+    session = FakeSession()
+    session.skills = tuple(
+        Skill(name=f"skill-{index}", path=session.cwd / f"skill-{index}.md", content="Skill")
+        for index in range(1, skill_count + 1)
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    for index in range(1, 6):
+        assert f"• skill-{index}" in output
+    assert "skill-6" not in output
+    assert "skill-7" not in output
+    if hidden_label is None:
+        assert "more)" not in output
+    else:
+        assert hidden_label in output
+
+
 def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:
     session = FakeSession()
     session.session_stats = SessionStats(input_tokens=1200, output_tokens=300)
@@ -2434,27 +2459,6 @@ async def test_tui_sidebar_fills_workspace_height() -> None:
 
         assert sidebar.region.height == workspace.region.height
         assert sidebar.outer_size.height == workspace.size.height
-
-
-@pytest.mark.anyio
-async def test_tui_sidebar_scrolls_overflow_without_showing_a_scrollbar() -> None:
-    session = FakeSession()
-    session.context_files = tuple(
-        ProjectContextFile(path=str(session.cwd / f"rules/{index}/AGENTS.md"), content="Rules.")
-        for index in range(30)
-    )
-    app = TauTuiApp(session)
-
-    async with app.run_test(size=(120, 40)) as pilot:
-        sidebar = app.query_one("#sidebar", VerticalScroll)
-
-        assert sidebar.max_scroll_y > 0
-        assert sidebar.styles.overflow_y == "auto"
-        assert sidebar.styles.scrollbar_size_vertical == 0
-
-        sidebar.scroll_down(animate=False)
-        await pilot.pause()
-        assert sidebar.scroll_y > 0
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -149,8 +149,9 @@ other context loaded from outside the project uses its full path.
 
 The wider, borderless sidebar uses the prompt field's background color, bright
 section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark
-pinned to its bottom edge. Tau does not render separate
-top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
+pinned to its bottom edge. When the content is taller than the available space,
+the sidebar scrolls vertically while keeping its scrollbar hidden. Tau does not
+render separate top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
 and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
 automatically when the terminal is small, while the tab title continues to
 identify the session.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -143,15 +143,16 @@ turn and tool-call totals, provider-reported token usage under **cumulative usag
 estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
 templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists. Skills and context files use bullet
-lists, with one item or path per line. Project context paths are relative to the
-working directory; context loaded from the home directory starts with `~/`, while
-other context loaded from outside the project uses its full path.
+lists, with one item or path per line. The skills section shows at most five
+skills, followed by `...(X more)` when additional skills are loaded. Project
+context paths are relative to the working directory; context loaded from the
+home directory starts with `~/`, while other context loaded from outside the
+project uses its full path.
 
 The wider, borderless sidebar uses the prompt field's background color, bright
 section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark
-pinned to its bottom edge. When the content is taller than the available space,
-the sidebar scrolls vertically while keeping its scrollbar hidden. Tau does not
-render separate top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
+pinned to its bottom edge. Tau does not render separate
+top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
 and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
 automatically when the terminal is small, while the tab title continues to
 identify the session.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -145,9 +145,7 @@ templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and 
 names use compact comma-separated lists limited to three rendered lines. Skills
 and context files use bullet lists, with one item or path per line, limited to
 five entries. Truncated sections end with `...(X more)` showing how many entries
-are hidden. Truncated tools, skills, and prompts sections also point to `/tools`,
-`/skills`, or `/prompts` for the full searchable list. Project context paths are
-relative to the working directory; context
+are hidden. Project context paths are relative to the working directory; context
 loaded from the home directory starts with `~/`, while other context loaded from
 outside the project uses its full path.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -142,12 +142,12 @@ redundant section label, followed by active-branch
 turn and tool-call totals, provider-reported token usage under **cumulative usage**,
 estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
 templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
-names use compact comma-separated lists. Skills and context files use bullet
-lists, with one item or path per line. The skills section shows at most five
-skills, followed by `...(X more)` when additional skills are loaded. Project
-context paths are relative to the working directory; context loaded from the
-home directory starts with `~/`, while other context loaded from outside the
-project uses its full path.
+names use compact comma-separated lists limited to three rendered lines. Skills
+and context files use bullet lists, with one item or path per line, limited to
+five entries. Truncated sections end with `...(X more)` showing how many entries
+are hidden. Project context paths are relative to the working directory; context
+loaded from the home directory starts with `~/`, while other context loaded from
+outside the project uses its full path.
 
 The wider, borderless sidebar uses the prompt field's background color, bright
 section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -145,7 +145,9 @@ templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and 
 names use compact comma-separated lists limited to three rendered lines. Skills
 and context files use bullet lists, with one item or path per line, limited to
 five entries. Truncated sections end with `...(X more)` showing how many entries
-are hidden. Project context paths are relative to the working directory; context
+are hidden. Truncated tools, skills, and prompts sections also point to `/tools`,
+`/skills`, or `/prompts` for the full searchable list. Project context paths are
+relative to the working directory; context
 loaded from the home directory starts with `~/`, while other context loaded from
 outside the project uses its full path.
 


### PR DESCRIPTION
## Description

Keep dense TUI sidebar sections compact:

- Show at most five skills and five context files.
- Limit comma-separated tools, prompt templates, and extensions to three rendered lines, adapting to the sidebar width instead of using a fixed item count.
- Add `...(X more)` with the hidden item count whenever a section is truncated.

## User experience

Large resource collections no longer dominate or overflow the sidebar. Users still see representative entries and the exact number of additional loaded resources, while the dedicated `/tools`, `/skills`, and `/prompts` commands remain available separately.

## Issue

No linked issue. Addresses sidebar overflow caused by large resource collections.

## Manual validation

1. Start `tau` with more than five skills and context files.
2. Verify each section shows its first five entries followed by `...(X more)`.
3. Load enough tools, prompt templates, or extensions to exceed three rendered lines.
4. Verify each comma-separated section shows at most three content lines followed by the correct `...(X more)` count.
5. Resize the sidebar and verify comma-separated sections adapt based on rendered line count.
6. Verify sections within their limits have no overflow label.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
