### PR TITLE
Add searchable /prompts picker

### DIFF
--- a/dev-notes/tui-prompts-picker.md
+++ b/dev-notes/tui-prompts-picker.md
@@ -1,0 +1,15 @@
+# Searchable prompt-template picker
+
+Issue #452 adds `/prompts` as a built-in TUI command. It opens a Textual modal over the coding session, keeping picker behavior in `tau_coding.tui` rather than the reusable agent harness.
+
+The modal sorts loaded templates by name, displays names and descriptions, and filters both fields case-insensitively. Up/Down move the selection, Enter inserts `/<template-name>` into the prompt editor without submitting, and Escape cancels. Dedicated messages explain empty and no-match states.
+
+The command registry communicates the UI request through `CommandResult.prompts_picker_requested`, matching existing session/model picker boundaries.
+
+Validate with:
+
+```bash
+uv run pytest tests/test_commands.py tests/test_tui_app.py -k prompts
+uv run ruff check .
+uv run mypy
+```

--- a/dev-notes/tui-prompts-picker.md
+++ b/dev-notes/tui-prompts-picker.md
@@ -4,7 +4,7 @@ Issue #452 adds `/prompts` as a built-in TUI command. It opens a Textual modal o
 
 The modal sorts loaded templates by name, displays names and descriptions, and filters both fields case-insensitively. Up/Down move the selection, Enter inserts `/<template-name>` into the prompt editor without submitting, and Escape cancels. Dedicated messages explain empty and no-match states.
 
-The command registry communicates the UI request through `CommandResult.prompts_picker_requested`, matching existing session/model picker boundaries.
+The command registry communicates the UI request through `CommandResult.prompts_picker_requested`, matching existing session/model picker boundaries. The resource loader reserves the case-insensitive template name `prompts`, ignores colliding files with a diagnostic, and therefore guarantees that a template cannot shadow the picker command.
 
 Validate with:
 

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -105,6 +105,7 @@ class CommandResult:
     export_format: str | None = None
     resume_session_id: str | None = None
     resume_picker_requested: bool = False
+    prompts_picker_requested: bool = False
     tree_picker_requested: bool = False
     login_picker_requested: bool = False
     custom_provider_login_requested: bool = False
@@ -272,6 +273,15 @@ def create_default_command_registry() -> CommandRegistry:
             description="Show common keyboard shortcuts.",
             handler=_hotkeys_command,
             search_terms=("keys", "shortcuts", "bindings"),
+        )
+    )
+    registry.register(
+        SlashCommand(
+            name="prompts",
+            usage="/prompts",
+            description="Choose a loaded prompt template.",
+            handler=_prompts_command,
+            search_terms=("templates", "picker"),
         )
     )
     registry.register(
@@ -512,6 +522,12 @@ def _skill_command(context: CommandContext) -> CommandResult:
         handled=True,
         message="Use /skill:<name> [request] to expand a loaded skill into your prompt.",
     )
+
+
+def _prompts_command(context: CommandContext) -> CommandResult:
+    if context.args:
+        return CommandResult(handled=True, message="Usage: /prompts")
+    return CommandResult(handled=True, prompts_picker_requested=True)
 
 
 def _resume_command(context: CommandContext) -> CommandResult:

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -17,6 +17,7 @@ from tau_coding.resources import (
 
 _TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
 _ARGUMENT_TEMPLATE_VARIABLES = {"arguments", "args"}
+_RESERVED_TEMPLATE_NAMES = frozenset({"prompts"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,6 +166,19 @@ def _load_prompt_templates_from_dir_with_diagnostics(
     seen: set[str] = set()
     for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
         name = path.stem
+        if name.casefold() in _RESERVED_TEMPLATE_NAMES:
+            diagnostics.append(
+                ResourceDiagnostic(
+                    kind="prompt",
+                    name=name,
+                    path=path,
+                    message=(
+                        f"prompt template name is reserved by the built-in /{name.casefold()} "
+                        "command; template ignored"
+                    ),
+                )
+            )
+            continue
         if name in seen:
             diagnostics.append(
                 ResourceDiagnostic(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4336,6 +4336,7 @@ class TauTuiApp(App[None]):
         if isinstance(
             self.screen,
             SessionPickerScreen
+            | PromptTemplatePickerScreen
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen
@@ -4362,6 +4363,7 @@ class TauTuiApp(App[None]):
         if isinstance(
             self.screen,
             SessionPickerScreen
+            | PromptTemplatePickerScreen
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen
@@ -4386,6 +4388,7 @@ class TauTuiApp(App[None]):
         if isinstance(
             self.screen,
             SessionPickerScreen
+            | PromptTemplatePickerScreen
             | TreePickerScreen
             | LoginMethodPickerScreen
             | LoginProviderPickerScreen

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -95,6 +95,7 @@ from tau_coding.oauth_types import (
     OAuthPrompt,
     OAuthSelectPrompt,
 )
+from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
     ProviderCatalogEntry,
@@ -986,6 +987,91 @@ class SessionPickerSearchInput(Input):
     def action_cancel(self) -> None:
         """Close the session picker."""
         self._picker().action_cancel()
+
+
+class PromptTemplatePickerScreen(ModalScreen[str | None]):
+    """Searchable picker for loaded prompt templates."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("up", "cursor_up", "Up", show=False),
+        Binding("down", "cursor_down", "Down", show=False),
+        Binding("enter", "select_cursor", "Select", show=False),
+    ]
+
+    def __init__(self, templates: Sequence[PromptTemplate]) -> None:
+        super().__init__()
+        self.templates = tuple(sorted(templates, key=lambda item: item.name.lower()))
+        self.visible_templates = self.templates
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="prompt-template-picker"):
+            yield Static("Prompt templates", id="prompt-template-picker-title")
+            yield SessionPickerSearchInput(
+                placeholder="Search prompt templates", id="prompt-template-picker-search"
+            )
+            yield ListView(id="prompt-template-picker-list")
+            yield Static("", id="prompt-template-picker-help")
+
+    def on_mount(self) -> None:
+        self.query_one("#prompt-template-picker-search", Input).focus()
+        self._refresh_list()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "prompt-template-picker-search":
+            return
+        event.stop()
+        query = event.value.casefold()
+        self.visible_templates = tuple(
+            template
+            for template in self.templates
+            if query in template.name.casefold() or query in (template.description or "").casefold()
+        )
+        self._refresh_list()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "prompt-template-picker-search":
+            event.stop()
+            self.action_select_cursor()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        event.stop()
+        self.action_select_cursor()
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#prompt-template-picker-list", ListView).action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        self.query_one("#prompt-template-picker-list", ListView).action_cursor_down()
+
+    def action_select_cursor(self) -> None:
+        picker_list = self.query_one("#prompt-template-picker-list", ListView)
+        if self.visible_templates and picker_list.index is not None:
+            self.dismiss(self.visible_templates[picker_list.index].name)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _refresh_list(self) -> None:
+        picker_list = self.query_one("#prompt-template-picker-list", ListView)
+        picker_list.clear()
+        picker_list.extend(
+            ListItem(
+                Label(
+                    f"/{template.name} — {template.description or 'No description'}",
+                    markup=False,
+                )
+            )
+            for template in self.visible_templates
+        )
+        picker_list.index = 0 if self.visible_templates else None
+        if self.visible_templates:
+            help_text = "Enter selects - Escape closes"
+        elif self.templates:
+            help_text = "No matching prompt templates - Escape closes"
+        else:
+            help_text = "No prompt templates loaded - Escape closes"
+        self.query_one("#prompt-template-picker-help", Static).update(help_text)
 
 
 class SessionPickerScreen(ModalScreen[str | None]):
@@ -2553,12 +2639,14 @@ class TauTuiApp(App[None]):
     }
 
     SessionPickerScreen,
+    PromptTemplatePickerScreen,
     TreePickerScreen,
     CommandOutputScreen {
         align: center middle;
     }
 
     #session-picker,
+    #prompt-template-picker,
     #tree-picker {
         width: 76;
         max-width: 90%;
@@ -2570,6 +2658,7 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-title,
+    #prompt-template-picker-title,
     #tree-picker-title {
         height: 1;
         color: $tau-chrome-text;
@@ -2577,7 +2666,8 @@ class TauTuiApp(App[None]):
         margin-bottom: 1;
     }
 
-    #session-picker-search {
+    #session-picker-search,
+    #prompt-template-picker-search {
         height: 3;
         margin-bottom: 1;
         background: $tau-prompt-background;
@@ -2586,6 +2676,7 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-list,
+    #prompt-template-picker-list,
     #tree-picker-list {
         height: auto;
         max-height: 16;
@@ -2604,6 +2695,7 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-help,
+    #prompt-template-picker-help,
     #tree-picker-help {
         height: 1;
         margin-top: 1;
@@ -3238,6 +3330,8 @@ class TauTuiApp(App[None]):
                 await self._resume_session(command.resume_session_id)
             if command.resume_picker_requested:
                 self.action_open_session_picker()
+            if command.prompts_picker_requested:
+                self._open_prompt_template_picker()
             if command.tree_picker_requested:
                 if self._is_agent_or_queue_active():
                     prompt.text = raw_text
@@ -4386,6 +4480,23 @@ class TauTuiApp(App[None]):
             SessionPickerScreen(records, theme=self.tui_settings.resolved_theme),
             callback=self._handle_session_picker_result,
         )
+
+    def _open_prompt_template_picker(self) -> None:
+        self.push_screen(
+            PromptTemplatePickerScreen(self.session.prompt_templates),
+            callback=self._handle_prompt_template_picker_result,
+        )
+
+    def _handle_prompt_template_picker_result(self, name: str | None) -> None:
+        prompt = self.query_one("#prompt", PromptInput)
+        prompt.focus()
+        if name is None:
+            return
+        invocation = f"/{name}"
+        prompt.text = invocation
+        prompt.move_cursor(_text_end_location(invocation))
+        self._completion_state = self._build_completion_state(invocation)
+        self._refresh_completions()
 
     def action_cycle_thinking(self) -> None:
         """Cycle the active thinking mode."""

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2274,6 +2274,36 @@ async def test_session_expands_prompt_templates_as_slash_commands(tmp_path: Path
 
 
 @pytest.mark.anyio
+async def test_reserved_prompts_template_cannot_shadow_picker_command(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    prompts_dir = resource_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    reserved_path = prompts_dir / "prompts.md"
+    reserved_path.write_text("Shadow the picker", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        )
+    )
+
+    result = session.handle_command("/prompts")
+
+    assert result.handled is True
+    assert result.prompts_picker_requested is True
+    assert session.prompt_templates == ()
+    assert any(
+        diagnostic.path == reserved_path
+        and "reserved by the built-in /prompts command" in diagnostic.message
+        for diagnostic in session.resource_diagnostics
+    )
+
+
+@pytest.mark.anyio
 async def test_session_skill_index_lets_agent_read_relevant_skill_file(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
     skills_dir = resource_root / "skills" / "testing"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -126,6 +126,7 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "model",
         "name",
         "new",
+        "prompts",
         "quit",
         "reload",
         "resume",
@@ -136,6 +137,14 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "theme",
         "tree",
     ]
+
+
+def test_prompts_command_requests_picker(tmp_path: Path) -> None:
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    assert registry.execute(session, "/prompts").prompts_picker_requested is True
+    assert registry.execute(session, "/prompts extra").message == "Usage: /prompts"
 
 
 def test_system_command_returns_active_prompt(tmp_path: Path) -> None:

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -90,6 +90,22 @@ def test_load_prompt_templates_with_diagnostics_reports_overrides(tmp_path: Path
     assert "overrides lower-precedence resource" in diagnostics[0].message
 
 
+def test_reserved_prompts_template_is_ignored_with_diagnostic(tmp_path: Path) -> None:
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    reserved_path = prompts_dir / "PROMPTS.md"
+    reserved_path.write_text("Shadow the picker", encoding="utf-8")
+
+    templates, diagnostics = load_prompt_templates_with_diagnostics(
+        TauResourcePaths(root=tmp_path, agents_root=None)
+    )
+
+    assert templates == []
+    assert len(diagnostics) == 1
+    assert diagnostics[0].path == reserved_path
+    assert "reserved by the built-in /prompts command" in diagnostics[0].message
+
+
 def test_render_prompt_template_replaces_variables() -> None:
     template = PromptTemplate(
         name="review",

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4031,7 +4031,13 @@ async def test_tui_app_prompts_picker_filters_and_inserts_without_submitting() -
 
         assert isinstance(app.screen, PromptTemplatePickerScreen)
         search = app.screen.query_one("#prompt-template-picker-search", Input)
+        picker_list = app.screen.query_one("#prompt-template-picker-list", ListView)
         assert search.has_focus
+        assert picker_list.index == 0
+        await pilot.press("down")
+        assert picker_list.index == 1
+        await pilot.press("up")
+        assert picker_list.index == 0
         await pilot.press("z")
         assert app.screen.visible_templates == ()
         assert "No matching prompt templates" in str(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -81,6 +81,7 @@ from tau_coding.tui.app import (
     ModelPickerScreen,
     OAuthLoginScreen,
     PromptInput,
+    PromptTemplatePickerScreen,
     SessionPickerScreen,
     TauTuiApp,
     ThemePickerScreen,
@@ -253,6 +254,8 @@ class FakeSession:
             return CommandResult(handled=True, resume_session_id=text.removeprefix("/resume "))
         if text == "/resume":
             return CommandResult(handled=True, resume_picker_requested=True)
+        if text == "/prompts":
+            return CommandResult(handled=True, prompts_picker_requested=True)
         if text == "/tree":
             return CommandResult(handled=True, tree_picker_requested=True)
         if text == "/login":
@@ -3999,6 +4002,74 @@ async def test_structured_assistant_ignores_empty_final_content_blocks() -> None
 
         transcript = app.query_one("#transcript", TranscriptView)
         assert [line.text for line in transcript.lines] == ["earlier", "done"]
+
+
+@pytest.mark.anyio
+async def test_tui_app_prompts_picker_filters_and_inserts_without_submitting() -> None:
+    session = FakeSession()
+    session.prompt_templates = (
+        PromptTemplate(
+            name="review",
+            path=Path("review.md"),
+            content="Review this.",
+            description="Inspect changes",
+        ),
+        PromptTemplate(
+            name="test",
+            path=Path("test.md"),
+            content="Test this.",
+            description="Run checks",
+        ),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/prompts"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, PromptTemplatePickerScreen)
+        search = app.screen.query_one("#prompt-template-picker-search", Input)
+        assert search.has_focus
+        await pilot.press("z")
+        assert app.screen.visible_templates == ()
+        assert "No matching prompt templates" in str(
+            app.screen.query_one("#prompt-template-picker-help", Static).content
+        )
+        search.value = "tes"
+        await pilot.pause()
+        assert [template.name for template in app.screen.visible_templates] == ["test"]
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert prompt.value == "/test"
+        assert prompt.has_focus
+        assert app.state.items == []
+
+
+@pytest.mark.anyio
+async def test_tui_app_prompts_picker_cancel_and_empty_state() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/prompts"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        picker = app.screen
+        assert isinstance(picker, PromptTemplatePickerScreen)
+        assert "No prompt templates loaded" in str(
+            picker.query_one("#prompt-template-picker-help", Static).content
+        )
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert prompt.value == ""
+        assert prompt.has_focus
+        assert app.state.items == []
 
 
 @pytest.mark.anyio

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -89,8 +89,9 @@ prompt and runs it as a normal turn.
 A prompt template is a saved prompt you trigger by its filename. For example,
 `~/.agents/prompts/wt.md` is invoked with `/wt`. Run `/prompts` in the TUI to
 search every loaded template and insert its invocation for editing; selection
-does not submit the prompt. Templates can include
-variables with `{{ name }}`:
+does not submit the prompt. The filename `prompts.md` is reserved for this
+built-in command; Tau ignores a template with that name and reports a resource
+diagnostic. Templates can include variables with `{{ name }}`:
 
 ```md
 ---

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -86,8 +86,10 @@ prompt and runs it as a normal turn.
 
 ## Prompt templates
 
-A prompt template is a saved prompt you trigger by its filename. For example
-`~/.agents/prompts/wt.md` becomes the prompt `wt`. Templates can include
+A prompt template is a saved prompt you trigger by its filename. For example,
+`~/.agents/prompts/wt.md` is invoked with `/wt`. Run `/prompts` in the TUI to
+search every loaded template and insert its invocation for editing; selection
+does not submit the prompt. Templates can include
 variables with `{{ name }}`:
 
 ```md
@@ -100,7 +102,8 @@ Implement this feature safely in a new worktree:
 ```
 
 If a template has no placeholders, your arguments are appended after a blank
-line. Variables are filled from the arguments you pass when invoking it.
+line. Variables are filled from the arguments you pass after the invocation,
+for example `/wt add caching`.
 
 ## Skill vs. prompt template — which?
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -58,6 +58,7 @@ to search and run them. Common ones:
 - `/model` — pick the active model
 - `/compact` — summarize and shrink the context
 - `/resume`, `/tree` — open previous sessions or branch from history
+- `/prompts` — search prompt templates and insert one for editing
 - `/hotkeys` — show the keyboard shortcuts
 
 The full list is in the [Slash commands reference]({{< relref "../reference/slash-commands.md" >}}).

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -23,6 +23,7 @@ command palette with **Ctrl+K**.
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
+| `/prompts` | Search loaded prompt templates and insert an invocation for editing |
 | `/hotkeys` | Show the keyboard shortcuts |
 | `/skill:<name> [request]` | Expand a loaded skill into your prompt |
 
@@ -40,4 +41,4 @@ Related:
 
 - **Thinking mode** is keyboard-driven, not a slash command — see
   [Keyboard shortcuts]({{< relref "./keybindings.md" >}}) and [Managing context]({{< relref "../guides/context.md#thinking-modes" >}}).
-- **Prompt templates** are invoked by filename (e.g. `wt …`), not with a slash.
+- **Prompt templates** use slash invocations (for example, `/wt …`). Use `/prompts` to search loaded templates and insert an invocation without submitting it.


### PR DESCRIPTION
## Description

Adds `/prompts`, a searchable TUI modal listing all loaded prompt templates by name and description. Selecting a template inserts its existing `/<template-name>` invocation into the prompt editor without submitting it.

The picker supports case-insensitive filtering, keyboard navigation, cancellation, and explicit empty/no-match states.

## User experience

Users no longer need to remember prompt-template names. They can discover and filter available templates, then edit the selected invocation to add arguments before submitting.

Closes #452.

## Manual validation

1. Add two Markdown prompt templates under `~/.tau/prompts/` or `<project>/.tau/prompts/`.
2. Start Tau's TUI and run `/prompts`.
3. Type part of a template name or description and use Up/Down to navigate.
4. Press Enter and verify `/<template-name>` appears in the prompt without running a turn.
5. Open `/prompts` again and press Escape; verify the picker closes without inserting a template.
6. Search for an absent name and verify the no-results message.
