### PR TITLE
Add searchable extensions inventory modal

### DIFF
--- a/dev-notes/design/extensions-management.md
+++ b/dev-notes/design/extensions-management.md
@@ -1,0 +1,69 @@
+---
+title: "Extensions inventory and management boundaries"
+---
+
+# Extensions inventory and management boundaries
+
+Issue #454 introduces `/extensions` as a searchable, read-only TUI inventory.
+It shows successful loads with source metadata and extension diagnostics in one
+place. This solves the immediate visibility problem without implying package
+management Tau does not yet provide.
+
+## Data model
+
+`ExtensionInfo` is runtime metadata, rebuilt during extension discovery:
+
+- `name`: loader identity
+- `path`: resolved entry file shown to the user
+- `scope`: `project`, `user`, or `explicit`
+- `status`: currently `loaded`
+
+Failures remain `ResourceDiagnostic` values. They are rows in the inventory,
+not installations. No registry or manifest is persisted.
+
+## Ownership and removal
+
+Current sources have these boundaries:
+
+| Source | Tau owns files? | Removal meaning |
+| --- | --- | --- |
+| `~/.tau/extensions` manually populated | No | Explain the path; user removes it |
+| `<project>/.tau/extensions` | No | Explain the project path; never delete |
+| explicit `-e` file/directory | No | Restart without the flag; never delete |
+| future Tau-managed user install | Yes | Remove only its registered managed directory, after confirmation |
+
+Therefore this phase exposes no Remove action. A future installer must keep a
+registry that distinguishes Tau-managed directories from coincidentally
+located user files before destructive actions are safe.
+
+## Enable and disable
+
+The runtime currently persists only global discovery choices. Per-extension
+enablement needs a registry recording a stable installation identity, source,
+path, scope, revision, and enabled state. Name alone is unsuitable because
+load precedence permits duplicate names. Changes must use the existing
+`session_shutdown` → reset/reload → `session_start` lifecycle. On failure, Tau
+must preserve or restore the prior registry, files, and usable runtime.
+
+## Repository installation trust model
+
+Installing from a URL is deferred. Before implementation, define:
+
+1. initially accepted canonical public GitHub HTTPS repository URLs;
+2. an installation ID and destination under a Tau-owned directory, separate
+   from manually populated extensions;
+3. pinned revision and entry discovery metadata in an atomic registry;
+4. clone into a temporary sibling, validate manifest/entries, then rename;
+5. explicit confirmation that arbitrary Python executes in Tau's process;
+6. rollback of files and registry on clone, validation, setup, or reload error;
+7. update and removal behavior, including local modifications;
+8. deterministic tests using local fake repositories, never the network.
+
+SSH/private authentication, automatic updates, and project installation should
+remain follow-ups until the public HTTPS flow and trust language are proven.
+
+## Validation
+
+Textual pilot tests cover populated inventory, case-insensitive filtering, no
+matches, empty state, and Escape cancellation. Command tests cover registration
+and argument validation.

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -115,6 +115,7 @@ class CommandResult:
     model_picker_requested: bool = False
     scoped_models_picker_requested: bool = False
     theme_picker_requested: bool = False
+    extensions_picker_requested: bool = False
     thinking_level: str | None = None
     theme: str | None = None
     message: str | None = None
@@ -272,6 +273,15 @@ def create_default_command_registry() -> CommandRegistry:
             description="Show common keyboard shortcuts.",
             handler=_hotkeys_command,
             search_terms=("keys", "shortcuts", "bindings"),
+        )
+    )
+    registry.register(
+        SlashCommand(
+            name="extensions",
+            usage="/extensions",
+            description="Browse loaded extensions and diagnostics.",
+            handler=_extensions_command,
+            search_terms=("plugins", "addons"),
         )
     )
     registry.register(
@@ -482,6 +492,12 @@ def _resources_command(context: CommandContext) -> CommandResult:
     else:
         lines.append("Resource diagnostics: none")
     return CommandResult(handled=True, message="\n".join(lines))
+
+
+def _extensions_command(context: CommandContext) -> CommandResult:
+    if context.args:
+        return CommandResult(handled=True, message="Usage: /extensions")
+    return CommandResult(handled=True, extensions_picker_requested=True)
 
 
 def _reload_command(context: CommandContext) -> CommandResult:

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -114,6 +114,16 @@ class BoundSession(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class ExtensionInfo:
+    """User-facing metadata for one loaded extension."""
+
+    name: str
+    path: Path
+    scope: Literal["project", "user", "explicit"]
+    status: Literal["loaded"] = "loaded"
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionCommand:
     """A slash command registered by an extension."""
 
@@ -167,6 +177,7 @@ class ExtensionRuntime:
         self._harness_unsubscribe: Callable[[], None] | None = None
         self._extension_turn_index = 0
         self._generation = ExtensionGeneration()
+        self._extension_info: list[ExtensionInfo] = []
 
     # -- loading -----------------------------------------------------------
 
@@ -186,8 +197,22 @@ class ExtensionRuntime:
             include_project_dir=include_project_dir,
         )
         self._load_diagnostics.extend(result.diagnostics)
+        project_dir = paths.cwd / ".tau" / "extensions" if paths.cwd is not None else None
+        user_dir = paths.root / "extensions"
         for extension in result.extensions:
             self._setup_extension(extension)
+            if extension.name in self.extension_names:
+                self._extension_info.append(
+                    ExtensionInfo(
+                        name=extension.name,
+                        path=extension.path,
+                        scope=_extension_scope(
+                            extension.path,
+                            project_dir=project_dir,
+                            user_dir=user_dir,
+                        ),
+                    )
+                )
 
     def reset_for_reload(self) -> None:
         """Drop all registrations and imported modules ahead of a re-load.
@@ -210,6 +235,7 @@ class ExtensionRuntime:
             self._harness_unsubscribe()
             self._harness_unsubscribe = None
         self._extensions.clear()
+        self._extension_info.clear()
         self._tools.clear()
         self._commands.clear()
         self._prompt_guidelines.clear()
@@ -538,6 +564,11 @@ class ExtensionRuntime:
     def extension_names(self) -> tuple[str, ...]:
         """Return loaded extension names in load order."""
         return tuple(extension.name for extension in self._extensions)
+
+    @property
+    def extension_info(self) -> tuple[ExtensionInfo, ...]:
+        """Return metadata for loaded extensions in load order."""
+        return tuple(self._extension_info)
 
     @property
     def diagnostics(self) -> tuple[ResourceDiagnostic, ...]:
@@ -895,6 +926,17 @@ class ExtensionRuntime:
                 ),
             )
         )
+
+
+def _extension_scope(
+    path: Path, *, project_dir: Path | None, user_dir: Path
+) -> Literal["project", "user", "explicit"]:
+    resolved = path.resolve()
+    if project_dir is not None and resolved.is_relative_to(project_dir.resolve()):
+        return "project"
+    if resolved.is_relative_to(user_dir.resolve()):
+        return "user"
+    return "explicit"
 
 
 async def _resolve(value: object) -> object:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -114,7 +114,7 @@ from tau_coding.provider_config import (
     upsert_saved_provider,
 )
 from tau_coding.provider_runtime import create_model_provider
-from tau_coding.resources import TauResourcePaths
+from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
 from tau_coding.session import (
     TREE_RUNNING_MESSAGE,
     CodingSession,
@@ -946,6 +946,90 @@ class ExtensionInputScreen(ModalScreen[str | None]):
     def action_cancel(self) -> None:
         """Close without submitting text."""
         self.dismiss(None)
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionInventoryItem:
+    """One searchable extension or diagnostic row."""
+
+    name: str
+    detail: str
+    search_text: str
+
+
+class ExtensionsScreen(ModalScreen[None]):
+    """Searchable read-only inventory of extensions and diagnostics."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [Binding("escape", "cancel", "Close")]
+
+    def __init__(self, runtime: object, *, theme: TuiTheme) -> None:
+        super().__init__()
+        info = tuple(getattr(runtime, "extension_info", ()))
+        diagnostics = tuple(
+            diagnostic
+            for diagnostic in getattr(runtime, "diagnostics", ())
+            if isinstance(diagnostic, ResourceDiagnostic) and diagnostic.kind == "extension"
+        )
+        rows = [
+            ExtensionInventoryItem(
+                name=extension.name,
+                detail=f"{extension.scope} · {extension.status}\n{extension.path}",
+                search_text=(
+                    f"{extension.name} {extension.scope} {extension.status} {extension.path}"
+                ).lower(),
+            )
+            for extension in info
+        ]
+        rows.extend(
+            ExtensionInventoryItem(
+                name=diagnostic.name or (diagnostic.path.name if diagnostic.path else "Diagnostic"),
+                detail=f"{diagnostic.severity} · {diagnostic.message}"
+                + (f"\n{diagnostic.path}" if diagnostic.path else ""),
+                search_text=diagnostic.format().lower(),
+            )
+            for diagnostic in diagnostics
+        )
+        self.rows = tuple(rows)
+        self.visible_rows = self.rows
+        self.theme = theme
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="extensions-screen"):
+            yield Static("Extensions", id="extensions-title")
+            yield Input(placeholder="Search extensions", id="extensions-search")
+            yield ListView(id="extensions-list")
+            yield Static("Escape closes", id="extensions-help")
+
+    def on_mount(self) -> None:
+        self.query_one("#extensions-search", Input).focus()
+        self._refresh_rows("")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "extensions-search":
+            event.stop()
+            self._refresh_rows(event.value)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _refresh_rows(self, query: str) -> None:
+        needle = query.strip().lower()
+        self.visible_rows = tuple(row for row in self.rows if needle in row.search_text)
+        listing = self.query_one("#extensions-list", ListView)
+        listing.clear()
+        if self.visible_rows:
+            listing.extend(
+                ListItem(Label(f"{row.name}\n{row.detail}", markup=False))
+                for row in self.visible_rows
+            )
+            help_text = "Escape closes"
+        else:
+            empty = (
+                "No extensions loaded" if not self.rows and not needle else "No matching extensions"
+            )
+            listing.append(ListItem(Label(empty, markup=False), disabled=True))
+            help_text = f"{empty} · Escape closes"
+        self.query_one("#extensions-help", Static).update(help_text)
 
 
 class SessionPickerSearchInput(Input):
@@ -2554,12 +2638,14 @@ class TauTuiApp(App[None]):
 
     SessionPickerScreen,
     TreePickerScreen,
-    CommandOutputScreen {
+    CommandOutputScreen,
+    ExtensionsScreen {
         align: center middle;
     }
 
     #session-picker,
-    #tree-picker {
+    #tree-picker,
+    #extensions-screen {
         width: 76;
         max-width: 90%;
         height: auto;
@@ -2570,14 +2656,16 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-title,
-    #tree-picker-title {
+    #tree-picker-title,
+    #extensions-title {
         height: 1;
         color: $tau-chrome-text;
         text-style: bold;
         margin-bottom: 1;
     }
 
-    #session-picker-search {
+    #session-picker-search,
+    #extensions-search {
         height: 3;
         margin-bottom: 1;
         background: $tau-prompt-background;
@@ -2586,7 +2674,8 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-list,
-    #tree-picker-list {
+    #tree-picker-list,
+    #extensions-list {
         height: auto;
         max-height: 16;
         background: $tau-transcript-background;
@@ -2604,7 +2693,8 @@ class TauTuiApp(App[None]):
     }
 
     #session-picker-help,
-    #tree-picker-help {
+    #tree-picker-help,
+    #extensions-help {
         height: 1;
         margin-top: 1;
         color: $tau-muted-text;
@@ -3261,6 +3351,13 @@ class TauTuiApp(App[None]):
                 self._open_scoped_models_picker()
             if command.theme_picker_requested:
                 self._open_theme_picker()
+            if command.extensions_picker_requested:
+                self.push_screen(
+                    ExtensionsScreen(
+                        self.session.extension_runtime,
+                        theme=self.tui_settings.resolved_theme,
+                    )
+                )
             if command.thinking_level is not None:
                 await self._set_thinking_level(command.thinking_level)
             if command.theme is not None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -120,6 +120,7 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
     assert [command.name for command in commands] == [
         "compact",
         "export",
+        "extensions",
         "hotkeys",
         "login",
         "logout",
@@ -415,6 +416,19 @@ def test_logout_command_rejects_unknown_provider(tmp_path: Path) -> None:
     assert result.handled is True
     assert result.message is not None
     assert "Unknown logout provider: local" in result.message
+
+
+def test_extensions_command_requests_inventory_modal(tmp_path: Path) -> None:
+    result = create_default_command_registry().execute(FakeSession(tmp_path), "/extensions")
+
+    assert result.handled is True
+    assert result.extensions_picker_requested is True
+    assert (
+        create_default_command_registry()
+        .execute(FakeSession(tmp_path), "/extensions extra")
+        .message
+        == "Usage: /extensions"
+    )
 
 
 def test_reload_command_requests_async_session_reload(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from rich.console import Console
@@ -75,6 +76,7 @@ from tau_coding.tui.app import (
     ExtensionConfirmScreen,
     ExtensionInputScreen,
     ExtensionSelectScreen,
+    ExtensionsScreen,
     LoginMethodPickerScreen,
     LoginProviderPickerScreen,
     LoginScreen,
@@ -3045,6 +3047,64 @@ async def test_theme_picker_highlight_uses_theme_selection_palette(theme: TuiThe
         highlighted_label = highlighted_item.query_one(Label)
         assert highlighted_label.styles.background == Color.parse(theme.highlight_background)
         assert highlighted_label.styles.color == Color.parse(theme.highlight_text)
+
+
+@pytest.mark.anyio
+async def test_extensions_screen_inventory_filter_empty_and_cancel(tmp_path: Path) -> None:
+    runtime = SimpleNamespace(
+        extension_info=(
+            SimpleNamespace(
+                name="Alpha Tools",
+                scope="user",
+                status="loaded",
+                path=tmp_path / "alpha.py",
+            ),
+            SimpleNamespace(
+                name="Beta",
+                scope="explicit",
+                status="loaded",
+                path=tmp_path / "beta.py",
+            ),
+        ),
+        diagnostics=(),
+    )
+    app = TauTuiApp(FakeSession())  # type: ignore[arg-type]
+
+    async with app.run_test() as pilot:
+        screen = ExtensionsScreen(runtime, theme=TAU_DARK_THEME)
+        app.push_screen(screen)
+        await pilot.pause()
+        assert len(screen.query("#extensions-list ListItem")) == 2
+
+        search = screen.query_one("#extensions-search", Input)
+        search.value = "ALPHA"
+        await pilot.pause()
+        assert len(screen.visible_rows) == 1
+        assert screen.visible_rows[0].name == "Alpha Tools"
+
+        search.value = "missing"
+        await pilot.pause()
+        assert screen.visible_rows == ()
+        help_text = screen.query_one("#extensions-help", Static).render()
+        assert "No matching extensions" in str(help_text)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, ExtensionsScreen)
+
+
+@pytest.mark.anyio
+async def test_extensions_screen_empty_state() -> None:
+    app = TauTuiApp(FakeSession())  # type: ignore[arg-type]
+
+    async with app.run_test() as pilot:
+        screen = ExtensionsScreen(
+            SimpleNamespace(extension_info=(), diagnostics=()), theme=TAU_DARK_THEME
+        )
+        app.push_screen(screen)
+        await pilot.pause()
+
+        assert "No extensions loaded" in str(screen.query_one("#extensions-help", Static).render())
 
 
 @pytest.mark.anyio

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -87,6 +87,13 @@ Use those lifecycle hooks to stop and restart background work and to remount UI.
 > Project extensions are therefore off by default — enable them with
 > `--project-extensions` only in repositories you trust.
 
+In the TUI, run `/extensions` to open a searchable inventory. Each loaded
+extension shows its name, entry path, source scope (`project`, `user`, or
+`explicit`), and load status. Discovery, import, setup, and runtime diagnostics
+appear in the same view. The inventory is intentionally read-only: Tau does not
+claim ownership of manually placed, project, or `-e` extension files and never
+deletes them.
+
 ## The extension API
 
 ```python

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -22,6 +22,7 @@ command palette with **Ctrl+K**.
 | `/theme [name]` | Show or set the TUI theme |
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/logout [provider]` | Remove saved credentials for a provider |
+| `/extensions` | Open a searchable inventory of loaded extensions and extension diagnostics |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
 | `/hotkeys` | Show the keyboard shortcuts |
 | `/skill:<name> [request]` | Expand a loaded skill into your prompt |


### PR DESCRIPTION
## Description

Adds a built-in `/extensions` TUI command and searchable, read-only inventory for loaded extensions. The modal shows extension name, source scope, load status, path, and extension diagnostics. It also documents ownership, removal, enable/disable, and repository-installation trust boundaries before destructive management is introduced.

## User experience

Users can now see which extensions Tau loaded, where each came from, and why an extension failed without digging through `/session` output. Case-insensitive filtering and clear empty/no-match states make larger extension sets easier to inspect.

## Issue

Closes #454.

## Manual validation

1. Place an extension in `~/.tau/extensions/`, or launch Tau with `-e PATH`.
2. Start the interactive TUI.
3. Run `/extensions`.
4. Confirm the extension name, scope, loaded status, and path are shown.
5. Type part of its name/path with different casing and confirm the list filters.
6. Press Escape to close the modal.
7. Optionally add a broken extension and restart; confirm its diagnostic appears in the modal.

## Checks

- `uv run pytest` (1122 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
