### PR TITLE
Clear /skills input when picker is cancelled

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3754,7 +3754,7 @@ class TauTuiApp(App[None]):
             if command.scoped_models_picker_requested:
                 self._open_scoped_models_picker()
             if command.skills_picker_requested:
-                self._open_skills_picker(raw_text)
+                self._open_skills_picker()
             if command.theme_picker_requested:
                 self._open_theme_picker()
             if command.thinking_level is not None:
@@ -4911,19 +4911,17 @@ class TauTuiApp(App[None]):
         self._completion_state = self._build_completion_state(invocation)
         self._refresh_completions()
 
-    def _open_skills_picker(self, original_text: str) -> None:
-        """Open loaded-skill discovery and preserve the submitted command on cancel."""
+    def _open_skills_picker(self) -> None:
+        """Open loaded-skill discovery."""
         self.push_screen(
             SkillPickerScreen(self.session.skills, theme=self.tui_settings.resolved_theme),
-            callback=lambda name: self._handle_skill_picker_result(name, original_text),
+            callback=self._handle_skill_picker_result,
         )
 
-    def _handle_skill_picker_result(
-        self, result: SkillPickerResult | None, original_text: str
-    ) -> None:
+    def _handle_skill_picker_result(self, result: SkillPickerResult | None) -> None:
         prompt = self.query_one("#prompt", PromptInput)
         if result is None:
-            prompt.text = original_text
+            prompt.text = ""
         elif result.action == "insert":
             prompt.text = f"/skill:{result.skill.name}"
         else:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3103,7 +3103,7 @@ async def test_tui_app_skills_picker_previews_description_and_shows_content_in_t
 
 
 @pytest.mark.anyio
-async def test_tui_app_skills_picker_cancel_preserves_prompt_and_shows_empty_states() -> None:
+async def test_tui_app_skills_picker_cancel_clears_prompt_and_shows_empty_states() -> None:
     session = FakeSession()
     session.skills = ()
     app = TauTuiApp(session)
@@ -3124,7 +3124,7 @@ async def test_tui_app_skills_picker_cancel_preserves_prompt_and_shows_empty_sta
         await pilot.press("escape")
         await pilot.pause()
 
-        assert prompt.text == "/skills"
+        assert prompt.text == ""
         assert prompt.has_focus
         assert session.prompt_texts == []
 


### PR DESCRIPTION
## Description

Clear the prompt after the `/skills` picker is cancelled instead of restoring the submitted `/skills` command.

## User experience

Pressing Escape now returns users to a clean prompt, avoiding the need to manually delete a command that has already been handled.

## Issue

Addresses the reported `/skills` picker cancellation behavior. No linked issue.

## Manual validation

1. Start the Tau TUI.
2. Enter `/skills`.
3. Press Escape to close the skills picker.
4. Confirm the prompt is focused and empty.
