### PR TITLE
Release Tau 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.3.1",
+    "date": "2026-07-23",
+    "sections": {
+      "New": [
+        "Add one-line installers for macOS, Linux, and Windows that install Tau through uv and verify the resulting command.",
+        "Add configurable desktop or bell notifications when an agent run finishes while Tau is unfocused.",
+        "Add searchable TUI pickers for prompt templates and skills, plus a searchable tools reference with full descriptions."
+      ],
+      "Changed": [
+        "Keep dense TUI sidebar sections compact by limiting rendered skills, context files, tools, prompts, and extensions while showing hidden-item counts.",
+        "Make user settings forward-compatible by ignoring unknown fields while continuing to validate recognized settings."
+      ],
+      "Fixed": [
+        "Clear the prompt after cancelling the `/skills` picker instead of restoring the handled command."
+      ]
+    }
+  },
+  {
     "version": "0.3.0",
     "date": "2026-07-22",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -629,7 +629,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.0" in console.export_text()
+    assert "τ = 2π  0.3.1" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

Prepare Tau 0.3.1 for release.

- bump the package and lockfile version from 0.3.0 to 0.3.1
- add structured 0.3.1 release notes for changes since v0.3.0
- update the sidebar version assertion

## Checks

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 1145 passed

## Release plan

After this PR merges, publish GitHub Release `v0.3.1` from the merge commit. The release workflow will build and publish `tau-ai==0.3.1` to PyPI.
