### PR TITLE
fix(resources): reserve all built-in slash-command prompt names

### DIFF
--- a/dev-notes/reserved-prompt-template-names.md
+++ b/dev-notes/reserved-prompt-template-names.md
@@ -1,0 +1,39 @@
+# Reserved prompt-template names
+
+## Problem
+
+`CodingSession.handle_command()` checks prompt templates before the slash-command
+registry. A template such as `new.md` therefore intercepted `/new` and expanded
+into custom prompt text instead of starting a new session. Only `prompts.md`,
+`skills.md`, and `tools.md` were reserved.
+
+## Policy
+
+At resource-loading time, Tau derives the reserved set from
+`create_default_command_registry()`:
+
+- every built-in command name (for example `new`, `quit`, `reload`)
+- every built-in alias (for example `exit` for `/quit`)
+
+Matching is case-insensitive on the markdown filename stem. Colliding templates
+are not loaded; each one emits a resource diagnostic with its path and the
+conflicting built-in command. Non-conflicting templates still expand before
+ordinary command dispatch.
+
+Command-first dispatch was rejected because it would silently change behavior for
+installations that intentionally shadowed commands with templates.
+
+Extension-provided commands are dynamic and may change on `/reload`, so they are
+out of scope for this reservation pass.
+
+## Verify
+
+```bash
+uv run pytest tests/test_prompt_templates.py \
+  tests/test_coding_session.py -k reserved
+uv run ruff check src/tau_coding tests
+```
+
+Manual check: add `~/.agents/prompts/new.md`, start `tau`, run `/new` — the
+session should request a new session and report a prompt diagnostic for the
+ignored template.

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -17,7 +17,24 @@ from tau_coding.resources import (
 
 _TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
 _ARGUMENT_TEMPLATE_VARIABLES = {"arguments", "args"}
-_RESERVED_TEMPLATE_NAMES = frozenset({"prompts", "skills", "tools"})
+
+
+def builtin_prompt_template_reservations() -> dict[str, str]:
+    """Map case-folded prompt-template stems to the built-in command they collide with.
+
+    Prompt templates are invoked by markdown filename stem before ordinary slash-command
+    dispatch. Any stem that matches a built-in command name or alias is ignored at load
+    time so commands such as ``/new`` and ``/quit`` stay reachable.
+    """
+    from tau_coding.commands import create_default_command_registry
+
+    registry = create_default_command_registry()
+    reservations: dict[str, str] = {}
+    for command in registry.list_commands():
+        reservations[command.name.casefold()] = f"/{command.name}"
+        for alias in command.aliases:
+            reservations[alias.casefold()] = f"/{alias}"
+    return reservations
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,17 +181,19 @@ def _load_prompt_templates_from_dir_with_diagnostics(
     templates: list[PromptTemplate] = []
     diagnostics: list[ResourceDiagnostic] = []
     seen: set[str] = set()
+    reserved_names = builtin_prompt_template_reservations()
     for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
         name = path.stem
-        if name.casefold() in _RESERVED_TEMPLATE_NAMES:
+        reserved_command = reserved_names.get(name.casefold())
+        if reserved_command is not None:
             diagnostics.append(
                 ResourceDiagnostic(
                     kind="prompt",
                     name=name,
                     path=path,
                     message=(
-                        f"prompt template name is reserved by the built-in /{name.casefold()} "
-                        "command; template ignored"
+                        f"prompt template name is reserved by the built-in "
+                        f"{reserved_command} command; template ignored"
                     ),
                 )
             )

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2305,6 +2305,101 @@ async def test_reserved_prompts_template_cannot_shadow_picker_command(tmp_path: 
 
 
 @pytest.mark.anyio
+async def test_reserved_new_template_cannot_shadow_new_command(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    prompts_dir = resource_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    reserved_path = prompts_dir / "new.md"
+    reserved_path.write_text("Shadow /new", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        )
+    )
+
+    result = session.handle_command("/new")
+
+    assert result.handled is True
+    assert result.new_session_requested is True
+    assert session.prompt_templates == ()
+    assert any(
+        diagnostic.path == reserved_path
+        and "reserved by the built-in /new command" in diagnostic.message
+        for diagnostic in session.resource_diagnostics
+    )
+
+
+@pytest.mark.anyio
+async def test_reserved_quit_and_exit_templates_cannot_shadow_quit_command(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    prompts_dir = resource_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    quit_path = prompts_dir / "quit.md"
+    exit_path = prompts_dir / "exit.md"
+    quit_path.write_text("Shadow /quit", encoding="utf-8")
+    exit_path.write_text("Shadow /exit", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        )
+    )
+
+    quit_result = session.handle_command("/quit")
+    assert quit_result.handled is True
+    assert quit_result.exit_requested is True
+    assert session.prompt_templates == ()
+    assert any(
+        diagnostic.path == quit_path
+        and "reserved by the built-in /quit command" in diagnostic.message
+        for diagnostic in session.resource_diagnostics
+    )
+    assert any(
+        diagnostic.path == exit_path
+        and "reserved by the built-in /exit command" in diagnostic.message
+        for diagnostic in session.resource_diagnostics
+    )
+
+
+@pytest.mark.anyio
+async def test_reserved_prompt_templates_stay_ignored_after_reload(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    prompts_dir = resource_root / "prompts"
+    prompts_dir.mkdir(parents=True)
+    reserved_path = prompts_dir / "new.md"
+    reserved_path.write_text("Shadow /new", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        )
+    )
+
+    await session.reload()
+
+    assert session.prompt_templates == ()
+    assert session.handle_command("/new").new_session_requested is True
+    assert any(
+        diagnostic.path == reserved_path
+        and "reserved by the built-in /new command" in diagnostic.message
+        for diagnostic in session.resource_diagnostics
+    )
+
+
+@pytest.mark.anyio
 async def test_reserved_tools_template_cannot_shadow_picker_command(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
     prompts_dir = resource_root / "prompts"

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -9,7 +9,11 @@ from tau_coding import (
     load_prompt_templates_with_diagnostics,
     render_prompt_template,
 )
-from tau_coding.prompt_templates import PromptTemplate
+from tau_coding.commands import create_default_command_registry
+from tau_coding.prompt_templates import (
+    PromptTemplate,
+    builtin_prompt_template_reservations,
+)
 from tau_coding.resources import ResourceError
 
 
@@ -90,7 +94,7 @@ def test_load_prompt_templates_with_diagnostics_reports_overrides(tmp_path: Path
     assert "overrides lower-precedence resource" in diagnostics[0].message
 
 
-@pytest.mark.parametrize("reserved_name", ["prompts", "skills", "tools"])
+@pytest.mark.parametrize("reserved_name", ["prompts", "skills", "tools", "new", "quit", "exit"])
 def test_reserved_picker_template_is_ignored_with_diagnostic(
     tmp_path: Path, reserved_name: str
 ) -> None:
@@ -106,7 +110,18 @@ def test_reserved_picker_template_is_ignored_with_diagnostic(
     assert templates == []
     assert len(diagnostics) == 1
     assert diagnostics[0].path == reserved_path
-    assert f"reserved by the built-in /{reserved_name} command" in diagnostics[0].message
+    reserved_command = builtin_prompt_template_reservations()[reserved_name.casefold()]
+    assert f"reserved by the built-in {reserved_command} command" in diagnostics[0].message
+
+
+def test_builtin_prompt_template_reservations_cover_registry_commands_and_aliases() -> None:
+    registry = create_default_command_registry()
+    reservations = builtin_prompt_template_reservations()
+
+    for command in registry.list_commands():
+        assert reservations[command.name.casefold()] == f"/{command.name}"
+        for alias in command.aliases:
+            assert reservations[alias.casefold()] == f"/{alias}"
 
 
 def test_render_prompt_template_replaces_variables() -> None:

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -92,9 +92,11 @@ prompt and runs it as a normal turn.
 A prompt template is a saved prompt you trigger by its filename. For example,
 `~/.agents/prompts/wt.md` is invoked with `/wt`. Run `/prompts` in the TUI to
 search every loaded template and insert its invocation for editing; selection
-does not submit the prompt. The filenames `prompts.md` and `tools.md` are
-reserved for built-in commands; Tau ignores templates with those names and
-reports a resource diagnostic. Templates can include variables with `{{ name }}`:
+does not submit the prompt. Prompt-template filenames that match a built-in slash
+command or alias (for example `new.md`, `quit.md`, or `exit.md`) are reserved;
+Tau ignores those templates and reports a resource diagnostic so `/new`, `/quit`,
+and other built-ins stay reachable. Non-conflicting templates can include variables
+with `{{ name }}`:
 
 ```md
 ---
@@ -109,9 +111,9 @@ If a template has no placeholders, your arguments are appended after a blank
 line. Variables are filled from the arguments you pass after the invocation,
 for example `/wt add caching`.
 
-The filenames `prompts.md` and `skills.md` are reserved for the built-in `/prompts`
-and `/skills` pickers. Tau ignores either template and reports a resource diagnostic;
-rename the file to load it as a custom prompt.
+Built-in slash-command names and aliases are always reserved. If you previously
+used a template filename such as `new.md` to shadow a command, rename the file
+(for example to `new-feature.md`) and invoke it with `/new-feature`.
 
 ## Skill vs. prompt template — which?
 


### PR DESCRIPTION
## Summary
- Derive reserved prompt-template stems from `create_default_command_registry()` so every built-in slash command name and alias (e.g. `new`, `quit`, `exit`) cannot shadow real commands via `*.md` templates
- Ignore colliding templates at resource load time with a clear resource diagnostic instead of silently changing `/new` or `/quit` behavior
- Document the migration policy in `website/content/guides/skills-and-prompts.md` and add a dev note for validation

Fixes #460

## Test plan
- [x] `uv run pytest tests/test_prompt_templates.py tests/test_commands.py tests/test_coding_session.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] Added coverage for `new.md`, `quit.md`, `exit.md`, and `/reload` consistency