### PR TITLE
Fix GPT-5.6 availability in Codex catalog

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -459,18 +459,17 @@ base_url = "https://chatgpt.com/backend-api"
 api_key_env = "OPENAI_CODEX_ACCESS_TOKEN"
 credential_name = "openai-codex"
 auth_methods = ["oauth"]
-models = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
+models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 default_model = "gpt-5.5"
 docs_url = "https://chatgpt.com/codex"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
-thinking_models = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
+thinking_models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
 thinking_default = "medium"
 thinking_parameter = "reasoning.effort"
 
 [providers.context_windows]
 # Conservative Codex-subscription fallbacks. The authenticated live catalog
 # overrides these values because Codex limits can vary by rollout/account.
-"gpt-5.6" = 272000
 "gpt-5.6-sol" = 272000
 "gpt-5.6-terra" = 272000
 "gpt-5.6-luna" = 272000
@@ -480,16 +479,6 @@ thinking_parameter = "reasoning.effort"
 "gpt-5.3-codex" = 400000
 "gpt-5.3-codex-spark" = 400000
 "gpt-5.2" = 400000
-
-[providers.model_metadata."gpt-5.6"]
-name = "GPT-5.6"
-reasoning = true
-input = ["text", "image"]
-context_window = 272000
-max_tokens = 128000
-cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 6.25 }
-thinking_level_map = { off = "none", xhigh = "xhigh" }
-unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata."gpt-5.6-sol"]
 name = "GPT-5.6 Sol"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -13,7 +13,8 @@
         "Make user settings forward-compatible by ignoring unknown fields while continuing to validate recognized settings."
       ],
       "Fixed": [
-        "Clear the prompt after cancelling the `/skills` picker instead of restoring the handled command."
+        "Clear the prompt after cancelling the `/skills` picker instead of restoring the handled command.",
+        "Hide the unsupported `gpt-5.6` API alias from the OpenAI Codex subscription catalog while retaining it for direct OpenAI API users."
       ]
     }
   },

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -139,6 +139,10 @@ def test_builtin_catalog_separates_openai_api_and_codex_context_limits() -> None
     assert codex is not None
     assert openai.context_windows is not None
     assert codex.context_windows is not None
+    assert "gpt-5.6" in openai.models
+    assert "gpt-5.6" not in codex.models
+    assert "gpt-5.6" not in codex.context_windows
+    assert "gpt-5.6" not in codex.model_metadata
     assert openai.context_windows["gpt-5.6-sol"] == 1_050_000
     assert codex.context_windows["gpt-5.6-sol"] == 272_000
     assert codex.context_windows["gpt-5.6-terra"] == 272_000

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1132,7 +1132,6 @@ def test_load_provider_settings_does_not_restore_stale_codex_builtin_models(
     provider = settings.get_provider("openai-codex")
 
     assert provider.models == (
-        "gpt-5.6",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -78,7 +78,9 @@ configured fallback.
 Live limits can vary by account or rollout and may change independently of Tau.
 A discovery failure is non-fatal: Tau reports it in `/session` and continues with
 the fallback. Direct OpenAI API sessions retain the context limits documented on
-the API model page.
+the API model page. The `gpt-5.6` alias, which routes to GPT-5.6 Sol, is only
+available through the direct OpenAI API; Codex subscription users should select
+the explicit `gpt-5.6-sol` model instead.
 
 ### OpenCode Go and Zen
 


### PR DESCRIPTION
## Summary

- remove the `gpt-5.6` API alias from the built-in OpenAI Codex subscription catalog
- retain `gpt-5.6` for direct OpenAI API users and retain explicit GPT-5.6 variants for Codex
- update regression coverage, provider documentation, and release notes

## User experience

Codex subscription users no longer see or select an alias that ChatGPT-account Codex requests reject with HTTP 400. Direct OpenAI API behavior is unchanged.

## Issue

Addresses the reported unsupported-model error for `openai-codex`; no linked GitHub issue.

## Manual validation

1. Start Tau and log in with `/login openai-codex`.
2. Open the model picker and confirm `gpt-5.6` is absent while `gpt-5.6-sol` remains available.
3. Configure the direct `openai` provider and confirm `gpt-5.6` remains available there.
4. Select `gpt-5.6-sol` with OpenAI Codex and send a prompt.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify && npx --yes pagefind@latest --site public`
