### PR TITLE
Release Tau 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "0.3.2",
+    "date": "2026-07-24",
+    "sections": {
+      "Fixed": [
+        "Hide the unsupported `gpt-5.6` API alias from the OpenAI Codex subscription catalog while retaining it for direct OpenAI API users."
+      ]
+    }
+  },
+  {
     "version": "0.3.1",
     "date": "2026-07-23",
     "sections": {
@@ -13,8 +22,7 @@
         "Make user settings forward-compatible by ignoring unknown fields while continuing to validate recognized settings."
       ],
       "Fixed": [
-        "Clear the prompt after cancelling the `/skills` picker instead of restoring the handled command.",
-        "Hide the unsupported `gpt-5.6` API alias from the OpenAI Codex subscription catalog while retaining it for direct OpenAI API users."
+        "Clear the prompt after cancelling the `/skills` picker instead of restoring the handled command."
       ]
     }
   },

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -629,7 +629,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.1" in console.export_text()
+    assert "τ = 2π  0.3.2" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

Prepare Tau 0.3.2 for release.

- bump the package and lockfile version from 0.3.1 to 0.3.2
- add structured 0.3.2 release notes for the OpenAI Codex model-catalog fix
- update the sidebar version assertion

## Checks

- `uv run pytest` — 1145 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-release-0.3.2-dist`
- `cd website && hugo --minify && npx --yes pagefind@latest --site public`

## Release plan

After this PR merges, publish GitHub Release `v0.3.2` from the merge commit. The release workflow will build and publish `tau-ai==0.3.2` to PyPI.
