### PR TITLE
Color terminal-command prompt input like a running tool

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -590,15 +590,15 @@ class PromptInput(TextArea):
             self._clear_pending_paste()
 
     def get_line(self, line_index: int) -> Text:
-        """Retrieve one prompt line with shell prefixes highlighted."""
+        """Retrieve one prompt line, coloring terminal commands like a running tool."""
         line = super().get_line(line_index)
-        if line_index != 0 or not self.shell_mode_style:
+        if not self.shell_mode_style:
             return line
         span = _terminal_command_prefix_span(self.text)
         if span is None:
             return line
-        start, end = span
-        line.stylize(self.shell_mode_style, start, end)
+        start, _ = span
+        line.stylize(self.shell_mode_style, start if line_index == 0 else 0)
         return line
 
     async def action_submit_follow_up(self) -> None:
@@ -3516,7 +3516,7 @@ class TauTuiApp(App[None]):
     async def on_mount(self) -> None:
         """Focus the prompt when the app starts."""
         prompt = self.query_one(PromptInput)
-        prompt.shell_mode_style = self.tui_settings.resolved_theme.accent
+        prompt.shell_mode_style = self.tui_settings.resolved_theme.role_styles["tool"].border
         self._sync_prompt_shell_mode(prompt.text)
         prompt.focus()
         self._update_responsive_layout(self.size.width, self.size.height)
@@ -5750,7 +5750,7 @@ class TauTuiApp(App[None]):
 
     def _sync_prompt_shell_mode(self, text: str) -> None:
         prompt = self.query_one("#prompt", PromptInput)
-        prompt.shell_mode_style = self.tui_settings.resolved_theme.accent
+        prompt.shell_mode_style = self.tui_settings.resolved_theme.role_styles["tool"].border
         prompt.set_class(_is_terminal_command_prompt(text), "-shell-mode")
         prompt.refresh()
         self._apply_activity_indicator()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2978,7 +2978,7 @@ class TauTuiApp(App[None]):
     }
 
     #prompt.-shell-mode {
-        border-left: tall $tau-accent;
+        border-left: tall $tau-tool-running;
     }
 
     #compact-session-info {
@@ -5766,7 +5766,7 @@ def _activity_prompt_border_color(
     """Return the prompt border color for the current activity animation frame."""
     del frame, running
     if shell_mode:
-        return theme.accent
+        return theme.role_styles["tool"].border
     return theme.prompt_border
 
 
@@ -6231,6 +6231,7 @@ def _theme_css_variables(theme: TuiTheme) -> dict[str, str]:
         "tau-prompt-border": theme.prompt_border,
         "tau-autocomplete-background": theme.autocomplete_background,
         "tau-accent": theme.accent,
+        "tau-tool-running": theme.role_styles["tool"].border,
         "tau-highlight-background": theme.highlight_background,
         "tau-highlight-text": theme.highlight_text,
         "tau-markdown-highlight": theme.markdown_heading,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5642,6 +5642,7 @@ class TauTuiApp(App[None]):
                 theme,
                 frame=self._activity_frame,
                 running=self.state.running,
+                shell_mode=shell_mode,
             ),
             layout=False,
         )
@@ -5770,8 +5771,16 @@ def _activity_prompt_border_color(
     return theme.prompt_border
 
 
-def _render_activity_indicator(theme: TuiTheme, *, frame: int, running: bool) -> Text:
-    """Render the prompt prefix, turning Tau into a moving square while running."""
+def _render_activity_indicator(
+    theme: TuiTheme,
+    *,
+    frame: int,
+    running: bool,
+    shell_mode: bool = False,
+) -> Text:
+    """Render the prompt prefix: a moving square while running, ``$`` in shell mode."""
+    if shell_mode and not running:
+        return Text("$", style=f"bold {theme.role_styles['tool'].border}")
     if not running:
         return Text("τ", style=f"bold {theme.accent}")
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2406,12 +2406,12 @@ def test_terminal_command_prefix_span_detects_shell_mode_prefix() -> None:
     assert _terminal_command_prefix_span("hello ! pwd") is None
 
 
-def test_activity_prompt_border_uses_theme_accent_color_in_shell_mode() -> None:
+def test_activity_prompt_border_uses_tool_running_color_in_shell_mode() -> None:
     theme = TAU_LIGHT_THEME
 
     assert (
         _activity_prompt_border_color(theme, frame=0, running=False, shell_mode=True)
-        == theme.accent
+        == theme.role_styles["tool"].border
     )
 
 
@@ -2425,6 +2425,7 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
         await pilot.pause()
 
         assert prompt.has_class("-shell-mode")
+        tool_running_color = app.tui_settings.resolved_theme.role_styles["tool"].border
         assert (
             _activity_prompt_border_color(
                 app.tui_settings.resolved_theme,
@@ -2432,9 +2433,8 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
                 running=False,
                 shell_mode=prompt.has_class("-shell-mode"),
             )
-            == app.tui_settings.resolved_theme.accent
+            == tool_running_color
         )
-        tool_running_color = app.tui_settings.resolved_theme.role_styles["tool"].border
         assert prompt.get_line(0).spans[-1].start == 0
         assert prompt.get_line(0).spans[-1].end == len("!! pwd")
         assert str(prompt.get_line(0).spans[-1].style) == tool_running_color

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2434,14 +2434,23 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
             )
             == app.tui_settings.resolved_theme.accent
         )
+        tool_running_color = app.tui_settings.resolved_theme.role_styles["tool"].border
         assert prompt.get_line(0).spans[-1].start == 0
-        assert prompt.get_line(0).spans[-1].end == 2
-        assert str(prompt.get_line(0).spans[-1].style) == app.tui_settings.resolved_theme.accent
+        assert prompt.get_line(0).spans[-1].end == len("!! pwd")
+        assert str(prompt.get_line(0).spans[-1].style) == tool_running_color
+
+        prompt.value = "! pwd\nls -la"
+        await pilot.pause()
+
+        assert prompt.get_line(1).spans[-1].start == 0
+        assert prompt.get_line(1).spans[-1].end == len("ls -la")
+        assert str(prompt.get_line(1).spans[-1].style) == tool_running_color
 
         prompt.value = "ask tau"
         await pilot.pause()
 
         assert not prompt.has_class("-shell-mode")
+        assert prompt.get_line(0).spans == []
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -91,6 +91,7 @@ from tau_coding.tui.app import (
     TreePickerScreen,
     _activity_prompt_border_color,
     _completion_selected_render_line,
+    _render_activity_indicator,
     _terminal_command_prefix_span,
     _textual_theme_for_tau_theme,
     _theme_css_variables,
@@ -2406,6 +2407,23 @@ def test_terminal_command_prefix_span_detects_shell_mode_prefix() -> None:
     assert _terminal_command_prefix_span("hello ! pwd") is None
 
 
+def test_activity_indicator_shows_dollar_sign_in_shell_mode() -> None:
+    theme = TAU_LIGHT_THEME
+
+    rendered = _render_activity_indicator(theme, frame=0, running=False, shell_mode=True)
+
+    assert rendered.plain == "$"
+    assert rendered.style == f"bold {theme.role_styles['tool'].border}"
+
+
+def test_activity_indicator_keeps_running_animation_in_shell_mode() -> None:
+    theme = TAU_LIGHT_THEME
+
+    rendered = _render_activity_indicator(theme, frame=0, running=True, shell_mode=True)
+
+    assert rendered.plain != "$"
+
+
 def test_activity_prompt_border_uses_tool_running_color_in_shell_mode() -> None:
     theme = TAU_LIGHT_THEME
 
@@ -2421,10 +2439,12 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
 
     async with app.run_test(size=(120, 30)) as pilot:
         prompt = app.query_one("#prompt", PromptInput)
+        indicator = app.query_one("#prompt-prefix", Static)
         prompt.value = "!! pwd"
         await pilot.pause()
 
         assert prompt.has_class("-shell-mode")
+        assert indicator.render().plain == "$"
         tool_running_color = app.tui_settings.resolved_theme.role_styles["tool"].border
         assert (
             _activity_prompt_border_color(
@@ -2451,6 +2471,7 @@ async def test_tui_app_highlights_prompt_shell_mode() -> None:
 
         assert not prompt.has_class("-shell-mode")
         assert prompt.get_line(0).spans == []
+        assert indicator.render().plain == "τ"
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -73,8 +73,9 @@ You can run a shell command yourself without asking the model:
 - `!!<command>` runs it and shows the output **without** adding it to context.
 
 As soon as the input starts with `!`, the whole input and its left border turn
-the same amber/orange color as a tool while it is running, so you can tell at a
-glance that submitting will execute a shell command instead of messaging the model.
+the same amber/orange color as a tool while it is running, and the `τ` prompt
+prefix becomes a matching `$`, so you can tell at a glance that submitting will
+execute a shell command instead of messaging the model.
 
 While typing a path after `!`/`!!`, press **Tab** to complete filenames from the
 working directory.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -72,6 +72,10 @@ You can run a shell command yourself without asking the model:
   command and output in the conversation context.
 - `!!<command>` runs it and shows the output **without** adding it to context.
 
+As soon as the input starts with `!`, the whole input turns the same amber/orange
+color as a tool while it is running, so you can tell at a glance that submitting
+will execute a shell command instead of messaging the model.
+
 While typing a path after `!`/`!!`, press **Tab** to complete filenames from the
 working directory.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -72,9 +72,9 @@ You can run a shell command yourself without asking the model:
   command and output in the conversation context.
 - `!!<command>` runs it and shows the output **without** adding it to context.
 
-As soon as the input starts with `!`, the whole input turns the same amber/orange
-color as a tool while it is running, so you can tell at a glance that submitting
-will execute a shell command instead of messaging the model.
+As soon as the input starts with `!`, the whole input and its left border turn
+the same amber/orange color as a tool while it is running, so you can tell at a
+glance that submitting will execute a shell command instead of messaging the model.
 
 While typing a path after `!`/`!!`, press **Tab** to complete filenames from the
 working directory.


### PR DESCRIPTION
## Summary

When the prompt input starts with `!` (or `!!`) — meaning submitting will run a shell command instead of messaging the model — the entire input text and the prompt's left border are now rendered in the theme's running-tool accent color, and the `τ` prompt prefix becomes a matching `$` (`roles.tool.border`: amber `#8a7a52` in tau-dark, `#a16207` in tau-light, `#ffd000` in high-contrast). Previously only the `!`/`!!` prefix itself was tinted with the theme accent color.

## How it improves user experience

The `!` prefix is easy to type accidentally or forget about while composing a longer command. Coloring the whole input, its left border, and a `$` prompt prefix the same orange/amber as a tool while it is running gives an immediate, glanceable signal that the submission will execute in the shell, consistent with colors the user already associates with tool execution. Multi-line commands are fully colored too, and the color is derived from the active theme so custom themes stay consistent.

## Issues

No tracking issue — small UX polish.

## Manual validation

1. Run `uv run tau` (or `python main.py` equivalent / `tau`) and focus the prompt.
2. Type `!pwd` — the whole input and its left border turn amber/orange, and the `τ` prefix becomes a `$` as soon as `!` is the first character.
3. Add a second line (`!echo a` then newline + `echo b`) — both lines stay colored.
4. Delete the `!` or type a normal message — input returns to the default prompt color.
5. While the agent runs, the prefix keeps the usual running animation; it returns to `$` when idle in shell mode.
6. Compare with a running tool row in the transcript — the input color matches the running tool's accent color.
7. Switch themes (`tau-dark`, `tau-light`, `high-contrast`) and repeat — the input follows each theme's running-tool color.

## Checks

- `uv run pytest` — 1145 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — no issues
