### PR TITLE
Release Tau 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.2"
+version = "0.3.3"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.3.3",
+    "date": "2026-07-25",
+    "sections": {
+      "New": [
+        "Add direct Anthropic support for Claude Opus 5, including its 1M-token context window and adaptive-thinking effort mappings."
+      ],
+      "Changed": [
+        "Highlight terminal-command prompt input, border, and prefix with the active theme's running-tool color."
+      ]
+    }
+  },
+  {
     "version": "0.3.2",
     "date": "2026-07-24",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -630,7 +630,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.2" in console.export_text()
+    assert "τ = 2π  0.3.3" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.3.2 to 0.3.3 in package and lock metadata
- add bundled 0.3.3 release highlights for Claude Opus 5 support and terminal-command prompt styling
- update the version assertion backing the TUI sidebar brand

## Included changes

- direct Anthropic support for `claude-opus-5`, with its 1M-token context window and adaptive-thinking mappings
- clearer shell-command mode through running-tool prompt colors

## Validation

- `uv sync --dev --locked`
- `uv run pytest` — 1,149 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`
- `uv build` — built and verified `tau_ai-0.3.3-py3-none-any.whl`
- confirmed `tau-ai==0.3.3` is not already published on PyPI
