### PR TITLE
Fix multiline context for skill invocations

### DIFF
--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -91,7 +91,9 @@ def expand_skill_command(text: str, skills: Sequence[Skill]) -> str | None:
     if not stripped.startswith("/skill:"):
         return None
 
-    command, separator, request = stripped.partition(" ")
+    command_and_request = stripped.split(maxsplit=1)
+    command = command_and_request[0]
+    request = command_and_request[1] if len(command_and_request) > 1 else None
     name = command.removeprefix("/skill:").strip()
     if not name:
         raise ResourceError("Skill command must include a skill name")
@@ -101,7 +103,7 @@ def expand_skill_command(text: str, skills: Sequence[Skill]) -> str | None:
     if skill is None:
         raise ResourceError(f"Unknown skill: {name}")
 
-    additional_instructions = request.strip() if separator else None
+    additional_instructions = request.strip() if request is not None else None
     return format_skill_invocation(skill, additional_instructions)
 
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2130,7 +2130,7 @@ async def test_session_loads_and_expands_skills(tmp_path: Path) -> None:
     )
     session = await CodingSession.load(config)
 
-    _events = await _collect_session_events(session.prompt("/skill:testing add tests"))
+    _events = await _collect_session_events(session.prompt("/skill:testing\n\nadd tests"))
 
     assert {skill.name for skill in session.skills} == {"testing"}
     assert '<skill name="testing" location="' in provider.calls[0][2][0].content

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -214,6 +214,23 @@ def test_expand_skill_command_includes_skill_and_user_request(tmp_path: Path) ->
     assert expanded.endswith("</skill>\n\nadd parser tests")
 
 
+def test_expand_skill_command_includes_multiline_user_request(tmp_path: Path) -> None:
+    skill = Skill(
+        name="testing",
+        path=tmp_path / "skills" / "testing" / "SKILL.md",
+        content="# Testing\nRun pytest.",
+        description="Test code",
+    )
+
+    expanded = expand_skill_command(
+        "/skill:testing\n\nhere are some instructions\n\n- keep this structure",
+        [skill],
+    )
+
+    assert expanded is not None
+    assert expanded.endswith("</skill>\n\nhere are some instructions\n\n- keep this structure")
+
+
 def test_format_skill_invocation_without_extra_instructions(tmp_path: Path) -> None:
     skill = Skill(
         name="testing",

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -84,8 +84,17 @@ explicitly:
 /skill:security-review check the changes on this branch
 ```
 
-`/skill:<name>` is a *prompt-expansion* path — Tau expands the skill into your
-prompt and runs it as a normal turn.
+For longer instructions, put the request on following lines:
+
+```text
+/skill:security-review
+
+Check the changes on this branch.
+Pay special attention to authentication boundaries.
+```
+
+`/skill:<name>` is a *prompt-expansion* path — Tau expands the skill and any
+inline or multiline request into your prompt, then runs it as a normal turn.
 
 ## Prompt templates
 

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -31,7 +31,8 @@ command palette with **Ctrl+K**.
 
 {{% note title="`/skill:` is special" %}}
 `/skill:<name>` is a *prompt-expansion* path, not a normal command — Tau expands
-the named skill into your prompt and runs it as a turn. See
+the named skill into your prompt and runs it as a turn. Its optional request may
+start on the same line or on following lines. See
 [Skills & prompt templates]({{< relref "../guides/skills-and-prompts.md" >}}).
 {{% /note %}}
 


### PR DESCRIPTION
## Description

Fix `/skill:<name>` parsing so additional instructions can begin after any whitespace boundary, including a newline or blank line. The skill name is now separated from the request with whitespace-aware parsing rather than a literal-space partition.

This PR also adds unit and session-level regression coverage and documents multiline skill requests in the user guide and slash-command reference.

## User experience

Users can compose readable multiline prompts such as:

```text
/skill:security-review

Check the changes on this branch.
Pay special attention to authentication boundaries.
```

Tau now resolves `security-review` correctly and preserves the multiline request instead of reporting following context as part of an unknown skill name. Existing inline requests continue to work.

## Issue

Closes #484.

## Manual validation

1. Start Tau with an existing skill loaded.
2. Enter `/skill:<existing-skill>` on the first line.
3. Add a blank line, followed by multiple lines of instructions.
4. Submit the prompt.
5. Confirm Tau invokes the selected skill and sends all following lines as additional instructions without an `Unknown skill` error.

## Validation completed

- `uv run pytest` (1170 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` (using a temporary output destination)
