### PR TITLE
Release Tau 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.3"
+version = "0.3.4"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.3.4",
+    "date": "2026-07-27",
+    "sections": {
+      "New": [
+        "Send images read from disk to vision-capable models across supported providers, while giving text-only models an explicit omission notice."
+      ],
+      "Changed": [
+        "Validate and safely process image reads, including BMP-to-PNG conversion and bounded resizing for oversized static images."
+      ],
+      "Fixed": [
+        "Allow multiline instructions after `/skill:<name>`, including instructions separated from the invocation by a blank line."
+      ]
+    }
+  },
+  {
     "version": "0.3.3",
     "date": "2026-07-25",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -630,7 +630,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.3" in console.export_text()
+    assert "τ = 2π  0.3.4" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.3.3 to 0.3.4 in package and lock metadata
- add bundled 0.3.4 release highlights for multimodal image reads, safer image processing, and multiline skill instructions
- update the version assertion backing the TUI sidebar brand

## Included changes

- send read-tool images to vision-capable models across supported providers
- validate, convert, and resize image reads within explicit safety limits
- parse multiline `/skill:<name>` instructions across newline boundaries

## Validation

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 1,195 passed
- `uv build` — built `tau_ai-0.3.4` wheel and source distribution
- `hugo --minify`
- `npx --yes pagefind@latest --site /tmp/tau-release-0.3.4-site`
- `uv run tau --version` — `tau 0.3.4`
- confirmed `tau-ai==0.3.4` is not already published on PyPI
