### PR TITLE
Fix Windows uv tool update handoff

### DIFF
--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -26,7 +26,14 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
 
 `tau update` inspects the active environment before running anything:
 
-- `uv-receipt.toml` means uv owns the tool. Tau fetches the latest stable PyPI version and runs `uv tool install tau-ai@<latest-version>`, explicitly replacing any version pin recorded when the tool was installed.
+- `uv-receipt.toml` means uv owns the tool. Tau fetches the latest stable PyPI
+  version and runs `uv tool install tau-ai@<latest-version>`, explicitly replacing
+  any version pin recorded when the tool was installed. On Windows, Tau hands
+  this command to a detached PowerShell process. The helper waits for the
+  original Tau PID to exit before invoking uv, preventing Windows from partially
+  replacing the still-running tool environment. Tau reports that the update was
+  scheduled—not completed—and gives the path to a log containing the eventual
+  command output and exit code.
 - `pipx_metadata.json` means pipx owns it, so Tau runs `pipx upgrade tau-ai`.
 - The distribution's standard `INSTALLER` metadata identifies ordinary uv and pip installs. Tau runs either `uv pip install --python <current-python> --upgrade tau-ai` or `<current-python> -m pip install --upgrade tau-ai`, targeting the environment that is running Tau.
 

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -33,7 +33,11 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
   original Tau PID to exit before invoking uv, preventing Windows from partially
   replacing the still-running tool environment. Tau reports that the update was
   scheduled—not completed—and gives the path to a log containing the eventual
-  command output and exit code.
+  command output and exit code. The helper treats process inspection or waiting
+  errors as fatal: uv never starts unless the original Tau process is confirmed
+  absent or its observed process object exits. The update command is staged as
+  base64-encoded JSON so spaces and PowerShell metacharacters remain literal
+  arguments.
 - `pipx_metadata.json` means pipx owns it, so Tau runs `pipx upgrade tau-ai`.
 - The distribution's standard `INSTALLER` metadata identifies ordinary uv and pip installs. Tau runs either `uv pip install --python <current-python> --upgrade tau-ai` or `<current-python> -m pip install --upgrade tau-ai`, targeting the environment that is running Tau.
 
@@ -46,3 +50,11 @@ Run:
 ```bash
 uv run pytest tests/test_updater.py tests/test_update_check.py tests/test_cli.py tests/test_tui_app.py
 ```
+
+`tests/test_updater.py` also contains Windows-and-PowerShell-only integration
+coverage. On Windows it launches the generated helper against a live fake parent
+and fake updater, checking blocking, exact argument delivery, exit-code logging,
+and fail-closed wait errors without installing uv or replacing Tau. These tests
+are skipped on development and CI hosts that do not provide Windows PowerShell;
+cross-platform tests still cover script generation, detached launch options,
+staging failures, and cleanup.

--- a/dev-notes/architecture/startup-update-check.md
+++ b/dev-notes/architecture/startup-update-check.md
@@ -35,9 +35,11 @@ This lives in `tau_coding`, not `tau_agent`, because update notification is CLI 
   scheduled—not completed—and gives the path to a log containing the eventual
   command output and exit code. The helper treats process inspection or waiting
   errors as fatal: uv never starts unless the original Tau process is confirmed
-  absent or its observed process object exits. The update command is staged as
-  base64-encoded JSON so spaces and PowerShell metacharacters remain literal
-  arguments.
+  absent or its observed process object exits. The update executable and a
+  Microsoft-runtime-quoted argument line are staged as base64-encoded JSON. The
+  helper launches them with non-shell `ProcessStartInfo`, preserving spaces,
+  metacharacters, embedded quotes, empty arguments, and trailing backslashes on
+  Windows PowerShell 5.1 and PowerShell 7 without interpolated shell execution.
 - `pipx_metadata.json` means pipx owns it, so Tau runs `pipx upgrade tau-ai`.
 - The distribution's standard `INSTALLER` metadata identifies ordinary uv and pip installs. Tau runs either `uv pip install --python <current-python> --upgrade tau-ai` or `<current-python> -m pip install --upgrade tau-ai`, targeting the environment that is running Tau.
 
@@ -53,8 +55,10 @@ uv run pytest tests/test_updater.py tests/test_update_check.py tests/test_cli.py
 
 `tests/test_updater.py` also contains Windows-and-PowerShell-only integration
 coverage. On Windows it launches the generated helper against a live fake parent
-and fake updater, checking blocking, exact argument delivery, exit-code logging,
-and fail-closed wait errors without installing uv or replacing Tau. These tests
-are skipped on development and CI hosts that do not provide Windows PowerShell;
-cross-platform tests still cover script generation, detached launch options,
-staging failures, and cleanup.
+and fake updater, checking blocking, exact executable and argument delivery,
+exit-code logging, and fail-closed wait errors without installing uv or replacing
+Tau. Every installed supported engine (`powershell.exe` and `pwsh.exe`) is tested;
+individual unavailable engines are omitted, and the runtime tests skip only when
+Windows has neither. Cross-platform tests cover the Windows quoting algorithm,
+encoded payload, script generation, detached launch options, staging failures,
+and cleanup. Current Ubuntu CI cannot execute the Windows runtime cases.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -455,7 +455,10 @@ def update_command() -> None:
         typer.echo(result.stdout)
     if result.stderr:
         typer.echo(result.stderr, err=True)
-    typer.echo(f"Tau update completed with: {' '.join(result.command or ())}")
+    if result.deferred:
+        typer.echo(f"Tau update handed off with: {' '.join(result.command or ())}")
+    else:
+        typer.echo(f"Tau update completed with: {' '.join(result.command or ())}")
 
 
 def render_session_list(records: list[CodingSessionRecord]) -> None:

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -160,7 +160,7 @@ def _update_command(
 _WINDOWS_UPDATE_SCRIPT = """param(
     [Parameter(Mandatory=$true)][int]$ParentProcessId,
     [Parameter(Mandatory=$true)][string]$LogPath,
-    [Parameter(Mandatory=$true)][string]$UpdateCommandBase64
+    [Parameter(Mandatory=$true)][string]$UpdatePayloadBase64
 )
 
 $ScriptPath = $MyInvocation.MyCommand.Path
@@ -191,17 +191,35 @@ try {
             throw "Could not wait for Tau process $ParentProcessId to exit. Update aborted: $Detail"
         }
     }
-    $CommandJson = [Text.Encoding]::UTF8.GetString(
-        [Convert]::FromBase64String($UpdateCommandBase64)
+    $PayloadJson = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($UpdatePayloadBase64)
     )
-    $UpdateCommand = @(ConvertFrom-Json -InputObject $CommandJson)
-    if ($UpdateCommand.Count -lt 1) {
-        throw "The staged update command is empty. Update aborted."
+    $UpdatePayload = ConvertFrom-Json -InputObject $PayloadJson
+    $StartInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $StartInfo.FileName = [string]$UpdatePayload.executable
+    $StartInfo.Arguments = [string]$UpdatePayload.arguments
+    $StartInfo.UseShellExecute = $false
+    $StartInfo.CreateNoWindow = $true
+    $StartInfo.RedirectStandardOutput = $true
+    $StartInfo.RedirectStandardError = $true
+    $UpdateProcess = New-Object System.Diagnostics.Process
+    $UpdateProcess.StartInfo = $StartInfo
+    if (-not $UpdateProcess.Start()) {
+        throw "Could not start the update command. Update aborted."
     }
-    $UpdateExecutable = [string]$UpdateCommand[0]
-    [string[]]$UpdateArguments = @($UpdateCommand | Select-Object -Skip 1)
-    & $UpdateExecutable @UpdateArguments *>> $LogPath
-    $UpdateExitCode = $LASTEXITCODE
+    $StandardOutputTask = $UpdateProcess.StandardOutput.ReadToEndAsync()
+    $StandardErrorTask = $UpdateProcess.StandardError.ReadToEndAsync()
+    $UpdateProcess.WaitForExit()
+    $StandardOutput = $StandardOutputTask.GetAwaiter().GetResult()
+    $StandardError = $StandardErrorTask.GetAwaiter().GetResult()
+    if ($StandardOutput) {
+        Write-Log $StandardOutput.TrimEnd("`r", "`n")
+    }
+    if ($StandardError) {
+        Write-Log $StandardError.TrimEnd("`r", "`n")
+    }
+    $UpdateExitCode = $UpdateProcess.ExitCode
+    $UpdateProcess.Dispose()
     Write-Log "Update command exited with code $UpdateExitCode."
 } catch {
     Write-Log ($_ | Out-String)
@@ -241,7 +259,13 @@ def _handoff_windows_update(
         _cleanup_windows_handoff(update_dir, script_path, remove_directory=owns_update_dir)
         return _failure(f"Could not stage the detached Windows updater: {exc}")
 
-    encoded_command = base64.b64encode(json.dumps(command).encode()).decode("ascii")
+    update_payload = {
+        "executable": command[0],
+        "arguments": _windows_command_line(command[1:]),
+    }
+    encoded_payload = base64.b64encode(
+        json.dumps(update_payload, ensure_ascii=False).encode("utf-8")
+    ).decode("ascii")
     powershell_command = (
         powershell,
         "-NoLogo",
@@ -255,8 +279,8 @@ def _handoff_windows_update(
         str(parent_pid),
         "-LogPath",
         str(log_path),
-        "-UpdateCommandBase64",
-        encoded_command,
+        "-UpdatePayloadBase64",
+        encoded_payload,
     )
     creationflags = getattr(subprocess, "DETACHED_PROCESS", 0x00000008) | getattr(
         subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
@@ -281,6 +305,31 @@ def _handoff_windows_update(
         ),
         deferred=True,
     )
+
+
+def _quote_windows_argument(argument: str) -> str:
+    """Quote one argv element using the documented Microsoft C runtime rules."""
+    quoted = ['"']
+    backslashes = 0
+    for character in argument:
+        if character == "\\":
+            backslashes += 1
+            continue
+        if character == '"':
+            quoted.append("\\" * (backslashes * 2 + 1))
+            quoted.append('"')
+        else:
+            quoted.append("\\" * backslashes)
+            quoted.append(character)
+        backslashes = 0
+    quoted.append("\\" * (backslashes * 2))
+    quoted.append('"')
+    return "".join(quoted)
+
+
+def _windows_command_line(arguments: tuple[str, ...]) -> str:
+    """Build the argv tail passed directly to CreateProcess by ProcessStartInfo."""
+    return " ".join(_quote_windows_argument(argument) for argument in arguments)
 
 
 def _cleanup_windows_handoff(

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import shutil
@@ -9,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
@@ -158,20 +160,51 @@ def _update_command(
 _WINDOWS_UPDATE_SCRIPT = """param(
     [Parameter(Mandatory=$true)][int]$ParentProcessId,
     [Parameter(Mandatory=$true)][string]$LogPath,
-    [Parameter(Mandatory=$true)][string]$UpdateExecutable,
-    [Parameter(ValueFromRemainingArguments=$true)][string[]]$UpdateArguments
+    [Parameter(Mandatory=$true)][string]$UpdateCommandBase64
 )
 
 $ScriptPath = $MyInvocation.MyCommand.Path
 $UpdateExitCode = 1
+function Write-Log([string]$Message) {
+    $Message | Add-Content -LiteralPath $LogPath -Encoding UTF8
+}
 try {
-    "Waiting for Tau process $ParentProcessId to exit..." | Set-Content -LiteralPath $LogPath
-    Wait-Process -Id $ParentProcessId -ErrorAction SilentlyContinue
+    $ErrorActionPreference = "Stop"
+    $WaitMessage = "Waiting for Tau process $ParentProcessId to exit..."
+    $WaitMessage | Set-Content -LiteralPath $LogPath -Encoding UTF8
+    $ParentProcess = $null
+    try {
+        $ParentProcess = Get-Process -Id $ParentProcessId -ErrorAction Stop
+    } catch {
+        if ($_.FullyQualifiedErrorId -like "NoProcessFoundForGivenId*") {
+            Write-Log "Tau process $ParentProcessId has already exited."
+        } else {
+            $Detail = $_.Exception.Message
+            throw "Could not inspect Tau process $ParentProcessId. Update aborted: $Detail"
+        }
+    }
+    if ($null -ne $ParentProcess) {
+        try {
+            Wait-Process -InputObject $ParentProcess -ErrorAction Stop
+        } catch {
+            $Detail = $_.Exception.Message
+            throw "Could not wait for Tau process $ParentProcessId to exit. Update aborted: $Detail"
+        }
+    }
+    $CommandJson = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($UpdateCommandBase64)
+    )
+    $UpdateCommand = @(ConvertFrom-Json -InputObject $CommandJson)
+    if ($UpdateCommand.Count -lt 1) {
+        throw "The staged update command is empty. Update aborted."
+    }
+    $UpdateExecutable = [string]$UpdateCommand[0]
+    [string[]]$UpdateArguments = @($UpdateCommand | Select-Object -Skip 1)
     & $UpdateExecutable @UpdateArguments *>> $LogPath
     $UpdateExitCode = $LASTEXITCODE
-    "Update command exited with code $UpdateExitCode." | Add-Content -LiteralPath $LogPath
+    Write-Log "Update command exited with code $UpdateExitCode."
 } catch {
-    $_ | Out-String | Add-Content -LiteralPath $LogPath
+    Write-Log ($_ | Out-String)
 } finally {
     Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue
 }
@@ -191,14 +224,24 @@ def _handoff_windows_update(
     if powershell is None:
         return _failure("Could not find PowerShell to safely finish the Windows update.")
 
-    if handoff_directory is None:
-        update_dir = Path(tempfile.mkdtemp(prefix="tau-update-"))
-    else:
-        update_dir = handoff_directory
-        update_dir.mkdir(parents=True, exist_ok=True)
-    script_path = update_dir / "update.ps1"
-    log_path = update_dir / "update.log"
-    script_path.write_text(_WINDOWS_UPDATE_SCRIPT, encoding="utf-8")
+    owns_update_dir = handoff_directory is None
+    update_dir: Path | None = None
+    script_path: Path | None = None
+    try:
+        if owns_update_dir:
+            update_dir = Path(tempfile.mkdtemp(prefix="tau-update-"))
+        else:
+            update_dir = handoff_directory
+            assert update_dir is not None
+            update_dir.mkdir(parents=True, exist_ok=True)
+        script_path = update_dir / "update.ps1"
+        log_path = update_dir / "update.log"
+        script_path.write_text(_WINDOWS_UPDATE_SCRIPT, encoding="utf-8")
+    except OSError as exc:
+        _cleanup_windows_handoff(update_dir, script_path, remove_directory=owns_update_dir)
+        return _failure(f"Could not stage the detached Windows updater: {exc}")
+
+    encoded_command = base64.b64encode(json.dumps(command).encode()).decode("ascii")
     powershell_command = (
         powershell,
         "-NoLogo",
@@ -208,9 +251,12 @@ def _handoff_windows_update(
         "Bypass",
         "-File",
         str(script_path),
+        "-ParentProcessId",
         str(parent_pid),
+        "-LogPath",
         str(log_path),
-        *command,
+        "-UpdateCommandBase64",
+        encoded_command,
     )
     creationflags = getattr(subprocess, "DETACHED_PROCESS", 0x00000008) | getattr(
         subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
@@ -225,7 +271,7 @@ def _handoff_windows_update(
             creationflags=creationflags,
         )
     except OSError as exc:
-        script_path.unlink(missing_ok=True)
+        _cleanup_windows_handoff(update_dir, script_path, remove_directory=owns_update_dir)
         return _failure(f"Could not start the detached Windows updater: {exc}")
     return UpdateResult(
         command=command,
@@ -235,6 +281,20 @@ def _handoff_windows_update(
         ),
         deferred=True,
     )
+
+
+def _cleanup_windows_handoff(
+    update_dir: Path | None,
+    script_path: Path | None,
+    *,
+    remove_directory: bool,
+) -> None:
+    if script_path is not None:
+        with suppress(OSError):
+            script_path.unlink(missing_ok=True)
+    if remove_directory and update_dir is not None:
+        with suppress(OSError):
+            update_dir.rmdir()
 
 
 def _installed_direct_url() -> str | None:

--- a/src/tau_coding/updater.py
+++ b/src/tau_coding/updater.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution
@@ -14,6 +18,8 @@ from typing import Literal
 from tau_coding.update_check import PYPI_PACKAGE_NAME, fetch_latest_pypi_version
 
 CommandRunner = Callable[..., CompletedProcess[str]]
+DetachedLauncher = Callable[..., object]
+ExecutableFinder = Callable[[str], str | None]
 LatestVersionFetcher = Callable[[], str | None]
 InstallMethod = Literal["uv-tool", "uv-pip", "pipx", "pip"]
 
@@ -26,6 +32,7 @@ class UpdateResult:
     stdout: str = ""
     stderr: str = ""
     failures: tuple[str, ...] = ()
+    deferred: bool = False
 
     @property
     def succeeded(self) -> bool:
@@ -41,6 +48,11 @@ def update_tau(
     installer: str | None = None,
     inspect_distribution: bool = True,
     latest_version_fetcher: LatestVersionFetcher = fetch_latest_pypi_version,
+    platform_name: str | None = None,
+    detached_launcher: DetachedLauncher = subprocess.Popen,
+    executable_finder: ExecutableFinder = shutil.which,
+    parent_pid: int | None = None,
+    handoff_directory: Path | None = None,
 ) -> UpdateResult:
     """Upgrade Tau with the installer that owns the active environment.
 
@@ -83,6 +95,15 @@ def update_tau(
 
     executable = python_executable or sys.executable
     command = _update_command(method, executable, latest_version=latest_version)
+    if (platform_name or sys.platform) == "win32" and method == "uv-tool":
+        return _handoff_windows_update(
+            command,
+            launcher=detached_launcher,
+            executable_finder=executable_finder,
+            parent_pid=parent_pid or os.getpid(),
+            handoff_directory=handoff_directory,
+        )
+
     completed = _run(runner, command)
     if isinstance(completed, str):
         return _failure(f"{' '.join(command)}: {completed}")
@@ -132,6 +153,88 @@ def _update_command(
     if method == "pipx":
         return ("pipx", "upgrade", PYPI_PACKAGE_NAME)
     return (python_executable, "-m", "pip", "install", "--upgrade", PYPI_PACKAGE_NAME)
+
+
+_WINDOWS_UPDATE_SCRIPT = """param(
+    [Parameter(Mandatory=$true)][int]$ParentProcessId,
+    [Parameter(Mandatory=$true)][string]$LogPath,
+    [Parameter(Mandatory=$true)][string]$UpdateExecutable,
+    [Parameter(ValueFromRemainingArguments=$true)][string[]]$UpdateArguments
+)
+
+$ScriptPath = $MyInvocation.MyCommand.Path
+$UpdateExitCode = 1
+try {
+    "Waiting for Tau process $ParentProcessId to exit..." | Set-Content -LiteralPath $LogPath
+    Wait-Process -Id $ParentProcessId -ErrorAction SilentlyContinue
+    & $UpdateExecutable @UpdateArguments *>> $LogPath
+    $UpdateExitCode = $LASTEXITCODE
+    "Update command exited with code $UpdateExitCode." | Add-Content -LiteralPath $LogPath
+} catch {
+    $_ | Out-String | Add-Content -LiteralPath $LogPath
+} finally {
+    Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue
+}
+exit $UpdateExitCode
+"""
+
+
+def _handoff_windows_update(
+    command: tuple[str, ...],
+    *,
+    launcher: DetachedLauncher,
+    executable_finder: ExecutableFinder,
+    parent_pid: int,
+    handoff_directory: Path | None,
+) -> UpdateResult:
+    powershell = executable_finder("powershell.exe") or executable_finder("pwsh.exe")
+    if powershell is None:
+        return _failure("Could not find PowerShell to safely finish the Windows update.")
+
+    if handoff_directory is None:
+        update_dir = Path(tempfile.mkdtemp(prefix="tau-update-"))
+    else:
+        update_dir = handoff_directory
+        update_dir.mkdir(parents=True, exist_ok=True)
+    script_path = update_dir / "update.ps1"
+    log_path = update_dir / "update.log"
+    script_path.write_text(_WINDOWS_UPDATE_SCRIPT, encoding="utf-8")
+    powershell_command = (
+        powershell,
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script_path),
+        str(parent_pid),
+        str(log_path),
+        *command,
+    )
+    creationflags = getattr(subprocess, "DETACHED_PROCESS", 0x00000008) | getattr(
+        subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+    )
+    try:
+        launcher(
+            powershell_command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            creationflags=creationflags,
+        )
+    except OSError as exc:
+        script_path.unlink(missing_ok=True)
+        return _failure(f"Could not start the detached Windows updater: {exc}")
+    return UpdateResult(
+        command=command,
+        stdout=(
+            "Tau update is scheduled and will start after this process exits. "
+            f"Progress will be written to {log_path}."
+        ),
+        deferred=True,
+    )
 
 
 def _installed_direct_url() -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,27 @@ def test_update_command_upgrades_without_startup_check(monkeypatch: pytest.Monke
     assert "Tau update completed with: uv tool install tau-ai@0.2.4" in result.stdout
 
 
+def test_update_command_reports_windows_handoff_without_claiming_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "update_tau",
+        lambda: UpdateResult(
+            command=("uv", "tool", "install", "tau-ai@0.2.4"),
+            stdout="Tau update is scheduled and will start after this process exits.",
+            deferred=True,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["update"])
+
+    assert result.exit_code == 0
+    assert "scheduled" in result.stdout
+    assert "Tau update handed off with:" in result.stdout
+    assert "Tau update completed" not in result.stdout
+
+
 def test_update_command_reports_installer_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         cli,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -35,11 +35,62 @@ def test_update_tau_uses_uv_tool_for_uv_owned_tool_environment(tmp_path: Path) -
         environment_prefix=tmp_path,
         inspect_distribution=False,
         latest_version_fetcher=lambda: "0.2.4",
+        platform_name="linux",
     )
 
     assert result.succeeded is True
     assert result.command == ("uv", "tool", "install", "tau-ai@0.2.4")
     assert calls == [("uv", "tool", "install", "tau-ai@0.2.4")]
+
+
+def test_update_tau_hands_windows_uv_tool_update_to_waiting_process(tmp_path: Path) -> None:
+    (tmp_path / "uv-receipt.toml").touch()
+    handoff_dir = tmp_path / "handoff"
+    launches: list[tuple[tuple[str, ...], dict[str, object]]] = []
+
+    def launcher(command: tuple[str, ...], **kwargs: object) -> object:
+        launches.append((command, kwargs))
+        return object()
+
+    def runner(*args: object, **kwargs: object) -> CompletedProcess[str]:
+        del args, kwargs
+        raise AssertionError("uv must not run in the live Tau process")
+
+    result = update_tau(
+        runner=runner,
+        environment_prefix=tmp_path,
+        inspect_distribution=False,
+        latest_version_fetcher=lambda: "0.2.4",
+        platform_name="win32",
+        detached_launcher=launcher,
+        executable_finder=lambda name: (
+            "C:/Windows/powershell.exe" if name == "powershell.exe" else None
+        ),
+        parent_pid=4242,
+        handoff_directory=handoff_dir,
+    )
+
+    assert result.succeeded is True
+    assert result.deferred is True
+    assert result.command == ("uv", "tool", "install", "tau-ai@0.2.4")
+    assert "scheduled" in result.stdout
+    assert str(handoff_dir / "update.log") in result.stdout
+    assert len(launches) == 1
+    detached_command, options = launches[0]
+    assert detached_command[-7:] == (
+        str(handoff_dir / "update.ps1"),
+        "4242",
+        str(handoff_dir / "update.log"),
+        "uv",
+        "tool",
+        "install",
+        "tau-ai@0.2.4",
+    )
+    assert options["creationflags"] == 0x00000208
+    script = (handoff_dir / "update.ps1").read_text(encoding="utf-8")
+    assert script.index("Wait-Process -Id $ParentProcessId") < script.index(
+        "& $UpdateExecutable @UpdateArguments"
+    )
 
 
 def test_update_tau_reports_uv_latest_version_lookup_failure(tmp_path: Path) -> None:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -93,15 +93,43 @@ def test_update_tau_hands_windows_uv_tool_update_to_waiting_process(tmp_path: Pa
         "4242",
         "-LogPath",
         str(handoff_dir / "update.log"),
-        "-UpdateCommandBase64",
+        "-UpdatePayloadBase64",
     )
-    assert tuple(json.loads(base64.b64decode(detached_command[-1]))) == result.command
+    assert json.loads(base64.b64decode(detached_command[-1])) == {
+        "executable": "uv",
+        "arguments": '"tool" "install" "tau-ai@0.2.4"',
+    }
     assert options["creationflags"] == 0x00000208
     script = (handoff_dir / "update.ps1").read_text(encoding="utf-8")
     assert "Wait-Process -InputObject $ParentProcess -ErrorAction Stop" in script
     assert "NoProcessFoundForGivenId" in script
     assert script.index("Wait-Process -InputObject $ParentProcess") < script.index(
-        "& $UpdateExecutable @UpdateArguments"
+        "$UpdateProcess.Start()"
+    )
+    assert "System.Diagnostics.ProcessStartInfo" in script
+    assert "$StartInfo.UseShellExecute = $false" in script
+
+
+@pytest.mark.parametrize(
+    ("argument", "expected"),
+    [
+        ("", '""'),
+        ("plain", '"plain"'),
+        ("space value", '"space value"'),
+        ('quote"value', '"quote\\"value"'),
+        ("trailing\\", '"trailing\\\\"'),
+        ('slashes\\\\"quote', '"slashes\\\\\\\\\\"quote"'),
+        ("semi;&$()", '"semi;&$()"'),
+        ("snowman ☃", '"snowman ☃"'),
+    ],
+)
+def test_quote_windows_argument_uses_microsoft_runtime_rules(argument: str, expected: str) -> None:
+    assert updater._quote_windows_argument(argument) == expected
+
+
+def test_windows_command_line_preserves_argument_boundaries() -> None:
+    assert updater._windows_command_line(("", "a b", 'c"', "tail\\")) == (
+        '"" "a b" "c\\"" "tail\\\\"'
     )
 
 
@@ -183,17 +211,24 @@ def _wait_for_text(path: Path, expected: str, timeout: float = 10) -> str:
     raise AssertionError(f"timed out waiting for {expected!r} in {path}")
 
 
-def _powershell() -> str | None:
-    return shutil.which("powershell.exe") or shutil.which("pwsh.exe")
+def _powershell_engines() -> list[str | None]:
+    if sys.platform != "win32":
+        return [None]
+    engines = [shutil.which(name) for name in ("powershell.exe", "pwsh.exe")]
+    available = list(dict.fromkeys(engine for engine in engines if engine is not None))
+    return available or [None]
 
 
-@pytest.mark.skipif(
-    sys.platform != "win32" or _powershell() is None,
-    reason="requires Windows and PowerShell",
-)
-def test_windows_handoff_blocks_for_live_parent_and_preserves_arguments(tmp_path: Path) -> None:
-    powershell = _powershell()
-    assert powershell is not None
+def _engine_id(engine: str | None) -> str:
+    return Path(engine).name if engine else "unavailable"
+
+
+@pytest.mark.parametrize("powershell", _powershell_engines(), ids=_engine_id)
+def test_windows_handoff_blocks_for_live_parent_and_preserves_arguments(
+    tmp_path: Path, powershell: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if powershell is None:
+        pytest.skip("requires Windows and PowerShell")
     parent = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     marker = tmp_path / "exact argv.json"
     fake_update = tmp_path / "fake updater.py"
@@ -203,11 +238,27 @@ def test_windows_handoff_blocks_for_live_parent_and_preserves_arguments(tmp_path
         "raise SystemExit(23)\n",
         encoding="utf-8",
     )
-    arguments = ("space value", "semi;&$()", 'quote"value', "-named-looking")
+    arguments = (
+        "space value",
+        "semi;&$()",
+        'quote"value',
+        "",
+        "trailing\\",
+        "-named-looking",
+    )
     update_dir = tmp_path / "handoff with spaces"
+    executable_dir = tmp_path / "executable path with spaces"
+    executable_dir.mkdir()
+    fake_python = executable_dir / Path(sys.executable).name
+    shutil.copy2(sys.executable, fake_python)
+    for runtime_dll in Path(sys.base_prefix).glob("python*.dll"):
+        shutil.copy2(runtime_dll, executable_dir / runtime_dll.name)
+
+    monkeypatch.setenv("PYTHONHOME", sys.base_prefix)
+
     try:
         result = updater._handoff_windows_update(
-            (sys.executable, str(fake_update), str(marker), *arguments),
+            (str(fake_python), str(fake_update), str(marker), *arguments),
             launcher=subprocess.Popen,
             executable_finder=lambda name: powershell,
             parent_pid=parent.pid,
@@ -227,13 +278,10 @@ def test_windows_handoff_blocks_for_live_parent_and_preserves_arguments(tmp_path
             parent.wait(timeout=10)
 
 
-@pytest.mark.skipif(
-    sys.platform != "win32" or _powershell() is None,
-    reason="requires Windows and PowerShell",
-)
-def test_windows_helper_wait_failure_is_fail_closed(tmp_path: Path) -> None:
-    powershell = _powershell()
-    assert powershell is not None
+@pytest.mark.parametrize("powershell", _powershell_engines(), ids=_engine_id)
+def test_windows_helper_wait_failure_is_fail_closed(tmp_path: Path, powershell: str | None) -> None:
+    if powershell is None:
+        pytest.skip("requires Windows and PowerShell")
     update_dir = tmp_path / "wait-failure"
     update_dir.mkdir()
     script_path = update_dir / "update.ps1"
@@ -270,9 +318,14 @@ def test_windows_helper_wait_failure_is_fail_closed(tmp_path: Path) -> None:
             str(os.getpid()),
             "-LogPath",
             str(log_path),
-            "-UpdateCommandBase64",
+            "-UpdatePayloadBase64",
             base64.b64encode(
-                json.dumps((sys.executable, str(fake_update), str(marker))).encode()
+                json.dumps(
+                    {
+                        "executable": sys.executable,
+                        "arguments": updater._windows_command_line((str(fake_update), str(marker))),
+                    }
+                ).encode()
             ).decode("ascii"),
         ],
         capture_output=True,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,6 +1,16 @@
+import base64
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
 from pathlib import Path
 from subprocess import CompletedProcess
 
+import pytest
+
+from tau_coding import updater
 from tau_coding.updater import detect_install_method, update_tau
 
 
@@ -77,20 +87,203 @@ def test_update_tau_hands_windows_uv_tool_update_to_waiting_process(tmp_path: Pa
     assert str(handoff_dir / "update.log") in result.stdout
     assert len(launches) == 1
     detached_command, options = launches[0]
-    assert detached_command[-7:] == (
+    assert detached_command[-7:-1] == (
         str(handoff_dir / "update.ps1"),
+        "-ParentProcessId",
         "4242",
+        "-LogPath",
         str(handoff_dir / "update.log"),
-        "uv",
-        "tool",
-        "install",
-        "tau-ai@0.2.4",
+        "-UpdateCommandBase64",
     )
+    assert tuple(json.loads(base64.b64decode(detached_command[-1]))) == result.command
     assert options["creationflags"] == 0x00000208
     script = (handoff_dir / "update.ps1").read_text(encoding="utf-8")
-    assert script.index("Wait-Process -Id $ParentProcessId") < script.index(
+    assert "Wait-Process -InputObject $ParentProcess -ErrorAction Stop" in script
+    assert "NoProcessFoundForGivenId" in script
+    assert script.index("Wait-Process -InputObject $ParentProcess") < script.index(
         "& $UpdateExecutable @UpdateArguments"
     )
+
+
+def test_windows_handoff_reports_staging_write_failure_and_removes_owned_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    update_dir = tmp_path / "owned-handoff"
+
+    def make_update_dir(*args: object, **kwargs: object) -> str:
+        del args, kwargs
+        update_dir.mkdir()
+        return str(update_dir)
+
+    original_write_text = Path.write_text
+
+    def fail_script_write(path: Path, *args: object, **kwargs: object) -> int:
+        if path == update_dir / "update.ps1":
+            raise OSError("disk is full")
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(updater.tempfile, "mkdtemp", make_update_dir)
+    monkeypatch.setattr(Path, "write_text", fail_script_write)
+
+    result = updater._handoff_windows_update(
+        ("uv", "tool", "install", "tau-ai@1.0"),
+        launcher=lambda *args, **kwargs: object(),
+        executable_finder=lambda name: "powershell.exe",
+        parent_pid=4242,
+        handoff_directory=None,
+    )
+
+    assert result.succeeded is False
+    assert result.failures == ("Could not stage the detached Windows updater: disk is full",)
+    assert not update_dir.exists()
+
+
+def test_windows_handoff_reports_launch_failure_and_preserves_caller_directory(
+    tmp_path: Path,
+) -> None:
+    update_dir = tmp_path / "caller-handoff"
+
+    def fail_launch(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise OSError("process creation denied")
+
+    result = updater._handoff_windows_update(
+        ("uv", "tool", "install", "tau-ai@1.0"),
+        launcher=fail_launch,
+        executable_finder=lambda name: "powershell.exe",
+        parent_pid=4242,
+        handoff_directory=update_dir,
+    )
+
+    assert result.succeeded is False
+    assert result.failures == (
+        "Could not start the detached Windows updater: process creation denied",
+    )
+    assert update_dir.is_dir()
+    assert list(update_dir.iterdir()) == []
+
+
+def _wait_for_file(path: Path, timeout: float = 10) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def _wait_for_text(path: Path, expected: str, timeout: float = 10) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            text = path.read_text(encoding="utf-8-sig")
+            if expected in text:
+                return text
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {expected!r} in {path}")
+
+
+def _powershell() -> str | None:
+    return shutil.which("powershell.exe") or shutil.which("pwsh.exe")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32" or _powershell() is None,
+    reason="requires Windows and PowerShell",
+)
+def test_windows_handoff_blocks_for_live_parent_and_preserves_arguments(tmp_path: Path) -> None:
+    powershell = _powershell()
+    assert powershell is not None
+    parent = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    marker = tmp_path / "exact argv.json"
+    fake_update = tmp_path / "fake updater.py"
+    fake_update.write_text(
+        "import json, pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text(json.dumps(sys.argv[2:]), encoding='utf-8')\n"
+        "raise SystemExit(23)\n",
+        encoding="utf-8",
+    )
+    arguments = ("space value", "semi;&$()", 'quote"value', "-named-looking")
+    update_dir = tmp_path / "handoff with spaces"
+    try:
+        result = updater._handoff_windows_update(
+            (sys.executable, str(fake_update), str(marker), *arguments),
+            launcher=subprocess.Popen,
+            executable_finder=lambda name: powershell,
+            parent_pid=parent.pid,
+            handoff_directory=update_dir,
+        )
+        assert result.succeeded is True
+        time.sleep(0.5)
+        assert not marker.exists(), "updater ran while the parent was alive"
+        parent.terminate()
+        parent.wait(timeout=10)
+        _wait_for_file(marker)
+        assert json.loads(marker.read_text(encoding="utf-8")) == list(arguments)
+        _wait_for_text(update_dir / "update.log", "Update command exited with code 23.")
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=10)
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32" or _powershell() is None,
+    reason="requires Windows and PowerShell",
+)
+def test_windows_helper_wait_failure_is_fail_closed(tmp_path: Path) -> None:
+    powershell = _powershell()
+    assert powershell is not None
+    update_dir = tmp_path / "wait-failure"
+    update_dir.mkdir()
+    script_path = update_dir / "update.ps1"
+    log_path = update_dir / "update.log"
+    marker = update_dir / "updater-ran"
+    fake_update = update_dir / "fake updater.py"
+    script_path.write_text(updater._WINDOWS_UPDATE_SCRIPT, encoding="utf-8")
+    fake_update.write_text(
+        "import pathlib, sys\npathlib.Path(sys.argv[1]).touch()\n",
+        encoding="utf-8",
+    )
+    wrapper = update_dir / "force-wait-failure.ps1"
+    wrapper.write_text(
+        "function Wait-Process { throw 'forced wait failure' }\n"
+        "$Target = $args[0]\n"
+        "$TargetArgs = $args[1..($args.Count - 1)]\n"
+        "& $Target @TargetArgs\n"
+        "exit $LASTEXITCODE\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(wrapper),
+            str(script_path),
+            "-ParentProcessId",
+            str(os.getpid()),
+            "-LogPath",
+            str(log_path),
+            "-UpdateCommandBase64",
+            base64.b64encode(
+                json.dumps((sys.executable, str(fake_update), str(marker))).encode()
+            ).decode("ascii"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert completed.returncode != 0
+    assert not marker.exists()
+    assert "Could not wait for Tau process" in log_path.read_text(encoding="utf-8-sig")
 
 
 def test_update_tau_reports_uv_latest_version_lookup_failure(tmp_path: Path) -> None:

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -29,7 +29,7 @@ features and fixes.
 | --- | --- |
 | `tau` | Open the interactive TUI |
 | `tau "<prompt>"` | Open the TUI with an initial prompt |
-| `tau update` | Upgrade Tau with the installer that owns its environment |
+| `tau update` | Upgrade Tau with the installer that owns its environment. Windows uv-tool updates are handed off and begin after Tau exits; follow the printed log path for the final result. |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |
 | `tau --export <ref> [dest]` | Same as `tau export`, as a top-level flag |


### PR DESCRIPTION
## Summary

- hand Windows uv-tool updates to a detached PowerShell process
- fail closed unless the invoking Tau PID is confirmed absent or its observed process exits
- stage the executable and Microsoft-runtime-quoted argument line as base64 JSON
- launch through non-shell `ProcessStartInfo` so Windows PowerShell 5.1 and PowerShell 7 preserve exact argv
- report staging/launch failures clearly and clean Tau-owned temporary artifacts
- preserve synchronous update behavior on non-Windows platforms

## User experience

`tau update` no longer asks uv to replace Tau's live tool environment on Windows. It exits after safely scheduling the update, clearly avoids claiming completion, and tells the user where to inspect the eventual output and exit code. If staging, process waiting, or launching fails, Tau returns actionable diagnostics without invoking uv unsafely.

Fixes #449

## Validation

- `uv run pytest tests/test_updater.py tests/test_cli.py -q` (76 passed, 2 Windows/PowerShell runtime cases skipped on macOS)
- `uv run pytest` (1208 passed, 2 skipped on macOS)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `git diff --check`

## Manual validation

On a Windows uv-tool installation:

1. Run `tau update`.
2. Confirm Tau reports that the update was scheduled and exits without uv modifying the live environment.
3. Open the printed `update.log` path after Tau exits.
4. Confirm the log first reports waiting for the Tau PID, then contains uv output and its exit code.
5. Run `tau --version` to verify the installation remains usable.

Developers can run `uv run pytest tests/test_updater.py -q` on Windows. Runtime tests enumerate every installed supported engine (`powershell.exe` and `pwsh.exe`) and verify live-parent blocking, fail-closed forced wait errors, exit reporting, an executable path containing spaces, and exact arguments containing spaces, metacharacters, embedded quotes, an empty string, and a trailing backslash. They use a fake updater and do not install uv or replace Tau.

## Platform-testing limitation

This revision was validated on macOS, where Windows runtime tests skip. Current Ubuntu CI also cannot execute them. Cross-platform tests cover the documented Windows argv quoting rules, encoded payload, non-shell process setup, detached flags, staging/launch failures, ownership-aware cleanup, and fail-closed script structure. No real Windows 11 uv-tool replacement was performed in this revision.
