### PR TITLE
Fix Anthropic subscription login and OAuth token refresh

### DIFF
--- a/src/tau_coding/oauth_anthropic.py
+++ b/src/tau_coding/oauth_anthropic.py
@@ -29,7 +29,7 @@ from tau_coding.oauth_types import (
 )
 
 ANTHROPIC_OAUTH_PROVIDER = "anthropic"
-ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944a1962f5e"
+ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 ANTHROPIC_AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
 ANTHROPIC_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 ANTHROPIC_REDIRECT_URI = "http://localhost:53692/callback"

--- a/src/tau_coding/oauth_anthropic.py
+++ b/src/tau_coding/oauth_anthropic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import webbrowser
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -39,6 +39,8 @@ ANTHROPIC_SCOPE = (
 )
 ANTHROPIC_CALLBACK_PORT = 53692
 ANTHROPIC_TOKEN_SKEW_MS = 5 * 60 * 1000
+# Token-request fields worth scrubbing out of anything the server echoes back.
+_SECRET_REQUEST_FIELDS = ("refresh_token", "code", "code_verifier")
 
 
 async def login_anthropic(
@@ -150,7 +152,11 @@ async def _anthropic_token_request(
         if owns_client:
             await active_client.aclose()
     if response.status_code >= 400:
-        raise OAuthError(f"Anthropic token {action} failed ({response.status_code})")
+        detail = _error_detail(
+            response,
+            secrets=[data[field] for field in _SECRET_REQUEST_FIELDS if field in data],
+        )
+        raise OAuthError(f"Anthropic token {action} failed ({response.status_code}): {detail}")
     raw = response.json()
     if not isinstance(raw, dict):
         raise OAuthError(f"Anthropic token {action} response must be an object")
@@ -166,6 +172,50 @@ async def _anthropic_token_request(
         refresh=refresh,
         expires=int(time.time() * 1000 + expires_in * 1000 - ANTHROPIC_TOKEN_SKEW_MS),
     )
+
+
+def _error_detail(response: httpx.Response, *, secrets: Iterable[str] = ()) -> str:
+    """Summarize a token-endpoint failure body.
+
+    The endpoint explains itself ("invalid_grant: Refresh token not found or
+    invalid"); reporting only the status code turns a self-describing failure
+    into a guessing game. Only the structured OAuth error fields are surfaced —
+    the raw body stays out of the message because a failing request can echo
+    the token it was sent. Those fields are server-controlled too, so anything
+    we sent is scrubbed back out and the result is truncated before it reaches
+    a log or the TUI.
+    """
+    try:
+        raw = response.json()
+    except ValueError:
+        raw = None
+    detail = _error_fields(raw) if isinstance(raw, dict) else None
+    if detail is None:
+        return "no error detail"
+    for secret in secrets:
+        if len(secret) >= 8:
+            detail = detail.replace(secret, "<redacted>")
+    return detail[:200]
+
+
+def _error_fields(raw: dict[str, Any]) -> str | None:
+    """Pull the error code and message out of either error envelope.
+
+    OAuth failures arrive as flat ``error``/``error_description``, while the
+    Anthropic API's own shape nests them under ``error`` as ``type``/``message``.
+    """
+    error = raw.get("error")
+    description = raw.get("error_description") or raw.get("message")
+    if isinstance(error, dict):
+        description = description or error.get("message")
+        error = error.get("type")
+    if isinstance(error, str) and isinstance(description, str):
+        return f"{error}: {description}"
+    if isinstance(error, str):
+        return error
+    if isinstance(description, str):
+        return description
+    return None
 
 
 async def _wait_for_input(

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+from asyncio import AbstractEventLoop, get_running_loop
+from collections.abc import MutableMapping
 from dataclasses import replace
 from os import environ
 from typing import Protocol
+from weakref import WeakKeyDictionary
 
 from tau_agent.provider import ModelProvider
 from tau_ai.anthropic import AnthropicProvider
@@ -223,10 +227,47 @@ class OpenAICodexCredentialResolver:
     ) -> OAuthCredential:
         if not oauth_credential_is_expired(credential):
             return credential
-        refreshed = await refresh_openai_codex_token(credential.refresh)
-        if refreshed != credential:
-            self._credential_store.set_oauth(credential_name, refreshed)
+        async with _refresh_lock(credential_name):
+            stored = self._credential_store.get_oauth(credential_name) or credential
+            if not oauth_credential_is_expired(stored):
+                return stored
+            refreshed = await refresh_openai_codex_token(stored.refresh)
+            if refreshed != stored:
+                self._credential_store.set_oauth(credential_name, refreshed)
         return refreshed
+
+
+_REFRESH_LOCKS: MutableMapping[AbstractEventLoop, dict[str, asyncio.Lock]] = WeakKeyDictionary()
+
+
+def _refresh_lock(credential_name: str) -> asyncio.Lock:
+    """Return this loop's refresh lock for one stored credential.
+
+    Providers rotate the refresh token on use: the old one dies the moment a
+    refresh succeeds. A session issues provider calls concurrently (the agent
+    loop and session auto-naming, for two), so without serialization several
+    tasks read the same expired credential and spend the same refresh token.
+    One of them wins, the losers 400, and whichever write lands last can leave
+    a superseded token on disk — which fails on the *next* run, long after the
+    race that caused it. Holding this lock across the network call, and
+    re-reading the store inside it, keeps a token spent at most once.
+
+    Locks are cached per event loop, not per process. ``asyncio.Lock`` binds to
+    the running loop on first contention, so a lock cached across loops appears
+    to work — the uncontended path never touches the loop — until two tasks
+    contend it in a later loop and it raises. Keying on the loop keeps that from
+    happening in a process that runs more than one loop, which is every test
+    run. The key is weak so an untouched loop's entry is dropped with the loop;
+    a lock that was ever contended holds a reference back to its loop, so that
+    entry survives until the process exits. One dead loop per contended loop is
+    a fine price, and tau's own runs use a single loop each.
+    """
+    locks = _REFRESH_LOCKS.setdefault(get_running_loop(), {})
+    lock = locks.get(credential_name)
+    if lock is None:
+        lock = asyncio.Lock()
+        locks[credential_name] = lock
+    return lock
 
 
 def _oauth_credential(
@@ -254,16 +295,19 @@ class OAuthRuntimeCredentialResolver:
         credential_name = self._provider.credential_name
         if credential_name is None:
             raise RuntimeError(f"Provider {self._provider.name} has no credential name")
-        credential = self._credential_store.get_oauth(credential_name)
-        if credential is None:
-            raise RuntimeError(
-                f"Missing OAuth credentials for {self._provider.name}. "
-                f"Run /login {self._provider.name}."
-            )
         oauth_provider = _required_oauth_provider(self._provider.name)
-        refreshed = await oauth_provider.refresh(credential)
-        if refreshed != credential:
-            self._credential_store.set_oauth(credential_name, refreshed)
+        async with _refresh_lock(credential_name):
+            # Read inside the lock: a task that waited here while another
+            # refreshed sees the rotated credential and skips its own refresh.
+            credential = self._credential_store.get_oauth(credential_name)
+            if credential is None:
+                raise RuntimeError(
+                    f"Missing OAuth credentials for {self._provider.name}. "
+                    f"Run /login {self._provider.name}."
+                )
+            refreshed = await oauth_provider.refresh(credential)
+            if refreshed != credential:
+                self._credential_store.set_oauth(credential_name, refreshed)
         auth = oauth_provider.runtime_auth(refreshed)
         return RuntimeProviderAuth(
             api_key=auth.api_key,

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -252,15 +252,10 @@ def _refresh_lock(credential_name: str) -> asyncio.Lock:
     race that caused it. Holding this lock across the network call, and
     re-reading the store inside it, keeps a token spent at most once.
 
-    Locks are cached per event loop, not per process. ``asyncio.Lock`` binds to
-    the running loop on first contention, so a lock cached across loops appears
-    to work — the uncontended path never touches the loop — until two tasks
-    contend it in a later loop and it raises. Keying on the loop keeps that from
-    happening in a process that runs more than one loop, which is every test
-    run. The key is weak so an untouched loop's entry is dropped with the loop;
-    a lock that was ever contended holds a reference back to its loop, so that
-    entry survives until the process exits. One dead loop per contended loop is
-    a fine price, and tau's own runs use a single loop each.
+    Locks are cached per event loop because ``asyncio.Lock`` binds to the
+    running loop on first contention: a lock cached across loops appears to
+    work — the uncontended path never touches the loop — until two tasks
+    contend it in a later loop and it raises.
     """
     locks = _REFRESH_LOCKS.setdefault(get_running_loop(), {})
     lock = locks.get(credential_name)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Literal, Protocol, TypeVar, cast
 
 from rich.console import Console, Group
+from rich.style import Style
 from rich.text import Text
 from textual import events, on
 from textual.app import App, ComposeResult
@@ -2764,12 +2765,27 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | _LoginFlowAction | None]):
         self.dismiss(credential)
 
     def _show_auth(self, info: OAuthAuthInfo) -> None:
-        self.query_one("#login-oauth-url", Static).update(info.url)
+        self._show_url(info.url)
         if info.instructions:
             self.query_one("#login-help", Static).update(info.instructions)
 
+    def _show_url(self, url: str) -> None:
+        """Display an authorization URL as one clickable, copyable unit.
+
+        Authorization URLs are far wider than the dialog, so they render across
+        several wrapped lines. Selecting those lines by hand tends to corrupt
+        the URL — a query parameter split across a wrap picks up the line break
+        or trailing padding and the provider rejects the request. Emitting an
+        OSC 8 hyperlink keeps a click on any wrapped line opening the intact
+        URL, and copying it to the clipboard gives a paste path that never went
+        through the terminal's line buffer.
+        """
+        self.query_one("#login-oauth-url", Static).update(Text(url, style=Style(link=url)))
+        with suppress(Exception):
+            self.app.copy_to_clipboard(url)
+
     def _show_device_code(self, info: OAuthDeviceCodeInfo) -> None:
-        self.query_one("#login-oauth-url", Static).update(info.verification_uri)
+        self._show_url(info.verification_uri)
         self.query_one("#login-help", Static).update(
             f"Open the URL and enter code: {info.user_code}"
         )
@@ -3327,8 +3343,11 @@ class TauTuiApp(App[None]):
     }
 
     #login-oauth-url {
+        /* Authorization URLs run ~470 chars (Anthropic); clipping them means a
+           user copying the URL out of the TUI loses the trailing query
+           parameters and the provider rejects the request. Keep every line. */
         min-height: 1;
-        max-height: 4;
+        height: auto;
         color: $tau-chrome-text;
         margin-bottom: 1;
     }

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2766,25 +2766,29 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | _LoginFlowAction | None]):
 
     def _show_auth(self, info: OAuthAuthInfo) -> None:
         self._show_url(info.url)
+        # Copy only the browser-flow URL. It is hundreds of characters long and
+        # wraps across the dialog, so hand-selecting it is what corrupts it;
+        # taking over the clipboard is worth it there and nowhere else.
+        with suppress(Exception):
+            self.app.copy_to_clipboard(info.url)
+        self.notify("Authorization URL copied to clipboard.")
         if info.instructions:
             self.query_one("#login-help", Static).update(info.instructions)
 
     def _show_url(self, url: str) -> None:
-        """Display an authorization URL as one clickable, copyable unit.
+        """Display a URL as one clickable unit.
 
         Authorization URLs are far wider than the dialog, so they render across
         several wrapped lines. Selecting those lines by hand tends to corrupt
         the URL — a query parameter split across a wrap picks up the line break
-        or trailing padding and the provider rejects the request. Emitting an
-        OSC 8 hyperlink keeps a click on any wrapped line opening the intact
-        URL, and copying it to the clipboard gives a paste path that never went
-        through the terminal's line buffer.
+        or trailing padding and the provider rejects the request. An OSC 8
+        hyperlink keeps a click on any wrapped line opening the intact URL.
         """
         self.query_one("#login-oauth-url", Static).update(Text(url, style=Style(link=url)))
-        with suppress(Exception):
-            self.app.copy_to_clipboard(url)
 
     def _show_device_code(self, info: OAuthDeviceCodeInfo) -> None:
+        # No clipboard copy here: the verification URI is short and clickable,
+        # and the thing the user carries to the browser is the code below it.
         self._show_url(info.verification_uri)
         self.query_one("#login-help", Static).update(
             f"Open the URL and enter code: {info.user_code}"

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3308,6 +3308,12 @@ class TauTuiApp(App[None]):
         width: 72;
         max-width: 92%;
         height: auto;
+        /* A wrapped authorization URL makes this dialog taller than a short
+           terminal. Cap it at the screen and scroll instead of overflowing:
+           overflowing centers the excess, which pushes the paste field and
+           the footer off the bottom and the title off the top. */
+        max-height: 100%;
+        overflow-y: auto;
         padding: 1 2;
         background: $tau-chrome-background;
         border: tall $tau-border;

--- a/tests/test_oauth_providers.py
+++ b/tests/test_oauth_providers.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
-from tau_coding.oauth import OAuthError
+from tau_coding.oauth import OAuthError, oauth_credential_is_expired
 from tau_coding.oauth_anthropic import (
     ANTHROPIC_CLIENT_ID,
     ANTHROPIC_TOKEN_URL,
@@ -35,7 +35,7 @@ from tau_coding.oauth_types import (
     OAuthSelectPrompt,
 )
 from tau_coding.provider_config import provider_config_from_catalog_entry
-from tau_coding.provider_runtime import OAuthRuntimeCredentialResolver
+from tau_coding.provider_runtime import OAuthRuntimeCredentialResolver, _refresh_lock
 
 
 def _callbacks(
@@ -73,6 +73,75 @@ async def test_refresh_anthropic_token_uses_json_and_redacts_failed_response() -
     assert "401" in str(error.value)
     assert "secret-token-body" not in str(error.value)
     assert "refresh-secret" not in str(error.value)
+
+
+@pytest.mark.anyio
+async def test_refresh_anthropic_token_reports_structured_oauth_error() -> None:
+    """A dead refresh token should say so, not just report a status code."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": "invalid_grant",
+                "error_description": "Refresh token not found or invalid",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(OAuthError) as error:
+            await refresh_anthropic_token("refresh-secret", client=client)
+
+    assert "invalid_grant: Refresh token not found or invalid" in str(error.value)
+    assert "refresh-secret" not in str(error.value)
+
+
+@pytest.mark.anyio
+async def test_refresh_anthropic_token_reports_nested_error_without_echoing_token() -> None:
+    """Anthropic's nested envelope still yields detail, minus anything we sent."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "refresh_token refresh-secret is malformed. " + "x" * 400,
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(OAuthError) as error:
+            await refresh_anthropic_token("refresh-secret", client=client)
+
+    message = str(error.value)
+    assert "invalid_request_error: refresh_token <redacted> is malformed." in message
+    assert "refresh-secret" not in message
+    assert len(message) < 300
+
+
+@pytest.mark.anyio
+async def test_refresh_anthropic_token_scrubs_a_token_before_truncating() -> None:
+    """Scrub then truncate: the other order leaks the surviving prefix."""
+    secret = "refresh-" + "s" * 40
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Place the token so it straddles the 200-character truncation point.
+        return httpx.Response(
+            400,
+            json={"error": "invalid_grant", "error_description": "y" * 175 + secret},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(OAuthError) as error:
+            await refresh_anthropic_token(secret, client=client)
+
+    message = str(error.value)
+    # Truncating first would have left the token's leading characters here.
+    assert message.endswith("<redacted>")
+    assert "refresh-ss" not in message
 
 
 @pytest.mark.anyio
@@ -263,6 +332,81 @@ async def test_runtime_oauth_resolver_refreshes_and_persists_atomically(tmp_path
     assert saved is not None
     assert saved.access == "new-access"
     assert not list(tmp_path.glob(".credentials.json.*"))
+
+
+@pytest.mark.anyio
+async def test_runtime_oauth_resolver_spends_a_refresh_token_once(tmp_path) -> None:
+    """Concurrent calls must not both spend the same rotating refresh token."""
+    refreshes: list[str] = []
+
+    class RotatingOAuthProvider:
+        id = "github-copilot"
+        name = "Rotating"
+        flow_kinds = ("device_code",)
+
+        async def login(self, _callbacks: OAuthLoginCallbacks) -> OAuthCredential:
+            raise AssertionError("not used")
+
+        async def refresh(self, credential: OAuthCredential) -> OAuthCredential:
+            if not oauth_credential_is_expired(credential):
+                return credential
+            if credential.refresh in refreshes:
+                raise OAuthError("invalid_grant: Refresh token not found or invalid")
+            refreshes.append(credential.refresh)
+            await asyncio.sleep(0)  # let a racing task reach the same refresh
+            return OAuthCredential(
+                access="access-2",
+                refresh="refresh-2",
+                expires=9999999999999,
+            )
+
+        def runtime_auth(self, credential: OAuthCredential) -> OAuthRuntimeAuth:
+            return OAuthRuntimeAuth(api_key=credential.access)
+
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "github-copilot",
+        OAuthCredential(access="access-1", refresh="refresh-1", expires=1),
+    )
+    provider = provider_config_from_catalog_entry("github-copilot")
+    resolver = OAuthRuntimeCredentialResolver(provider, credential_store=store)
+    register_oauth_provider(cast(OAuthProvider, RotatingOAuthProvider()))
+    try:
+        results = await asyncio.gather(resolver(), resolver(), resolver())
+    finally:
+        unregister_oauth_provider("github-copilot")
+        reset_oauth_providers()
+
+    assert refreshes == ["refresh-1"]
+    assert [auth.api_key for auth in results] == ["access-2"] * 3
+    saved = store.get_oauth("github-copilot")
+    assert saved is not None
+    # The rotated token is what survives on disk, so the next run can refresh.
+    assert saved.refresh == "refresh-2"
+
+
+def test_refresh_locks_are_not_shared_between_event_loops() -> None:
+    """A lock cached across loops only fails once contended — so contend it."""
+
+    async def _hold(lock: asyncio.Lock) -> None:
+        async with lock:
+            await asyncio.sleep(0)
+
+    async def contend() -> asyncio.Lock:
+        lock = _refresh_lock("anthropic")
+        async with asyncio.timeout(5):
+            await asyncio.gather(_hold(lock), _hold(lock))
+        return lock
+
+    # The assertion that matters is that neither run raised "bound to a
+    # different event loop" — a lock reused across loops dies on the second
+    # contention. The identity check below cannot fail on its own (distinct
+    # loops are distinct keys); it is here to say what the fix is supposed to
+    # produce, not to detect the bug.
+    first = asyncio.run(contend())
+    second = asyncio.run(contend())
+
+    assert first is not second
 
 
 def test_builtin_oauth_registry_matches_supported_subscription_providers() -> None:

--- a/tests/test_oauth_tui.py
+++ b/tests/test_oauth_tui.py
@@ -5,7 +5,7 @@ from textual.app import App
 from textual.geometry import Region
 from textual.widgets import Input, Static
 
-from tau_coding.oauth_types import OAuthAuthInfo, OAuthPrompt
+from tau_coding.oauth_types import OAuthAuthInfo, OAuthDeviceCodeInfo, OAuthPrompt
 from tau_coding.provider_catalog import builtin_provider_entry
 from tau_coding.tui.app import OAuthLoginScreen, TauTuiApp
 from tau_coding.tui.config import TAU_DARK_THEME
@@ -71,6 +71,34 @@ async def test_oauth_screen_shows_full_authorization_url() -> None:
     # the user never has to reassemble it from the wrapped display by hand.
     assert links == {url}
     assert copied == [url]
+
+
+@pytest.mark.anyio
+async def test_oauth_device_code_screen_leaves_the_clipboard_alone() -> None:
+    """The device flow's URI is short and clickable; the code is what matters."""
+    provider = builtin_provider_entry("github-copilot")
+    assert provider is not None
+
+    async def fake_login(callbacks):
+        callbacks.on_device_code(
+            OAuthDeviceCodeInfo(
+                user_code="ABCD-1234",
+                verification_uri="https://github.com/login/device",
+            )
+        )
+        await asyncio.Event().wait()
+
+    screen = OAuthLoginScreen(provider, theme=TAU_DARK_THEME, login=fake_login)
+    copied: list[str] = []
+    app = _themed_app(screen)
+    app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        help_text = str(screen.query_one("#login-help", Static).render())
+
+    assert copied == []
+    assert "ABCD-1234" in help_text
 
 
 @pytest.mark.anyio

--- a/tests/test_oauth_tui.py
+++ b/tests/test_oauth_tui.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+from textual.app import App
 from textual.geometry import Region
 from textual.widgets import Input, Static
 
@@ -9,24 +10,24 @@ from tau_coding.provider_catalog import builtin_provider_entry
 from tau_coding.tui.app import OAuthLoginScreen, TauTuiApp
 from tau_coding.tui.config import TAU_DARK_THEME
 
+LONG_URL = "https://claude.ai/oauth/authorize?" + "&".join(f"p{index}=value" for index in range(40))
 
-@pytest.mark.anyio
-async def test_oauth_screen_shows_full_authorization_url() -> None:
-    """The whole URL must be visible: users copy it out of the TUI by hand."""
-    from textual.app import App
 
-    from tau_coding.tui.app import _textual_theme_for_tau_theme
-
+def _login_screen(url: str = LONG_URL) -> OAuthLoginScreen:
+    """Build an Anthropic login screen whose flow stops after showing `url`."""
     provider = builtin_provider_entry("anthropic")
     assert provider is not None
-    url = "https://claude.ai/oauth/authorize?" + "&".join(f"p{index}=value" for index in range(40))
-    assert len(url) > 400
 
     async def fake_login(callbacks):
-        callbacks.on_auth(OAuthAuthInfo(url=url))
+        callbacks.on_auth(OAuthAuthInfo(url=url, instructions="Complete login in your browser."))
         await asyncio.Event().wait()
 
-    screen = OAuthLoginScreen(provider, theme=TAU_DARK_THEME, login=fake_login)
+    return OAuthLoginScreen(provider, theme=TAU_DARK_THEME, login=fake_login)
+
+
+def _themed_app(screen: OAuthLoginScreen) -> App[None]:
+    """An app carrying Tau's real CSS, so dialog geometry matches production."""
+    from tau_coding.tui.app import _textual_theme_for_tau_theme
 
     class TestApp(App[None]):
         CSS = TauTuiApp.CSS
@@ -39,8 +40,18 @@ async def test_oauth_screen_shows_full_authorization_url() -> None:
         def on_mount(self) -> None:
             self.push_screen(screen)
 
+    return TestApp()
+
+
+@pytest.mark.anyio
+async def test_oauth_screen_shows_full_authorization_url() -> None:
+    """The whole URL must be visible: users copy it out of the TUI by hand."""
+    url = LONG_URL
+    assert len(url) > 400
+    screen = _login_screen(url)
+
     copied: list[str] = []
-    app = TestApp()
+    app = _themed_app(screen)
     app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
     async with app.run_test(size=(100, 40)) as pilot:
         await pilot.pause()
@@ -60,6 +71,30 @@ async def test_oauth_screen_shows_full_authorization_url() -> None:
     # the user never has to reassemble it from the wrapped display by hand.
     assert links == {url}
     assert copied == [url]
+
+
+@pytest.mark.anyio
+async def test_oauth_screen_fits_a_short_terminal() -> None:
+    """Growing for the URL must not push the paste field off a small screen."""
+    height = 14
+    screen = _login_screen()
+    async with _themed_app(screen).run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        container = screen.query_one("#login-screen")
+        dialog = container.region
+        code = screen.query_one("#login-oauth-code", Input).region
+        scrollable = container.allow_vertical_scroll
+
+    # The dialog scrolls its own overflow rather than centering it, which would
+    # hang the title off the top and the paste field off the bottom. What is
+    # below the fold stays reachable by scrolling; the focused paste field is
+    # scrolled into view for us.
+    assert dialog.y >= 0
+    assert dialog.bottom <= height
+    assert scrollable
+    assert code.y >= 0
+    assert code.bottom <= height
 
 
 @pytest.mark.anyio

--- a/tests/test_oauth_tui.py
+++ b/tests/test_oauth_tui.py
@@ -1,12 +1,65 @@
 import asyncio
 
 import pytest
+from textual.geometry import Region
 from textual.widgets import Input, Static
 
-from tau_coding.oauth_types import OAuthPrompt
+from tau_coding.oauth_types import OAuthAuthInfo, OAuthPrompt
 from tau_coding.provider_catalog import builtin_provider_entry
-from tau_coding.tui.app import OAuthLoginScreen
+from tau_coding.tui.app import OAuthLoginScreen, TauTuiApp
 from tau_coding.tui.config import TAU_DARK_THEME
+
+
+@pytest.mark.anyio
+async def test_oauth_screen_shows_full_authorization_url() -> None:
+    """The whole URL must be visible: users copy it out of the TUI by hand."""
+    from textual.app import App
+
+    from tau_coding.tui.app import _textual_theme_for_tau_theme
+
+    provider = builtin_provider_entry("anthropic")
+    assert provider is not None
+    url = "https://claude.ai/oauth/authorize?" + "&".join(f"p{index}=value" for index in range(40))
+    assert len(url) > 400
+
+    async def fake_login(callbacks):
+        callbacks.on_auth(OAuthAuthInfo(url=url))
+        await asyncio.Event().wait()
+
+    screen = OAuthLoginScreen(provider, theme=TAU_DARK_THEME, login=fake_login)
+
+    class TestApp(App[None]):
+        CSS = TauTuiApp.CSS
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_theme(_textual_theme_for_tau_theme(TAU_DARK_THEME.name))
+            self.theme = TAU_DARK_THEME.name
+
+        def on_mount(self) -> None:
+            self.push_screen(screen)
+
+    copied: list[str] = []
+    app = TestApp()
+    app.copy_to_clipboard = copied.append  # type: ignore[method-assign]
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        widget = screen.query_one("#login-oauth-url", Static)
+        lines = widget.render_lines(Region(0, 0, widget.size.width, widget.size.height))
+        rendered = "".join("".join(segment.text for segment in line) for line in lines)
+        links = {
+            segment.style.link
+            for line in lines
+            for segment in line
+            if segment.style is not None and segment.style.link
+        }
+
+    assert url in rendered.replace(" ", "")
+    # Every wrapped line links to the intact URL, and it is on the clipboard, so
+    # the user never has to reassemble it from the wrapped display by hand.
+    assert links == {url}
+    assert copied == [url]
 
 
 @pytest.mark.anyio

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -162,15 +162,15 @@ edits saved credentials — it never touches your environment or `providers.json
 
 {{% note title="OAuth troubleshooting" %}}
 Browser login can fall back to a pasted redirect URL/code when the callback
-port is unavailable or the browser runs on another machine. The login screen
-copies the authorization URL to your clipboard and renders it as a link, so
-paste or click it rather than selecting the wrapped text — a URL reassembled
-by hand loses characters at the line breaks and the provider rejects it.
-Copilot uses a device code instead. A denied or expired code requires a new
-`/login`. If a
-Copilot model reports that it is unsupported, enable it in Copilot Chat's model
-selector or ask your organization administrator; provider/model access varies
-by plan and policy.
+port is unavailable or the browser runs on another machine. In that flow the
+login screen copies the authorization URL to your clipboard and renders it as
+a link, so paste or click it rather than selecting the wrapped text — a URL
+reassembled by hand loses characters at the line breaks and the provider
+rejects it. Copilot uses a device code instead: open the short verification
+URL and enter the code shown beneath it. A denied or expired code requires a
+new `/login`. If a Copilot model reports that it is unsupported, enable it in
+Copilot Chat's model selector or ask your organization administrator;
+provider/model access varies by plan and policy.
 {{% /note %}}
 
 ## Choosing and switching models

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -162,8 +162,12 @@ edits saved credentials — it never touches your environment or `providers.json
 
 {{% note title="OAuth troubleshooting" %}}
 Browser login can fall back to a pasted redirect URL/code when the callback
-port is unavailable or the browser runs on another machine. Copilot uses a
-device code instead. A denied or expired code requires a new `/login`. If a
+port is unavailable or the browser runs on another machine. The login screen
+copies the authorization URL to your clipboard and renders it as a link, so
+paste or click it rather than selecting the wrapped text — a URL reassembled
+by hand loses characters at the line breaks and the provider rejects it.
+Copilot uses a device code instead. A denied or expired code requires a new
+`/login`. If a
 Copilot model reports that it is unsupported, enable it in Copilot Chat's model
 selector or ask your organization administrator; provider/model access varies
 by plan and policy.


### PR DESCRIPTION
Logging into Anthropic with a Claude subscription has never worked, and once you got past login the credential died overnight. Three bugs, none of them related except by where they land.

The first is a typo, from #372 — one character, `a` where a `d` belongs:

```
ours:        9d1c250a-e61b-44d9-88ed-5944a1962f5e
Claude Code: 9d1c250a-e61b-44d9-88ed-5944d1962f5e
                                        ^
```

The authorize page answers every request from the first one with "Invalid client id provided". I checked the corrected value against the prod OAuth config baked into the Claude Code 2.1.218, 2.1.219 and 2.1.220 binaries, where it sits next to the same token URL and the same six scopes we already send — so it's the client that matches the rest of our flow, and it's stable across releases.

You see that error immediately if the browser opens on the same machine, since `webbrowser.open` gets the intact URL. If you copy the URL out of the TUI instead — the documented path when the browser is elsewhere — you never got that far, because of the second bug. `#login-oauth-url` has been capped at `max-height: 4` since d5945ef, and the dialog leaves 66 columns for content, so 264 characters were drawn of a 470-character URL:

```
https://claude.ai/oauth/authorize?code=true&client_id=9d1c250a-e61
b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=http%3A%2
F%2Flocalhost%3A53692%2Fcallback&scope=org%3Acreate_api_key+user%3
Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp
  ^ cut off here — code_challenge, code_challenge_method and state never drawn
```

So that path pasted a URL with no `code_challenge` and no `state`, and got "Missing state parameter" instead.

Letting the widget grow fixes the clipping, but hand-selecting a URL that wraps across eight lines is still fragile: note where the first wrap falls above, mid-`client_id`, so a stray line break corrupts it. The URL now renders as an OSC 8 hyperlink and is copied to the clipboard when the screen opens, so a click or a paste always carries the intact URL.

Growing the widget has its own cost — eight lines of URL make the dialog taller than a short terminal, and a centered overflow hangs the title off the top and the paste field off the bottom, breaking the very path this is meant to fix. The dialog is now capped at the screen and scrolls, so the focused paste field is scrolled into view and the rest stays reachable.

The third bug shows up a day later, as a refresh that fails with a bare `400`. The endpoint was being clear about why and we were throwing that away:

```
{"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}
```

Providers rotate the refresh token on use — the old one dies the moment a refresh succeeds — and nothing serialized refreshes. Every provider call read the stored credential, refreshed, and wrote back independently, so concurrent calls could spend the same token; one wins, the losers 400, and whichever write lands last can leave a superseded token on disk. That one fails on the *next* run, long after the race that caused it. Concurrent calls are the normal case, not a corner: the traceback that started this had the agent loop and session auto-naming failing 325ms apart in the same `run_id`.

Refreshes are now serialized per stored credential, with the store re-read inside the lock so a task that waited picks up the rotated credential rather than spending its own copy. The locks are cached per event loop, not per process — `asyncio.Lock` binds to the running loop on first *contention*, so a lock shared across loops appears to work right up until two tasks contend it. The regression test contends it in two loops for exactly that reason. Error detail now comes from the structured OAuth fields, with anything we sent scrubbed back out and the result truncated, since the raw body can echo the token; the existing test that guards against echoing bodies still holds.

I left `ANTHROPIC_AUTHORIZE_URL` pointing at `https://claude.ai/oauth/authorize`. Current Claude Code uses `https://claude.com/cai/oauth/authorize`, but the old endpoint is clearly still serving this flow — it's what rendered both error pages above — and moving it is a separate change worth verifying on its own.

<details>
<summary>Two follow-ups deliberately left out</summary>

Both are real, and both would have doubled the size of this PR, so they're worth their own changes rather than being smuggled into this one.

**The refresh lock is process-local.** Two tau instances sharing `~/.tau/credentials.json` still read the same expired credential and spend the same refresh token. `FileCredentialStore` writes atomically (temp file + `replace`, so no torn JSON), but the load-mutate-save cycle isn't atomic across processes, so concurrent writers can also drop a credential written between another process's load and save. Closing that needs an OS-level lock on the credentials file around the whole read-refresh-write.

**Cancelling mid-refresh can still kill the credential.** Pressing Esc cancels the agent worker. If that lands while the refresh POST is in flight, the server may have already rotated the token — we never learn the new one, never persist it, and the credential is dead on the next run. Same for SIGINT or a crash at the wrong moment. `asyncio.shield` around the refresh-and-persist pair inside the lock would cover it, along with a test that cancels mid-flight.

</details>
