### PR TITLE
Expose print-mode session IDs to automation

### DIFF
--- a/dev-notes/print-mode-session-ids.md
+++ b/dev-notes/print-mode-session-ids.md
@@ -1,0 +1,52 @@
+# Machine-safe print-mode session ids
+
+Issue #499 asks how an orchestrator can record the durable Tau session created
+for a print-mode worker without parsing human output or searching the session
+index.
+
+## Pi investigation
+
+Pi was inspected at `earendil-works/pi` commit
+`47ca25fcd8535b80710fad5be758f1f2cf81443c`. Its CLI exposes:
+
+```text
+--session-id <id>  Use exact project session ID, creating it if missing
+```
+
+Pi validates ids as file-safe names. If the id already exists in the project,
+Pi opens that session; otherwise it warns and creates it. This means automation
+can generate a unique id before launching Pi and already knows the exact id
+without consuming another output channel.
+
+## Tau design
+
+Tau now follows Pi's option name and caller-selected-id approach:
+
+```bash
+tau --print --new-session --session-id worker-01 "..."
+```
+
+The option is intentionally scoped to print mode because Tau already uses
+`--session` for TUI resume behavior and issue #499 concerns isolated workers.
+Tau also refuses an existing id instead of resuming it. This small semantic
+difference protects the existing guarantee that every Tau print invocation
+creates an isolated session and prevents an orchestrator typo or collision from
+appending to another worker's transcript.
+
+No id is written to stdout or stderr. Text, JSON, and transcript rendering are
+therefore unchanged. The caller should generate a unique id (for example, a
+UUID), pass it to Tau, record it beside the worker report, and use the process
+exit status to determine whether startup/the model turn succeeded.
+
+Custom ids use Pi's validation rule: alphanumeric characters plus `.`, `_`, and
+`-`, beginning and ending with an alphanumeric character. Validation happens
+before provider/resource startup. A collision also fails before the coding
+session starts. Failures later in startup or during the model turn retain the
+same requested id and normal non-zero exit behavior, so diagnostics can inspect
+the session if it reached durable initialization.
+
+## Testing
+
+`tests/test_cli.py` covers all output modes, validation, print-only use, exact id
+creation, and collisions. `tests/test_session_manager.py` verifies the filename
+safety rule at the persistence boundary.

--- a/dev-notes/print-mode-session-ids.md
+++ b/dev-notes/print-mode-session-ids.md
@@ -38,15 +38,25 @@ therefore unchanged. The caller should generate a unique id (for example, a
 UUID), pass it to Tau, record it beside the worker report, and use the process
 exit status to determine whether startup/the model turn succeeded.
 
-Custom ids use Pi's validation rule: alphanumeric characters plus `.`, `_`, and
-`-`, beginning and ending with an alphanumeric character. Validation happens
-before provider/resource startup. A collision also fails before the coding
-session starts. Failures later in startup or during the model turn retain the
-same requested id and normal non-zero exit behavior, so diagnostics can inspect
-the session if it reached durable initialization.
+Custom ids start with Pi's validation rule: alphanumeric characters plus `.`,
+`_`, and `-`, beginning and ending with an alphanumeric character. Tau adds a
+128-byte limit so every accepted id leaves room for the `.jsonl` suffix on
+common filesystems. It also rejects `index`, `default`, and the current project's
+dynamic default-session id because those names overlap session metadata or the
+TUI's default transcript.
+
+Validation happens before provider/resource startup where it does not require
+project context. Print-session creation then exclusively creates the transcript
+before indexing it. This filesystem reservation makes an orphaned transcript or
+two concurrent workers requesting the same id fail without overwriting; an
+indexing failure removes the new reservation. Failures later in startup or
+during the model turn retain the same requested id and normal non-zero exit
+behavior, so diagnostics can inspect the session if it reached durable
+initialization.
 
 ## Testing
 
 `tests/test_cli.py` covers all output modes, validation, print-only use, exact id
-creation, and collisions. `tests/test_session_manager.py` verifies the filename
-safety rule at the persistence boundary.
+creation, and indexed collisions. `tests/test_session_manager.py` verifies the
+filename safety and length rules, reserved ids, orphan handling, atomic
+same-id concurrency, and reservation rollback at the persistence boundary.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -718,10 +718,8 @@ def _create_print_session(
     model: str,
     session_id: str | None,
 ) -> CodingSessionRecord:
-    """Create an isolated print-mode session, refusing custom-id collisions."""
-    if session_id is not None and manager.get_session(session_id) is not None:
-        raise RuntimeError(f"Session already exists with id '{session_id}'")
-    return manager.create_session(cwd=cwd, model=model, session_id=session_id)
+    """Create an isolated print-mode session, refusing transcript collisions."""
+    return manager.create_session_exclusive(cwd=cwd, model=model, session_id=session_id)
 
 
 async def run_print_mode(

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -52,7 +52,7 @@ from tau_coding.session_export import (
     export_session_artifact,
     normalize_export_format,
 )
-from tau_coding.session_manager import CodingSessionRecord, SessionManager
+from tau_coding.session_manager import CodingSessionRecord, SessionManager, validate_session_id
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.tui import run_tui_app
 from tau_coding.update_check import (
@@ -230,6 +230,13 @@ def main(
         bool,
         typer.Option("--new-session", help="Create a new session in TUI mode (default)."),
     ] = False,
+    session_id: Annotated[
+        str | None,
+        typer.Option(
+            "--session-id",
+            help="Set the exact id for the newly created print-mode session.",
+        ),
+    ] = None,
     auto_compact_threshold: Annotated[
         int | None,
         typer.Option(
@@ -312,6 +319,14 @@ def main(
 
     print_requested = print_mode or mode is not None
     effective_output = mode or PrintOutputMode.text
+
+    if session_id is not None:
+        if not print_requested:
+            raise typer.BadParameter("--session-id is only supported in print mode")
+        try:
+            validate_session_id(session_id)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
 
     positional_args = prompt_args or []
     command = positional_args[0] if positional_args else None
@@ -400,6 +415,7 @@ def main(
             extension_paths,
             not no_extensions,
             project_extensions,
+            session_id,
         )
     except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -655,6 +671,7 @@ async def run_openai_print_mode(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    session_id: str | None = None,
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     settings = load_provider_settings()
@@ -665,9 +682,14 @@ async def run_openai_print_mode(
         model=selection.model,
         thinking_level=resolve_startup_thinking_level(selection.provider, selection.model),
     )
-    manager = session_manager or SessionManager()
-    record = manager.create_session(cwd=cwd, model=selection.model)
     try:
+        manager = session_manager or SessionManager()
+        record = _create_print_session(
+            manager,
+            cwd=cwd,
+            model=selection.model,
+            session_id=session_id,
+        )
         return await run_print_mode(
             prompt=prompt,
             model=selection.model,
@@ -687,6 +709,19 @@ async def run_openai_print_mode(
         )
     finally:
         await provider.aclose()
+
+
+def _create_print_session(
+    manager: SessionManager,
+    *,
+    cwd: Path,
+    model: str,
+    session_id: str | None,
+) -> CodingSessionRecord:
+    """Create an isolated print-mode session, refusing custom-id collisions."""
+    if session_id is not None and manager.get_session(session_id) is not None:
+        raise RuntimeError(f"Session already exists with id '{session_id}'")
+    return manager.create_session(cwd=cwd, model=model, session_id=session_id)
 
 
 async def run_print_mode(

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
@@ -12,6 +13,13 @@ from pydantic import BaseModel, ConfigDict
 
 from tau_coding.paths import TauPaths
 
+_MAX_SESSION_ID_BYTES = 128
+_RESERVED_SESSION_IDS = frozenset({"default", "index"})
+_WINDOWS_RESERVED_FILE_STEMS = frozenset(
+    {"aux", "con", "nul", "prn"}
+    | {f"com{index}" for index in range(1, 10)}
+    | {f"lpt{index}" for index in range(1, 10)}
+)
 _SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
 
 
@@ -22,6 +30,13 @@ def validate_session_id(session_id: str) -> None:
             "Session id must be non-empty, contain only alphanumeric characters, '-', '_', "
             "and '.', and start and end with an alphanumeric character"
         )
+    if len(session_id.encode("utf-8")) > _MAX_SESSION_ID_BYTES:
+        raise ValueError(f"Session id must be at most {_MAX_SESSION_ID_BYTES} bytes")
+    normalized_id = session_id.casefold()
+    if normalized_id in _RESERVED_SESSION_IDS:
+        raise ValueError(f"Session id is reserved: {session_id}")
+    if normalized_id.partition(".")[0] in _WINDOWS_RESERVED_FILE_STEMS:
+        raise ValueError(f"Session id is not a portable file name: {session_id}")
 
 
 class SessionRecordModel(BaseModel):
@@ -137,6 +152,43 @@ class SessionManager:
         self.index_session(record)
         return record
 
+    def create_session_exclusive(
+        self,
+        *,
+        cwd: Path,
+        model: str,
+        provider_name: str | None = None,
+        title: str | None = None,
+        session_id: str | None = None,
+    ) -> CodingSessionRecord:
+        """Atomically reserve and index a session transcript without overwriting."""
+        record = self.prepare_session(
+            cwd=cwd,
+            model=model,
+            provider_name=provider_name,
+            title=title,
+            session_id=session_id,
+        )
+        if self.get_session(record.id) is not None:
+            raise RuntimeError(f"Session already exists with id '{record.id}'")
+        try:
+            with record.path.open("x", encoding="utf-8"):
+                pass
+        except FileExistsError as exc:
+            raise RuntimeError(f"Session already exists with id '{record.id}'") from exc
+        except Exception:
+            with suppress(OSError):
+                record.path.unlink(missing_ok=True)
+            raise
+        try:
+            return self.index_session(record)
+        except Exception:
+            with suppress(Exception):
+                self._remove(record)
+            with suppress(OSError):
+                record.path.unlink(missing_ok=True)
+            raise
+
     def prepare_session(
         self,
         *,
@@ -151,7 +203,11 @@ class SessionManager:
         resolved_cwd = cwd.resolve()
         record_id = uuid4().hex if session_id is None else session_id
         validate_session_id(record_id)
-        path = self.paths.project_session_dir(resolved_cwd) / f"{record_id}.jsonl"
+        project_session_dir = self.paths.project_session_dir(resolved_cwd)
+        default_session_id = f"default-{project_session_dir.name}"
+        if record_id.casefold() == default_session_id.casefold():
+            raise ValueError(f"Session id is reserved: {record_id}")
+        path = project_session_dir / f"{record_id}.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
         return CodingSessionRecord(
             id=record_id,
@@ -260,6 +316,11 @@ class SessionManager:
         path = self.project_index_path(record.cwd)
         records = [item for item in self._read_index(path) if item.id != record.id]
         records.append(record)
+        self._write_index(path, records)
+
+    def _remove(self, record: CodingSessionRecord) -> None:
+        path = self.project_index_path(record.cwd)
+        records = [item for item in self._read_index(path) if item.id != record.id]
         self._write_index(path, records)
 
 

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
@@ -10,6 +11,17 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict
 
 from tau_coding.paths import TauPaths
+
+_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+def validate_session_id(session_id: str) -> None:
+    """Reject custom session ids that are unsafe as file names."""
+    if not _SESSION_ID_PATTERN.fullmatch(session_id):
+        raise ValueError(
+            "Session id must be non-empty, contain only alphanumeric characters, '-', '_', "
+            "and '.', and start and end with an alphanumeric character"
+        )
 
 
 class SessionRecordModel(BaseModel):
@@ -137,7 +149,8 @@ class SessionManager:
         """Return metadata for a session without adding it to the resume index."""
         now = time()
         resolved_cwd = cwd.resolve()
-        record_id = session_id or uuid4().hex
+        record_id = uuid4().hex if session_id is None else session_id
+        validate_session_id(record_id)
         path = self.paths.project_session_dir(resolved_cwd) / f"{record_id}.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
         return CodingSessionRecord(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -678,6 +678,88 @@ async def test_run_print_mode_can_emit_live_transcript(
     assert captured.err == ""
 
 
+@pytest.mark.parametrize("mode", ["text", "json", "transcript"])
+def test_print_mode_passes_exact_session_id_without_changing_output(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    calls: list[str | None] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        session_manager: SessionManager | None,
+        extension_paths: tuple[Path, ...],
+        extensions_enabled: bool,
+        project_extensions_enabled: bool,
+        session_id: str | None,
+    ) -> bool:
+        del (
+            prompt,
+            model,
+            cwd,
+            output,
+            provider_name,
+            session_manager,
+            extension_paths,
+            extensions_enabled,
+            project_extensions_enabled,
+        )
+        calls.append(session_id)
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(
+        app,
+        ["--mode", mode, "--new-session", "--session-id", "worker-499", "hello"],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert calls == ["worker-499"]
+
+
+@pytest.mark.parametrize("session_id", ["", "-bad", "bad id", "bad/"])
+def test_print_mode_rejects_invalid_session_id(session_id: str) -> None:
+    result = CliRunner().invoke(app, ["-p", "--session-id", session_id, "hello"])
+
+    assert result.exit_code == 2
+    assert "Session id must be non-empty" in _strip_ansi(result.output)
+
+
+def test_session_id_is_print_mode_only() -> None:
+    result = CliRunner().invoke(app, ["--session-id", "worker-499"])
+
+    assert result.exit_code == 2
+    assert "--session-id is only supported in print mode" in _strip_ansi(result.output)
+
+
+def test_create_print_session_uses_requested_id_and_rejects_collision(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    record = cli._create_print_session(
+        manager,
+        cwd=tmp_path,
+        model="fake",
+        session_id="worker-499",
+    )
+
+    assert record.id == "worker-499"
+    assert record.path.name == "worker-499.jsonl"
+    with pytest.raises(RuntimeError, match="Session already exists with id 'worker-499'"):
+        cli._create_print_session(
+            manager,
+            cwd=tmp_path,
+            model="fake",
+            session_id="worker-499",
+        )
+
+
 def test_cli_exits_nonzero_when_print_mode_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_openai_print_mode(
         prompt: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -724,12 +724,22 @@ def test_print_mode_passes_exact_session_id_without_changing_output(
     assert calls == ["worker-499"]
 
 
-@pytest.mark.parametrize("session_id", ["", "-bad", "bad id", "bad/"])
-def test_print_mode_rejects_invalid_session_id(session_id: str) -> None:
+@pytest.mark.parametrize(
+    ("session_id", "error"),
+    [
+        ("", "Session id must be non-empty"),
+        ("-bad", "Session id must be non-empty"),
+        ("bad id", "Session id must be non-empty"),
+        ("bad/", "Session id must be non-empty"),
+        ("index", "Session id is reserved: index"),
+        ("a" * 129, "Session id must be at most 128 bytes"),
+    ],
+)
+def test_print_mode_rejects_invalid_session_id(session_id: str, error: str) -> None:
     result = CliRunner().invoke(app, ["-p", "--session-id", session_id, "hello"])
 
     assert result.exit_code == 2
-    assert "Session id must be non-empty" in _strip_ansi(result.output)
+    assert error in _strip_ansi(result.output)
 
 
 def test_session_id_is_print_mode_only() -> None:

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -45,6 +45,14 @@ def test_session_manager_round_trips_unicode_line_separator_in_title(
     assert manager.list_sessions(cwd) == [record]
 
 
+@pytest.mark.parametrize("session_id", ["", "-bad", "bad-", "bad id", "../escape"])
+def test_session_manager_rejects_invalid_custom_session_id(tmp_path: Path, session_id: str) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    with pytest.raises(ValueError, match="Session id must be non-empty"):
+        manager.prepare_session(cwd=tmp_path, model="fake", session_id=session_id)
+
+
 def test_session_manager_prepares_unindexed_session(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
     cwd = tmp_path / "project"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,10 +1,12 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 
 from tau_coding.paths import TauPaths
-from tau_coding.session_manager import SessionManager
+from tau_coding.session_manager import CodingSessionRecord, SessionManager
 
 
 def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
@@ -51,6 +53,104 @@ def test_session_manager_rejects_invalid_custom_session_id(tmp_path: Path, sessi
 
     with pytest.raises(ValueError, match="Session id must be non-empty"):
         manager.prepare_session(cwd=tmp_path, model="fake", session_id=session_id)
+
+
+@pytest.mark.parametrize("session_id", ["default", "Default", "index", "INDEX"])
+def test_session_manager_rejects_reserved_transcript_names(tmp_path: Path, session_id: str) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    with pytest.raises(ValueError, match=f"Session id is reserved: {session_id}"):
+        manager.prepare_session(cwd=tmp_path, model="fake", session_id=session_id)
+
+
+def test_session_manager_rejects_dynamic_default_session_id(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    default_id = f"default-{manager.paths.project_session_dir(tmp_path).name}"
+
+    with pytest.raises(ValueError, match=f"Session id is reserved: {default_id}"):
+        manager.prepare_session(cwd=tmp_path, model="fake", session_id=default_id)
+
+
+@pytest.mark.parametrize("session_id", ["CON", "nul.txt", "LPT9.worker"])
+def test_session_manager_rejects_nonportable_file_names(tmp_path: Path, session_id: str) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    with pytest.raises(ValueError, match=f"Session id is not a portable file name: {session_id}"):
+        manager.prepare_session(cwd=tmp_path, model="fake", session_id=session_id)
+
+
+def test_session_manager_rejects_overlong_session_id(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    with pytest.raises(ValueError, match="Session id must be at most 128 bytes"):
+        manager.prepare_session(cwd=tmp_path, model="fake", session_id="a" * 129)
+
+
+def test_session_manager_exclusive_creation_rejects_orphaned_transcript(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    orphan = manager.prepare_session(cwd=tmp_path, model="fake", session_id="orphan")
+    orphan.path.write_text("existing transcript\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Session already exists with id 'orphan'"):
+        manager.create_session_exclusive(cwd=tmp_path, model="fake", session_id="orphan")
+
+    assert orphan.path.read_text(encoding="utf-8") == "existing transcript\n"
+    assert manager.get_session("orphan") is None
+
+
+def test_session_manager_exclusive_creation_is_atomic(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    barrier = Barrier(2)
+
+    def create() -> str:
+        manager = SessionManager(paths)
+        barrier.wait()
+        return manager.create_session_exclusive(
+            cwd=tmp_path,
+            model="fake",
+            session_id="shared-worker",
+        ).id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(create) for _ in range(2)]
+    outcomes: list[str] = []
+    errors: list[Exception] = []
+    for future in futures:
+        try:
+            outcomes.append(future.result())
+        except Exception as exc:
+            errors.append(exc)
+
+    assert outcomes == ["shared-worker"]
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+    assert str(errors[0]) == "Session already exists with id 'shared-worker'"
+    assert SessionManager(paths).get_session("shared-worker") is not None
+
+
+def test_session_manager_exclusive_creation_rolls_back_reservation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.prepare_session(cwd=tmp_path, model="fake", session_id="rollback-worker")
+
+    index_session = manager.index_session
+
+    def fail_after_index(record_to_index: CodingSessionRecord) -> None:
+        index_session(record_to_index)
+        raise OSError("index failed")
+
+    monkeypatch.setattr(manager, "index_session", fail_after_index)
+
+    with pytest.raises(OSError, match="index failed"):
+        manager.create_session_exclusive(
+            cwd=tmp_path,
+            model="fake",
+            session_id="rollback-worker",
+        )
+
+    assert not record.path.exists()
+    assert manager.get_session(record.id) is None
 
 
 def test_session_manager_prepares_unindexed_session(tmp_path: Path) -> None:

--- a/website/content/guides/print-mode.md
+++ b/website/content/guides/print-mode.md
@@ -65,6 +65,27 @@ tau --provider local -p "explain this module"
 tau --cwd ./services/api -p "audit for secrets"
 ```
 
+## Recording the session id
+
+Automation can choose the exact id of a new print-mode session with
+`--session-id`. This keeps stdout dedicated to the selected output format and
+avoids scanning `~/.tau/sessions/`:
+
+```bash
+worker_session_id="$(python -c 'import uuid; print(uuid.uuid4().hex)')"
+tau --print --new-session \
+  --session-id "$worker_session_id" \
+  --cwd /path/to/project \
+  "review the current changes"
+printf 'Tau session: %s\n' "$worker_session_id"
+```
+
+Ids may contain letters, numbers, `.`, `_`, and `-`, and must start and end with
+a letter or number. Use a unique id for each worker. Tau exits with an error
+rather than opening or overwriting an existing session with the requested id.
+The option applies to text, JSON, and transcript modes without adding metadata
+to their stdout output.
+
 ## Exit status
 
 Print mode exits non-zero if the run fails, so you can use it in scripts:

--- a/website/content/guides/print-mode.md
+++ b/website/content/guides/print-mode.md
@@ -80,11 +80,13 @@ tau --print --new-session \
 printf 'Tau session: %s\n' "$worker_session_id"
 ```
 
-Ids may contain letters, numbers, `.`, `_`, and `-`, and must start and end with
-a letter or number. Use a unique id for each worker. Tau exits with an error
-rather than opening or overwriting an existing session with the requested id.
-The option applies to text, JSON, and transcript modes without adding metadata
-to their stdout output.
+Ids may contain letters, numbers, `.`, `_`, and `-`, must start and end with a
+letter or number, and may be at most 128 bytes. `default` and `index` are
+reserved. Use a unique id for each worker. Tau atomically reserves the transcript
+and exits with an error rather than opening or overwriting an existing session,
+even if an unindexed transcript already uses that id or two workers start at the
+same time. The option applies to text, JSON, and transcript modes without adding
+metadata to their stdout output.
 
 ## Exit status
 

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -47,6 +47,7 @@ features and fixes.
 | `--mode [text\|json\|transcript]` | Output mode for print mode (default `text`); also triggers print mode on its own |
 | `--session TEXT` | Resume a session id in the TUI |
 | `--new-session` | Start a new session instead of resuming the default |
+| `--session-id TEXT` | Set the exact id for a newly created print-mode session; errors if it already exists |
 | `--auto-compact-threshold INT` | Auto-compact above this rough token estimate |
 | `-e, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |
 | `--no-extensions` | Disable extension directory discovery (explicit `-e` paths still load) |


### PR DESCRIPTION
## Description

Adds a Pi-aligned `--session-id` option for print mode. Automation can choose a unique, file-safe id for each newly created durable session without parsing model output or scanning Tau's session index.

The implementation preserves text, JSON, and transcript stdout, validates custom ids at the persistence boundary, and refuses collisions rather than appending to an existing worker session. Documentation includes the Pi parity investigation and a scripting example.

## User experience

Orchestrators can now record a worker's exact Tau session id before launch while keeping stdout dedicated to the worker report. Concurrent workers in the same directory remain unambiguous when given unique ids, and invalid or duplicate ids fail with actionable errors.

## Issue

Closes #499.

## Manual validation

```bash
session_id="$(python -c 'import uuid; print(uuid.uuid4().hex)')"
uv run tau --print --new-session \
  --session-id "$session_id" \
  --cwd . \
  "summarize this project"
uv run tau sessions | grep "$session_id"
```

Also verify a repeated invocation with the same `--session-id` exits non-zero and does not append to the existing session.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
