### PR TITLE
Cache Anthropic prompts instead of re-billing every turn

### DIFF
--- a/dev-notes/prompt-caching.md
+++ b/dev-notes/prompt-caching.md
@@ -1,0 +1,134 @@
+# Anthropic prompt caching
+
+Tau's Anthropic provider parsed and priced cache usage from the very first
+release — `Usage.cache_read`, `Usage.cache_write`, and `cache_write_1h` are all
+read out of `message_start` — but it never placed a single `cache_control`
+breakpoint in a request. The reporting half was wired up and the requesting half
+was not, so those counters read zero on every real turn and each request re-billed
+the system prompt, the whole tool schema block, and the entire conversation as
+fresh input. In a coding session that is expensive: the tool schemas alone run to
+tens of thousands of tokens and are resent on every tool call.
+
+## The breakpoint budget
+
+Anthropic rejects a request carrying more than four `cache_control` markers, and
+the cache prefix is evaluated in `tools` → `system` → `messages` order. Tau spends
+all four, in `_build_messages_payload`:
+
+1. The **last tool** in the array, which caches the whole schema block.
+2. The **final system block only**. When OAuth is active the system field holds a
+   Claude Code identity block followed by Tau's prompt; a breakpoint on the
+   identity block would cache a ~15-token prefix that the block after it already
+   covers, so it would waste a slot.
+3. and 4. **Two message positions** — this request's tail, and the previous
+   request's tail.
+
+Note that "request" is not "user turn". One prompt from the user drives as many
+requests as the agent needs tool-call round trips, and all four markers are
+recomputed on every one of them. Positions 3 and 4 therefore roll forward several
+times within a single user turn, not once per thing the user types.
+
+It also matters that Anthropic's wire format sends tool results with
+`role: "user"`. The two message positions are the tails of *requests*, and a
+mid-turn request ends with the batch of tool results the agent just collected — so
+in practice these breakpoints land on `tool_result` blocks far more often than on
+anything a human wrote. A prompt from the user is position 4 only on the first
+request of a turn, and position 3 only on the second.
+
+Two message breakpoints rather than one because Anthropic checks at most 20 block
+positions back from a breakpoint before giving up. One Tau turn appends `2N+2`
+blocks for `N` tool calls (one text block, `N` `tool_use` blocks, and `N`
+single-block `tool_result` user messages), so a turn with nine or more parallel
+tool calls pushes the previous cache entry outside that window and misses. Marking
+where the previous request ended opens a second lookback window there. Breakpoints
+are not themselves billed, so a marker that already hits costs nothing.
+
+That second position is *reconstructed from the payload* rather than remembered
+across requests, and it is not a fixed distance back. Tau's transcript is
+append-only and every request stops immediately before the assistant message it
+produces, so the last user-role message preceding the final assistant message is
+exactly where the previous request's tail breakpoint sat — again, usually a
+`tool_result`. `_previous_request_boundary` walks back to find it. Two cases
+return an older position than the literal previous request — a turn whose
+assistant message was empty and errored or aborted is filtered out of provider
+context by `_provider_context`, and consecutive assistant messages leave no user
+message at the true boundary — but both only shorten the reusable prefix rather
+than corrupting anything.
+
+`_mark_cache_breakpoint` will only mark `text`, `image`, or `tool_result` blocks,
+promotes a string `content` to a one-element text block first, and skips empty
+text and empty `tool_result` content, because a breakpoint on an empty block is
+rejected outright.
+
+## Retention
+
+`AnthropicConfig.cache_retention` is a `Literal["none", "short", "long"]`:
+
+- `long` emits `ttl: "1h"`. Applied to Anthropic **subscription OAuth** only.
+  Subscription auth is not billed per token, and the default five-minute TTL is
+  shorter than a test run, a build, or reading a diff — all of which would
+  otherwise expire the prefix mid-session. Note that Pi deliberately defaults to
+  five minutes, but for a reason that does not apply here: Pi is not a permitted
+  subscription harness, so its users pay per-token API prices where the one-hour
+  write premium does not pay off. Claude Code itself uses one hour for its own
+  subscription users. See "Prompt Caching In Agents" in the sources below.
+- `short` is the provider default TTL. This is what **API-key** Anthropic auth
+  gets, so nobody silently pays the 2x cache-write premium they did not ask for.
+- `none` emits no breakpoints at all and leaves the payload byte-identical to the
+  pre-caching shape, plain-string `system` field included.
+
+`none` exists because several catalog providers speak the Anthropic wire protocol
+through a gateway rather than being Anthropic. `minimax`, `minimax-cn`,
+`fireworks`, and `vercel-ai-gateway` are all `kind = "anthropic"` and so route
+through `anthropic_config_from_provider`, and `vercel-ai-gateway` proxies to
+non-Anthropic models entirely. Those backends may reject `cache_control` blocks or
+the block-list `system` field, so `_cache_retention_for_base_url` opts out anything
+whose host is not `api.anthropic.com`. The OAuth `long` override refuses to
+re-enable a backend already set to `none`.
+
+## Observability
+
+Without a visible hit rate there is no way to tell caching is working except by
+watching a rate limit, so `SessionStats` now accumulates `cached_input_tokens` and
+`cache_write_tokens` and exposes a `cache_hit_rate` property. The session sidebar
+renders it between the token counts and the cost estimate. The rate is `None` —
+and the sidebar omits it — when no provider in the branch reported any cache
+activity at all, so backends without prompt caching are not shown a permanent
+misleading `0%`.
+
+## Validate
+
+```bash
+uv run pytest tests/test_prompt_caching.py tests/test_provider_runtime.py \
+  tests/test_tau_ai.py tests/test_session_stats.py tests/test_tui_app.py
+uv run ruff check .
+uv run mypy
+```
+
+`tests/test_prompt_caching.py` covers the awkward transcripts rather than the
+happy path: the four-breakpoint ceiling, a twelve-call parallel turn, adjacent
+assistant messages, image and `tool_result` tails, empty content, and that the
+caller's messages are never mutated.
+
+To confirm end to end against the live API, drive `_build_messages_payload`
+directly with `cache_retention="long"` over successive turns and read
+`cache_read_input_tokens` and `cache_creation.ephemeral_1h_input_tokens` off the
+response. A cold turn writes, the next turn reads back what it wrote, and a turn
+adding more than 20 blocks still reads — that last case is the one the second
+message breakpoint exists for.
+
+## Sources
+
+- <https://platform.claude.com/docs/en/build-with-claude/prompt-caching> — the
+  four-breakpoint limit, the `tools` → `system` → `messages` prefix order, the
+  20-block lookback window (with a worked example matching Tau's wide-turn case),
+  and the rule that breakpoints are not themselves billed.
+- "Prompt Caching In Agents", Earendil Engineering, 22 July 2026 —
+  <https://earendil.com/posts/prompt-caching/>. Why Pi's five-minute default is a
+  licensing artifact rather than a recommendation, why idle gaps rather than bad
+  breakpoint placement dominate real-world misses, and the break-even argument for
+  not pruning tool results to save tokens.
+- `packages/ai/src/api/anthropic-messages.ts` in Pi — the reference
+  implementation Tau's placement is adapted from. Tau differs in two ways: it does
+  not mark the OAuth identity block, and it spends the freed slot on a second
+  message breakpoint.

--- a/dev-notes/prompt-caching.md
+++ b/dev-notes/prompt-caching.md
@@ -82,9 +82,29 @@ through a gateway rather than being Anthropic. `minimax`, `minimax-cn`,
 `fireworks`, and `vercel-ai-gateway` are all `kind = "anthropic"` and so route
 through `anthropic_config_from_provider`, and `vercel-ai-gateway` proxies to
 non-Anthropic models entirely. Those backends may reject `cache_control` blocks or
-the block-list `system` field, so `_cache_retention_for_base_url` opts out anything
-whose host is not `api.anthropic.com`. The OAuth `long` override refuses to
-re-enable a backend already set to `none`.
+the block-list `system` field.
+
+Capability and intent are resolved separately, in `anthropic_cache_settings`.
+Intent comes from the auth mode: OAuth wants `long`, an API key wants `short`.
+Capability comes from three `compat` booleans, layered detected default → provider
+compat → per-model compat, exactly like `forceAdaptiveThinking`:
+
+| Key | Effect when `false` |
+| --- | --- |
+| `supportsCacheControl` | Resolves to `none`. Detected `false` for any host that is not `api.anthropic.com` |
+| `supportsLongCacheRetention` | Clamps `long` to `short` |
+| `supportsCacheControlOnTools` | Drops only the tools breakpoint |
+
+Capability only ever narrows intent, so the two compose with no precedence rule.
+That also makes the failure mode recoverable without a source edit: if Anthropic
+ever stops honoring `ttl: "1h"` on subscriptions the request 400s and tau does not
+retry 400s, but a three-line catalog overlay setting
+`supportsLongCacheRetention = false` clamps it back to five minutes.
+
+Two of these keys already existed in the catalog before anything read them —
+`_detected_compat` emitted `supportsLongCacheRetention` and the Fireworks model
+entries carry both it and `supportsCacheControlOnTools`, mirrored in from Pi. This
+wiring makes that data live rather than inventing a parallel vocabulary.
 
 ## Observability
 

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -417,7 +417,10 @@ def _build_messages_payload(
 
 
 def _cache_control(cache_retention: CacheRetention) -> dict[str, JSONValue] | None:
-    """Return the cache_control marker for a retention preference, if enabled."""
+    """Return the cache_control marker for a retention preference, if enabled.
+
+    Attach sites copy the result, so no two breakpoints share one dict.
+    """
     if cache_retention == CACHE_RETENTION_NONE:
         return None
     if cache_retention == CACHE_RETENTION_LONG:
@@ -451,7 +454,7 @@ def _anthropic_system(
     if not blocks:
         # An empty text block carrying cache_control is rejected outright.
         return system
-    blocks[-1]["cache_control"] = cache_control
+    blocks[-1]["cache_control"] = dict(cache_control)
     return cast("JSONValue", blocks)
 
 
@@ -519,7 +522,9 @@ def _mark_cache_breakpoint(
     if isinstance(content, str):
         if not content:
             return
-        message["content"] = [{"type": "text", "text": content, "cache_control": cache_control}]
+        message["content"] = [
+            {"type": "text", "text": content, "cache_control": dict(cache_control)}
+        ]
         return
     if not isinstance(content, list) or not content:
         return
@@ -534,7 +539,7 @@ def _mark_cache_breakpoint(
         inner = last_block.get("content")
         if isinstance(inner, list) and not inner:
             return
-    last_block["cache_control"] = cache_control
+    last_block["cache_control"] = dict(cache_control)
 
 
 def _anthropic_message(message: AgentMessage, *, supports_images: bool) -> dict[str, JSONValue]:
@@ -620,7 +625,7 @@ def _anthropic_tool(
         "input_schema": dict(tool.input_schema),
     }
     if cache_control is not None:
-        payload["cache_control"] = cache_control
+        payload["cache_control"] = dict(cache_control)
     return payload
 
 

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping
 from json import loads
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -37,7 +37,13 @@ from tau_ai.content import (
     messages_have_images,
     text_and_images,
 )
-from tau_ai.env import AnthropicConfig
+from tau_ai.env import (
+    CACHE_RETENTION_LONG,
+    CACHE_RETENTION_NONE,
+    CACHE_RETENTION_SHORT,
+    AnthropicConfig,
+    CacheRetention,
+)
 from tau_ai.events import AssistantMessageEvent
 from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
@@ -47,6 +53,20 @@ from tau_ai.stream import canonicalize_provider_stream
 
 ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_MAX_TOKENS = 4096
+CACHE_TTL_LONG = "1h"
+
+# Anthropic rejects a request carrying more than four cache breakpoints, so the
+# budget is spent where it buys the most: the tool schemas, the system prompt, and
+# the two most recent request tails. See _apply_message_cache_breakpoints.
+MAX_CACHE_BREAKPOINTS = 4
+SYSTEM_CACHE_BREAKPOINTS = 1
+TOOLS_CACHE_BREAKPOINTS = 1
+MESSAGE_CACHE_BREAKPOINTS = (
+    MAX_CACHE_BREAKPOINTS - SYSTEM_CACHE_BREAKPOINTS - TOOLS_CACHE_BREAKPOINTS
+)
+
+# Block types that may carry cache_control.
+CACHEABLE_BLOCK_TYPES = frozenset({"text", "image", "tool_result"})
 
 
 class AnthropicProvider:
@@ -120,6 +140,7 @@ class AnthropicProvider:
                 thinking_effort=self._config.thinking_effort,
                 thinking_mode=self._config.thinking_mode,
                 supports_images=self._config.supports_images,
+                cache_retention=self._config.cache_retention,
             )
             headers = {
                 "anthropic-version": ANTHROPIC_VERSION,
@@ -359,25 +380,22 @@ def _build_messages_payload(
     thinking_effort: str | None = None,
     thinking_mode: str = "budget",
     supports_images: bool = False,
+    cache_retention: CacheRetention = CACHE_RETENTION_SHORT,
 ) -> dict[str, JSONValue]:
     resolved_max_tokens = max_tokens or DEFAULT_MAX_TOKENS
     if thinking_budget_tokens is not None:
         resolved_max_tokens = max(resolved_max_tokens, thinking_budget_tokens + 1024)
+    cache_control = _cache_control(cache_retention)
+    payload_messages = [
+        _anthropic_message(message, supports_images=supports_images) for message in messages
+    ]
+    _apply_message_cache_breakpoints(payload_messages, cache_control)
     payload: dict[str, JSONValue] = {
         "model": model,
         "max_tokens": resolved_max_tokens,
         "stream": True,
-        "system": (
-            [
-                {"type": "text", "text": oauth_system_prompt},
-                {"type": "text", "text": system},
-            ]
-            if oauth_system_prompt
-            else system
-        ),
-        "messages": [
-            _anthropic_message(message, supports_images=supports_images) for message in messages
-        ],
+        "system": _anthropic_system(system, oauth_system_prompt, cache_control),
+        "messages": cast("JSONValue", payload_messages),
     }
     if thinking_mode == "disabled":
         payload["thinking"] = {"type": "disabled"}
@@ -390,8 +408,133 @@ def _build_messages_payload(
             "budget_tokens": thinking_budget_tokens,
         }
     if tools:
-        payload["tools"] = [_anthropic_tool(tool) for tool in tools]
+        last_index = len(tools) - 1
+        payload["tools"] = [
+            _anthropic_tool(tool, cache_control=cache_control if index == last_index else None)
+            for index, tool in enumerate(tools)
+        ]
     return payload
+
+
+def _cache_control(cache_retention: CacheRetention) -> dict[str, JSONValue] | None:
+    """Return the cache_control marker for a retention preference, if enabled."""
+    if cache_retention == CACHE_RETENTION_NONE:
+        return None
+    if cache_retention == CACHE_RETENTION_LONG:
+        return {"type": "ephemeral", "ttl": CACHE_TTL_LONG}
+    return {"type": "ephemeral"}
+
+
+def _anthropic_system(
+    system: str,
+    oauth_system_prompt: str | None,
+    cache_control: dict[str, JSONValue] | None,
+) -> JSONValue:
+    """Build the system field, marking its tail as a cache breakpoint when enabled.
+
+    Only the final block is marked. A breakpoint on the OAuth identity block would
+    cache a prefix already covered by the block after it, wasting one of the four
+    breakpoints Anthropic allows.
+    """
+    if cache_control is None:
+        if oauth_system_prompt:
+            return [
+                {"type": "text", "text": oauth_system_prompt},
+                {"type": "text", "text": system},
+            ]
+        return system
+    blocks: list[dict[str, JSONValue]] = []
+    if oauth_system_prompt:
+        blocks.append({"type": "text", "text": oauth_system_prompt})
+    if system:
+        blocks.append({"type": "text", "text": system})
+    if not blocks:
+        # An empty text block carrying cache_control is rejected outright.
+        return system
+    blocks[-1]["cache_control"] = cache_control
+    return cast("JSONValue", blocks)
+
+
+def _apply_message_cache_breakpoints(
+    messages: list[dict[str, JSONValue]],
+    cache_control: dict[str, JSONValue] | None,
+) -> None:
+    """Mark this request's tail and the previous request's tail, in place.
+
+    Two breakpoints rather than one: Anthropic checks at most 20 block positions
+    back from a breakpoint when searching for a reusable prefix, and one tau turn
+    appends 2N+2 blocks for N tool calls. Marking where the previous request ended
+    opens a second lookback window there, so a wide parallel-tool turn still gets
+    a read hit instead of falling out of the window. Either position may be
+    ineligible, in which case fewer breakpoints are emitted.
+    """
+    if cache_control is None or not messages:
+        return
+    indexes = {len(messages) - 1}
+    boundary = _previous_request_boundary(messages)
+    if boundary is not None:
+        indexes.add(boundary)
+    if len(indexes) > MESSAGE_CACHE_BREAKPOINTS:  # pragma: no cover - defensive
+        raise AssertionError("message cache breakpoints exceed the Anthropic budget")
+    for index in indexes:
+        _mark_cache_breakpoint(messages[index], cache_control)
+
+
+def _previous_request_boundary(messages: list[dict[str, JSONValue]]) -> int | None:
+    """Return the index where the previous request's message list ended.
+
+    Tau's transcript is append-only and every request stops immediately before the
+    assistant message it produces, so the last user message preceding the final
+    assistant turn is where the previous request's tail breakpoint was placed.
+
+    Two cases return an older position than the literal previous request. A turn
+    whose assistant message was empty and errored or aborted is filtered out of
+    provider context, and consecutive assistant messages (a retained failure
+    followed by a continue) leave no user message at the true boundary. Both only
+    shorten the prefix this breakpoint can reuse; a marked position that was never
+    written simply opens a lookback window that finds an older entry, and
+    breakpoints themselves are not billed.
+    """
+    last_assistant = None
+    for index in range(len(messages) - 1, -1, -1):
+        if messages[index].get("role") == "assistant":
+            last_assistant = index
+            break
+    if last_assistant is None:
+        return None
+    for index in range(last_assistant - 1, -1, -1):
+        if messages[index].get("role") == "user":
+            return index
+    return None
+
+
+def _mark_cache_breakpoint(
+    message: dict[str, JSONValue],
+    cache_control: dict[str, JSONValue],
+) -> None:
+    """Attach cache_control to a user message's final content block, if eligible."""
+    if message.get("role") != "user":
+        return
+    content = message.get("content")
+    if isinstance(content, str):
+        if not content:
+            return
+        message["content"] = [{"type": "text", "text": content, "cache_control": cache_control}]
+        return
+    if not isinstance(content, list) or not content:
+        return
+    last_block = content[-1]
+    if not isinstance(last_block, dict):
+        return
+    if last_block.get("type") not in CACHEABLE_BLOCK_TYPES:
+        return
+    if last_block.get("type") == "tool_result":
+        # A breakpoint on a tool_result carrying no content risks the same
+        # rejection as an empty text block.
+        inner = last_block.get("content")
+        if isinstance(inner, list) and not inner:
+            return
+    last_block["cache_control"] = cache_control
 
 
 def _anthropic_message(message: AgentMessage, *, supports_images: bool) -> dict[str, JSONValue]:
@@ -466,12 +609,19 @@ def _anthropic_image(image: ImageContent) -> dict[str, JSONValue]:
     }
 
 
-def _anthropic_tool(tool: AgentTool) -> dict[str, JSONValue]:
-    return {
+def _anthropic_tool(
+    tool: AgentTool,
+    *,
+    cache_control: dict[str, JSONValue] | None = None,
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
         "name": tool.name,
         "description": tool.description,
         "input_schema": dict(tool.input_schema),
     }
+    if cache_control is not None:
+        payload["cache_control"] = cache_control
+    return payload
 
 
 def _parse_sse_line(line: str) -> str | None:

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -141,6 +141,7 @@ class AnthropicProvider:
                 thinking_mode=self._config.thinking_mode,
                 supports_images=self._config.supports_images,
                 cache_retention=self._config.cache_retention,
+                cache_control_on_tools=self._config.cache_control_on_tools,
             )
             headers = {
                 "anthropic-version": ANTHROPIC_VERSION,
@@ -381,6 +382,7 @@ def _build_messages_payload(
     thinking_mode: str = "budget",
     supports_images: bool = False,
     cache_retention: CacheRetention = CACHE_RETENTION_SHORT,
+    cache_control_on_tools: bool = True,
 ) -> dict[str, JSONValue]:
     resolved_max_tokens = max_tokens or DEFAULT_MAX_TOKENS
     if thinking_budget_tokens is not None:
@@ -408,9 +410,14 @@ def _build_messages_payload(
             "budget_tokens": thinking_budget_tokens,
         }
     if tools:
+        # Some Anthropic-protocol gateways accept cache_control everywhere except
+        # inside tool objects, so the tools breakpoint is separately suppressible.
+        tools_cache_control = cache_control if cache_control_on_tools else None
         last_index = len(tools) - 1
         payload["tools"] = [
-            _anthropic_tool(tool, cache_control=cache_control if index == last_index else None)
+            _anthropic_tool(
+                tool, cache_control=tools_cache_control if index == last_index else None
+            )
             for index, tool in enumerate(tools)
         ]
     return payload

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from os import environ
+from typing import Literal
 
 from tau_agent.types import JSONValue
 
@@ -13,6 +14,15 @@ DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
 DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS = 60.0
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES = 2
 DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS = 1.0
+
+# Prompt-cache retention preferences. "short" uses the provider default TTL
+# (5 minutes on Anthropic), "long" requests the 1 hour TTL, and "none" disables
+# cache breakpoints entirely for backends that reject them.
+type CacheRetention = Literal["none", "short", "long"]
+
+CACHE_RETENTION_NONE: CacheRetention = "none"
+CACHE_RETENTION_SHORT: CacheRetention = "short"
+CACHE_RETENTION_LONG: CacheRetention = "long"
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +78,7 @@ class AnthropicConfig:
     thinking_mode: str = "budget"
     provider_name: str = "Anthropic"
     oauth_system_prompt: str | None = None
+    cache_retention: CacheRetention = CACHE_RETENTION_SHORT
     credential_resolver: RuntimeProviderAuthResolver | None = None
 
 

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -79,6 +79,7 @@ class AnthropicConfig:
     provider_name: str = "Anthropic"
     oauth_system_prompt: str | None = None
     cache_retention: CacheRetention = CACHE_RETENTION_SHORT
+    cache_control_on_tools: bool = True
     credential_resolver: RuntimeProviderAuthResolver | None = None
 
 

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -10,14 +10,18 @@ from pathlib import Path
 from shutil import copy2
 from tempfile import NamedTemporaryFile
 from typing import Any, Protocol, cast
+from urllib.parse import urlsplit
 
 from tau_ai.env import (
+    CACHE_RETENTION_NONE,
+    CACHE_RETENTION_SHORT,
     DEFAULT_ANTHROPIC_BASE_URL,
     DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES,
     DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS,
     DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
     AnthropicConfig,
+    CacheRetention,
     OpenAICompatibleConfig,
 )
 from tau_ai.openai_codex import DEFAULT_OPENAI_CODEX_BASE_URL
@@ -1534,10 +1538,12 @@ def anthropic_config_from_provider(
         model=selected_model,
         thinking_level=thinking_level,
     )
+    base_url = _normalize_anthropic_base_url(_model_base_url(provider, selected_model))
     return AnthropicConfig(
         api_key=api_key,
         provider_name=provider.name,
-        base_url=_normalize_anthropic_base_url(_model_base_url(provider, selected_model)),
+        base_url=base_url,
+        cache_retention=_cache_retention_for_base_url(base_url),
         headers=_model_headers(provider, selected_model),
         timeout_seconds=provider.timeout_seconds,
         max_retries=provider.max_retries,
@@ -1730,6 +1736,18 @@ def _normalize_anthropic_base_url(base_url: str) -> str:
     if normalized.endswith("/v1"):
         return normalized
     return f"{normalized}/v1"
+
+
+def _cache_retention_for_base_url(base_url: str) -> CacheRetention:
+    """Enable cache breakpoints only for first-party Anthropic.
+
+    Several catalog providers speak the Anthropic protocol through a gateway, and
+    some of those proxy to non-Anthropic models entirely. They may reject
+    cache_control blocks or the block-list system field, so they stay opted out.
+    """
+    if urlsplit(base_url).hostname == urlsplit(DEFAULT_ANTHROPIC_BASE_URL).hostname:
+        return CACHE_RETENTION_SHORT
+    return CACHE_RETENTION_NONE
 
 
 def _provider_from_json(data: object) -> ProviderConfig:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -13,6 +13,7 @@ from typing import Any, Protocol, cast
 from urllib.parse import urlsplit
 
 from tau_ai.env import (
+    CACHE_RETENTION_LONG,
     CACHE_RETENTION_NONE,
     CACHE_RETENTION_SHORT,
     DEFAULT_ANTHROPIC_BASE_URL,
@@ -1406,6 +1407,7 @@ def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
     is_openrouter = provider.name == "openrouter" or "openrouter.ai" in base_url
     is_nonstandard = is_cerebras or is_grok or is_together or is_deepseek or is_zai or is_moonshot
     use_max_tokens = is_moonshot or is_together
+    is_anthropic_api = urlsplit(base_url).hostname == urlsplit(DEFAULT_ANTHROPIC_BASE_URL).hostname
     return {
         "supportsStore": not is_nonstandard,
         "supportsReasoningEffort": not (is_grok or is_zai or is_moonshot or is_together),
@@ -1424,6 +1426,12 @@ def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
         ),
         "supportsStrictMode": not (is_moonshot or is_together),
         "supportsLongCacheRetention": not is_together,
+        # Only first-party Anthropic is known to accept cache_control. Several
+        # catalog providers speak the Anthropic protocol through a gateway, and one
+        # proxies to non-Anthropic models, so they default to no breakpoints. This
+        # is a detected default, overridable per provider or per model.
+        "supportsCacheControl": is_anthropic_api,
+        "supportsCacheControlOnTools": True,
     }
 
 
@@ -1539,11 +1547,13 @@ def anthropic_config_from_provider(
         thinking_level=thinking_level,
     )
     base_url = _normalize_anthropic_base_url(_model_base_url(provider, selected_model))
+    cache_retention, cache_control_on_tools = anthropic_cache_settings(provider, selected_model)
     return AnthropicConfig(
         api_key=api_key,
         provider_name=provider.name,
         base_url=base_url,
-        cache_retention=_cache_retention_for_base_url(base_url),
+        cache_retention=cache_retention,
+        cache_control_on_tools=cache_control_on_tools,
         headers=_model_headers(provider, selected_model),
         timeout_seconds=provider.timeout_seconds,
         max_retries=provider.max_retries,
@@ -1738,16 +1748,27 @@ def _normalize_anthropic_base_url(base_url: str) -> str:
     return f"{normalized}/v1"
 
 
-def _cache_retention_for_base_url(base_url: str) -> CacheRetention:
-    """Enable cache breakpoints only for first-party Anthropic.
+def anthropic_cache_settings(
+    provider: ProviderConfig,
+    model: str | None = None,
+    *,
+    oauth: bool = False,
+) -> tuple[CacheRetention, bool]:
+    """Resolve prompt-cache settings for one Anthropic-protocol request.
 
-    Several catalog providers speak the Anthropic protocol through a gateway, and
-    some of those proxy to non-Anthropic models entirely. They may reject
-    cache_control blocks or the block-list system field, so they stay opted out.
+    Capability comes from compat, which layers a detected default under the
+    provider's own compat and then per-model compat. Intent comes from the auth
+    mode: subscription OAuth is not billed per token, so it asks for the 1 hour
+    TTL, while an API key keeps the shorter default. Capability only ever narrows
+    intent, so the two compose without any precedence rule.
     """
-    if urlsplit(base_url).hostname == urlsplit(DEFAULT_ANTHROPIC_BASE_URL).hostname:
-        return CACHE_RETENTION_SHORT
-    return CACHE_RETENTION_NONE
+    compat = _model_compat(provider, model)
+    if compat.get("supportsCacheControl") is False:
+        return CACHE_RETENTION_NONE, False
+    retention = CACHE_RETENTION_LONG if oauth else CACHE_RETENTION_SHORT
+    if retention == CACHE_RETENTION_LONG and compat.get("supportsLongCacheRetention") is False:
+        retention = CACHE_RETENTION_SHORT
+    return retention, compat.get("supportsCacheControlOnTools") is not False
 
 
 def _provider_from_json(data: object) -> ProviderConfig:

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -8,7 +8,12 @@ from typing import Protocol
 
 from tau_agent.provider import ModelProvider
 from tau_ai.anthropic import AnthropicProvider
-from tau_ai.env import AnthropicConfig, RuntimeProviderAuth
+from tau_ai.env import (
+    CACHE_RETENTION_LONG,
+    CACHE_RETENTION_NONE,
+    AnthropicConfig,
+    RuntimeProviderAuth,
+)
 from tau_ai.google import GoogleGenerativeAIProvider
 from tau_ai.mistral import MistralConversationsProvider
 from tau_ai.openai_codex import (
@@ -75,6 +80,15 @@ def create_model_provider(
                 bearer_auth=True,
                 headers={**dict(config.headers or {}), **dict(runtime_auth.headers or {})},
                 oauth_system_prompt="You are Claude Code, Anthropic's official CLI for Claude.",
+                # Subscription auth is not billed per token, so the 1 hour cache
+                # TTL is a clear win: it outlives builds, test runs, and reviews
+                # that would expire the 5 minute default mid-session. Backends
+                # already opted out of breakpoints stay opted out.
+                cache_retention=(
+                    CACHE_RETENTION_LONG
+                    if config.cache_retention != CACHE_RETENTION_NONE
+                    else CACHE_RETENTION_NONE
+                ),
                 credential_resolver=OAuthRuntimeCredentialResolver(
                     provider,
                     credential_store=credentials,
@@ -142,6 +156,9 @@ def create_model_provider(
                 bearer_auth=True,
                 credential_resolver=compatible_config.credential_resolver,
                 supports_images=compatible_config.supports_images,
+                # Third-party gateways speaking the Anthropic protocol may reject
+                # cache_control blocks, so leave breakpoints off for them.
+                cache_retention=CACHE_RETENTION_NONE,
             )
             return AnthropicProvider(anthropic_config)
         if selected_api == "google-generative-ai":

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -8,12 +8,7 @@ from typing import Protocol
 
 from tau_agent.provider import ModelProvider
 from tau_ai.anthropic import AnthropicProvider
-from tau_ai.env import (
-    CACHE_RETENTION_LONG,
-    CACHE_RETENTION_NONE,
-    AnthropicConfig,
-    RuntimeProviderAuth,
-)
+from tau_ai.env import AnthropicConfig, RuntimeProviderAuth
 from tau_ai.google import GoogleGenerativeAIProvider
 from tau_ai.mistral import MistralConversationsProvider
 from tau_ai.openai_codex import (
@@ -36,6 +31,7 @@ from tau_coding.provider_config import (
     OpenAICompatibleProviderConfig,
     ProviderConfig,
     ProviderConfigError,
+    anthropic_cache_settings,
     anthropic_config_from_provider,
     openai_compatible_config_from_provider,
     provider_model_supports_images,
@@ -74,21 +70,14 @@ def create_model_provider(
         )
         if credential is not None:
             runtime_auth = _required_oauth_provider(provider.name).runtime_auth(credential)
+            oauth_retention, _ = anthropic_cache_settings(provider, model, oauth=True)
             config = replace(
                 config,
                 api_key=runtime_auth.api_key,
                 bearer_auth=True,
                 headers={**dict(config.headers or {}), **dict(runtime_auth.headers or {})},
                 oauth_system_prompt="You are Claude Code, Anthropic's official CLI for Claude.",
-                # Subscription auth is not billed per token, so the 1 hour cache
-                # TTL is a clear win: it outlives builds, test runs, and reviews
-                # that would expire the 5 minute default mid-session. Backends
-                # already opted out of breakpoints stay opted out.
-                cache_retention=(
-                    CACHE_RETENTION_LONG
-                    if config.cache_retention != CACHE_RETENTION_NONE
-                    else CACHE_RETENTION_NONE
-                ),
+                cache_retention=oauth_retention,
                 credential_resolver=OAuthRuntimeCredentialResolver(
                     provider,
                     credential_store=credentials,
@@ -145,6 +134,9 @@ def create_model_provider(
                 raise ProviderConfigError(
                     "Anthropic-protocol models on openai-compatible providers require OAuth"
                 )
+            gateway_retention, gateway_cache_control_on_tools = anthropic_cache_settings(
+                provider, model, oauth=True
+            )
             anthropic_config = AnthropicConfig(
                 api_key=compatible_config.api_key,
                 base_url=compatible_config.base_url,
@@ -156,9 +148,10 @@ def create_model_provider(
                 bearer_auth=True,
                 credential_resolver=compatible_config.credential_resolver,
                 supports_images=compatible_config.supports_images,
-                # Third-party gateways speaking the Anthropic protocol may reject
-                # cache_control blocks, so leave breakpoints off for them.
-                cache_retention=CACHE_RETENTION_NONE,
+                # Resolved from compat like the first-party path, so a gateway
+                # proxying real Claude can opt back in per provider or per model.
+                cache_retention=gateway_retention,
+                cache_control_on_tools=gateway_cache_control_on_tools,
             )
             return AnthropicProvider(anthropic_config)
         if selected_api == "google-generative-ai":

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -21,7 +21,22 @@ class SessionStats:
     tool_call_count: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_write_tokens: int = 0
     estimated_cost: float | None = None
+
+    @property
+    def cache_hit_rate(self) -> float | None:
+        """Share of prompt tokens served from the provider's cache.
+
+        None when no provider in the branch reported any cache activity, so that
+        backends without prompt caching are not shown a permanent 0%.
+        """
+        if self.input_tokens <= 0:
+            return None
+        if self.cached_input_tokens == 0 and self.cache_write_tokens == 0:
+            return None
+        return self.cached_input_tokens / self.input_tokens
 
 
 def calculate_session_stats(
@@ -34,6 +49,8 @@ def calculate_session_stats(
     tool_call_count = 0
     input_tokens = 0
     output_tokens = 0
+    cached_input_tokens = 0
+    cache_write_tokens = 0
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
@@ -52,6 +69,8 @@ def calculate_session_stats(
         usage = message.usage
         prompt_tokens = usage.input + usage.cache_read + usage.cache_write
         input_tokens += prompt_tokens
+        cached_input_tokens += usage.cache_read
+        cache_write_tokens += usage.cache_write
         output_tokens += usage.output
         if prompt_tokens == 0 and usage.output == 0:
             continue
@@ -77,6 +96,8 @@ def calculate_session_stats(
         tool_call_count=tool_call_count,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+        cache_write_tokens=cache_write_tokens,
         estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
     )
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1494,6 +1494,10 @@ def render_session_sidebar(
     usage = Text(style=theme.completion_description)
     usage.append(f"{_compact_usage_count(stats.input_tokens)} in, ")
     usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
+    hit_rate = stats.cache_hit_rate
+    if hit_rate is not None:
+        usage.append(" · ", style=theme.completion_description)
+        usage.append(f"{hit_rate:.0%} cached", style=theme.completion_description)
     usage.append(" · ", style=theme.completion_description)
     if stats.estimated_cost is None:
         usage.append("$N/A", style=theme.completion_description)

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -1,0 +1,301 @@
+"""Anthropic prompt-cache breakpoint placement."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tau_agent import (
+    AssistantMessage,
+    ImageContent,
+    TextContent,
+    ToolResultMessage,
+    UserMessage,
+)
+from tau_agent.tools import AgentTool, ToolCall
+from tau_ai.anthropic import (
+    MAX_CACHE_BREAKPOINTS,
+    _build_messages_payload,
+)
+from tau_ai.env import (
+    CACHE_RETENTION_LONG,
+    CACHE_RETENTION_NONE,
+    CACHE_RETENTION_SHORT,
+)
+
+OAUTH_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude."
+
+
+async def _never_called(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+    raise AssertionError("tool must not execute")
+
+
+def _tool(name: str) -> AgentTool:
+    return AgentTool(
+        name=name,
+        label=name,
+        description=f"{name} tool",
+        parameters={"type": "object", "properties": {}},
+        execute_fn=_never_called,
+    )
+
+
+def _assistant_with_calls(count: int, *, offset: int = 0) -> AssistantMessage:
+    return AssistantMessage(
+        content=[
+            TextContent(text="working"),
+            *[
+                ToolCall(id=f"call-{offset + index}", name="read", arguments={})
+                for index in range(count)
+            ],
+        ],
+        stop_reason="toolUse",
+    )
+
+
+def _results(count: int, *, offset: int = 0) -> list[ToolResultMessage]:
+    return [
+        ToolResultMessage(
+            tool_call_id=f"call-{offset + index}",
+            tool_name="read",
+            content=[TextContent(text=f"result {offset + index}")],
+        )
+        for index in range(count)
+    ]
+
+
+def _payload(
+    messages: list[Any],
+    *,
+    tools: list[AgentTool] | None = None,
+    cache_retention: str = CACHE_RETENTION_SHORT,
+    oauth_system_prompt: str | None = None,
+) -> dict[str, Any]:
+    return _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        oauth_system_prompt=oauth_system_prompt,
+        messages=messages,
+        tools=tools or [],
+        cache_retention=cache_retention,
+    )
+
+
+def _count_breakpoints(payload: dict[str, Any]) -> int:
+    def walk(value: object) -> int:
+        if isinstance(value, dict):
+            return sum(
+                (1 if key == "cache_control" else 0) + walk(item) for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return sum(walk(item) for item in value)
+        return 0
+
+    return sum(walk(payload.get(field)) for field in ("system", "tools", "messages"))
+
+
+def _marked_message_indexes(payload: dict[str, Any]) -> list[int]:
+    indexes = []
+    for index, message in enumerate(payload["messages"]):
+        content = message.get("content")
+        if isinstance(content, list) and any(
+            isinstance(block, dict) and "cache_control" in block for block in content
+        ):
+            indexes.append(index)
+    return indexes
+
+
+def test_retention_none_leaves_payload_untouched() -> None:
+    """Gateways that reject cache_control must see exactly the legacy payload."""
+    payload = _payload(
+        [UserMessage(content="Say hello")],
+        tools=[_tool("read")],
+        cache_retention=CACHE_RETENTION_NONE,
+    )
+
+    assert _count_breakpoints(payload) == 0
+    assert payload["system"] == "You are Tau."
+    assert payload["messages"] == [{"role": "user", "content": "Say hello"}]
+    assert "cache_control" not in payload["tools"][0]
+
+
+def test_long_retention_requests_one_hour_ttl_everywhere() -> None:
+    long_ttl = {"type": "ephemeral", "ttl": "1h"}
+    payload = _payload(
+        [UserMessage(content="Say hello")],
+        tools=[_tool("read")],
+        cache_retention=CACHE_RETENTION_LONG,
+    )
+
+    assert payload["system"][0]["cache_control"] == long_ttl
+    assert payload["tools"][0]["cache_control"] == long_ttl
+    assert payload["messages"][0]["content"][0]["cache_control"] == long_ttl
+
+
+def test_string_user_content_is_promoted_to_a_marked_block() -> None:
+    payload = _payload([UserMessage(content="Say hello")])
+
+    assert payload["messages"][0]["content"] == [
+        {
+            "type": "text",
+            "text": "Say hello",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def test_only_the_last_tool_and_last_system_block_are_marked() -> None:
+    payload = _payload(
+        [UserMessage(content="Say hello")],
+        tools=[_tool("read"), _tool("write"), _tool("bash")],
+        oauth_system_prompt=OAUTH_PROMPT,
+    )
+
+    assert [("cache_control" in tool) for tool in payload["tools"]] == [False, False, True]
+    system = payload["system"]
+    assert system[0]["text"] == OAUTH_PROMPT
+    assert "cache_control" not in system[0]
+    assert "cache_control" in system[1]
+
+
+def test_full_oauth_payload_stays_within_the_breakpoint_budget() -> None:
+    """Anthropic rejects a fifth breakpoint outright."""
+    messages = [
+        UserMessage(content="first"),
+        _assistant_with_calls(2),
+        *_results(2),
+        UserMessage(content="second"),
+        _assistant_with_calls(2, offset=2),
+        *_results(2, offset=2),
+    ]
+    payload = _payload(
+        messages,
+        tools=[_tool("read"), _tool("write")],
+        cache_retention=CACHE_RETENTION_LONG,
+        oauth_system_prompt=OAUTH_PROMPT,
+    )
+
+    assert _count_breakpoints(payload) == MAX_CACHE_BREAKPOINTS
+
+
+def test_second_breakpoint_lands_on_the_previous_request_tail() -> None:
+    """The prior turn's last tool result is where the last request's breakpoint sat."""
+    messages = [
+        UserMessage(content="first"),
+        _assistant_with_calls(1),
+        *_results(1),
+        _assistant_with_calls(1, offset=1),
+        *_results(1, offset=1),
+    ]
+    payload = _payload(messages)
+
+    # Index 2 is the previous request's tail; index 4 is this request's tail.
+    assert _marked_message_indexes(payload) == [2, 4]
+
+
+def test_many_parallel_tool_calls_still_mark_the_previous_tail() -> None:
+    """A 12-call turn exceeds the 20-block lookback, which is why B exists."""
+    messages = [
+        UserMessage(content="first"),
+        _assistant_with_calls(12),
+        *_results(12),
+        _assistant_with_calls(12, offset=12),
+        *_results(12, offset=12),
+    ]
+    payload = _payload(messages)
+
+    marked = _marked_message_indexes(payload)
+    assert marked == [13, 26]
+    assert payload["messages"][13]["content"][0]["tool_use_id"] == "call-11"
+    assert payload["messages"][26]["content"][0]["tool_use_id"] == "call-23"
+
+
+def test_adjacent_assistant_messages_never_mark_an_assistant() -> None:
+    """A retained errored turn followed by a continue leaves two assistants adjacent."""
+    messages = [
+        UserMessage(content="first"),
+        AssistantMessage(content=[TextContent(text="partial")], stop_reason="error"),
+        AssistantMessage(content=[TextContent(text="retry")], stop_reason="stop"),
+    ]
+    payload = _payload(messages, tools=[_tool("read")])
+
+    # The tail is an assistant message, so only the older user prefix is marked.
+    assert _marked_message_indexes(payload) == [0]
+    for message in payload["messages"]:
+        if message["role"] != "assistant":
+            continue
+        for block in message["content"]:
+            assert "cache_control" not in block
+    # One message breakpoint plus system and tools.
+    assert _count_breakpoints(payload) == 3
+
+
+def test_empty_user_message_is_not_marked() -> None:
+    """An empty text block carrying cache_control is rejected by the API."""
+    payload = _payload([UserMessage(content="")])
+
+    assert payload["messages"][0]["content"] == ""
+    assert _count_breakpoints(payload) == 1
+
+
+def test_first_request_marks_only_its_own_tail() -> None:
+    payload = _payload([UserMessage(content="first")])
+
+    assert _marked_message_indexes(payload) == [0]
+
+
+def test_boundary_skips_back_over_a_retained_failed_turn() -> None:
+    """Consecutive assistants leave no user message at the true boundary."""
+    messages = [
+        UserMessage(content="first"),
+        AssistantMessage(content=[TextContent(text="partial")], stop_reason="error"),
+        AssistantMessage(content=[TextContent(text="retry")], stop_reason="stop"),
+        UserMessage(content="second"),
+    ]
+    payload = _payload(messages)
+
+    # Index 0 is an older prefix than the true boundary, which costs nothing.
+    assert _marked_message_indexes(payload) == [0, 3]
+
+
+def test_image_tail_is_marked_on_the_image_block() -> None:
+    messages = [
+        UserMessage(
+            content=[
+                TextContent(text="look"),
+                ImageContent(data="aW1hZ2U=", mime_type="image/png"),
+            ]
+        )
+    ]
+    payload = _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        messages=messages,
+        tools=[],
+        supports_images=True,
+    )
+
+    content = payload["messages"][0]["content"]
+    assert content[-1]["type"] == "image"
+    assert content[-1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in content[0]
+
+
+def test_empty_tool_result_tail_is_not_marked() -> None:
+    """A tool_result carrying no content risks the same rejection as empty text."""
+    messages = [
+        ToolResultMessage(tool_call_id="call-0", tool_name="read", content=[]),
+    ]
+    payload = _payload(messages)
+
+    assert payload["messages"][0]["content"][0]["content"] == []
+    assert _marked_message_indexes(payload) == []
+
+
+def test_caller_messages_are_not_mutated() -> None:
+    """Breakpoints are applied to freshly built payload dicts, never session state."""
+    messages = [UserMessage(content="first"), _assistant_with_calls(1), *_results(1)]
+    before = [message.model_dump_json() for message in messages]
+
+    _payload(messages, tools=[_tool("read")], cache_retention=CACHE_RETENTION_LONG)
+
+    assert [message.model_dump_json() for message in messages] == before

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -131,6 +131,21 @@ def test_long_retention_requests_one_hour_ttl_everywhere() -> None:
     assert payload["messages"][0]["content"][0]["cache_control"] == long_ttl
 
 
+def test_tools_breakpoint_can_be_suppressed_on_its_own() -> None:
+    """A gateway may accept cache_control everywhere except inside tool objects."""
+    payload = _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        messages=[UserMessage(content="Say hello")],
+        tools=[_tool("read")],
+        cache_control_on_tools=False,
+    )
+
+    assert "cache_control" not in payload["tools"][0]
+    assert "cache_control" in payload["system"][0]
+    assert _count_breakpoints(payload) == 2
+
+
 def test_string_user_content_is_promoted_to_a_marked_block() -> None:
     payload = _payload([UserMessage(content="Say hello")])
 

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -66,6 +66,38 @@ def test_create_model_provider_uses_anthropic_oauth_runtime_auth(tmp_path) -> No
     assert provider._config.oauth_system_prompt is not None
     assert provider._config.headers is not None
     assert provider._config.headers["Authorization"] == "Bearer anthropic-oauth-access"
+    # Subscription auth is not billed per token, so ask for the 1 hour cache TTL.
+    assert provider._config.cache_retention == "long"
+
+
+def test_anthropic_api_key_auth_keeps_the_default_cache_retention(tmp_path) -> None:
+    """1h cache writes cost 2x base, so an API-key user must not get them silently."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key("anthropic", "sk-test")
+
+    provider = create_model_provider(AnthropicProviderConfig(), credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "short"
+
+
+@pytest.mark.parametrize(
+    "provider_name",
+    ["minimax", "minimax-cn", "fireworks", "vercel-ai-gateway"],
+)
+def test_anthropic_protocol_gateways_disable_cache_breakpoints(
+    provider_name: str,
+    tmp_path,
+) -> None:
+    """Gateways speaking the Anthropic protocol may reject cache_control blocks."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key(provider_name, "gateway-key")
+    config = provider_config_from_catalog_entry(provider_name)
+
+    provider = create_model_provider(config, credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "none"
 
 
 def test_create_model_provider_uses_copilot_token_base_url(tmp_path) -> None:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -100,6 +100,28 @@ def test_anthropic_protocol_gateways_disable_cache_breakpoints(
     assert provider._config.cache_retention == "none"
 
 
+def test_copilot_anthropic_protocol_models_disable_cache_breakpoints(tmp_path) -> None:
+    """Copilot proxies the Anthropic protocol, so it gets no cache_control either."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "github-copilot",
+        OAuthCredential(
+            access="tid=1;proxy-ep=proxy.business.githubcopilot.com",
+            refresh="github-token",
+            expires=9999999999999,
+        ),
+    )
+
+    provider = create_model_provider(
+        provider_config_from_catalog_entry("github-copilot"),
+        credential_store=store,
+        model="claude-haiku-4.5",
+    )
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "none"
+
+
 def test_create_model_provider_uses_copilot_token_base_url(tmp_path) -> None:
     store = FileCredentialStore(tmp_path / "credentials.json")
     store.set_oauth(

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 
 from tau_ai import AnthropicProvider, OpenAICodexProvider, OpenAICompatibleProvider
@@ -100,6 +102,48 @@ def test_anthropic_protocol_gateways_disable_cache_breakpoints(
     assert provider._config.cache_retention == "none"
 
 
+def test_provider_compat_can_re_enable_cache_breakpoints_on_a_gateway(tmp_path) -> None:
+    """A gateway proxying real Claude must be able to opt back in without a source edit."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key("minimax", "gateway-key")
+    config = provider_config_from_catalog_entry("minimax")
+    config = replace(config, compat={**config.compat, "supportsCacheControl": True})
+
+    provider = create_model_provider(config, credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "short"
+    assert provider._config.cache_control_on_tools is True
+
+
+def test_provider_compat_can_clamp_the_one_hour_ttl_on_oauth(tmp_path) -> None:
+    """The escape hatch if Anthropic ever stops honoring ttl=1h on subscriptions."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "anthropic",
+        OAuthCredential(access="a", refresh="r", expires=9999999999999),
+    )
+    config = replace(AnthropicProviderConfig(), compat={"supportsLongCacheRetention": False})
+
+    provider = create_model_provider(config, credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "short"
+
+
+def test_provider_compat_can_suppress_only_the_tools_breakpoint(tmp_path) -> None:
+    """Some gateways accept cache_control everywhere except inside tool objects."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key("anthropic", "sk-test")
+    config = replace(AnthropicProviderConfig(), compat={"supportsCacheControlOnTools": False})
+
+    provider = create_model_provider(config, credential_store=store)
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "short"
+    assert provider._config.cache_control_on_tools is False
+
+
 def test_copilot_anthropic_protocol_models_disable_cache_breakpoints(tmp_path) -> None:
     """Copilot proxies the Anthropic protocol, so it gets no cache_control either."""
     store = FileCredentialStore(tmp_path / "credentials.json")
@@ -120,6 +164,35 @@ def test_copilot_anthropic_protocol_models_disable_cache_breakpoints(tmp_path) -
 
     assert isinstance(provider, AnthropicProvider)
     assert provider._config.cache_retention == "none"
+
+
+def test_copilot_model_metadata_compat_can_enable_cache_breakpoints(tmp_path) -> None:
+    """Per-model compat reaches the openai-compatible Anthropic-protocol branch."""
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_oauth(
+        "github-copilot",
+        OAuthCredential(
+            access="tid=1;proxy-ep=proxy.business.githubcopilot.com",
+            refresh="github-token",
+            expires=9999999999999,
+        ),
+    )
+    config = provider_config_from_catalog_entry("github-copilot")
+    metadata = config.model_metadata["claude-haiku-4.5"]
+    config = replace(
+        config,
+        model_metadata={
+            **config.model_metadata,
+            "claude-haiku-4.5": replace(
+                metadata, compat={**metadata.compat, "supportsCacheControl": True}
+            ),
+        },
+    )
+
+    provider = create_model_provider(config, credential_store=store, model="claude-haiku-4.5")
+
+    assert isinstance(provider, AnthropicProvider)
+    assert provider._config.cache_retention == "long"
 
 
 def test_create_model_provider_uses_copilot_token_base_url(tmp_path) -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -7,7 +7,31 @@ from tau_agent.messages import (
     UserMessage,
 )
 from tau_agent.session import CompactionEntry, MessageEntry
-from tau_coding.session_stats import calculate_session_stats
+from tau_coding.session_stats import SessionStats, calculate_session_stats
+
+
+def test_cache_hit_rate_is_hidden_when_no_provider_reported_cache_usage() -> None:
+    """Backends without prompt caching must not show a permanent 0%."""
+    stats = SessionStats(input_tokens=5_000, output_tokens=100)
+
+    assert stats.cache_hit_rate is None
+
+
+def test_cache_hit_rate_is_zero_when_a_write_happened_but_nothing_was_read() -> None:
+    """A cold first turn genuinely is 0% cached, and saying so is useful."""
+    stats = SessionStats(input_tokens=5_000, cache_write_tokens=4_000)
+
+    assert stats.cache_hit_rate == 0.0
+
+
+def test_cache_hit_rate_is_none_without_billed_input() -> None:
+    assert SessionStats().cache_hit_rate is None
+
+
+def test_cache_hit_rate_divides_reads_by_total_prompt_tokens() -> None:
+    stats = SessionStats(input_tokens=1_000, cached_input_tokens=950, cache_write_tokens=50)
+
+    assert stats.cache_hit_rate == 0.95
 
 
 def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1560,8 +1560,25 @@ async def test_anthropic_provider_formats_request_and_streams_text() -> None:
     payload = loads(request.content)
     assert payload["model"] == "claude-test"
     assert payload["stream"] is True
-    assert payload["system"] == "You are Tau."
-    assert payload["messages"] == [{"role": "user", "content": "Say hello"}]
+    assert payload["system"] == [
+        {
+            "type": "text",
+            "text": "You are Tau.",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+    assert payload["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Say hello",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -626,6 +626,18 @@ def test_session_sidebar_uses_na_when_cost_is_unavailable() -> None:
     assert "cost unavailable" not in output
 
 
+def test_session_sidebar_omits_cache_rate_for_providers_without_caching() -> None:
+    session = FakeSession()
+    session.session_stats = SessionStats(input_tokens=1200, output_tokens=300)
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "cached" not in output
+    assert "1.2k in, 300 out" in output
+
+
 def test_session_sidebar_brand_includes_current_version() -> None:
     console = Console(record=True, width=80)
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -192,6 +192,7 @@ class FakeSession:
             tool_call_count=23,
             input_tokens=1_200_000,
             output_tokens=48_000,
+            cached_input_tokens=1_140_000,
             estimated_cost=1.24,
         )
         self.system_prompt = "You are Tau."
@@ -493,7 +494,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "14 turns, 23 tool calls" in output
     assert "cumulative usage" in output
     assert "1.2m in, 48k out" in output
-    assert "1.2m in, 48k out · ~$1.24" in output
+    assert "1.2m in, 48k out · 95% cached · ~$1.24" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert "• review" in output

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -60,6 +60,25 @@ OAuth tokens refresh automatically. `/logout` removes Tau's local credential,
 but does not revoke the grant remotely; use the provider's account settings for
 remote revocation.
 
+#### Anthropic prompt caching
+
+Tau marks cache breakpoints on Anthropic requests so the system prompt, tool
+schemas, and conversation history are reused between turns instead of being
+reprocessed. Which retention Tau asks for depends on how you authenticated:
+
+- **Claude Pro/Max via OAuth** requests the one-hour cache. Subscription auth is
+  not billed per token, and the five-minute default is shorter than a build, a
+  test run, or the time it takes to read a diff — any of which would otherwise
+  expire the cache mid-session.
+- **An Anthropic API key** uses the five-minute default, because one-hour cache
+  writes cost more per token and that should be a deliberate choice.
+
+Providers that speak the Anthropic protocol through a gateway rather than being
+Anthropic itself — `minimax`, `minimax-cn`, `fireworks`, and `vercel-ai-gateway` —
+send no cache breakpoints, since not every gateway accepts them. Watch the
+sidebar's cache hit rate to see caching working; see
+[The interactive session]({{< relref "./tui.md" >}}) for how to read it.
+
 #### Codex subscription context limits
 
 OpenAI's public API and the ChatGPT/Codex subscription are separate serving

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -145,7 +145,7 @@ when you want to reduce what is sent to the model.
 On wide-enough terminals Tau shows the session name prominently without a
 redundant section label, followed by active-branch
 turn and tool-call totals, provider-reported token usage under **cumulative usage**,
-estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
+prompt-cache hit rate, estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
 templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists limited to three rendered lines. Skills
 and context files use bullet lists, with one item or path per line, limited to
@@ -167,6 +167,13 @@ compaction. Input usage counts tokens processed on every
 provider request, so it can be much larger than the context used by the next
 request. Cost is an estimate based on provider-reported usage and configured
 catalog rates; the sidebar shows `$N/A` when Tau lacks complete pricing data.
+
+The cache hit rate is the share of those input tokens the provider served from its
+prompt cache instead of processing again. A healthy long coding session sits well
+above 90%; a low rate usually means something early in the request keeps changing,
+such as a reloaded tool list or a changed thinking level, or that a pause outlived
+the provider's cache. Tau hides the figure entirely for providers that do not
+report cache usage.
 
 The compact status block below the prompt puts `provider:model (thinking)` on its
 first line and the approximate active context as `used/limit` on the second.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -97,10 +97,35 @@ Catalog entries support `kind` values of `openai-compatible`, `anthropic`, and
 
 User catalog overlays can be partial when they use the same `name` as a built-in
 provider. Scalar fields replace built-in values, `models` are merged with user
-models first, and `context_windows` are merged. Model metadata is merged by model;
+models first, and `context_windows` are merged. Provider-level `compat` is merged
+key by key. Model metadata is merged by model;
 its `headers`, `compat`, and `thinking_level_map` mappings are merged, while other
 metadata fields—including the complete `cost_tiers` array—replace the built-in
-value. The thinking fields (`thinking_levels`, `thinking_models`,
+value. A model's `compat` wins over the provider's, so a built-in per-model value
+overrides a provider-level overlay — override at the model level to change it.
+
+### Anthropic prompt-cache compat keys
+
+Providers using the `anthropic-messages` API accept three `compat` booleans
+controlling prompt caching. All default to enabled, except that `cache_control` is
+detected as unsupported for any base URL that is not `api.anthropic.com`, since
+several providers speak the Anthropic protocol through a gateway.
+
+| Key | Effect when `false` |
+| --- | --- |
+| `supportsCacheControl` | No cache breakpoints at all; the request is byte-identical to an uncached one |
+| `supportsLongCacheRetention` | Clamps the 1 hour TTL to the 5 minute default |
+| `supportsCacheControlOnTools` | Drops only the tool-schema breakpoint |
+
+Set them per provider or per model. For example, to stop requesting the one-hour
+cache on a Claude subscription:
+
+```toml
+schema_version = 1
+[[providers]]
+name = "anthropic"
+compat = { supportsLongCacheRetention = false }
+``` The thinking fields (`thinking_levels`, `thinking_models`,
 `thinking_default`, `thinking_parameter`) replace as a group when
 `thinking_levels` is present.
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -125,7 +125,9 @@ schema_version = 1
 [[providers]]
 name = "anthropic"
 compat = { supportsLongCacheRetention = false }
-``` The thinking fields (`thinking_levels`, `thinking_models`,
+```
+
+The thinking fields (`thinking_levels`, `thinking_models`,
 `thinking_default`, `thinking_parameter`) replace as a group when
 `thinking_levels` is present.
 


### PR DESCRIPTION
I was working in a long session on my Claude subscription and noticed my usage being eaten up far faster than the equivalent work in Claude Code. I realised it was due to lack of prompt caching.

Tau has always *read* cache usage — `cache_read`, `cache_write` and `ephemeral_1h_input_tokens` are all parsed off `message_start` and priced — but it never put `cache_control` breakpoints in a request. The reporting half was wired up and the requesting half was not, so those counters sat at zero and every request re-billed the system prompt, the whole tool schema block, and the entire conversation as fresh input. Tool schemas alone are tens of thousands of tokens, resent on every tool call.

After implementing this change I am seeing cache usage in the high 90%s for longer sessions as expected.

## What this adds

Anthropic allows four cache breakpoints per request:

| # | Position | Why |
| --- | --- | --- |
| 1 | Last tool schema | Caches the whole tool block |
| 2 | Final system block | Not the OAuth identity block — its prefix is already covered |
| 3 | Previous request's tail | Guarantees the read hit (see below) |
| 4 | Current request's tail | Extends the cache to the new tip |

Breakpoints 3 and 4 are the interesting pair. Anthropic only looks back 20 block positions from a breakpoint, and one turn appends `2N+2` blocks for `N` tool calls — so a turn with ~9+ parallel tool calls pushes the previous cache entry out of the window and misses. Marking where the previous request ended opens a second lookback window there. That position is derived from the payload, not tracked across requests: the transcript is append-only and every request stops just before the assistant message it produces.

## The one-hour cache

One of the efficiencies of the Claude Code subscription is the one-hour prompt cache it includes, rather than the five-minute API default. Five minutes is shorter than a build, a test run, or reading a diff — so it expires mid-session constantly. This asks for the one-hour TTL on subscription OAuth, which is where it's free.

- **Subscription OAuth** → 1h TTL
- **Anthropic API key** → 5m default, so nobody silently pays the 2x cache-write premium
- **Anthropic-protocol gateways** → no breakpoints at all, unless opted back in

That last case is worth noting: `minimax`, `minimax-cn`, `fireworks` and `vercel-ai-gateway` are all `kind = "anthropic"` and route through `anthropic_config_from_provider` despite not being Anthropic, and `vercel-ai-gateway` proxies to non-Anthropic models entirely. They're detected by base-URL host, along with Copilot's Anthropic-protocol models, and receive an identical payload to today's.

Capability and intent are resolved separately, so that detection is a default rather than a hard rule. Intent comes from the auth mode above; capability comes from three `compat` booleans layered detected → provider → per-model, the same path `forceAdaptiveThinking` already takes on this provider:

| Key | Effect when `false` |
| --- | --- |
| `supportsCacheControl` | No breakpoints at all |
| `supportsLongCacheRetention` | Clamps the 1h TTL to 5m |
| `supportsCacheControlOnTools` | Drops only the tool-schema breakpoint |

Capability only ever narrows intent, so the two compose with no precedence rule. Two of those keys were already in the catalog with nothing reading them — `_detected_compat` emitted `supportsLongCacheRetention`, and the Fireworks model entries declare both it and `supportsCacheControlOnTools`, mirrored in from Pi — so this makes existing data live rather than adding a parallel vocabulary. It also means a gateway fronting real Claude, or a caching-capable proxy, can opt in without a source edit.

The session sidebar now shows a cache hit rate, since otherwise there's no way to tell this is working short of watching a rate limit. It's hidden rather than shown as 0% for providers that never report cache usage.

## Verified against the live API

Not just unit tests — driving `_build_messages_payload` on a real subscription credential:

| Turn | Read | Write |
| --- | --- | --- |
| Cold | 0 | 4737 |
| +12 tool calls | 4737 | 1149 |
| +12 more (26 new blocks) | 5886 | 1153 |

The third row is the case breakpoint 3 exists for — 26 new blocks is outside the 20-block lookback, so a single-breakpoint design misses there. Also confirmed `ttl: "1h"` is genuinely honored on OAuth rather than silently downgraded to 5m.

`uv run pytest` (1258), `ruff check`, `ruff format --check`, `mypy` all clean.

## Prior art

Placement is adapted from Pi's [`anthropic-messages.ts`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/api/anthropic-messages.ts), with two deliberate differences: Tau doesn't mark the OAuth identity block, and spends the freed slot on the second message breakpoint.

["Prompt Caching In Agents"](https://earendil.com/posts/prompt-caching/) by one of Pi's creators is why the OAuth default here is one hour rather than Pi's five minutes — Pi defaults short because it isn't a permitted subscription harness and its users pay per-token API prices, which doesn't apply to a subscription.

## For reviewers

Two things I'd flag, and one known follow-up:

1. **1h write pricing.** `_response_cost` still prices 1h writes at the 5m `cacheWrite` rate and `Usage.cache_write_1h` is unconsumed. Harmless while `long` is OAuth-only, but it understates cost if `long` ever reaches an API-key path.
2. **Unverified:** I confirmed OAuth *honors* the 1h TTL, but not how Anthropic weights cache writes against subscription rate limits. Writes bill 2x for 1h vs 1.25x for 5m, so if limit accounting mirrors cost weights, very short sessions could conceivably consume limit faster. Reads dominate writes heavily in real sessions so I expect a large net win regardless — but I couldn't verify it and didn't want to imply I had. If it does turn out wrong, or if Anthropic stops honoring `ttl: "1h"` at all, `supportsLongCacheRetention = false` in a catalog overlay clamps it back to 5m without a source edit. Worth having, since an unsupported ttl is a hard 400 and Tau doesn't retry 400s.

**Follow-up:** compaction and branch-summary requests still inherit full retention, so they write a cache entry that can never be read back — they use their own system prompt and no tools, so they share no prefix with the conversation. Pi passes `cacheRetention: "none"` for these. Left out here since compaction is infrequent and the plumbing outweighed the saving.

Contributor notes in `dev-notes/prompt-caching.md`; user-facing docs under `website/content/guides/` and `website/content/reference/configuration.md`.

