### PR TITLE
TUI: show working state and finished notification during manual /compact

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3403,6 +3403,7 @@ class TauTuiApp(App[None]):
         self._connect_extension_runtime(session)
         self._prompt_worker: Worker[None] | None = None
         self._compaction_worker: Worker[None] | None = None
+        self._compacting = False
         self._prompt_run_id = 0
         self._optimistic_user_messages: list[tuple[int, str]] = []
         self._completion_state = CompletionState()
@@ -3425,11 +3426,15 @@ class TauTuiApp(App[None]):
         """Reflect the active session name in the terminal tab title."""
         self._sync_terminal_title()
 
+    def _is_working(self) -> bool:
+        """Return whether the app should show working affordances (agent turn or compaction)."""
+        return self.state.running or self._compacting
+
     def _sync_terminal_title(self) -> None:
         """Reflect the active session name and running state in the terminal tab title."""
         self._terminal_title.update(
             getattr(self.session, "session_title", None),
-            running=self.state.running,
+            running=self._is_working(),
             frame=self._activity_frame,
         )
 
@@ -3800,7 +3805,9 @@ class TauTuiApp(App[None]):
     def _is_compaction_active(self) -> bool:
         """Return whether a manual compaction worker is still running."""
         worker = self._compaction_worker
-        return worker is not None and not worker.is_finished and not worker.is_cancelled
+        if worker is not None and not worker.is_finished and not worker.is_cancelled:
+            return True
+        return self._compacting
 
     def _is_agent_or_queue_active(self) -> bool:
         """Return whether compaction would race an active or queued agent turn."""
@@ -3817,6 +3824,7 @@ class TauTuiApp(App[None]):
 
     async def _run_compaction(self, summary: str) -> None:
         """Run manual compaction without disabling prompt editing."""
+        self._compacting = True
         self.state.clear()
         self.state.add_item("status", "Compacting session…")
         self._refresh()
@@ -3828,12 +3836,16 @@ class TauTuiApp(App[None]):
             self._notify(f"Error: {exc}", severity="error")
             return
         finally:
+            self._compacting = False
             self._compaction_worker = None
+            self._refresh_chrome_if_mounted()
         self.state.clear()
         self.state.set_skills(self.session.skills)
         self._load_session_messages_from_session()
         self._notify(compact_message)
         self._refresh()
+        if not self._app_has_focus:
+            self._terminal_notification.notify_turn_finished()
 
     async def _submit_prompt(
         self,
@@ -4699,6 +4711,7 @@ class TauTuiApp(App[None]):
 
         worker.cancel()
         self._compaction_worker = None
+        self._compacting = False
         self.state.clear()
         self.state.set_skills(self.session.skills)
         self._load_session_messages_from_session()
@@ -5552,9 +5565,16 @@ class TauTuiApp(App[None]):
             return
         self.adapter.apply(queue_event())
 
+    def _refresh_chrome_if_mounted(self) -> None:
+        """Refresh chrome when the app is mounted, ignoring teardown races."""
+        if not self.screen_stack:
+            return
+        with suppress(NoMatches):
+            self._refresh_chrome()
+
     def _sync_activity_indicator(self) -> None:
         self._sync_terminal_title()
-        if self.state.running:
+        if self._is_working():
             if self._activity_timer is None:
                 self._activity_timer = self.set_interval(
                     ACTIVITY_TICK_SECONDS,
@@ -5571,7 +5591,7 @@ class TauTuiApp(App[None]):
         self._apply_activity_indicator()
 
     def _tick_activity(self) -> None:
-        if not self.state.running:
+        if not self._is_working():
             return
         self._activity_frame += 1
         self._apply_activity_indicator()
@@ -5622,7 +5642,7 @@ class TauTuiApp(App[None]):
             theme.screen_background,
             theme.prompt_border,
             self._activity_frame,
-            self.state.running,
+            self._is_working(),
             shell_mode,
         )
         if render_key == self._last_activity_indicator_key:
@@ -5633,7 +5653,7 @@ class TauTuiApp(App[None]):
             _activity_prompt_border_color(
                 theme,
                 frame=self._activity_frame,
-                running=self.state.running,
+                running=self._is_working(),
                 shell_mode=shell_mode,
             ),
         )
@@ -5641,7 +5661,7 @@ class TauTuiApp(App[None]):
             _render_activity_indicator(
                 theme,
                 frame=self._activity_frame,
-                running=self.state.running,
+                running=self._is_working(),
                 shell_mode=shell_mode,
             ),
             layout=False,
@@ -5747,7 +5767,9 @@ class TauTuiApp(App[None]):
 
     def _refresh_footer_bindings(self) -> None:
         prompt = self.query_one("#prompt", PromptInput)
-        prompt.set_footer_mode(_prompt_footer_mode(self.state, self._completion_state))
+        prompt.set_footer_mode(
+            _prompt_footer_mode(self.state, self._completion_state, working=self._is_working())
+        )
 
     def _sync_prompt_shell_mode(self, text: str) -> None:
         prompt = self.query_one("#prompt", PromptInput)
@@ -6283,10 +6305,13 @@ def _queued_message_preview(message: str) -> str:
 def _prompt_footer_mode(
     state: TuiState,
     completion_state: CompletionState,
+    *,
+    working: bool | None = None,
 ) -> Literal["normal", "completion", "running"]:
     if completion_state.items:
         return "completion"
-    if state.running:
+    is_working = state.running if working is None else working
+    if is_working:
         return "running"
     return "normal"
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3404,6 +3404,7 @@ class TauTuiApp(App[None]):
         self._prompt_worker: Worker[None] | None = None
         self._compaction_worker: Worker[None] | None = None
         self._compacting = False
+        self._compaction_run_id = 0
         self._prompt_run_id = 0
         self._optimistic_user_messages: list[tuple[int, str]] = []
         self._completion_state = CompletionState()
@@ -3824,11 +3825,13 @@ class TauTuiApp(App[None]):
 
     async def _run_compaction(self, summary: str) -> None:
         """Run manual compaction without disabling prompt editing."""
+        self._compaction_run_id += 1
+        run_id = self._compaction_run_id
         self._compacting = True
-        self.state.clear()
-        self.state.add_item("status", "Compacting session…")
-        self._refresh()
         try:
+            self.state.clear()
+            self.state.add_item("status", "Compacting session…")
+            self._refresh()
             compact_message = await self.session.compact(summary)
         except asyncio.CancelledError:
             return
@@ -3836,9 +3839,12 @@ class TauTuiApp(App[None]):
             self._notify(f"Error: {exc}", severity="error")
             return
         finally:
-            self._compacting = False
-            self._compaction_worker = None
-            self._refresh_chrome_if_mounted()
+            # A cancelled run can tear down after a newer compaction started, so only
+            # clear working state this run still owns.
+            if self._compaction_run_id == run_id:
+                self._compacting = False
+                self._compaction_worker = None
+                self._refresh_chrome_if_mounted()
         self.state.clear()
         self.state.set_skills(self.session.skills)
         self._load_session_messages_from_session()
@@ -4710,6 +4716,7 @@ class TauTuiApp(App[None]):
             return False
 
         worker.cancel()
+        self._compaction_run_id += 1
         self._compaction_worker = None
         self._compacting = False
         self.state.clear()
@@ -5768,7 +5775,7 @@ class TauTuiApp(App[None]):
     def _refresh_footer_bindings(self) -> None:
         prompt = self.query_one("#prompt", PromptInput)
         prompt.set_footer_mode(
-            _prompt_footer_mode(self.state, self._completion_state, working=self._is_working())
+            _prompt_footer_mode(self._completion_state, working=self._is_working())
         )
 
     def _sync_prompt_shell_mode(self, text: str) -> None:
@@ -6303,15 +6310,13 @@ def _queued_message_preview(message: str) -> str:
 
 
 def _prompt_footer_mode(
-    state: TuiState,
     completion_state: CompletionState,
     *,
-    working: bool | None = None,
+    working: bool,
 ) -> Literal["normal", "completion", "running"]:
     if completion_state.items:
         return "completion"
-    is_working = state.running if working is None else working
-    if is_working:
+    if working:
         return "running"
     return "normal"
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4047,6 +4047,88 @@ async def test_tui_app_clears_working_state_when_compaction_is_cancelled() -> No
 
 
 @pytest.mark.anyio
+async def test_tui_app_keeps_working_state_when_recompacting_during_cancel_teardown() -> None:
+    class GatedCompactSession(FakeSession):
+        def __init__(self, messages=()) -> None:
+            super().__init__(messages=messages)
+            self.started = (asyncio.Event(), asyncio.Event())
+            self.teardown_gate = asyncio.Event()
+            self.finish = asyncio.Event()
+            self.calls = 0
+
+        async def compact(self, summary: str) -> str:
+            index = self.calls
+            self.calls += 1
+            self.compact_summaries.append(summary)
+            self.started[index].set()
+            try:
+                await self.finish.wait()
+            except asyncio.CancelledError:
+                # Delay teardown so it lands after the next compaction started.
+                await self.teardown_gate.wait()
+                raise
+            return "Compacted 2 context entries."
+
+    session = GatedCompactSession(messages=[UserMessage(content="Earlier")])
+    app = TauTuiApp(session)
+    app._notify = lambda message, **kwargs: None  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/compact First summary"
+        await pilot.press("enter")
+        await asyncio.wait_for(session.started[0].wait(), timeout=1)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        prompt.value = "/compact Second summary"
+        await pilot.press("enter")
+        await asyncio.wait_for(session.started[1].wait(), timeout=1)
+        await pilot.pause()
+        second_worker = app._compaction_worker
+
+        session.teardown_gate.set()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app._is_working() is True
+        assert app._is_compaction_active() is True
+        assert app._compaction_worker is second_worker
+
+        session.finish.set()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app._is_working() is False
+        assert app._is_compaction_active() is False
+
+
+@pytest.mark.anyio
+async def test_tui_app_clears_working_state_when_compaction_setup_fails() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="Earlier")]))
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    def failing_refresh() -> None:
+        raise RuntimeError("no matches")
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test():
+        app._refresh = failing_refresh  # type: ignore[method-assign]
+        await app._run_compaction("Summary")
+
+        assert notifications == ["Error: no matches"]
+        assert app._is_working() is False
+        assert app._is_compaction_active() is False
+
+
+@pytest.mark.anyio
 async def test_tui_app_notifies_once_when_manual_compaction_finishes_unfocused() -> None:
     app = TauTuiApp(
         FakeSession(messages=[UserMessage(content="Earlier")]),

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -44,7 +44,13 @@ from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
 from tau_coding.catalog_loader import user_catalog_path
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
-from tau_coding.events import AgentSettledEvent, CodingSessionEvent, QueueUpdateEvent
+from tau_coding.events import (
+    AgentSettledEvent,
+    CodingSessionEvent,
+    CompactionEndEvent,
+    CompactionStartEvent,
+    QueueUpdateEvent,
+)
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_config import (
@@ -3932,6 +3938,172 @@ async def test_tui_app_escape_cancels_active_compaction() -> None:
         assert session.new_session_count == 1
         assert session.messages == ()
         assert not any(item.role == "compaction_summary" for item in app.state.items)
+
+
+@pytest.mark.anyio
+async def test_tui_app_shows_working_state_during_manual_compaction() -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    class SlowCompactSession(FakeSession):
+        async def compact(self, summary: str) -> str:
+            self.compact_summaries.append(summary)
+            started.set()
+            await finish.wait()
+            return "Compacted 2 context entries."
+
+    session = SlowCompactSession(messages=[UserMessage(content="Earlier")])
+    session._session_title = "build notes"
+    app = TauTuiApp(session)
+    titles: list[str] = []
+    app._terminal_title = TerminalTitleController(enabled=True, writer=titles.append)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        indicator = app.query_one("#prompt-prefix", Static)
+        prompt.value = "/compact Summary of earlier work."
+        await pilot.press("enter")
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await pilot.pause()
+
+        assert app._is_working() is True
+        assert app.state.running is False
+        assert app._is_agent_or_queue_active() is False
+        assert app._is_compaction_active() is True
+        assert prompt._footer_mode == "running"
+        assert indicator.render().plain != "τ"
+        assert titles[-1] == "\x1b]0;⠋ τ | build notes\x07"
+
+        app._tick_activity()
+        assert titles[-1] == "\x1b]0;⠙ τ | build notes\x07"
+
+        finish.set()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app._is_working() is False
+        assert app._is_compaction_active() is False
+        assert prompt._footer_mode == "normal"
+        assert indicator.render().plain == "τ"
+        assert titles[-1] == "\x1b]0;τ | build notes\x07"
+
+
+@pytest.mark.anyio
+async def test_tui_app_clears_working_state_when_manual_compaction_fails() -> None:
+    class FailingCompactSession(FakeSession):
+        async def compact(self, summary: str) -> str:
+            del summary
+            raise RuntimeError("boom")
+
+    app = TauTuiApp(FailingCompactSession(messages=[UserMessage(content="Earlier")]))
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **kwargs: object) -> None:
+        del kwargs
+        notifications.append(message)
+
+    app._notify = fake_notify  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/compact Summary"
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert notifications == ["Error: boom"]
+        assert app._is_working() is False
+        assert app._is_compaction_active() is False
+
+
+@pytest.mark.anyio
+async def test_tui_app_clears_working_state_when_compaction_is_cancelled() -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    class SlowCompactSession(FakeSession):
+        async def compact(self, summary: str) -> str:
+            del summary
+            started.set()
+            await finish.wait()
+            return "Compacted 2 context entries."
+
+    app = TauTuiApp(SlowCompactSession(messages=[UserMessage(content="Earlier")]))
+    app._notify = lambda message, **kwargs: None  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/compact Summary"
+        await pilot.press("enter")
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await pilot.pause()
+        assert app._is_working() is True
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert app._is_working() is False
+        assert app._is_compaction_active() is False
+
+
+@pytest.mark.anyio
+async def test_tui_app_notifies_once_when_manual_compaction_finishes_unfocused() -> None:
+    app = TauTuiApp(
+        FakeSession(messages=[UserMessage(content="Earlier")]),
+        tui_settings=TuiSettings(turn_notification="desktop"),
+    )
+    writes: list[str] = []
+    app._terminal_notification = TerminalNotificationController(
+        "desktop",
+        enabled=True,
+        writer=writes.append,
+        environ={"TERM_PROGRAM": "ghostty"},
+    )
+    app._notify = lambda message, **kwargs: None  # type: ignore[method-assign]
+
+    async with app.run_test():
+        await app._run_compaction("focused summary")
+        assert writes == []
+
+        app.on_app_blur()
+        await app._run_compaction("background summary")
+        assert writes == ["\x1b]9;Tau turn finished\x07"]
+
+
+@pytest.mark.anyio
+async def test_tui_app_notifies_once_for_turn_with_automatic_compaction() -> None:
+    class AutoCompactSession(FakeSession):
+        async def prompt(
+            self,
+            text: str,
+            *,
+            streaming_behavior: str | None = None,
+            source: str = "interactive",
+            custom_type: str | None = None,
+            details: dict[str, object] | None = None,
+        ) -> AsyncIterator[CodingSessionEvent]:
+            del streaming_behavior, source, custom_type, details
+            self.prompt_texts.append(text)
+            yield AgentStartEvent()
+            yield CompactionStartEvent(reason="overflow")
+            yield CompactionEndEvent(reason="overflow")
+            yield AgentEndEvent()
+            yield AgentSettledEvent()
+
+    app = TauTuiApp(AutoCompactSession(), tui_settings=TuiSettings(turn_notification="desktop"))
+    writes: list[str] = []
+    app._terminal_notification = TerminalNotificationController(
+        "desktop",
+        enabled=True,
+        writer=writes.append,
+        environ={"TERM_PROGRAM": "ghostty"},
+    )
+
+    async with app.run_test():
+        app.on_app_blur()
+        await app._run_prompt("work")
+
+        assert writes == ["\x1b]9;Tau turn finished\x07"]
 
 
 @pytest.mark.anyio

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -71,6 +71,11 @@ Optional text after `/compact` is added as extra focus for the summary. Manual
 compaction summarizes the whole active context into one summary and fails visibly
 if the request fails.
 
+In the TUI, a manual compaction looks like a normal working turn: the prompt
+activity indicator and terminal tab title animate while it runs, and a
+turn-finished notification fires when it completes while the app is unfocused.
+Press `Esc` to cancel a running compaction.
+
 ## Thinking modes
 
 Some models can spend extra effort reasoning before answering. Tau exposes a


### PR DESCRIPTION
## Summary

Manual `/compact` in the TUI now presents the same "agent working" affordances as a
normal agent turn, and emits a turn-finished notification when it completes.

A dedicated app-level `_compacting` flag feeds the existing running-state
derivations through a new `_is_working()` helper:

- `_sync_terminal_title` (animated tab title)
- `_sync_activity_indicator` / `_tick_activity` / `_apply_activity_indicator`
  (animated prompt indicator + prompt border)
- `_prompt_footer_mode(..., working=...)` (running footer bindings)

`TuiState.running` is deliberately left untouched, so `ALLOW_SELECT`
(`_sync_text_selection_state`) and `_is_agent_or_queue_active()` keep their current
semantics and starting a compaction never looks like an active agent turn.

The flag is cleared in `_run_compaction`'s `finally` (covering success, error, and
cancellation) plus synchronously in `_cancel_active_compaction`, followed by a
guarded chrome refresh so the spinner/title stop immediately. `_is_compaction_active`
also honours the flag, so no two compactions can overlap.

On success and when the app is unfocused, `_run_compaction` fires
`notify_turn_finished()` once. Automatic compaction (threshold/overflow inside an
agent turn) is untouched: the enclosing turn still emits exactly one notification on
`AgentSettledEvent`.

## User-experience improvement

Running `/compact` no longer looks like a frozen prompt: the spinner and tab title
animate for the duration, the footer shows running bindings, and users get a desktop
notification when a long compaction finishes in the background.

## Issue

Closes #503

## Manual validation

1. `uv run tau` in a session with some history.
2. Run `/compact`; observe the animated prompt indicator, prompt border, and tab title.
3. Unfocus the terminal before it completes; a turn-finished notification fires once.
4. Run `/compact` again and press `Esc`; the working state clears immediately.
5. Run a normal agent turn; behaviour unchanged (one notification at settle).

## Checks

- `uv run pytest` — 1246 passed, 2 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — passed
