### PR TITLE
Accept file drops while the terminal is unfocused

### DIFF
--- a/dev-notes/tui-file-drop.md
+++ b/dev-notes/tui-file-drop.md
@@ -31,17 +31,63 @@ The exact dropped text varies by terminal:
   `normalize_dropped_paths` first; on a match it inserts the normalized text at
   the cursor with smart spacing (a separating space is added before/after only
   when the neighboring character is not whitespace). Otherwise paste handling
-  falls through to the existing large-paste placeholder logic untouched.
+  falls through to the existing large-paste placeholder logic untouched. The
+  rules live in `PromptInput.handle_pasted_text(text)` so other entry points can
+  reuse them; `PromptInput.insert_pasted_text(text)` adds verbatim insertion for
+  callers that bypass Textual's default paste handler.
+- `TauTuiApp.on_paste` in `src/tau_coding/tui/app.py` — app-level fallback for
+  drops that arrive while no widget holds focus (see below).
+
+## Drops that arrive while the terminal is unfocused
+
+Some drag sources never hand keyboard focus back to the terminal before the drop
+lands — most visibly the **macOS Dock** (e.g. the Downloads stack). Those drops
+silently disappeared while Finder drops worked, because of this chain in Textual:
+
+1. Textual enables focus reporting (`CSI ? 1004 h`), so the terminal reports
+   `FocusOut` when the drag source takes over.
+2. `App._watch_app_focus` calls `screen.set_focus(None)` on blur, so the prompt
+   is no longer the focused widget.
+3. `App.on_event` forwards `events.Paste` to `self.focused`, or to the screen
+   when nothing is focused; `Screen` has no paste handler, so the text is lost.
+4. Textual restores `app_focus` on `Key`/`MouseDown` only, never on `Paste`, so
+   the blur is still in effect when the dropped path arrives.
+
+Finder drags activate the terminal (`FocusIn`) before/with the drop, which is why
+they always worked: the prompt still had focus.
+
+The fix keeps focus reporting enabled — Tau uses `AppBlur`/`AppFocus` for turn
+notifications — and closes the dispatch hole instead: `TauTuiApp.on_paste`
+receives the paste as it bubbles up from the screen and, **only when
+`self.focused is None`**, routes the text to `#prompt` via
+`insert_pasted_text`. The focus guard prevents double insertion, since
+`TextArea._on_paste` does not stop propagation. `query_one("#prompt", ...)` is
+scoped to the active screen, so modal screens keep their own paste handling.
+Clipboard pastes always require terminal focus, so this path only ever rescues
+drops.
+
+Diagnosing this needed raw-input tracing inside the real app: wrapping
+`XTermParser.feed` (raw stdin bytes) and `LinuxDriver.process_message` (emitted
+messages), plus selectively suppressing individual mode-setting sequences
+(`?1004h`, `?1003h`, kitty keyboard flags, `?2048`, `?7l`) to bisect which one
+changed the behavior. Suppressing `?1004h` made Dock drops work, which pinned the
+cause to focus-driven dispatch rather than to the byte stream or path parsing.
 
 ## Tests
 
 `tests/test_tui_file_drop.py` covers the detection/normalization matrix
 (escaped, quoted, bare, URI, multi-file, newline-separated, directories, and
 non-drop text) and the prompt insertion behavior (empty prompt, existing text,
-mid-text cursor, default paste passthrough).
+mid-text cursor, default paste passthrough). `TestUnfocusedDropRouting` runs a
+real `TauTuiApp` under `run_test()`, posts `events.AppBlur()` followed by
+`events.Paste(path)`, and asserts the path reaches the prompt; a companion test
+posts a paste while the prompt *is* focused to assert the app-level fallback does
+not insert the path twice.
 
 ## Manual validation
 
 Run `tau` in a terminal, drag a file from Finder/your file manager onto the
 window, and confirm the prompt shows the file's path (quoted if it contains
-spaces), preserving anything already typed.
+spaces), preserving anything already typed. On macOS, also drag an item out of
+the Dock's Downloads stack — that source keeps the terminal unfocused and
+exercises the `TauTuiApp.on_paste` fallback.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -632,17 +632,34 @@ class PromptInput(TextArea):
         as a paste; when the pasted text is only existing file paths, insert the
         normalized paths instead of the raw (possibly escaped) drop text.
         """
-        dropped_paths = normalize_dropped_paths(event.text)
-        if dropped_paths is not None:
+        if self.handle_pasted_text(event.text):
             event.stop()
             event.prevent_default()
+
+    def handle_pasted_text(self, text: str) -> bool:
+        """Apply Tau's paste rules to *text*.
+
+        Returns ``True`` when the text was inserted here (file drop or large
+        paste placeholder) and ``False`` when it should be inserted verbatim by
+        the caller (or by Textual's default paste handling).
+        """
+        dropped_paths = normalize_dropped_paths(text)
+        if dropped_paths is not None:
             self._insert_dropped_paths(dropped_paths)
-            return
-        if len(event.text) <= PASTE_DISPLAY_THRESHOLD:
-            return
-        event.stop()
-        event.prevent_default()
-        self._show_large_paste_placeholder(event.text)
+            return True
+        if len(text) <= PASTE_DISPLAY_THRESHOLD:
+            return False
+        self._show_large_paste_placeholder(text)
+        return True
+
+    def insert_pasted_text(self, text: str) -> None:
+        """Insert pasted text that Textual could not deliver to this widget.
+
+        Used for drops that arrive while the terminal is unfocused, where no
+        default paste handler runs, so verbatim insertion is done here.
+        """
+        if not self.handle_pasted_text(text):
+            self.insert(text)
 
     def _insert_dropped_paths(self, insertion: str) -> None:
         """Insert dropped paths at the cursor, separated from surrounding text."""
@@ -3581,6 +3598,27 @@ class TauTuiApp(App[None]):
     def on_app_focus(self) -> None:
         """Suppress turn notifications while the Tau terminal surface is active."""
         self._app_has_focus = True
+
+    def on_paste(self, event: events.Paste) -> None:
+        """Route pastes that arrive while no widget holds keyboard focus.
+
+        Textual clears widget focus whenever the terminal reports lost focus
+        (``CSI ? 1004 h``), and pastes are dropped when nothing is focused. OS
+        drag-and-drop from sources that never hand focus back to the terminal --
+        notably the macOS Dock -- delivers the dropped paths in exactly that
+        state, so the paste bubbles up here instead of reaching the prompt.
+        Clipboard pastes always require terminal focus, so this only reroutes
+        drops that would otherwise be silently discarded.
+        """
+        if self.focused is not None:
+            return
+        try:
+            prompt = self.screen.query_one("#prompt", PromptInput)
+        except NoMatches:
+            # A modal screen owns the input; leave its own handling alone.
+            return
+        event.stop()
+        prompt.insert_pasted_text(event.text)
 
     def on_resize(self, event: Resize) -> None:
         """Update responsive chrome when the terminal changes size."""

--- a/tests/test_tui_file_drop.py
+++ b/tests/test_tui_file_drop.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 
+import pytest
 from textual import events
 
-from tau_coding.tui.app import PromptInput
+from tau_coding.tui.app import PromptInput, TauTuiApp
 from tau_coding.tui.file_drop import normalize_dropped_paths
 
 
@@ -147,3 +148,64 @@ class TestPromptInputFileDrop:
         prompt.on_paste(event)
 
         assert prompt.text == ""
+
+    def test_insert_pasted_text_inserts_dropped_path(self, tmp_path: Path) -> None:
+        prompt = PromptInput()
+        file = tmp_path / "notes.txt"
+        file.touch()
+
+        prompt.insert_pasted_text(str(file))
+
+        assert prompt.text == f"{file} "
+
+    def test_insert_pasted_text_inserts_plain_text_verbatim(self) -> None:
+        prompt = PromptInput()
+
+        prompt.insert_pasted_text("just some regular text")
+
+        assert prompt.text == "just some regular text"
+
+
+class TestUnfocusedDropRouting:
+    """Drops delivered while the terminal reports no focus must not be lost.
+
+    Textual clears widget focus on ``AppBlur`` and discards pastes when nothing
+    is focused, which is how macOS Dock drags arrive.
+    """
+
+    @pytest.mark.anyio
+    async def test_drop_while_blurred_reaches_prompt(self, tmp_path: Path) -> None:
+        from test_tui_app import FakeSession
+
+        file = tmp_path / "notes.txt"
+        file.touch()
+        app = TauTuiApp(FakeSession())
+
+        async with app.run_test() as pilot:
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            assert app.focused is None
+
+            app.post_message(events.Paste(str(file)))
+            await pilot.pause()
+
+            prompt = app.query_one("#prompt", PromptInput)
+            assert prompt.text == f"{file} "
+
+    @pytest.mark.anyio
+    async def test_focused_drop_is_not_inserted_twice(self, tmp_path: Path) -> None:
+        from test_tui_app import FakeSession
+
+        file = tmp_path / "notes.txt"
+        file.touch()
+        app = TauTuiApp(FakeSession())
+
+        async with app.run_test() as pilot:
+            prompt = app.query_one("#prompt", PromptInput)
+            prompt.focus()
+            await pilot.pause()
+
+            app.post_message(events.Paste(str(file)))
+            await pilot.pause()
+
+            assert prompt.text == f"{file} "

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -101,6 +101,9 @@ spaces. Paths that contain spaces are quoted automatically, and any text you
 already typed is preserved. This works anywhere over the TUI, not just above
 the input box, because the terminal delivers the drop as text input.
 
+Drops are also accepted from sources that do not give the terminal keyboard focus
+first, such as the macOS Dock's Downloads stack.
+
 ## Tool output
 
 Tool calls keep a static marker in the transcript while they run: orange means


### PR DESCRIPTION
## Problem

Dragging a file from the **macOS Dock** (for example the Downloads stack) into the Tau TUI did nothing, while dragging the same file from Finder inserted its path correctly.

## Root cause

The byte stream is identical for both sources; what differs is focus timing.

1. Textual enables focus reporting (`CSI ? 1004 h`), so the terminal reports `FocusOut` when the drag source takes over.
2. `App._watch_app_focus` calls `screen.set_focus(None)` on blur, so the prompt is no longer focused.
3. `App.on_event` forwards `events.Paste` to `self.focused`, or to the screen when nothing is focused. `Screen` has no paste handler, so the dropped path is silently discarded.
4. Textual restores `app_focus` on `Key`/`MouseDown` only, never on `Paste`, so the blur is still in effect when the drop arrives.

Finder drags activate the terminal (`FocusIn`) before/with the drop, so the prompt still had focus — hence the source-dependent behavior.

Diagnosis used raw-input tracing inside the real app (wrapping `XTermParser.feed` and `LinuxDriver.process_message`) plus bisecting Textual's mode-setting sequences. Suppressing `?1004h` made Dock drops work, which pinned the cause to focus-driven dispatch rather than the byte stream or path parsing. Mouse tracking (`?1003h`) and inline mode were ruled out earlier.

## Fix

Focus reporting stays enabled — Tau uses `AppBlur`/`AppFocus` for turn notifications — and the dispatch hole is closed instead:

- `TauTuiApp.on_paste` receives the paste as it bubbles up from the screen and routes it to `#prompt`, **only when `self.focused is None`**. The focus guard prevents double insertion, since `TextArea._on_paste` does not stop propagation. `self.screen.query_one` scoping leaves modal screens' own paste handling alone. Clipboard pastes always require terminal focus, so this path only ever rescues drops.
- `PromptInput.handle_pasted_text(text)` holds the existing paste rules (file drop vs. large-paste placeholder) so both entry points share one implementation.
- `PromptInput.insert_pasted_text(text)` adds the verbatim insertion that Textual's default handler would otherwise have performed.

No terminal modes are disabled, so mouse clicks, selection, sidebar interaction, and blur-driven notifications are unchanged.

## Tests

- `TestUnfocusedDropRouting` runs a real `TauTuiApp` under `run_test()`, posts `events.AppBlur()` then `events.Paste(path)`, and asserts the path reaches the prompt; a companion test posts a paste while the prompt *is* focused to assert no double insertion.
- Two widget-level tests cover `insert_pasted_text` (dropped path and plain text).
- Verified the new test genuinely reproduces the bug: with `TauTuiApp.on_paste` removed it fails with `assert '' == '.../notes.txt '`.

Checks run:

- `uv run pytest -q -x` → 1245 passed, 2 skipped
- `uv run ruff check` and `uv run ruff format --check` on touched files → clean
- Manual: Dock Downloads-stack drop and Finder drop in Ghostty on macOS

## Docs

- `dev-notes/tui-file-drop.md` — full mechanism, the fix, and how it was diagnosed
- `website/content/guides/tui.md` — notes that drops from sources that do not focus the terminal (macOS Dock) work
