### PR TITLE
refactor: made the StopReason variable a type based on it's usage.

### DIFF
--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -113,7 +113,7 @@ class AssistantMessageDiagnostic(WireModel):
     details: dict[str, JSONValue] | None = None
 
 
-StopReason = Literal["stop", "length", "toolUse", "error", "aborted"]
+type StopReason = Literal["stop", "length", "toolUse", "error", "aborted"]
 
 
 class AssistantMessage(WireModel):


### PR DESCRIPTION
# Description #
- The `StopReason` earlier used as variable while only used in types that why I converted it into a `type`

# Checks #
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`