### PR TITLE
fix: enable @ file completion in custom prompts

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -133,10 +133,12 @@ def build_completion_state(
     if argument_completions is not None:
         return CompletionState(argument_completions)
 
-    if has_argument_text and (
-        _matches_prompt_template_command(token, prompt_templates)
-        or _matches_registered_command(token, command_registry)
-    ):
+    if has_argument_text and _matches_prompt_template_command(token, prompt_templates):
+        if cwd is not None:
+            return CompletionState(_file_reference_completions(text=text, cwd=cwd))
+        return CompletionState()
+
+    if has_argument_text and _matches_registered_command(token, command_registry):
         return CompletionState()
 
     return CompletionState(

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -444,6 +444,56 @@ def test_file_reference_completion_matches_workspace_files(tmp_path: Path) -> No
     assert state.selected.apply("please read @app") == "please read @src/app.py"
 
 
+def test_file_reference_completion_works_in_custom_prompt_arguments(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    text = "/review inspect @app"
+
+    state = build_completion_state(
+        text,
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="review",
+                path=Path("review.md"),
+                content="Review:\n{{ arguments }}",
+            ),
+        ),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["@src/app.py"]
+    assert state.selected is not None
+    assert state.selected.apply(text) == "/review inspect @src/app.py"
+
+
+def test_file_reference_completion_works_in_multiline_custom_prompt_arguments(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    text = "/review inspect\n@app"
+
+    state = build_completion_state(
+        text,
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(
+            PromptTemplate(
+                name="review",
+                path=Path("review.md"),
+                content="Review:\n{{ arguments }}",
+            ),
+        ),
+        cwd=tmp_path,
+    )
+
+    assert [item.display for item in state.items] == ["@src/app.py"]
+    assert state.selected is not None
+    assert state.selected.apply(text) == "/review inspect\n@src/app.py"
+
+
 def test_file_reference_completion_stays_off_for_slash_commands(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
 


### PR DESCRIPTION
Addresses the custom-prompt portion of #489.

## Motivation

#489 documents the same missing `@` file-reference authoring workflow in two prompt-expansion contexts: explicit skill invocations and custom prompt templates. A recognized custom prompt currently returns an empty completion state as soon as it has argument text, so inputs such as `/review inspect @app` never reach the existing file-reference completer.

## What changed

- route completed, recognized custom-prompt invocations through the existing `_file_reference_completions()` path;
- keep generic built-in slash commands such as `/help @read` on their existing completion path;
- reuse the current replacement spans, workspace ignore rules, and result limit;
- add focused regression coverage for suggestion selection/application, multiline request text, and a prompt template containing `{{ arguments }}`.

## Relationship to #340

#340 already addresses the `/skill:<name>` form reported in #316. To avoid duplicating that contributor's work, this PR intentionally does not modify the `/skill:` branch or repeat its regression test.

The intended maintainer decision is therefore explicit:

- merge #340 for the skill-invocation half and this PR for the custom-prompt half; together they cover the two cases described by #489; or
- if one combined PR is preferred, this commit is isolated to the custom-prompt branch so it can be folded into #340 without carrying duplicate skill changes.

This PR can otherwise be reviewed independently: the two fixes affect separate routing branches in `build_completion_state()`.

## Validation

- `uv run pytest tests/test_tui_autocomplete.py -q` — 32 passed
- `uv run pytest -q` — 1254 passed, 2 skipped (Windows/PowerShell-only updater tests)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `git diff --check`

## Compatibility and scope

No public API, configuration format, session behavior, filesystem search implementation, or built-in command semantics change. Skill chaining and a broader completion-context refactor remain out of scope, as requested in #489.