### PR TITLE
Fix: Static type checking error in windows

### DIFF
--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -1160,8 +1160,9 @@ def _base64_text(data: bytes) -> str:
 
 def _kill_process_tree(process: asyncio.subprocess.Process) -> None:
     if os.name == "posix":
-        killpg = getattr(os, "killpg")
-        sigkill = getattr(signal, "SIGKILL")
+        # `getattr` keeps mypy happy on the Windows stubs (see issue #513).
+        killpg = getattr(os, "killpg")  # noqa: B009
+        sigkill = getattr(signal, "SIGKILL")  # noqa: B009
         try:
             killpg(process.pid, sigkill)
         except ProcessLookupError:

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -1160,8 +1160,10 @@ def _base64_text(data: bytes) -> str:
 
 def _kill_process_tree(process: asyncio.subprocess.Process) -> None:
     if os.name == "posix":
+        killpg = getattr(os, "killpg")
+        sigkill = getattr(signal, "SIGKILL")
         try:
-            os.killpg(process.pid, signal.SIGKILL)
+            killpg(process.pid, sigkill)
         except ProcessLookupError:
             return
     else:


### PR DESCRIPTION
## Description ##
- The methods and attributes which were causing error in type checking, I made then runtime dependent by using `getattr` 

## Tests ##
- `uv run mypy`

Fixes #513 