### PR TITLE
Release Tau 0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.4"
+version = "0.3.5"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.3.5",
+    "date": "2026-07-31",
+    "sections": {
+      "New": [
+        "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees."
+      ],
+      "Changed": [
+        "Cache Anthropic prompt prefixes to reduce repeated input billing, with auth-aware retention, compatibility overrides, and a sidebar cache hit rate.",
+        "Redesign self-contained HTML session exports with compact accordions, entry filters and counts, expand/collapse controls, clearer tool labels, and offline JSONL download.",
+        "Show normal working indicators and unfocused completion notifications while manual `/compact` runs."
+      ],
+      "Fixed": [
+        "Fix Anthropic subscription login and serialize OAuth token refreshes so rotating refresh tokens are not spent concurrently.",
+        "Accept file drops when the terminal is unfocused without duplicating focused paste events.",
+        "Safely hand off `tau update` on Windows after the running process exits, preserving executable paths and arguments exactly."
+      ]
+    }
+  },
+  {
     "version": "0.3.4",
     "date": "2026-07-27",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -649,7 +649,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.4" in console.export_text()
+    assert "τ = 2π  0.3.5" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.3.4 to 0.3.5 in package and lock metadata
- add bundled 0.3.5 release highlights
- update the version assertion backing the TUI sidebar brand

## Included changes

- cache Anthropic prompt prefixes and expose cache hit rate
- add caller-selected, machine-safe print-mode session IDs
- redesign HTML session exports with filters, accordions, and offline JSONL download
- show working state and completion notifications for manual `/compact`
- fix Anthropic subscription login and concurrent OAuth refreshes
- fix unfocused terminal file drops and Windows updater handoff

## Validation

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 1,290 passed, 2 skipped (Windows-only)
- `uv build` — built `tau_ai-0.3.5` wheel and source distribution
- `uv run tau --version` — `tau 0.3.5`
- `hugo --minify`
- `npx --yes pagefind@latest --site /tmp/tau-release-0.3.5-site`
- confirmed `tau-ai==0.3.5` is not already published on PyPI
