### PR TITLE
perf: cache the workspace walk behind @ file completions

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from time import monotonic
 
 from tau_coding.commands import CommandRegistry, SlashCommand
 from tau_coding.prompt_templates import PromptTemplate
@@ -27,6 +28,11 @@ IGNORED_FILE_COMPLETION_DIRS = frozenset(
     }
 )
 MAX_FILE_COMPLETIONS = 50
+# Long enough that a burst of typing reuses one workspace walk, short enough
+# that newly created files show up without a restart.
+FILE_REFERENCE_CACHE_TTL_SECONDS = 2.0
+
+_file_reference_cache: tuple[Path, float, tuple[tuple[str, str], ...]] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -154,13 +160,11 @@ def _file_reference_completions(*, text: str, cwd: Path) -> tuple[CompletionItem
     if token is None:
         return ()
     start, end = token
-    prefix = text[start + 1 : end]
+    prefix = text[start + 1 : end].lower()
     suggestions: list[CompletionItem] = []
-    for path in _iter_file_reference_paths(cwd):
-        relative = path.relative_to(cwd).as_posix()
-        if prefix.lower() not in relative.lower():
+    for searchable, display in _file_reference_candidates(cwd):
+        if prefix not in searchable:
             continue
-        display = f"@{relative}{'/' if path.is_dir() else ''}"
         suggestions.append(
             CompletionItem(
                 display=display,
@@ -173,6 +177,35 @@ def _file_reference_completions(*, text: str, cwd: Path) -> tuple[CompletionItem
         if len(suggestions) >= MAX_FILE_COMPLETIONS:
             break
     return tuple(suggestions)
+
+
+def _file_reference_candidates(cwd: Path) -> tuple[tuple[str, str], ...]:
+    """Return `(searchable, display)` completion candidates for a workspace.
+
+    Walking the workspace dominates the cost of building these completions, so
+    without caching every keystroke re-walks the whole tree (issue #463). One
+    slot is enough because a session completes against a single workspace, and
+    the short TTL keeps newly created files appearing promptly.
+    """
+    global _file_reference_cache
+
+    now = monotonic()
+    cached = _file_reference_cache
+    if (
+        cached is not None
+        and cached[0] == cwd
+        and now - cached[1] < FILE_REFERENCE_CACHE_TTL_SECONDS
+    ):
+        return cached[2]
+
+    candidates = tuple(
+        (relative.lower(), f"@{relative}{'/' if path.is_dir() else ''}")
+        for path, relative in (
+            (path, path.relative_to(cwd).as_posix()) for path in _iter_file_reference_paths(cwd)
+        )
+    )
+    _file_reference_cache = (cwd, now, candidates)
+    return candidates
 
 
 def _active_file_reference_token(text: str) -> tuple[int, int] | None:

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from tau_coding.commands import create_default_command_registry
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.skills import Skill
+from tau_coding.tui import autocomplete as autocomplete_module
 from tau_coding.tui.autocomplete import CompletionOption, build_completion_state
 from tau_coding.tui.widgets import render_completion_suggestions
 
@@ -421,6 +422,59 @@ def test_resume_argument_completion_uses_session_options_with_descriptions() -> 
         "Newer - qwen - /repo",
         "Older - gpt - /repo",
     ]
+
+
+def test_file_reference_completions_reuse_one_workspace_walk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Regression test for issue #463: the workspace was re-walked on every
+    # keystroke, so completions slowed to a crawl on large workspaces.
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')", encoding="utf-8")
+    walks: list[Path] = []
+    original_walk = autocomplete_module._iter_file_reference_paths
+
+    def counting_walk(cwd: Path) -> tuple[Path, ...]:
+        walks.append(cwd)
+        return original_walk(cwd)
+
+    monkeypatch.setattr(autocomplete_module, "_file_reference_cache", None)
+    monkeypatch.setattr(autocomplete_module, "_iter_file_reference_paths", counting_walk)
+
+    for text in ("look at @a", "look at @ap", "look at @app"):
+        state = build_completion_state(
+            text,
+            command_registry=create_default_command_registry(),
+            skills=(),
+            prompt_templates=(),
+            cwd=tmp_path,
+        )
+        assert [item.display for item in state.items] == ["@src/app.py"]
+
+    assert len(walks) == 1
+
+
+def test_file_reference_completions_refresh_after_cache_expires(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The cache must not hide files created after the first completion.
+    (tmp_path / "first.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(autocomplete_module, "_file_reference_cache", None)
+    monkeypatch.setattr(autocomplete_module, "FILE_REFERENCE_CACHE_TTL_SECONDS", 0.0)
+
+    def complete() -> list[str]:
+        state = build_completion_state(
+            "read @",
+            command_registry=create_default_command_registry(),
+            skills=(),
+            prompt_templates=(),
+            cwd=tmp_path,
+        )
+        return [item.display for item in state.items]
+
+    assert complete() == ["@first.py"]
+    (tmp_path / "second.py").write_text("", encoding="utf-8")
+    assert complete() == ["@first.py", "@second.py"]
 
 
 def test_file_reference_completion_matches_workspace_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #463.

`@` file-reference completions re-walked the entire workspace on **every keystroke**, so typing a reference on a large tree dropped keystrokes (as reported on a 50+ repository codebase).

## Root cause

`_file_reference_completions` in `src/tau_coding/tui/autocomplete.py` calls `_iter_file_reference_paths(cwd)` per keystroke. Three problems compound:

1. **No caching** - the full recursive walk runs again for every character typed.
2. **`MAX_FILE_COMPLETIONS` never short-circuits the walk** - `_iter_file_reference_paths` materializes the whole tuple before any filtering, so the 50-suggestion cap bounds only the result list, not the work.
3. **Per-keystroke recomputation** - `relative_to(cwd).as_posix()` and `is_dir()` run for every candidate on every keystroke.

Profiled on this repo, which has only 361 candidate files:

```
files=361   walk=87.2 ms   filter=17.0 ms   -> ~130 ms per keystroke
```

The walk dominates and scales linearly with workspace size, so tens of thousands of files means seconds per key.

## Fix

Cache the walked candidates in a single slot keyed by workspace, storing the searchable and display strings precomputed. A burst of typing then pays for at most one walk, and each subsequent keystroke filters in memory.

One slot is enough because a session completes against a single workspace, and it avoids unbounded growth. `FILE_REFERENCE_CACHE_TTL_SECONDS = 2.0` is long enough that a typing burst shares one walk, short enough that newly created files appear without a restart.

Measured on this repo:

| | 7-keystroke burst | per key |
|---|---|---|
| before | 918 ms | 131 ms |
| after | 131 ms | 19 ms |

The gain grows with workspace size, since the walk is the part that scales.

Matching semantics are unchanged: the prefix is still matched against the workspace-relative path (not the rendered `@…` string), and directories keep their trailing `/`.

## Compatibility with #473

This deliberately leaves `_iter_file_reference_paths` untouched, so the open `.gitignore` PR (#473) rebases cleanly on top - it changes what the walk yields, and this change only caches the result. Happy to sequence behind it if you would rather land that first.

## Tests

Two regression tests in `tests/test_tui_autocomplete.py`, both confirmed failing without the fix:

- `test_file_reference_completions_reuse_one_workspace_walk` - counts walks across three keystrokes and asserts exactly one.
- `test_file_reference_completions_refresh_after_cache_expires` - forces TTL expiry and asserts a newly created file appears, so the cache cannot serve stale results.

`tests/test_tui_autocomplete.py`: 32 passed. `ruff` and `mypy` clean.

Note: `tests/test_tui_app.py` shows 5 failures in my environment, but they fail identically on unmodified `main` (Windows path-separator expectations, the category from the closed #335) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
