### PR TITLE
fix: stream tool progress updates while the tool is still running

### DIFF
--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -252,14 +252,15 @@ async def _execute_tool_call(
             result = _error_result(f"Tool {call.name} not found")
             is_error = True
         else:
-            result, is_error, updates = await _run_tool(tool, call, signal)
-            for update in updates:
+            outcome: list[tuple[AgentToolResult, bool]] = []
+            async for update in _run_tool(tool, call, signal, outcome):
                 yield ToolExecutionUpdateEvent(
                     tool_call_id=call.id,
                     tool_name=call.name,
                     args=call.arguments,
                     partial_result=update,
                 )
+            result, is_error = outcome[0]
 
     if after_tool_call is not None:
         result, is_error = await after_tool_call(call, result, is_error)
@@ -286,23 +287,56 @@ async def _run_tool(
     tool: AgentTool,
     call: ToolCall,
     signal: CancellationToken | None,
-) -> tuple[AgentToolResult, bool, list[AgentToolResult]]:
-    updates: list[AgentToolResult] = []
+    outcome: list[tuple[AgentToolResult, bool]],
+) -> AsyncIterator[AgentToolResult]:
+    """Run a tool, yielding progress partials as the tool reports them.
+
+    `on_update` is synchronous while only this generator can emit events, so
+    partials are handed over through a queue and raced against the tool itself.
+    Buffering them until the tool returned made progress events useless to a
+    consumer while a long-running tool was still working (issue #382).
+
+    The final `(result, is_error)` pair is appended to `outcome`, since an async
+    generator cannot return a value to its consumer.
+    """
+    queue: asyncio.Queue[AgentToolResult] = asyncio.Queue()
     accepting = True
 
     def on_update(partial: AgentToolResult) -> None:
         if accepting:
-            updates.append(partial.model_copy(deep=True))
+            queue.put_nowait(partial.model_copy(deep=True))
+
+    task = asyncio.ensure_future(tool.execute(call.id, call.arguments, signal, on_update))
+    try:
+        while not task.done():
+            pending_update = asyncio.ensure_future(queue.get())
+            try:
+                await asyncio.wait(
+                    {pending_update, task}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                if not pending_update.done():
+                    pending_update.cancel()
+            if pending_update.done() and not pending_update.cancelled():
+                yield pending_update.result()
+    finally:
+        # Stop accepting as soon as the tool is done, matching the previous
+        # behaviour, and never leave the tool running if the consumer stops
+        # early.
+        accepting = False
+        if not task.done():
+            task.cancel()
+
+    # Emit anything the tool reported just before it returned.
+    while not queue.empty():
+        yield queue.get_nowait()
 
     try:
-        result = await tool.execute(call.id, call.arguments, signal, on_update)
-        return result, False, updates
+        outcome.append((task.result(), False))
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 - tools are an isolation boundary
-        return _error_result(str(exc)), True, updates
-    finally:
-        accepting = False
+        outcome.append((_error_result(str(exc)), True))
 
 
 def _error_result(message: str) -> AgentToolResult:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -27,7 +27,7 @@ from tau_agent import (
     ToolResultMessage,
     UserMessage,
 )
-from tau_agent.loop import run_agent_loop
+from tau_agent.loop import _execute_tool_call, run_agent_loop
 from tau_agent.provider_events import ThinkingDeltaEvent
 from tau_agent.types import JSONValue
 from tau_ai import CancellationToken, FakeProvider
@@ -213,6 +213,104 @@ async def test_agent_loop_passes_call_id_signal_and_progress_to_tool() -> None:
     assert observed == [("call-1", signal)]
     updates = [event for event in events if isinstance(event, ToolExecutionUpdateEvent)]
     assert [event.partial_result.text for event in updates] == ["working"]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_streams_tool_updates_while_the_tool_runs() -> None:
+    # Regression test for issue #382: partials were buffered and only emitted
+    # after the tool returned, so progress events carried no information at a
+    # time a consumer could act on them.
+    reported_first = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(
+        tool_call_id: str,
+        arguments: Mapping[str, JSONValue],
+        signal: CancellationToken | None = None,
+        on_update=None,  # noqa: ANN001
+    ) -> AgentToolResult:
+        del tool_call_id, arguments, signal
+        assert on_update is not None
+        on_update(AgentToolResult(content="step 1"))
+        reported_first.set()
+        await release.wait()
+        on_update(AgentToolResult(content="step 2"))
+        return AgentToolResult(content="done")
+
+    call = ToolCall(id="call-1", name="work", arguments={})
+    outcome: list[tuple[AgentToolResult, bool]] = []
+    events: list[AgentEvent] = []
+
+    async def consume() -> None:
+        async for event in _execute_tool_call(
+            call=call,
+            tools={"work": _tool("work", execute)},
+            signal=None,
+            before_tool_call=None,
+            after_tool_call=None,
+        ):
+            events.append(event)
+
+    consumer = asyncio.create_task(consume())
+    await reported_first.wait()
+    for _ in range(10):
+        if any(isinstance(event, ToolExecutionUpdateEvent) for event in events):
+            break
+        await asyncio.sleep(0)
+
+    # The first partial must be observable before the tool finishes.
+    assert [
+        event.partial_result.text
+        for event in events
+        if isinstance(event, ToolExecutionUpdateEvent)
+    ] == ["step 1"]
+
+    release.set()
+    await consumer
+    del outcome
+
+    assert [
+        event.partial_result.text
+        for event in events
+        if isinstance(event, ToolExecutionUpdateEvent)
+    ] == ["step 1", "step 2"]
+    end_events = [event for event in events if isinstance(event, ToolExecutionEndEvent)]
+    assert [event.result.text for event in end_events] == ["done"]
+    assert [event.is_error for event in end_events] == [False]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_keeps_tool_updates_reported_before_a_failure() -> None:
+    async def execute(
+        tool_call_id: str,
+        arguments: Mapping[str, JSONValue],
+        signal: CancellationToken | None = None,
+        on_update=None,  # noqa: ANN001
+    ) -> AgentToolResult:
+        del tool_call_id, arguments, signal
+        assert on_update is not None
+        on_update(AgentToolResult(content="partial"))
+        raise ValueError("kaboom")
+
+    events = [
+        event
+        async for event in _execute_tool_call(
+            call=ToolCall(id="call-1", name="work", arguments={}),
+            tools={"work": _tool("work", execute)},
+            signal=None,
+            before_tool_call=None,
+            after_tool_call=None,
+        )
+    ]
+
+    assert [
+        event.partial_result.text
+        for event in events
+        if isinstance(event, ToolExecutionUpdateEvent)
+    ] == ["partial"]
+    end_events = [event for event in events if isinstance(event, ToolExecutionEndEvent)]
+    assert [event.is_error for event in end_events] == [True]
+    assert [event.result.text for event in end_events] == ["kaboom"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes #382.

Tool progress partials reported through `on_update` were buffered and emitted only after the tool returned, so `ToolExecutionUpdateEvent`s all arrived in one batch immediately before `tool_execution_end`. The events existed but carried no information at a time a consumer could act on them.

## Reproduction

A tool that reports a partial, blocks, then reports a second partial before returning:

```
events seen WHILE tool still running : ['ToolExecutionStartEvent']
events after completion              : ['ToolExecutionStartEvent', 'ToolExecutionUpdateEvent',
                                        'ToolExecutionUpdateEvent', 'ToolExecutionEndEvent', ...]
```

Even with a 200 ms window nothing surfaced mid-run. After the change:

```
events seen WHILE tool still running : ['ToolExecutionStartEvent', 'ToolExecutionUpdateEvent']
```

## Fix

As @rian-dolphin noted in the issue, the cause is structural: `on_update` is a synchronous callback, while the only thing that can emit events is the async generator currently awaiting the tool. Nothing bridged the two.

`_run_tool` is now an async generator that hands partials over through an `asyncio.Queue` and races the queue against the tool task, yielding each partial as soon as it is reported and draining anything left once the tool finishes. The final `(result, is_error)` pair is appended to a caller-provided list, since an async generator cannot return a value to its consumer.

## Behaviour preserved

Each of these was verified explicitly, since the change touches the tool isolation boundary and cancellation:

| Property | Result |
|---|---|
| Ordering across many partials | 20/20 in order |
| Partial reported immediately before returning | delivered, not dropped |
| Tool raises | `is_error=True`, message preserved, earlier partials still delivered |
| Updates reported after completion | ignored, as before |
| Consumer stops early | tool task cancelled, no leaked tasks, tool does not run to completion |

The last one is a small improvement on the previous behaviour: a tool left running after its consumer went away is now cancelled rather than orphaned.

## Tests

Two regression tests in `tests/test_agent_loop.py`:

- `test_agent_loop_streams_tool_updates_while_the_tool_runs` - asserts a partial is observable *while* the tool is still blocked, not merely present at the end. Verified **failing on unfixed code and passing on fixed code**.
- `test_agent_loop_keeps_tool_updates_reported_before_a_failure` - guards the error path, which this change could plausibly have broken. It passes before and after; it is a guard rather than a bug reproduction.

`tests/test_agent_loop.py`, `test_agent_harness.py`, `test_coding_session.py`: all pass (137 passed).

Note: 3 failures remain in `tests/test_coding_tools.py` in my environment. They are the Windows bash-only tests (`shell_command_prefix` and `sleep 1 & wait` job control); I confirmed they fail identically with this change stashed, and they call `tool.execute` directly without going through the loop, so they cannot be affected by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
