### PR TITLE
Prevent stale config from restoring GPT-5.6 Codex alias

### DIFF
--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -32,6 +32,7 @@ from tau_coding.provider_catalog import (
     ProviderApi,
     ProviderCatalogEntry,
     ProviderKind,
+    provider_model_is_unsupported,
 )
 from tau_coding.thinking import ThinkingLevel, ThinkingParameter
 
@@ -137,7 +138,9 @@ def effective_catalog(paths: TauPaths | None = None) -> tuple[ProviderCatalogEnt
         return builtin_catalog()
     overlay_raw = _parse_catalog_text(path.read_text(encoding="utf-8"), source=str(path))
     _validate_catalog_root(overlay_raw, source=str(path))
-    merged = _merge_raw_catalogs(_builtin_raw(), overlay_raw)
+    builtin_raw = _builtin_raw()
+    merged = _merge_raw_catalogs(builtin_raw, overlay_raw)
+    merged = _filter_unsupported_provider_models(merged, base=builtin_raw)
     return _entries_from_raw(merged, source=str(path))
 
 
@@ -219,6 +222,38 @@ def _merge_raw_catalogs(base: dict[str, Any], overlay: dict[str, Any]) -> dict[s
         "schema_version": overlay.get("schema_version", base.get("schema_version")),
         "providers": [by_name[name] for name in order],
     }
+
+
+def _filter_unsupported_provider_models(
+    raw: dict[str, Any], *, base: dict[str, Any]
+) -> dict[str, Any]:
+    """Keep stale user overlays from restoring models unsupported by a provider."""
+    base_by_name = {_raw_provider_name(provider): provider for provider in _raw_providers(base)}
+    providers = []
+    for provider in _raw_providers(raw):
+        name = _raw_provider_name(provider)
+        filtered = {**provider}
+        for field in ("models", "thinking_models"):
+            values = filtered.get(field)
+            if isinstance(values, list):
+                filtered[field] = [
+                    model
+                    for model in values
+                    if not (isinstance(model, str) and provider_model_is_unsupported(name, model))
+                ]
+        for field in ("context_windows", "model_metadata"):
+            values = filtered.get(field)
+            if isinstance(values, dict):
+                filtered[field] = {
+                    model: value
+                    for model, value in values.items()
+                    if not provider_model_is_unsupported(name, model)
+                }
+        default_model = filtered.get("default_model")
+        if isinstance(default_model, str) and provider_model_is_unsupported(name, default_model):
+            filtered["default_model"] = base_by_name[name]["default_model"]
+        providers.append(filtered)
+    return {**raw, "providers": providers}
 
 
 def _merge_raw_provider(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -27,6 +27,15 @@ ModelInput = Literal["text", "image"]
 ThinkingLevelMap = dict[ThinkingLevel, str | None]
 AuthMethod = Literal["api_key", "oauth"]
 
+UNSUPPORTED_PROVIDER_MODELS: dict[str, frozenset[str]] = {
+    "openai-codex": frozenset({"gpt-5.6"}),
+}
+
+
+def provider_model_is_unsupported(provider_name: str, model: str) -> bool:
+    """Return whether a model must be excluded from a provider's catalog."""
+    return model in UNSUPPORTED_PROVIDER_MODELS.get(provider_name, ())
+
 
 @dataclass(frozen=True, slots=True)
 class ModelCostTier:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -37,6 +37,7 @@ from tau_coding.provider_catalog import (
     ProviderApi,
     ProviderCatalogEntry,
     ProviderKind,
+    provider_model_is_unsupported,
 )
 from tau_coding.thinking import (
     DEFAULT_THINKING_LEVEL,
@@ -1156,6 +1157,8 @@ def _apply_provider_preference(
         if "default_model" in value
         else provider.default_model
     )
+    if provider_model_is_unsupported(provider.name, default_model):
+        default_model = provider.default_model
     models = (
         provider.models if default_model in provider.models else (*provider.models, default_model)
     )
@@ -1214,7 +1217,11 @@ def _thinking_defaults_dict(
     provider: ProviderConfig,
     field_name: str,
 ) -> dict[str, ThinkingLevel]:
-    raw = _raw_thinking_defaults_dict(value, field_name)
+    raw = {
+        model: thinking_level
+        for model, thinking_level in _raw_thinking_defaults_dict(value, field_name).items()
+        if not provider_model_is_unsupported(provider.name, model)
+    }
     for model, thinking_level in raw.items():
         validate_provider_model(provider, model)
         available = provider_thinking_levels(provider, model=model)

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -512,6 +512,34 @@ default_model = "claude-next-1"
     assert entry.thinking_parameter == "anthropic.thinking"
 
 
+def test_user_catalog_cannot_restore_unsupported_codex_alias(tmp_path: Path) -> None:
+    paths = _write_user_catalog(
+        tmp_path / ".tau",
+        """
+[[providers]]
+name = "openai-codex"
+models = ["gpt-5.6"]
+default_model = "gpt-5.6"
+thinking_models = ["gpt-5.6"]
+
+[providers.context_windows]
+"gpt-5.6" = 272000
+
+[providers.model_metadata."gpt-5.6"]
+name = "GPT-5.6"
+""",
+    )
+
+    entry = next(e for e in effective_catalog(paths) if e.name == "openai-codex")
+
+    assert entry.default_model == "gpt-5.5"
+    assert "gpt-5.6" not in entry.models
+    assert "gpt-5.6" not in entry.thinking_models
+    assert entry.context_windows is not None
+    assert "gpt-5.6" not in entry.context_windows
+    assert "gpt-5.6" not in entry.model_metadata
+
+
 def test_user_catalog_thinking_fields_replace_as_group(tmp_path: Path) -> None:
     paths = _write_user_catalog(
         tmp_path / ".tau",

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -34,6 +34,32 @@ from tau_coding.provider_config import (
 )
 
 
+def test_stale_preferences_cannot_restore_unsupported_codex_alias(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        json.dumps(
+            {
+                "default_provider": "openai-codex",
+                "provider_preferences": {
+                    "openai-codex": {
+                        "default_model": "gpt-5.6",
+                        "thinking_defaults": {"gpt-5.6": "low"},
+                    }
+                },
+                "scoped_models": [],
+            }
+        )
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+    codex = settings.get_provider("openai-codex")
+
+    assert codex.default_model == "gpt-5.5"
+    assert "gpt-5.6" not in codex.models
+    assert "gpt-5.6" not in codex.thinking_defaults
+
+
 def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path) -> None:
     settings = load_provider_settings(TauPaths(home=tmp_path / ".tau"))
 

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -101,7 +101,8 @@ the API model page. Vision-capable Codex models retain their image-input
 metadata separately from these runtime context limits, allowing image files read
 by Tau to reach the model. The `gpt-5.6` alias, which routes to GPT-5.6 Sol, is only
 available through the direct OpenAI API; Codex subscription users should select
-the explicit `gpt-5.6-sol` model instead.
+the explicit `gpt-5.6-sol` model instead. Tau also ignores this alias in older
+user catalog overlays and saved Codex preferences.
 
 ### OpenCode Go and Zen
 


### PR DESCRIPTION
## Summary

- filter the unsupported `gpt-5.6` alias from OpenAI Codex user catalog overlays
- ignore stale saved defaults and thinking preferences for that alias
- retain `gpt-5.6` for direct OpenAI API users
- add regression coverage and document the upgrade behavior

## User experience

Existing users who saved provider state before the built-in catalog fix no longer see or select the unsupported alias after upgrading. Tau now prevents stale `~/.tau/catalog.toml` and `~/.tau/providers.json` data from restoring it.

## Issue

Follow-up to #469. No separate linked issue.

## Manual validation

1. Add `gpt-5.6` to the `openai-codex` entry in `~/.tau/catalog.toml`.
2. Optionally set the Codex `default_model` or a thinking default to `gpt-5.6` in `~/.tau/providers.json`.
3. Start Tau and open the model picker.
4. Confirm `openai-codex:gpt-5.6` is absent while `openai:gpt-5.6` and `openai-codex:gpt-5.6-sol` remain available.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify && npx --yes pagefind@latest --site public`
