### PR TITLE
Make provider catalog upgrades resilient

### DIFF
--- a/dev-notes/provider-settings-v2-migration.md
+++ b/dev-notes/provider-settings-v2-migration.md
@@ -1,0 +1,56 @@
+# Provider settings v2 migration
+
+## What changed
+
+Tau now writes `~/.tau/providers.json` as a versioned, preferences-only document.
+The effective provider catalog remains the source of truth for model lists,
+context windows, transports, model metadata, and thinking capabilities.
+
+When Tau loads the old `providers` array format, it immediately:
+
+1. loads the current bundled catalog plus the user's catalog overlay;
+2. rebuilds known providers from those current definitions;
+3. copies only runtime preferences such as the selected model, headers, retry
+   settings, and valid per-model thinking defaults;
+4. moves providers absent from the catalog into `~/.tau/catalog.toml`;
+5. atomically rewrites `providers.json` with `schema_version: 2`; and
+6. retains the original file as `providers.json.bak`.
+
+Stale scoped-model and thinking-default references are removed during migration.
+
+## Why
+
+Legacy settings stored complete snapshots of built-in providers. A later Tau
+release could add a model while the old snapshot still supplied an outdated
+`thinking_models` list or other capability metadata. The model would then appear
+to have unavailable thinking controls despite the bundled catalog supporting
+it.
+
+Provider definitions and user preferences have different lifecycles. Catalog
+metadata should update with Tau, while preferences should survive updates. The
+v2 boundary makes that ownership explicit and avoids silently moving stale
+built-in snapshots into a user catalog overlay.
+
+## Architecture
+
+This stays in `tau_coding`, the application configuration layer. `tau_ai` and
+`tau_agent` remain independent of user file locations and migration policy.
+Runtime provider objects are still assembled from catalog definitions plus
+preferences before they reach the provider streaming layer.
+
+## Validation
+
+Run:
+
+```bash
+uv run pytest tests/test_provider_config.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+For a manual check, start Tau with a legacy `providers.json` containing stale
+built-in model or thinking metadata. The current catalog capabilities should be
+available, the file should become schema v2, and the untouched legacy document
+should remain in `providers.json.bak`.

--- a/dev-notes/provider-settings-v2-migration.md
+++ b/dev-notes/provider-settings-v2-migration.md
@@ -18,6 +18,13 @@ When Tau loads the old `providers` array format, it immediately:
 
 Stale scoped-model and thinking-default references are removed during migration.
 
+Provider catalogs also support additive `removed_models` tombstones. Tau applies
+them after merging built-in and user catalogs, removing matching model,
+context-window, metadata, thinking, and default references. This handles stale
+user overlays that were written before Tau stopped advertising a model for a
+provider. The first tombstone removes the API-only `gpt-5.6` alias from
+`openai-codex` without affecting `openai:gpt-5.6`.
+
 ## Why
 
 Legacy settings stored complete snapshots of built-in providers. A later Tau

--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -104,6 +104,7 @@ class _CatalogProvider(BaseModel):
     thinking_models: tuple[_NonEmptyString, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    removed_models: tuple[_NonEmptyString, ...] = ()
     auth_methods: tuple[AuthMethod, ...] = ("api_key",)
 
 
@@ -122,7 +123,9 @@ def builtin_catalog_resource_text() -> str:
 @cache
 def builtin_catalog() -> tuple[ProviderCatalogEntry, ...]:
     """Return Tau's built-in provider catalog from the packaged data file."""
-    return _entries_from_raw(_builtin_raw(), source="built-in catalog.toml")
+    raw = _builtin_raw()
+    filtered = _apply_model_tombstones(raw, base=raw)
+    return _entries_from_raw(filtered, source="built-in catalog.toml")
 
 
 def user_catalog_path(paths: TauPaths | None = None) -> Path:
@@ -137,8 +140,10 @@ def effective_catalog(paths: TauPaths | None = None) -> tuple[ProviderCatalogEnt
         return builtin_catalog()
     overlay_raw = _parse_catalog_text(path.read_text(encoding="utf-8"), source=str(path))
     _validate_catalog_root(overlay_raw, source=str(path))
-    merged = _merge_raw_catalogs(_builtin_raw(), overlay_raw)
-    return _entries_from_raw(merged, source=str(path))
+    builtin_raw = _builtin_raw()
+    merged = _merge_raw_catalogs(builtin_raw, overlay_raw)
+    filtered = _apply_model_tombstones(merged, base=builtin_raw)
+    return _entries_from_raw(filtered, source=str(path))
 
 
 def save_user_catalog_entries(
@@ -227,6 +232,10 @@ def _merge_raw_provider(base: dict[str, Any], overlay: dict[str, Any]) -> dict[s
     overlay_models = overlay.get("models", [])
     if isinstance(base_models, list) and isinstance(overlay_models, list):
         merged["models"] = list(dict.fromkeys([*overlay_models, *base_models]))
+    base_removed = base.get("removed_models", [])
+    overlay_removed = overlay.get("removed_models", [])
+    if isinstance(base_removed, list) and isinstance(overlay_removed, list):
+        merged["removed_models"] = list(dict.fromkeys([*base_removed, *overlay_removed]))
     for key in ("context_windows", "headers", "compat"):
         base_mapping = base.get(key)
         overlay_mapping = overlay.get(key)
@@ -243,6 +252,45 @@ def _merge_raw_provider(base: dict[str, Any], overlay: dict[str, Any]) -> dict[s
             else:
                 merged.pop(field, None)
     return merged
+
+
+def _apply_model_tombstones(
+    raw: dict[str, Any],
+    *,
+    base: dict[str, Any],
+) -> dict[str, Any]:
+    """Remove provider-scoped models withdrawn by bundled or user catalogs."""
+    base_by_name = {_raw_provider_name(provider): provider for provider in _raw_providers(base)}
+    providers: list[dict[str, Any]] = []
+    for provider in _raw_providers(raw):
+        removed = {model for model in provider.get("removed_models", []) if isinstance(model, str)}
+        if not removed:
+            providers.append(provider)
+            continue
+        filtered = {**provider}
+        for field in ("models", "thinking_models"):
+            values = filtered.get(field)
+            if isinstance(values, list):
+                filtered[field] = [model for model in values if model not in removed]
+        for field in ("context_windows", "model_metadata"):
+            values = filtered.get(field)
+            if isinstance(values, dict):
+                filtered[field] = {
+                    model: value for model, value in values.items() if model not in removed
+                }
+        if filtered.get("default_model") in removed:
+            name = _raw_provider_name(provider)
+            base_default = base_by_name.get(name, {}).get("default_model")
+            remaining = filtered.get("models", [])
+            filtered["default_model"] = (
+                base_default
+                if isinstance(base_default, str) and base_default not in removed
+                else remaining[0]
+                if isinstance(remaining, list) and remaining
+                else ""
+            )
+        providers.append(filtered)
+    return {**raw, "providers": providers}
 
 
 def _merge_model_metadata(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -344,6 +392,7 @@ def _entry_from_provider(provider: _CatalogProvider, *, source: str) -> Provider
         thinking_models=provider.thinking_models,
         thinking_default=provider.thinking_default,
         thinking_parameter=provider.thinking_parameter,
+        removed_models=provider.removed_models,
         auth_methods=provider.auth_methods,
     )
 
@@ -476,6 +525,8 @@ def _raw_provider_from_entry(entry: ProviderCatalogEntry) -> dict[str, Any]:
         raw["thinking_default"] = entry.thinking_default
     if entry.thinking_parameter is not None:
         raw["thinking_parameter"] = entry.thinking_parameter
+    if entry.removed_models:
+        raw["removed_models"] = list(entry.removed_models)
     if entry.auth_methods != ("api_key",):
         raw["auth_methods"] = list(entry.auth_methods)
     return raw
@@ -547,6 +598,7 @@ def _catalog_to_toml(raw: dict[str, Any]) -> str:
             "thinking_models",
             "thinking_default",
             "thinking_parameter",
+            "removed_models",
             "auth_methods",
         ):
             if key in provider:

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -460,6 +460,7 @@ api_key_env = "OPENAI_CODEX_ACCESS_TOKEN"
 credential_name = "openai-codex"
 auth_methods = ["oauth"]
 models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2"]
+removed_models = ["gpt-5.6"]
 default_model = "gpt-5.5"
 docs_url = "https://chatgpt.com/codex"
 thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -35,6 +35,11 @@ thinking_level_map = { xhigh = "max" }
 unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
 ```
 
+When withdrawing a model from one built-in provider, add it to that provider's
+`removed_models` list. Tombstones are applied after user overlays, preventing
+stale saved catalog definitions from restoring an unroutable provider/model
+combination while leaving the same model ID available on other providers.
+
 Test both the exposed levels and the actual API value produced by provider configuration. Update `website/content/guides/providers-and-models.md` and add a beginner-friendly development note for substantial user-facing changes. Inspect `src/tau_coding/data/release-notes/releases.json`, but update it only when appropriate.
 
 Run focused provider tests followed by the repository's full pytest, Ruff, formatting, and mypy checks. Build the website when published provider documentation changes.

--- a/src/tau_coding/provider_catalog.py
+++ b/src/tau_coding/provider_catalog.py
@@ -89,6 +89,7 @@ class ProviderCatalogEntry:
     thinking_models: tuple[str, ...] = ()
     thinking_default: ThinkingLevel | None = None
     thinking_parameter: ThinkingParameter | None = None
+    removed_models: tuple[str, ...] = ()
     auth_methods: tuple[AuthMethod, ...] = ("api_key",)
 
 

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -50,6 +50,7 @@ from tau_coding.thinking import (
 
 DEFAULT_PROVIDER_NAME = "openai"
 DEFAULT_MODEL = "gpt-5.4"
+PROVIDER_SETTINGS_SCHEMA_VERSION = 2
 
 
 class ProviderConfigError(ValueError):
@@ -360,6 +361,7 @@ class ProviderSettings:
     def to_json(self) -> dict[str, Any]:
         """Serialize runtime preferences to JSON-compatible data."""
         return {
+            "schema_version": PROVIDER_SETTINGS_SCHEMA_VERSION,
             "default_provider": self.default_provider,
             "provider_preferences": {
                 provider.name: _provider_preference_to_json(provider) for provider in self.providers
@@ -508,6 +510,10 @@ def load_provider_settings(paths: TauPaths | None = None) -> ProviderSettings:
     if not isinstance(raw, dict):
         raise ProviderConfigError("Provider settings must be a JSON object")
     settings = provider_settings_from_json(raw, paths=resolved_paths)
+    if "provider_preferences" not in raw:
+        settings = _migrate_legacy_provider_settings(settings, paths=resolved_paths)
+        _save_migrated_provider_settings(settings, paths=resolved_paths)
+        return settings
     return _with_builtin_catalog_models(settings, paths=resolved_paths)
 
 
@@ -517,10 +523,7 @@ def save_provider_settings(settings: ProviderSettings, paths: TauPaths | None = 
     _save_provider_definitions_to_catalog(settings, paths=resolved_paths)
     path = provider_settings_path(resolved_paths)
     path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        with suppress(OSError):
-            copy2(path, path.with_suffix(path.suffix + ".bak"))
-    _atomic_write_text(path, dumps(settings.to_json(), indent=2, sort_keys=True) + "\n")
+    _write_provider_settings(settings, path=path, backup=True)
     return path
 
 
@@ -717,6 +720,82 @@ def _with_builtin_catalog_models(
         providers=providers,
         scoped_models=settings.scoped_models,
     )
+
+
+def _migrate_legacy_provider_settings(
+    settings: ProviderSettings,
+    *,
+    paths: TauPaths,
+) -> ProviderSettings:
+    """Move legacy full provider records onto catalog-owned definitions.
+
+    Built-in and user-catalog provider capabilities come exclusively from the
+    current effective catalog. Legacy records contribute only runtime
+    preferences. Providers absent from the catalog remain intact so the
+    migration can persist them as custom catalog entries.
+    """
+    catalog_configs = {config.name: config for config in _effective_provider_configs(paths)}
+    providers: list[ProviderConfig] = []
+    for legacy in settings.providers:
+        catalog_provider = catalog_configs.get(legacy.name)
+        if catalog_provider is None:
+            providers.append(legacy)
+            continue
+        preferences = _provider_preference_to_json(legacy)
+        if legacy.default_model not in catalog_provider.models:
+            preferences.pop("default_model")
+        preferences["thinking_defaults"] = {
+            model: level
+            for model, level in legacy.thinking_defaults.items()
+            if model in catalog_provider.models
+            and level in provider_thinking_levels(catalog_provider, model=model)
+        }
+        providers.append(_apply_provider_preference(catalog_provider, preferences))
+
+    merged = _append_catalog_providers(tuple(providers), catalog_configs, paths=paths)
+    names = {provider.name for provider in merged}
+    default_provider = settings.default_provider
+    if default_provider not in names:
+        default_provider = merged[0].name if merged else DEFAULT_PROVIDER_NAME
+    return ProviderSettings(
+        default_provider=default_provider,
+        providers=merged,
+        scoped_models=tuple(
+            scoped
+            for scoped in settings.scoped_models
+            if scoped.provider in names
+            and scoped.model
+            in next(provider.models for provider in merged if provider.name == scoped.provider)
+        ),
+    )
+
+
+def _save_migrated_provider_settings(settings: ProviderSettings, *, paths: TauPaths) -> None:
+    """Persist one legacy migration without turning built-ins into user overlays."""
+    catalog_names = {entry.name for entry in effective_catalog(paths)}
+    custom_entries = [
+        _catalog_entry_from_provider(provider)
+        for provider in settings.providers
+        if provider.name not in catalog_names
+    ]
+    if custom_entries:
+        save_user_catalog_entries(custom_entries, paths=paths)
+    path = provider_settings_path(paths)
+    _write_provider_settings(settings, path=path, backup=True)
+
+
+def _write_provider_settings(
+    settings: ProviderSettings,
+    *,
+    path: Path,
+    backup: bool,
+) -> None:
+    """Atomically write preferences, optionally retaining the previous file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if backup and path.exists():
+        with suppress(OSError):
+            copy2(path, path.with_suffix(path.suffix + ".bak"))
+    _atomic_write_text(path, dumps(settings.to_json(), indent=2, sort_keys=True) + "\n")
 
 
 def _effective_provider_configs(paths: TauPaths | None = None) -> tuple[ProviderConfig, ...]:
@@ -1081,6 +1160,11 @@ def provider_settings_from_json(
     migration and compatibility; saves rewrite it to provider_preferences and
     move custom provider definitions to catalog.toml.
     """
+    schema_version = data.get("schema_version")
+    if schema_version not in (None, PROVIDER_SETTINGS_SCHEMA_VERSION):
+        raise ProviderConfigError(
+            f"Unsupported provider settings schema_version: {schema_version!r}"
+        )
     default_provider = _string(data.get("default_provider"), "default_provider")
     scoped_models = _scoped_models_from_json(data.get("scoped_models"))
     if "provider_preferences" in data:

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -771,7 +771,9 @@ def _migrate_legacy_provider_settings(
 
 
 def _save_migrated_provider_settings(settings: ProviderSettings, *, paths: TauPaths) -> None:
-    """Persist one legacy migration without turning built-ins into user overlays."""
+    """Persist one legacy migration after creating its required recovery backup."""
+    path = provider_settings_path(paths)
+    _backup_provider_settings(path, strict=True)
     catalog_names = {entry.name for entry in effective_catalog(paths)}
     custom_entries = [
         _catalog_entry_from_provider(provider)
@@ -780,8 +782,18 @@ def _save_migrated_provider_settings(settings: ProviderSettings, *, paths: TauPa
     ]
     if custom_entries:
         save_user_catalog_entries(custom_entries, paths=paths)
-    path = provider_settings_path(paths)
-    _write_provider_settings(settings, path=path, backup=True)
+    _write_provider_settings(settings, path=path, backup=False)
+
+
+def _backup_provider_settings(path: Path, *, strict: bool) -> None:
+    """Copy existing settings to the recovery path, optionally requiring success."""
+    if not path.exists():
+        return
+    if strict:
+        copy2(path, path.with_suffix(path.suffix + ".bak"))
+        return
+    with suppress(OSError):
+        copy2(path, path.with_suffix(path.suffix + ".bak"))
 
 
 def _write_provider_settings(
@@ -792,9 +804,8 @@ def _write_provider_settings(
 ) -> None:
     """Atomically write preferences, optionally retaining the previous file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    if backup and path.exists():
-        with suppress(OSError):
-            copy2(path, path.with_suffix(path.suffix + ".bak"))
+    if backup:
+        _backup_provider_settings(path, strict=False)
     _atomic_write_text(path, dumps(settings.to_json(), indent=2, sort_keys=True) + "\n")
 
 

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1240,9 +1240,8 @@ def _apply_provider_preference(
         if "default_model" in value
         else provider.default_model
     )
-    models = (
-        provider.models if default_model in provider.models else (*provider.models, default_model)
-    )
+    if default_model not in provider.models:
+        default_model = provider.default_model
     headers = (
         _string_dict(value.get("headers"), f"provider_preferences.{provider.name}.headers")
         if "headers" in value
@@ -1277,13 +1276,13 @@ def _apply_provider_preference(
             value.get("thinking_defaults"),
             provider,
             f"provider_preferences.{provider.name}.thinking_defaults",
+            ignore_unknown_models=True,
         )
         if "thinking_defaults" in value
         else provider.thinking_defaults
     )
     return replace(
         provider,
-        models=models,
         default_model=default_model,
         headers=headers,
         timeout_seconds=timeout_seconds,
@@ -1297,8 +1296,12 @@ def _thinking_defaults_dict(
     value: object,
     provider: ProviderConfig,
     field_name: str,
+    *,
+    ignore_unknown_models: bool = False,
 ) -> dict[str, ThinkingLevel]:
     raw = _raw_thinking_defaults_dict(value, field_name)
+    if ignore_unknown_models:
+        raw = {model: level for model, level in raw.items() if model in provider.models}
     for model, thinking_level in raw.items():
         validate_provider_model(provider, model)
         available = provider_thinking_levels(provider, model=model)

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -154,6 +154,7 @@ def test_builtin_catalog_separates_openai_api_and_codex_context_limits() -> None
     assert "gpt-5.6" not in codex.models
     assert "gpt-5.6" not in codex.context_windows
     assert "gpt-5.6" not in codex.model_metadata
+    assert codex.removed_models == ("gpt-5.6",)
     assert openai.context_windows["gpt-5.6-sol"] == 1_050_000
     assert codex.context_windows["gpt-5.6-sol"] == 272_000
     assert codex.context_windows["gpt-5.6-terra"] == 272_000
@@ -510,6 +511,35 @@ default_model = "claude-next-1"
     # Untouched fields come from the builtin entry.
     assert entry.base_url == "https://api.anthropic.com"
     assert entry.thinking_parameter == "anthropic.thinking"
+
+
+def test_builtin_tombstone_removes_model_from_user_catalog_overlay(tmp_path: Path) -> None:
+    paths = _write_user_catalog(
+        tmp_path / ".tau",
+        """
+[[providers]]
+name = "openai-codex"
+models = ["gpt-5.6"]
+default_model = "gpt-5.6"
+thinking_models = ["gpt-5.6"]
+
+[providers.context_windows]
+"gpt-5.6" = 272000
+
+[providers.model_metadata."gpt-5.6"]
+name = "GPT-5.6"
+""",
+    )
+
+    entry = next(e for e in effective_catalog(paths) if e.name == "openai-codex")
+
+    assert entry.default_model == "gpt-5.5"
+    assert "gpt-5.6" not in entry.models
+    assert "gpt-5.6" not in entry.thinking_models
+    assert entry.context_windows is not None
+    assert "gpt-5.6" not in entry.context_windows
+    assert "gpt-5.6" not in entry.model_metadata
+    assert entry.removed_models == ("gpt-5.6",)
 
 
 def test_user_catalog_thinking_fields_replace_as_group(tmp_path: Path) -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -34,6 +34,33 @@ from tau_coding.provider_config import (
 )
 
 
+def test_stale_preferences_cannot_restore_removed_codex_alias(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "providers.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "default_provider": "openai-codex",
+                "provider_preferences": {
+                    "openai-codex": {
+                        "default_model": "gpt-5.6",
+                        "thinking_defaults": {"gpt-5.6": "low"},
+                    }
+                },
+                "scoped_models": [],
+            }
+        )
+    )
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+    codex = settings.get_provider("openai-codex")
+
+    assert codex.default_model == "gpt-5.5"
+    assert "gpt-5.6" not in codex.models
+    assert "gpt-5.6" not in codex.thinking_defaults
+
+
 def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path) -> None:
     settings = load_provider_settings(TauPaths(home=tmp_path / ".tau"))
 

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -340,6 +340,7 @@ def test_save_and_load_provider_settings_round_trip(
     loaded = load_provider_settings(paths)
 
     assert path == tmp_path / ".tau" / "providers.json"
+    assert json.loads(path.read_text())["schema_version"] == 2
     assert loaded == settings
 
 
@@ -1189,7 +1190,11 @@ def test_load_provider_settings_does_not_restore_stale_codex_builtin_models(
       "api_key_env": "OPENAI_CODEX_ACCESS_TOKEN",
       "credential_name": "openai-codex",
       "models": ["gpt-5", "gpt-5.5"],
-      "default_model": "gpt-5"
+      "default_model": "gpt-5",
+      "thinking_levels": ["off", "minimal", "low", "medium", "high", "xhigh"],
+      "thinking_models": ["gpt-5.5"],
+      "thinking_default": "medium",
+      "thinking_parameter": "reasoning.effort"
     }
   ]
 }
@@ -1212,6 +1217,18 @@ def test_load_provider_settings_does_not_restore_stale_codex_builtin_models(
         "gpt-5.2",
     )
     assert provider.default_model == "gpt-5.5"
+    assert provider_thinking_levels(provider, model="gpt-5.6-sol") == (
+        "off",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+    migrated = json.loads((tau_home / "providers.json").read_text())
+    assert migrated["schema_version"] == 2
+    assert "providers" not in migrated
+    assert (tau_home / "providers.json.bak").exists()
+    assert not (tau_home / "catalog.toml").exists()
 
 
 def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> None:
@@ -1246,7 +1263,46 @@ def test_load_provider_settings_merges_builtin_model_catalog(tmp_path: Path) -> 
     assert provider.context_windows["MiniMaxAI/MiniMax-M2.7"] == 204_800
     assert "Qwen/Qwen3-Coder-480B-A35B-Instruct" in provider.models
     assert "moonshotai/Kimi-K2.6" in provider.models
-    assert "custom/coder" in provider.models
+    assert "custom/coder" not in provider.models
+
+
+def test_load_provider_settings_migrates_custom_provider_to_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(provider_config, "environ", {})
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    original = {
+        "default_provider": "local",
+        "providers": [
+            {
+                "type": "openai-compatible",
+                "name": "local",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "LOCAL_API_KEY",
+                "credential_name": None,
+                "models": ["qwen"],
+                "default_model": "qwen",
+                "context_windows": {"qwen": 64000},
+                "headers": {"X-Test": "yes"},
+            }
+        ],
+    }
+    (tau_home / "providers.json").write_text(json.dumps(original), encoding="utf-8")
+
+    settings = load_provider_settings(TauPaths(home=tau_home))
+
+    provider = settings.get_provider("local")
+    assert provider.context_windows == {"qwen": 64_000}
+    assert provider.headers == {"X-Test": "yes"}
+    assert json.loads((tau_home / "providers.json.bak").read_text()) == original
+    migrated = json.loads((tau_home / "providers.json").read_text())
+    assert migrated["schema_version"] == 2
+    assert migrated["provider_preferences"]["local"]["default_model"] == "qwen"
+    catalog = (tau_home / "catalog.toml").read_text()
+    assert 'name = "local"' in catalog
+    assert 'models = ["qwen"]' in catalog
 
 
 def test_load_provider_settings_restores_builtin_providers_with_stored_credentials(
@@ -1346,6 +1402,17 @@ def test_load_provider_settings_restores_builtin_credential_name(
         credential_reader=FakeCredentials(),
     )
     assert config.api_key == "stored-key"
+
+
+def test_provider_settings_from_json_rejects_unknown_schema_version() -> None:
+    with pytest.raises(ProviderConfigError, match="schema_version"):
+        provider_settings_from_json(
+            {
+                "schema_version": 99,
+                "default_provider": "openai",
+                "provider_preferences": {},
+            }
+        )
 
 
 def test_provider_settings_from_json_rejects_invalid_headers() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1332,6 +1332,42 @@ def test_load_provider_settings_migrates_custom_provider_to_catalog(
     assert 'models = ["qwen"]' in catalog
 
 
+def test_legacy_migration_aborts_before_changes_when_backup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(provider_config, "environ", {})
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    original = {
+        "default_provider": "local",
+        "providers": [
+            {
+                "type": "openai-compatible",
+                "name": "local",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "LOCAL_API_KEY",
+                "models": ["qwen"],
+                "default_model": "qwen",
+            }
+        ],
+    }
+    settings_path = tau_home / "providers.json"
+    settings_path.write_text(json.dumps(original), encoding="utf-8")
+
+    def fail_backup(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("backup denied")
+
+    monkeypatch.setattr(provider_config, "copy2", fail_backup)
+
+    with pytest.raises(PermissionError, match="backup denied"):
+        load_provider_settings(TauPaths(home=tau_home))
+
+    assert json.loads(settings_path.read_text()) == original
+    assert not (tau_home / "providers.json.bak").exists()
+    assert not (tau_home / "catalog.toml").exists()
+
+
 def test_load_provider_settings_restores_builtin_providers_with_stored_credentials(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -101,7 +101,9 @@ the API model page. Vision-capable Codex models retain their image-input
 metadata separately from these runtime context limits, allowing image files read
 by Tau to reach the model. The `gpt-5.6` alias, which routes to GPT-5.6 Sol, is only
 available through the direct OpenAI API; Codex subscription users should select
-the explicit `gpt-5.6-sol` model instead.
+the explicit `gpt-5.6-sol` model instead. Tau tombstones the API-only alias for
+the Codex provider, so older user catalog overlays and saved preferences cannot
+restore it after an upgrade.
 
 ### OpenCode Go and Zen
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -104,6 +104,12 @@ metadata fields—including the complete `cost_tiers` array—replace the built-
 value. A model's `compat` wins over the provider's, so a built-in per-model value
 overrides a provider-level overlay — override at the model level to change it.
 
+`removed_models` is an additive provider-scoped tombstone list. Tau applies it
+last and removes matching model-list, metadata, context-window, thinking, and
+default references after merging. Bundled tombstones therefore prevent stale
+user overlays from restoring models that Tau previously advertised for the wrong
+provider. They do not affect the same model ID on another provider.
+
 ### Anthropic prompt-cache compat keys
 
 Providers using the `anthropic-messages` API accept three `compat` booleans

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -169,6 +169,7 @@ Provider preferences live in `~/.tau/providers.json`:
 
 ```json
 {
+  "schema_version": 2,
   "default_provider": "local-gateway",
   "provider_preferences": {
     "local-gateway": {

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -201,12 +201,18 @@ Provider preferences live in `~/.tau/providers.json`:
   custom or local model names to `models` before using them as defaults,
   CLI/TUI selections, or scoped models.
 - `scoped_models` are favorites for the **Ctrl+P** quick-cycle.
-- Older `providers.json` files that contain full `providers` entries are still
-  accepted for compatibility. Tau ignores unrecognized top-level settings and
-  provider-preference fields so files written by newer Tau versions do not block
-  older versions from starting. Recognized fields remain strictly validated.
-  When Tau saves settings again, provider definitions are moved to
-  `~/.tau/catalog.toml` and `providers.json` is rewritten as runtime preferences.
+- `providers.json` uses `schema_version: 2` and stores preferences only. Provider
+  capabilities—model lists, context windows, transports, metadata, and thinking
+  support—always come from the current effective catalog.
+- Older `providers.json` files that contain full `providers` entries are migrated
+  automatically on first load. Tau keeps the original as `providers.json.bak`,
+  moves custom provider definitions to `~/.tau/catalog.toml`, and rewrites
+  built-in providers from the current catalog while preserving safe preferences.
+  This prevents old model or thinking metadata from hiding capabilities added by
+  a Tau upgrade.
+- Tau ignores unrecognized preference fields for cross-version compatibility,
+  but rejects an unsupported `schema_version` rather than risking a destructive
+  rewrite with the wrong format.
 - Custom models declare thinking support in `catalog.toml` with
   `thinking_levels`, `thinking_default`, `thinking_models`, and
   `thinking_parameter` (`"reasoning_effort"`, `"reasoning.effort"`, or


### PR DESCRIPTION
## Summary

- version `~/.tau/providers.json` as a preferences-only schema v2 document
- eagerly migrate legacy full-provider snapshots while keeping the original `.bak`
- rebuild known providers from the current effective catalog so stale model and thinking metadata cannot override upgrades
- move legacy custom providers into `~/.tau/catalog.toml` without generating built-in overlays
- add additive, provider-scoped `removed_models` tombstones that apply after user catalog overlays
- tombstone the API-only `gpt-5.6` alias for `openai-codex` while retaining `openai:gpt-5.6`

This supersedes #520 by combining its stale Codex alias protection with the broader provider-settings ownership and migration fix.

## User experience

Users upgrading Tau automatically receive current provider capabilities. Old model lists, `thinking_models`, context limits, or transport metadata can no longer make newly supported models appear unavailable. Models withdrawn from one provider cannot be restored by stale user catalog overlays or preferences. Existing safe preferences and genuine custom providers survive migration, and the original settings file remains recoverable.

## Issue

Follow-up to #469. Supersedes #520. No separate linked issue.

## Manual validation

1. Create a legacy `~/.tau/providers.json` with a full `openai-codex` entry whose model and thinking lists are stale.
2. Add `gpt-5.6` to an `openai-codex` overlay in `~/.tau/catalog.toml` and save it as the Codex default preference.
3. Start Tau and confirm `openai-codex:gpt-5.6` is absent, while `openai:gpt-5.6` and `openai-codex:gpt-5.6-sol` remain available.
4. Confirm thinking levels are available for `openai-codex:gpt-5.6-sol`.
5. Confirm `providers.json` now has `schema_version: 2` and `provider_preferences`, while the original is retained as `providers.json.bak`.
6. For a legacy custom provider, confirm its definition appears in `~/.tau/catalog.toml`.

## Validation

- `uv run pytest` (1295 passed, 2 platform skips)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-provider-config-dist`
- `hugo --source website --destination <temp-dir> --minify`
- `npx --yes pagefind@latest --site <temp-dir>`


