### PR TITLE
Add macOS clipboard image paste

### DIFF
--- a/dev-notes/tui-clipboard-image-paste.md
+++ b/dev-notes/tui-clipboard-image-paste.md
@@ -1,0 +1,42 @@
+# TUI clipboard image paste
+
+## What was added
+
+Tau's Textual prompt now handles `Ctrl+V` on macOS like Pi:
+
+1. Read an image from the native clipboard through Pillow's `ImageGrab` support.
+2. Save it under the system temporary directory as `tau-clipboard-<uuid>.png`.
+3. Insert that absolute path at the prompt cursor using the same spacing rules as file drops.
+4. Fall back to `pbpaste` text when the clipboard contains no image.
+
+The shortcut is configured as `keybindings.paste_clipboard` in `~/.tau/tui.json` and defaults to `ctrl+v`.
+
+## Why paths instead of inline prompt images
+
+Tau's provider-neutral image flow already lives in the built-in `read` tool. Inserting a temporary path lets the agent inspect clipboard images through that existing validated pipeline, including model capability checks, image normalization, and provider serialization. The TUI does not need its own image-message type or terminal image renderer.
+
+This preserves Tau's layer boundary:
+
+- `tau_agent` remains independent of the operating system and Textual.
+- `tau_coding.tui.clipboard` owns native clipboard access.
+- `tau_coding.tools.read` remains responsible for model-facing image attachments.
+
+## Platform scope
+
+The first implementation is macOS-only. It uses Pillow's built-in macOS clipboard reader and `pbpaste` for the text fallback. Other platforms return no clipboard content rather than failing the TUI.
+
+## Verification
+
+```bash
+uv run pytest tests/test_tui_clipboard.py tests/test_tui_app.py tests/test_tui_config.py
+uv run ruff check src tests
+uv run mypy
+```
+
+Manual macOS check:
+
+1. Copy a screenshot to the clipboard.
+2. Start Tau with `uv run tau`.
+3. Focus the prompt and press `Ctrl+V`.
+4. Confirm that a `/var/folders/.../T/tau-clipboard-<uuid>.png` path appears.
+5. Ask Tau to inspect the screenshot and confirm the `read` tool attaches it for a vision-capable model.

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -475,6 +475,7 @@ def _hotkeys_command(context: CommandContext) -> CommandResult:
         "- Ctrl+T: toggle thinking tokens",
         "- Ctrl+O: collapse or expand tool output",
         "- Ctrl+C: clear prompt input",
+        "- Ctrl+V: paste clipboard image or text",
         "- Ctrl+D: quit",
     ]
     return CommandResult(handled=True, message="\n".join(lines))

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -138,6 +138,7 @@ from tau_coding.tui.autocomplete import (
     CompletionState,
     build_completion_state,
 )
+from tau_coding.tui.clipboard import ClipboardReader, read_clipboard_for_prompt
 from tau_coding.tui.config import (
     TAU_DARK_THEME,
     TuiKeybindings,
@@ -483,11 +484,13 @@ class PromptInput(TextArea):
         self,
         *,
         tui_keybindings: TuiKeybindings | None = None,
+        clipboard_reader: ClipboardReader | None = None,
         **kwargs: Any,
     ) -> None:
         kwargs.setdefault("highlight_cursor_line", False)
         super().__init__(**kwargs)
         self.tui_keybindings = tui_keybindings or TuiKeybindings()
+        self._clipboard_reader = clipboard_reader or read_clipboard_for_prompt
         self._base_bindings = self._bindings.copy()
         self._footer_mode: Literal["normal", "completion", "running"] = "normal"
         self._pending_pastes: list[tuple[str, str]] = []
@@ -614,6 +617,15 @@ class PromptInput(TextArea):
         """Insert a newline in the prompt."""
         self.insert("\n")
 
+    async def action_paste_clipboard(self) -> None:
+        """Insert an OS clipboard image path, falling back to clipboard text."""
+        try:
+            content = await self._clipboard_reader()
+        except Exception:  # noqa: BLE001 - clipboard integrations must not crash the TUI
+            return
+        if content:
+            self.insert_pasted_text(content)
+
     async def action_quit(self) -> None:
         """Quit the app through the app-level action."""
         await self.app.action_quit()
@@ -720,7 +732,11 @@ class PromptInput(TextArea):
         bindings), so there is no interceptor splice here.
         """
         keybindings = self.tui_keybindings
-        if event.key == keybindings.queue_follow_up:
+        if event.key == keybindings.paste_clipboard:
+            event.stop()
+            event.prevent_default()
+            await self.action_paste_clipboard()
+        elif event.key == keybindings.queue_follow_up:
             event.stop()
             event.prevent_default()
             await self._completion_target().action_submit_follow_up()
@@ -6508,6 +6524,7 @@ def _hidden_prompt_bindings(
         (keybindings.model_cycle, "cycle_model"),
         (keybindings.toggle_tool_results, "toggle_tool_results"),
         (keybindings.toggle_thinking, "toggle_thinking"),
+        (keybindings.paste_clipboard, "paste_clipboard"),
         (keybindings.copy_message, "clear_prompt"),
         (keybindings.accept_completion, "accept_completion"),
         (keybindings.completion_next, "completion_next"),

--- a/src/tau_coding/tui/clipboard.py
+++ b/src/tau_coding/tui/clipboard.py
@@ -1,0 +1,70 @@
+"""Read macOS clipboard images or text for the TUI prompt."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import tempfile
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from uuid import uuid4
+
+from PIL import Image, ImageGrab
+
+CLIPBOARD_TIMEOUT_SECONDS = 3
+
+# Injectable seam used by PromptInput pilot tests.
+type ClipboardReader = Callable[[], Awaitable[str | None]]
+
+
+async def read_clipboard_for_prompt() -> str | None:
+    """Return a temporary image path or clipboard text on supported platforms."""
+    return await asyncio.to_thread(_read_clipboard_for_prompt_sync)
+
+
+def _read_clipboard_for_prompt_sync() -> str | None:
+    """Read macOS clipboard contents without blocking Textual's event loop."""
+    if sys.platform != "darwin":
+        return None
+
+    image_path = materialize_clipboard_image()
+    if image_path is not None:
+        return str(image_path)
+    return _read_macos_clipboard_text()
+
+
+def materialize_clipboard_image(*, temp_dir: Path | None = None) -> Path | None:
+    """Save a clipboard image as a temporary PNG and return its path."""
+    try:
+        clipboard = ImageGrab.grabclipboard()
+    except (ChildProcessError, NotImplementedError, OSError):
+        return None
+    if not isinstance(clipboard, Image.Image):
+        return None
+
+    directory = temp_dir or Path(tempfile.gettempdir())
+    path = directory / f"tau-clipboard-{uuid4()}.png"
+    try:
+        clipboard.save(path, format="PNG")
+    except (OSError, ValueError):
+        path.unlink(missing_ok=True)
+        return None
+    finally:
+        clipboard.close()
+    return path
+
+
+def _read_macos_clipboard_text() -> str | None:
+    try:
+        result = subprocess.run(
+            ["pbpaste"],
+            capture_output=True,
+            timeout=CLIPBOARD_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout.decode("utf-8", errors="replace")

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -61,6 +61,7 @@ class TuiKeybindings:
     model_cycle: str = "ctrl+p"
     toggle_thinking: str = "ctrl+t"
     toggle_tool_results: str = "ctrl+o"
+    paste_clipboard: str = "ctrl+v"
     copy_message: str = "ctrl+c"
     quit: str = "ctrl+d"
 
@@ -78,6 +79,7 @@ class TuiKeybindings:
             "model_cycle": self.model_cycle,
             "toggle_thinking": self.toggle_thinking,
             "toggle_tool_results": self.toggle_tool_results,
+            "paste_clipboard": self.paste_clipboard,
             "copy_message": self.copy_message,
             "quit": self.quit,
         }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -278,6 +278,7 @@ def test_hotkeys_command_lists_common_tui_shortcuts(tmp_path: Path) -> None:
     assert "Ctrl+K: open slash-command completions" in result.message
     assert "Ctrl+R: open session picker" in result.message
     assert "Shift+Tab: cycle thinking mode" in result.message
+    assert "Ctrl+V: paste clipboard image or text" in result.message
 
 
 def test_model_command_requests_picker_and_switches_models(tmp_path: Path) -> None:

--- a/tests/test_tui_clipboard.py
+++ b/tests/test_tui_clipboard.py
@@ -1,0 +1,107 @@
+"""Tests for clipboard image materialization in the TUI."""
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tau_coding.tui import clipboard
+from tau_coding.tui.app import PromptInput, TauTuiApp
+
+
+@pytest.mark.anyio
+async def test_prompt_ctrl_v_inserts_clipboard_image_path(tmp_path: Path) -> None:
+    from test_tui_app import FakeSession
+
+    image_path = tmp_path / "tau-clipboard-test.png"
+    image_path.touch()
+
+    async def read_clipboard() -> str:
+        return str(image_path)
+
+    app = TauTuiApp(FakeSession())
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt._clipboard_reader = read_clipboard
+        prompt.text = "inspect"
+        prompt.move_cursor((0, len(prompt.text)))
+
+        await pilot.press("ctrl+v")
+        await pilot.pause()
+
+        assert prompt.text == f"inspect {image_path} "
+
+
+@pytest.mark.anyio
+async def test_prompt_ctrl_v_falls_back_to_clipboard_text() -> None:
+    from test_tui_app import FakeSession
+
+    async def read_clipboard() -> str:
+        return "clipboard text"
+
+    app = TauTuiApp(FakeSession())
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt._clipboard_reader = read_clipboard
+
+        await pilot.press("ctrl+v")
+        await pilot.pause()
+
+        assert prompt.text == "clipboard text"
+
+
+def test_materialize_clipboard_image_writes_png(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(clipboard.ImageGrab, "grabclipboard", lambda: Image.new("RGB", (3, 2)))
+
+    path = clipboard.materialize_clipboard_image(temp_dir=tmp_path)
+
+    assert path is not None
+    assert path.parent == tmp_path
+    assert path.name.startswith("tau-clipboard-")
+    assert path.suffix == ".png"
+    with Image.open(path) as saved:
+        assert saved.format == "PNG"
+        assert saved.size == (3, 2)
+
+
+def test_materialize_clipboard_image_returns_none_for_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(clipboard.ImageGrab, "grabclipboard", lambda: None)
+
+    assert clipboard.materialize_clipboard_image(temp_dir=tmp_path) is None
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.anyio
+async def test_read_clipboard_prefers_image_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "tau-clipboard-test.png"
+    image_path.touch()
+    monkeypatch.setattr(clipboard.sys, "platform", "darwin")
+    monkeypatch.setattr(clipboard, "materialize_clipboard_image", lambda: image_path)
+    monkeypatch.setattr(clipboard, "_read_macos_clipboard_text", lambda: "fallback text")
+
+    assert await clipboard.read_clipboard_for_prompt() == str(image_path)
+
+
+@pytest.mark.anyio
+async def test_read_clipboard_falls_back_to_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clipboard.sys, "platform", "darwin")
+    monkeypatch.setattr(clipboard, "materialize_clipboard_image", lambda: None)
+    monkeypatch.setattr(clipboard, "_read_macos_clipboard_text", lambda: "clipboard text")
+
+    assert await clipboard.read_clipboard_for_prompt() == "clipboard text"
+
+
+@pytest.mark.anyio
+async def test_read_clipboard_is_unsupported_off_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clipboard.sys, "platform", "linux")
+
+    assert await clipboard.read_clipboard_for_prompt() is None

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -59,6 +59,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     assert settings.keybindings.queue_follow_up == "f5"
     assert settings.keybindings.toggle_tool_results == "ctrl+o"
     assert settings.keybindings.toggle_thinking == "f4"
+    assert settings.keybindings.paste_clipboard == "ctrl+v"
     assert settings.keybindings.accept_completion == "f2"
     assert settings.keybindings.thinking_cycle == "f3"
     assert settings.keybindings.model_cycle == "f6"
@@ -170,6 +171,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
             thinking_cycle="f3",
             model_cycle="f6",
             toggle_thinking="f4",
+            paste_clipboard="f7",
             copy_message="ctrl+b",
         ),
         theme="high-contrast",
@@ -180,6 +182,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
     assert settings.to_json()["keybindings"]["queue_follow_up"] == "f5"
     assert settings.to_json()["keybindings"]["toggle_tool_results"] == "ctrl+o"
     assert settings.to_json()["keybindings"]["toggle_thinking"] == "f4"
+    assert settings.to_json()["keybindings"]["paste_clipboard"] == "f7"
     assert settings.to_json()["keybindings"]["accept_completion"] == "f2"
     assert settings.to_json()["keybindings"]["thinking_cycle"] == "f3"
     assert settings.to_json()["keybindings"]["model_cycle"] == "f6"

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -104,6 +104,19 @@ the input box, because the terminal delivers the drop as text input.
 Drops are also accepted from sources that do not give the terminal keyboard focus
 first, such as the macOS Dock's Downloads stack.
 
+## Pasting screenshots from the macOS clipboard
+
+Press **Ctrl+V** in the prompt after copying an image or taking a screenshot to
+the clipboard. Tau saves the image as a temporary
+`tau-clipboard-<uuid>.png` file and inserts its path at the cursor, matching the
+path-based workflow used for dropped files. If the clipboard contains no image,
+Ctrl+V pastes its text instead. The shortcut can be remapped with the
+`paste_clipboard` keybinding.
+
+This native clipboard-image shortcut currently requires macOS. The image is sent
+when the agent reads the temporary path, so the active model must support image
+input. Tau does not render the image inline in the terminal.
+
 ## Tool output
 
 Tool calls keep a static marker in the transcript while they run: orange means

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -272,6 +272,7 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
     "model_cycle": "ctrl+p",
     "toggle_thinking": "ctrl+t",
     "toggle_tool_results": "ctrl+o",
+    "paste_clipboard": "ctrl+v",
     "copy_message": "ctrl+c",
     "quit": "ctrl+d"
   }

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -41,6 +41,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 | --- | --- |
 | `Ctrl+O` | Toggle full tool output (vs. compact preview) |
 | `Ctrl+C` | Clear the prompt input |
+| `Ctrl+V` | Paste a macOS clipboard image as a temporary path, or paste clipboard text |
 | `Ctrl+D` | Quit |
 
 {{% note title="Remapping" %}}


### PR DESCRIPTION
## Summary

- add `Ctrl+V` support for macOS clipboard images in the Textual prompt
- materialize clipboard images as temporary `tau-clipboard-<uuid>.png` files and insert their paths using the existing file-drop spacing rules
- fall back to `pbpaste` text when the clipboard does not contain an image
- expose a remappable `paste_clipboard` TUI keybinding and update the user docs
- keep clipboard access inside `tau_coding.tui` while reusing the existing `read` tool image pipeline

## Testing

- `uv run pytest` — 1297 passed, 2 skipped
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy`
- manually verified on macOS that a screenshot becomes a `/var/folders/.../T/tau-clipboard-<uuid>.png` prompt path and can be read by the agent
