### PR TITLE
Repair dangling tool calls when /tree switches to a broken branch

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -401,10 +401,6 @@ class CodingSession:
         await session._refresh_runtime_model_limits()
         if fresh_extension_runtime:
             extension_runtime.bind(session)
-            # Attach to session._harness, not the local `harness`:
-            # _persist_loaded_interrupted_tool_repairs() above may have
-            # replaced the harness, and listeners on the discarded one would
-            # never see an agent event.
             extension_runtime.attach_harness_listener(session._harness.subscribe)
             # session_start is deferred: hosts emit it via
             # emit_pending_session_start() after installing their UI bridge,
@@ -560,6 +556,11 @@ class CodingSession:
 
         await self._refresh_persisted_state(leaf_id=target_id)
         self._harness.replace_messages(self._state.messages)
+        # The selected branch may carry a dangling tool call whose interrupted
+        # result was never persisted; repair it here so the next prompt sends a
+        # provider-safe transcript instead of appending the synthetic result at
+        # the transcript tail.
+        await self._persist_loaded_interrupted_tool_repairs()
         self._invalidate_context_usage_cache()
         self._thinking_level = _state_thinking_level(
             self._state,
@@ -1771,17 +1772,9 @@ class CodingSession:
         await self._append_session_entry(leaf)
         self._last_parent_id = parent_id
         await self._refresh_persisted_state(leaf_id=parent_id)
-        self._harness = AgentHarness(
-            AgentHarnessConfig(
-                provider=self._harness.config.provider,
-                model=self._harness.config.model,
-                system=self._harness.config.system,
-                tools=self._harness.config.tools,
-                max_turns=self._harness.config.max_turns,
-                queue_mode=self._harness.config.queue_mode,
-            ),
-            messages=self._state.messages,
-        )
+        # Keep the harness object: subscribers (extension event fan-out) stay
+        # attached when the repair runs mid-session, e.g. from branch_to_entry.
+        self._harness.replace_messages(self._state.messages)
 
     async def _persist_messages_since(self, persisted_count: int) -> int:
         """Persist completed harness messages after ``persisted_count``.

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1430,6 +1430,85 @@ async def test_session_branches_to_previous_entry_without_destroying_history(
 
 
 @pytest.mark.anyio
+async def test_branch_to_entry_persists_repair_for_interrupted_tool_call(
+    tmp_path: Path,
+) -> None:
+    # Regression: /tree onto a branch whose persisted history has a dangling
+    # tool call replayed the hole into the harness; the next prompt appended
+    # the synthetic result at the transcript tail instead of adjacent to its
+    # tool call, and Anthropic rejected the request with a 400.
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(id="root", message=UserMessage(content="Read README.md"))
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    call_entry = MessageEntry(
+        id="call",
+        parent_id="root",
+        message=AssistantMessage(content=assistant_content("I'll read it.", [tool_call])),
+    )
+    note = MessageEntry(id="note", parent_id="call", message=UserMessage(content="Ran it myself."))
+    reply = MessageEntry(
+        id="reply", parent_id="note", message=AssistantMessage(content="Understood.")
+    )
+    clean = MessageEntry(id="clean", parent_id="root", message=AssistantMessage(content="Clean"))
+    for entry in (root, call_entry, note, reply, clean):
+        await storage.append(entry)
+    await storage.append(LeafEntry(entry_id="clean"))
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                assistant_done(message=AssistantMessage(content="Recovered.")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(_config(tmp_path, provider, storage))
+    assert provider.calls == []
+
+    await session.branch_to_entry("reply")
+
+    expected_repair = ToolResultMessage(
+        tool_call_id="call-1",
+        tool_name="read",
+        content=[TextContent(text="Tool call interrupted by user")],
+        is_error=True,
+    )
+    _assert_messages(
+        session.messages,
+        (
+            UserMessage(content="Read README.md"),
+            AssistantMessage(content=assistant_content("I'll read it.", [tool_call])),
+            expected_repair,
+            UserMessage(content="Ran it myself."),
+            AssistantMessage(content="Understood."),
+        ),
+    )
+    entries = await storage.read_all()
+    repair_entries = [
+        entry
+        for entry in entries
+        if entry.type == "message" and isinstance(entry.message, ToolResultMessage)
+    ]
+    assert len(repair_entries) == 1
+    assert repair_entries[0].parent_id == "call"
+
+    _ = await _collect_session_events(session.prompt("continue"))
+
+    _model, _system, sent, _tools = provider.calls[0]
+    call_index = next(
+        index
+        for index, message in enumerate(sent)
+        if isinstance(message, AssistantMessage) and message.tool_calls
+    )
+    _assert_messages([sent[call_index + 1]], [expected_repair])
+    assert sum(isinstance(message, ToolResultMessage) for message in session.messages) == 1
+
+    entry_count = len(await storage.read_all())
+    restored = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+    assert restored.messages == session.messages
+    assert len(await storage.read_all()) == entry_count
+
+
+@pytest.mark.anyio
 async def test_persist_after_branch_keeps_state_on_active_branch(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1627,11 +1627,11 @@ async def test_prompt_input_hook_source_extension(tmp_path: Path) -> None:
 async def test_agent_events_reach_extension_after_interrupted_tool_repair(
     tmp_path: Path,
 ) -> None:
-    # Regression: load() attached the extension event fan-out to the local
-    # harness it built before _persist_loaded_interrupted_tool_repairs() could
-    # replace session._harness. Loading a session that died mid-tool-call then
-    # left extensions subscribed to the discarded harness — they silently
-    # received zero agent events for the whole session.
+    # Regression: load() must attach the extension event fan-out only after the
+    # interrupted-tool repair has run. An older build attached it to a harness
+    # the repair then discarded, so loading a session that died mid-tool-call
+    # left extensions subscribed to a dead object — they silently received zero
+    # agent events for the whole session.
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     user_entry = MessageEntry(message=UserMessage(content="Read README.md"))
     await storage.append(user_entry)
@@ -1659,6 +1659,50 @@ async def test_agent_events_reach_extension_after_interrupted_tool_repair(
     session = await CodingSession.load(_session_config(tmp_path, provider, extension_body=body))
     module = _loaded_extension_module("integration")
 
+    _ = [event async for event in session.prompt("continue")]
+
+    assert "agent_start" in module.EVENTS  # type: ignore[attr-defined]
+    assert "agent_end" in module.EVENTS  # type: ignore[attr-defined]
+
+
+async def test_agent_events_reach_extension_after_branch_tool_repair(
+    tmp_path: Path,
+) -> None:
+    # Mid-session /tree onto a branch with a dangling tool call triggers the
+    # interrupted-tool repair. The repair must keep the harness object the
+    # extension fan-out subscribed to at load, or extensions silently stop
+    # receiving agent events for the rest of the session.
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(id="root", message=UserMessage(content="Read README.md"))
+    tool_call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    call_entry = MessageEntry(
+        id="call",
+        parent_id="root",
+        message=AssistantMessage(content=assistant_content("I'll read it.", [tool_call])),
+    )
+    note = MessageEntry(id="note", parent_id="call", message=UserMessage(content="Ran it myself."))
+    clean = MessageEntry(id="clean", parent_id="root", message=AssistantMessage(content="Clean"))
+    for entry in (root, call_entry, note, clean):
+        await storage.append(entry)
+    await storage.append(LeafEntry(entry_id="clean"))
+
+    body = (
+        "EVENTS = []\n\n\n"
+        "def setup(tau):\n"
+        "    tau.on('agent_event', lambda event, context: EVENTS.append(event.type))\n"
+    )
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                assistant_done(message=AssistantMessage(content="Recovered.")),
+            ]
+        ]
+    )
+    session = await CodingSession.load(_session_config(tmp_path, provider, extension_body=body))
+    module = _loaded_extension_module("integration")
+
+    await session.branch_to_entry("note")
     _ = [event async for event in session.prompt("continue")]
 
     assert "agent_start" in module.EVENTS  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

- The user stops a tool call. The frontend closes the prompt generator. The harness writes the synthetic tool result only to memory (`AgentHarness._run`, `finally` block). The persist step after the event loop does not run.
- The user then runs a terminal command. `run_terminal_command` reads the message count, which includes the result that is not persisted. It writes only the new user message.
- The session file now has a tool call with no tool result. This race is in the current build. The docstring of `_persist_loaded_interrupted_tool_repairs` says only older builds have it. That is not correct.
- The user runs `/tree` and selects a branch that has this fault.
- `branch_to_entry` replays the branch from the session file. The transcript in the harness now has the fault again.
- The user sends the next prompt. The harness adds the synthetic result at the end of the transcript. The result is not adjacent to its tool call.
- Anthropic rejects the request with error 400: `tool_use ids were found without tool_result blocks immediately after`.
- Tau then writes the misplaced result to the tree tip. The branch stays defective. Each retry makes one more defective entry.

## Fix

Two changes in `src/tau_coding/session.py`:

1. `branch_to_entry` now runs the interrupted-tool repair after it replays the branch. The repair puts the synthetic result immediately after its tool call. The repair writes the result to the session tree. The next prompt sends a transcript that the provider accepts.
2. `_persist_loaded_interrupted_tool_repairs` now keeps the same harness object. It calls `replace_messages`. Before, it made a new `AgentHarness`. The new object lost the event subscribers and the `before_tool_call`/`after_tool_call` hooks. Extensions then received no agent events for the rest of the session.

## Tests (red before the fix, green after)

- `test_branch_to_entry_persists_repair_for_interrupted_tool_call`: makes sure the repair entry is adjacent to its tool call, in memory, in the session file, and in the request to the provider. Also makes sure a reload does not repair again.
- `test_agent_events_reach_extension_after_branch_tool_repair`: makes sure extensions receive agent events after a mid-session repair. This test fails if change (1) is applied without change (2).

`uv run pytest`, `uv run ruff check .`, `uv run ruff format --check .`, and `uv run mypy` pass. One test fails before and after this change: `test_load_empty_session_defers_transcript_file`. It is not related.

## Out of scope, possible follow-up work

- Sessions that a misplaced result already poisoned. `_interrupted_tool_repair_plan` examines membership, not adjacency. It cannot heal these sessions.
- The root cause above: persist the repair from the `finally` block of `AgentHarness._run` before the next message. Also correct the docstring of `_persist_loaded_interrupted_tool_repairs`.
- The compaction path also calls `replace_messages` and does not run the repair.
- The repair re-parents the full suffix of the branch. A long branch gets duplicate entries, and model or thinking-level changes in the suffix do not survive.
