### PR TITLE
Fix shell commands cancelling active agent runs

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3754,6 +3754,7 @@ class TauTuiApp(App[None]):
                     terminal_command.command,
                     add_to_context=terminal_command.add_to_context,
                 ),
+                group="terminal-command",
                 exclusive=True,
             )
             return

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6697,6 +6697,50 @@ async def test_tui_app_runs_terminal_command_without_context() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_app_terminal_command_does_not_cancel_active_agent() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    completed = asyncio.Event()
+
+    class RunningSession(FakeSession):
+        async def prompt(
+            self,
+            text: str,
+            **kwargs: object,
+        ) -> AsyncIterator[AgentEvent]:
+            del kwargs
+            self.prompt_texts.append(text)
+            yield AgentStartEvent()
+            started.set()
+            await release.wait()
+            yield AgentEndEvent()
+            yield AgentSettledEvent()
+            completed.set()
+
+    session = RunningSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "keep working"
+        await pilot.press("enter")
+        await started.wait()
+
+        prompt.value = "!! code ."
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.terminal_commands == [("code .", False)]
+        assert not completed.is_set()
+
+        release.set()
+        await pilot.pause()
+
+        assert completed.is_set()
+        assert app.state.running is False
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("add_to_context", [True, False])
 async def test_tui_app_renders_terminal_command_while_running(add_to_context: bool) -> None:
     session = FakeSession()


### PR DESCRIPTION
## Summary

- isolate direct terminal commands in their own Textual worker group
- prevent `!` / `!!` commands from cancelling an active agent worker
- add a regression test covering a shell action during an active run

## User experience

Users can run a direct shell action such as `!! code .` while an agent tool is running without interrupting the agent or leaving Tau stuck in its running state.

## Validation

- `uv run pytest` (1291 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`

Manual reproduction:

1. Start an agent turn that invokes a long-running tool.
2. While it runs, execute `!! code .` from Tau's prompt.
3. Confirm the shell action completes and the original agent turn continues to completion.
