### PR TITLE
Fix provider-anchored context recovery

### DIFF
--- a/dev-notes/provider-anchored-context-recovery.md
+++ b/dev-notes/provider-anchored-context-recovery.md
@@ -1,0 +1,56 @@
+# Provider-anchored context accounting and overflow recovery
+
+## What changed
+
+Tau now anchors active context accounting to the latest applicable successful
+assistant response's provider-reported usage. It estimates only messages and
+dynamically added tools after that response. The existing character-based
+estimate remains the fallback when no valid provider usage is available.
+
+The TUI also treats a recognized context-overflow response as provisional while
+the coding session compacts and retries. It shows recovery progress and only
+surfaces the provider error if compaction or retry cannot recover. The low-level
+`agent_end` event no longer settles session-driven TUI runs; `agent_settled`
+remains the final boundary.
+
+## Why
+
+Character-only accounting can substantially undercount token-dense tool output,
+provider framing, and opaque reasoning state. In a production Codex session,
+the provider reported almost 397K processed tokens while Tau displayed a much
+smaller estimate, so proactive compaction did not run.
+
+A provider overflow is stronger evidence than a local estimate. Tau's existing
+overflow path already bypassed the threshold and retried once, but the TUI
+rendered its intermediate provider error as terminal before recovery completed.
+
+## Pi mapping
+
+This follows Pi's hybrid accounting in `packages/ai/src/utils/estimate.ts`:
+provider usage describes a valid context prefix and deterministic estimation
+covers only the trailing messages. Errored, aborted, zero-usage, and stale
+pre-compaction responses cannot anchor the count.
+
+It also preserves Pi's lifecycle distinction: `agent_end` closes one low-level
+agent run, while `agent_settled` means no compaction, retry, or queued continuation
+remains.
+
+## Validation
+
+Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+Manual check:
+
+1. Start a long Codex subscription session and run `/session` after a successful
+   turn. Confirm it shows a provider token basis plus estimated trailing tokens.
+2. Trigger a context overflow with automatic compaction enabled.
+3. Confirm the TUI shows `Context limit reached; compacting and retrying` and no
+   terminal error when retry succeeds.
+4. Make summarization fail and confirm the original overflow becomes visible.

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -439,12 +439,19 @@ def _status_command(context: CommandContext) -> CommandResult:
     if discovery_error:
         lines.append(f"Model limit discovery: unavailable ({discovery_error})")
     if context_usage is not None:
-        lines.append(
-            "Context token breakdown: "
-            f"system={context_usage.system_tokens}, "
-            f"messages={context_usage.message_tokens}, "
-            f"tools={context_usage.tool_tokens}",
-        )
+        if context_usage.uses_provider_usage:
+            lines.append(
+                "Context token basis: "
+                f"provider={context_usage.provider_tokens}, "
+                f"estimated trailing={context_usage.trailing_tokens}",
+            )
+        else:
+            lines.append(
+                "Context token breakdown: "
+                f"system={context_usage.system_tokens}, "
+                f"messages={context_usage.message_tokens}, "
+                f"tools={context_usage.tool_tokens}",
+            )
     lines.extend(_thinking_status_lines(session))
     lines.append(f"Resource diagnostics: {len(session.resource_diagnostics)}")
     if session.auto_compact_token_threshold is not None:

--- a/src/tau_coding/context_window.py
+++ b/src/tau_coding/context_window.py
@@ -108,7 +108,7 @@ TURN_PREFIX_SUMMARIZATION_PROMPT = (
 
 @dataclass(frozen=True, slots=True)
 class ContextUsageEstimate:
-    """Deterministic context-size accounting for one provider request."""
+    """Best available context-size accounting for one provider request."""
 
     total_tokens: int
     system_tokens: int
@@ -116,6 +116,13 @@ class ContextUsageEstimate:
     tool_tokens: int
     message_count: int
     tool_count: int
+    provider_tokens: int = 0
+    trailing_tokens: int = 0
+
+    @property
+    def uses_provider_usage(self) -> bool:
+        """Return whether a provider-reported usage block anchors this estimate."""
+        return self.provider_tokens > 0
 
 
 def estimate_text_tokens(text: str) -> int:
@@ -170,13 +177,77 @@ def auto_compaction_threshold_for_context_window(context_window_tokens: int) -> 
     return max(1, context_window_tokens - DEFAULT_COMPACTION_RESERVE_TOKENS)
 
 
+def provider_context_tokens(message: AssistantMessage) -> int:
+    """Return the provider-reported context represented by an assistant response."""
+    usage = message.usage
+    return usage.total_tokens or (usage.input + usage.output + usage.cache_read + usage.cache_write)
+
+
+def _last_applicable_provider_usage(
+    messages: tuple[AgentMessage, ...],
+) -> tuple[int, int] | None:
+    """Find the latest valid usage block that still describes the active prefix.
+
+    A newer prefix message can be inserted by compaction or history rewriting. In that
+    case an older assistant's usage describes the pre-rewrite context and must not be
+    reused.
+    """
+    latest_prefix_timestamp = -1
+    usage_info: tuple[int, int] | None = None
+    for index, message in enumerate(messages):
+        if isinstance(message, AssistantMessage):
+            tokens = provider_context_tokens(message)
+            if (
+                message.timestamp >= latest_prefix_timestamp
+                and message.stop_reason not in {"aborted", "error"}
+                and tokens > 0
+            ):
+                usage_info = (index, tokens)
+        latest_prefix_timestamp = max(latest_prefix_timestamp, message.timestamp)
+    return usage_info
+
+
 def estimate_context_usage(
     *,
     system: str,
     messages: tuple[AgentMessage, ...],
     tools: tuple[AgentTool, ...],
 ) -> ContextUsageEstimate:
-    """Return deterministic context accounting for the active provider request."""
+    """Return provider-anchored context accounting with a deterministic fallback.
+
+    Provider usage is authoritative for the prefix represented by the latest successful
+    assistant response. Only messages and dynamically added tools after that response
+    are estimated. Without applicable usage, the whole request uses the character-based
+    fallback.
+    """
+    usage_info = _last_applicable_provider_usage(messages)
+    if usage_info is not None:
+        usage_index, provider_tokens = usage_info
+        trailing_messages = messages[usage_index + 1 :]
+        trailing_message_tokens = sum(
+            estimate_message_tokens(message) for message in trailing_messages
+        )
+        added_tool_names = {
+            name
+            for message in trailing_messages
+            if isinstance(message, ToolResultMessage) and message.added_tool_names
+            for name in message.added_tool_names
+        }
+        added_tool_tokens = sum(
+            estimate_tool_tokens(tool) for tool in tools if tool.name in added_tool_names
+        )
+        trailing_tokens = trailing_message_tokens + added_tool_tokens
+        return ContextUsageEstimate(
+            total_tokens=provider_tokens + trailing_tokens,
+            system_tokens=0,
+            message_tokens=trailing_message_tokens,
+            tool_tokens=added_tool_tokens,
+            message_count=len(messages),
+            tool_count=len(tools),
+            provider_tokens=provider_tokens,
+            trailing_tokens=trailing_tokens,
+        )
+
     system_tokens = estimate_text_tokens(system)
     message_tokens = sum(estimate_message_tokens(message) for message in messages)
     tool_tokens = sum(estimate_tool_tokens(tool) for tool in tools)
@@ -187,6 +258,7 @@ def estimate_context_usage(
         tool_tokens=tool_tokens,
         message_count=len(messages),
         tool_count=len(tools),
+        trailing_tokens=system_tokens + message_tokens + tool_tokens,
     )
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -648,8 +648,13 @@ class CodingSession:
 
     @property
     def context_token_estimate(self) -> int:
-        """Return a rough token estimate for the active provider context."""
+        """Return the best available token count for the active provider context."""
         return self.context_usage.total_tokens
+
+    @property
+    def has_provider_context_usage(self) -> bool:
+        """Return whether valid provider usage anchors the active context count."""
+        return self.context_usage.uses_provider_usage
 
     @property
     def context_usage(self) -> ContextUsageEstimate:

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -12,7 +12,15 @@ from tau_agent.events import (
 )
 from tau_agent.messages import AssistantMessage, CustomMessage, ToolCall, UserMessage
 from tau_ai.events import TextDeltaEvent, ThinkingDeltaEvent
-from tau_coding.events import AutoRetryStartEvent, CodingSessionEvent, QueueUpdateEvent
+from tau_coding.events import (
+    AutoRetryStartEvent,
+    CodingSessionEvent,
+    CompactionEndEvent,
+    CompactionStartEvent,
+    QueueUpdateEvent,
+    SessionAgentEndEvent,
+)
+from tau_coding.session import is_context_overflow_error
 from tau_coding.tui.state import TuiState
 
 
@@ -20,6 +28,7 @@ class TuiEventAdapter:
     def __init__(self, state: TuiState) -> None:
         self.state = state
         self._assistant_start_item_index: int | None = None
+        self._pending_overflow_error: AssistantMessage | None = None
 
     def apply(self, event: CodingSessionEvent) -> None:
         if isinstance(event, AgentStartEvent):
@@ -27,11 +36,19 @@ class TuiEventAdapter:
             self.state.error = None
             return
         if isinstance(event, AgentEndEvent):
+            # A bare harness event is terminal for legacy/direct adapter callers.
             self._flush()
             self.state.running = False
             return
+        if isinstance(event, SessionAgentEndEvent):
+            # Session orchestration may still compact, retry, or drain queued work.
+            self._flush()
+            return
         if event.type == "agent_settled":
             self._flush()
+            if self._pending_overflow_error is not None:
+                self.state.add_assistant_error(self._pending_overflow_error)
+                self._pending_overflow_error = None
             self.state.running = False
             return
         if isinstance(event, QueueUpdateEvent):
@@ -66,9 +83,15 @@ class TuiEventAdapter:
                 if start is not None:
                     del self.state.items[start:]
                 if message.stop_reason in {"error", "aborted"}:
-                    self.state.add_assistant_error(message)
-                    self.state.running = False
+                    if is_context_overflow_error(message):
+                        # Keep the provider failure provisional while session-level
+                        # overflow compaction and retry are still in progress.
+                        self._pending_overflow_error = message
+                    else:
+                        self.state.add_assistant_error(message)
+                        self.state.running = False
                 else:
+                    self._pending_overflow_error = None
                     self.state.add_assistant_message(message, include_tool_calls=False)
                 self.state.assistant_buffer = ""
                 self._assistant_start_item_index = None
@@ -89,6 +112,14 @@ class TuiEventAdapter:
                 event.result,
                 event.is_error,
             )
+            return
+        if isinstance(event, CompactionStartEvent) and event.reason == "overflow":
+            self.state.add_item("status", "… Context limit reached; compacting and retrying")
+            return
+        if isinstance(event, CompactionEndEvent) and event.reason == "overflow":
+            if (event.aborted or event.error_message) and self._pending_overflow_error is not None:
+                self.state.add_assistant_error(self._pending_overflow_error)
+                self._pending_overflow_error = None
             return
         if isinstance(event, AutoRetryStartEvent):
             self.state.add_item("status", f"… {event.error_message}")

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -88,6 +88,9 @@ class TuiEventAdapter:
                         # overflow compaction and retry are still in progress.
                         self._pending_overflow_error = message
                     else:
+                        # Successful overflow compaction makes the retry failure the
+                        # only terminal error worth presenting.
+                        self._pending_overflow_error = None
                         self.state.add_assistant_error(message)
                         self.state.running = False
                 else:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -77,6 +77,8 @@ from tau_coding.events import (
     AgentSettledEvent,
     AutoRetryStartEvent,
     CodingSessionEvent,
+    CompactionEndEvent,
+    CompactionStartEvent,
     QueueUpdateEvent,
 )
 from tau_coding.extensions.api import (
@@ -4627,6 +4629,12 @@ class TauTuiApp(App[None]):
                 ):
                     _attach_diagnostic_log_path_to_error(self.state, self.session)
                     _attach_retry_hint_to_error(self.state, event.message)
+                elif (
+                    isinstance(event, CompactionEndEvent)
+                    and event.reason == "overflow"
+                    and (event.aborted or event.error_message)
+                ):
+                    _attach_diagnostic_log_path_to_error(self.state, self.session)
                 await self._apply_streaming_transcript_event(event)
                 if isinstance(event, AgentSettledEvent) and not self._app_has_focus:
                     self._terminal_notification.notify_turn_finished()
@@ -4743,15 +4751,23 @@ class TauTuiApp(App[None]):
                 )
             self._refresh_chrome()
             return
-        if isinstance(event, AutoRetryStartEvent):
+        if isinstance(event, (AutoRetryStartEvent, CompactionStartEvent)):
             await transcript.finish_assistant_message()
-            if self.state.items:
+            if self.state.items and (
+                isinstance(event, AutoRetryStartEvent) or event.reason == "overflow"
+            ):
                 await transcript.append_item(
                     self.state.items[-1],
                     theme=theme,
                     show_tool_results=self.state.show_tool_results,
                 )
             self._refresh_chrome()
+            return
+        if isinstance(event, CompactionEndEvent):
+            if event.reason == "overflow" and (event.aborted or event.error_message):
+                self._refresh()
+            else:
+                self._refresh_chrome()
             return
         if isinstance(event, ToolExecutionEndEvent):
             updated_item = self.state.find_tool_item(event.tool_call_id)

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1998,7 +1998,7 @@ def _plain_text(text: str, *, body_style: str) -> Text:
 def _context_usage(session: SessionSummarySource) -> str:
     threshold = session.auto_compact_token_threshold
     limit = session.context_window_tokens if threshold is None or threshold <= 0 else threshold
-    return f"{_compact_token_count(session.context_token_estimate)}/{_compact_token_count(limit)}"
+    return f"~{_compact_token_count(session.context_token_estimate)}/{_compact_token_count(limit)}"
 
 
 def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -162,6 +162,7 @@ def _session_summary_fingerprint(
         session.model,
         session.thinking_level,
         session.context_token_estimate,
+        session.has_provider_context_usage,
         session.auto_compact_token_threshold,
         session.context_window_tokens,
         session.session_title,

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -80,6 +80,9 @@ class SessionSummarySource(Protocol):
     def context_token_estimate(self) -> int: ...
 
     @property
+    def has_provider_context_usage(self) -> bool: ...
+
+    @property
     def auto_compact_token_threshold(self) -> int | None: ...
 
     @property
@@ -1998,7 +2001,12 @@ def _plain_text(text: str, *, body_style: str) -> Text:
 def _context_usage(session: SessionSummarySource) -> str:
     threshold = session.auto_compact_token_threshold
     limit = session.context_window_tokens if threshold is None or threshold <= 0 else threshold
-    return f"~{_compact_token_count(session.context_token_estimate)}/{_compact_token_count(limit)}"
+    used = (
+        _compact_token_count(session.context_token_estimate)
+        if session.has_provider_context_usage
+        else "?"
+    )
+    return f"{used}/{_compact_token_count(limit)}"
 
 
 def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -20,6 +20,7 @@ from tau_agent import (
     ThinkingContent,
     ToolCall,
     ToolResultMessage,
+    Usage,
     UserMessage,
 )
 from tau_agent.messages import AssistantMessageDiagnostic, assistant_content
@@ -2713,6 +2714,61 @@ async def test_session_auto_compacts_after_response_when_threshold_is_exceeded(
             UserMessage(content="Next."),
         ],
     )
+
+
+@pytest.mark.anyio
+async def test_session_auto_compacts_from_provider_reported_usage(
+    tmp_path: Path,
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                assistant_done(
+                    message=AssistantMessage(
+                        content="First answer",
+                        usage=Usage(total_tokens=1_000),
+                        timestamp=2_000_000_000_000,
+                    )
+                ),
+            ],
+            [
+                assistant_start(model="fake"),
+                assistant_done(
+                    message=AssistantMessage(
+                        content="Second answer",
+                        usage=Usage(total_tokens=60_000),
+                        timestamp=2_000_000_000_001,
+                    )
+                ),
+            ],
+            [
+                assistant_start(model="fake"),
+                assistant_done(message=AssistantMessage(content="Provider-usage summary")),
+            ],
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            auto_compact_token_threshold=50_000,
+        )
+    )
+
+    # The first turn is large enough to provide a compaction cut point, while its
+    # character estimate remains below the configured 50k threshold.
+    await _collect_session_events(session.prompt("First prompt.\n" + ("old " * 25_000)))
+    assert session.context_usage.provider_tokens == 1_000
+    await _collect_session_events(session.prompt("Second short prompt."))
+
+    compactions = [entry for entry in await storage.read_all() if entry.type == "compaction"]
+    assert len(compactions) == 1
+    assert compactions[0].summary == "Provider-usage summary"
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2764,6 +2764,7 @@ async def test_session_auto_compacts_from_provider_reported_usage(
     # character estimate remains below the configured 50k threshold.
     await _collect_session_events(session.prompt("First prompt.\n" + ("old " * 25_000)))
     assert session.context_usage.provider_tokens == 1_000
+    assert session.has_provider_context_usage is True
     await _collect_session_events(session.prompt("Second short prompt."))
 
     compactions = [entry for entry in await storage.read_all() if entry.type == "compaction"]

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from tau_agent import AssistantMessage, TextContent, ToolCall, ToolResultMessage, UserMessage
+from tau_agent import AssistantMessage, TextContent, ToolCall, ToolResultMessage, Usage, UserMessage
 from tau_agent.messages import assistant_content
 from tau_coding.context_window import (
     ContextUsageEstimate,
@@ -51,6 +51,53 @@ def test_context_token_estimate_includes_system_messages_and_tools(tmp_path: Pat
     )
 
     assert estimate > estimate_text_tokens("You are Tau.hellohi")
+
+
+def test_context_usage_uses_latest_provider_report_and_estimates_only_trailing_messages() -> None:
+    reported = AssistantMessage(
+        content="answer",
+        usage=Usage(input=70_000, output=2_000, cache_read=28_000, total_tokens=100_000),
+        timestamp=200,
+    )
+    trailing = UserMessage(content="follow up", timestamp=300)
+
+    usage = estimate_context_usage(
+        system="ignored because provider usage includes it",
+        messages=(UserMessage(content="large history", timestamp=100), reported, trailing),
+        tools=(),
+    )
+
+    assert usage.uses_provider_usage is True
+    assert usage.provider_tokens == 100_000
+    assert usage.trailing_tokens == estimate_message_tokens(trailing)
+    assert usage.total_tokens == 100_000 + usage.trailing_tokens
+
+
+def test_context_usage_ignores_stale_provider_report_after_newer_prefix_is_inserted() -> None:
+    stale = AssistantMessage(
+        content="old answer",
+        usage=Usage(total_tokens=100_000),
+        timestamp=100,
+    )
+    summary = UserMessage(content="Previous conversation summary", timestamp=200)
+
+    usage = estimate_context_usage(system="system", messages=(summary, stale), tools=())
+
+    assert usage.uses_provider_usage is False
+    assert usage.total_tokens < 100_000
+
+
+def test_context_usage_ignores_error_response_usage() -> None:
+    failed = AssistantMessage(
+        stop_reason="error",
+        error_message="failed",
+        usage=Usage(total_tokens=100_000),
+    )
+
+    usage = estimate_context_usage(system="system", messages=(failed,), tools=())
+
+    assert usage.uses_provider_usage is False
+    assert usage.total_tokens < 100_000
 
 
 def test_auto_compaction_threshold_keeps_pi_style_reserve() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -17,7 +17,12 @@ from tau_agent import (
     UserMessage,
 )
 from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
-from tau_coding.events import AutoRetryStartEvent, QueueUpdateEvent
+from tau_coding.events import (
+    AgentSettledEvent,
+    AutoRetryStartEvent,
+    QueueUpdateEvent,
+    SessionAgentEndEvent,
+)
 from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.tui import TuiEventAdapter, TuiState
 from tau_coding.tui.state import format_tool_call_block, format_tool_result_block
@@ -35,6 +40,18 @@ def test_tui_adapter_tracks_running_state() -> None:
     assert state.running is True
 
     adapter.apply(AgentEndEvent())
+    assert state.running is False
+
+
+def test_tui_adapter_waits_for_session_settlement_after_low_level_agent_end() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+
+    adapter.apply(AgentStartEvent())
+    adapter.apply(SessionAgentEndEvent())
+    assert state.running is True
+
+    adapter.apply(AgentSettledEvent())
     assert state.running is False
 
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -20,6 +20,8 @@ from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
 from tau_coding.events import (
     AgentSettledEvent,
     AutoRetryStartEvent,
+    CompactionEndEvent,
+    CompactionStartEvent,
     QueueUpdateEvent,
     SessionAgentEndEvent,
 )
@@ -53,6 +55,35 @@ def test_tui_adapter_waits_for_session_settlement_after_low_level_agent_end() ->
 
     adapter.apply(AgentSettledEvent())
     assert state.running is False
+
+
+def test_tui_adapter_replaces_recovered_overflow_with_terminal_retry_error() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    overflow = AssistantMessage(
+        stop_reason="error",
+        error_message="prompt is too long: context window exceeded",
+    )
+    retry_error = AssistantMessage(
+        stop_reason="error",
+        error_message="authentication failed: API token expired",
+    )
+
+    adapter.apply(AgentStartEvent())
+    adapter.apply(MessageEndEvent(message=overflow))
+    adapter.apply(SessionAgentEndEvent())
+    adapter.apply(CompactionStartEvent(reason="overflow"))
+    adapter.apply(CompactionEndEvent(reason="overflow", will_retry=True))
+    adapter.apply(AgentStartEvent())
+    adapter.apply(MessageEndEvent(message=retry_error))
+    adapter.apply(SessionAgentEndEvent())
+    adapter.apply(AgentSettledEvent())
+
+    error_items = [item for item in state.items if item.role == "error"]
+    assert len(error_items) == 1
+    assert error_items[0].text == "Error: authentication failed: API token expired"
+    assert state.error == "authentication failed: API token expired"
+    assert "context window exceeded" not in state.error
 
 
 def test_tui_adapter_builds_assistant_item_from_nested_stream_events() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -121,6 +121,7 @@ from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
     TRANSCRIPT_WINDOW_ITEMS,
     TRANSCRIPT_WINDOW_OVERSCAN_ITEMS,
+    CompactSessionInfo,
     LeftAlignedMarkdownHeading,
     StreamingTranscriptMessageWidget,
     TauMarkdownBlock,
@@ -733,6 +734,28 @@ def test_compact_session_info_shows_unknown_without_provider_usage() -> None:
     console.print(render_compact_session_info(session))
 
     assert "?/200k" in console.export_text()
+
+
+def test_compact_session_info_redraws_when_provider_usage_becomes_available() -> None:
+    session = FakeSession()
+    session.has_provider_context_usage = False
+    widget = CompactSessionInfo()
+    updates: list[object] = []
+    widget.update = updates.append  # type: ignore[method-assign]
+
+    widget.update_from_session(session)
+    first_console = Console(record=True, width=120)
+    first_console.print(updates[-1])
+    assert "?/200k" in first_console.export_text()
+
+    session.has_provider_context_usage = True
+    widget.update_from_session(session)
+    assert len(updates) == 2
+    second_console = Console(record=True, width=120)
+    second_console.print(updates[-1])
+    second_output = second_console.export_text()
+    assert "12k/200k" in second_output
+    assert "?/200k" not in second_output
 
 
 def test_compact_session_info_styles_provider_as_metadata() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -187,6 +187,7 @@ class FakeSession:
             ProjectContextFile(path=str(self.cwd / "AGENTS.md"), content="Follow rules."),
         )
         self.context_token_estimate = 12034
+        self.has_provider_context_usage = True
         self.auto_compact_token_threshold = 200000
         self.context_window_tokens = 216384
         self.thinking_level = "medium"
@@ -716,12 +717,22 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
     output = console.export_text()
     lines = output.splitlines()
     provider_line = next(index for index, line in enumerate(lines) if "openai:fake-model" in line)
-    context_line = next(index for index, line in enumerate(lines) if "~12k/200k" in line)
+    context_line = next(index for index, line in enumerate(lines) if "12k/200k" in line)
     assert "/workspace/project (--)" in output
-    assert "context ~12k/200k" not in output
+    assert "context 12k/200k" not in output
     assert "openai:fake-model" in lines[provider_line]
     assert "(medium)" in lines[provider_line]
     assert context_line == provider_line + 1
+
+
+def test_compact_session_info_shows_unknown_without_provider_usage() -> None:
+    console = Console(record=True, width=120)
+    session = FakeSession()
+    session.has_provider_context_usage = False
+
+    console.print(render_compact_session_info(session))
+
+    assert "?/200k" in console.export_text()
 
 
 def test_compact_session_info_styles_provider_as_metadata() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -50,6 +50,7 @@ from tau_coding.events import (
     CompactionEndEvent,
     CompactionStartEvent,
     QueueUpdateEvent,
+    SessionAgentEndEvent,
 )
 from tau_coding.paths import TauPaths
 from tau_coding.prompt_templates import PromptTemplate
@@ -7506,7 +7507,7 @@ async def test_tui_prompt_worker_shows_diagnostic_log_path_for_error_event(tmp_p
 
 
 @pytest.mark.anyio
-async def test_tui_prompt_worker_skips_retry_hint_for_context_overflow() -> None:
+async def test_tui_prompt_worker_shows_recovery_status_instead_of_overflow_error() -> None:
     class OverflowSession(FakeSession):
         def __init__(self) -> None:
             super().__init__(
@@ -7518,7 +7519,13 @@ async def test_tui_prompt_worker_skips_retry_hint_for_context_overflow() -> None
                             error_message="prompt is too long: context window exceeded",
                         )
                     ),
-                    AgentEndEvent(),
+                    SessionAgentEndEvent(will_retry=False),
+                    CompactionStartEvent(reason="overflow"),
+                    CompactionEndEvent(reason="overflow", will_retry=True),
+                    AgentStartEvent(),
+                    MessageEndEvent(message=AssistantMessage(content="Recovered answer")),
+                    SessionAgentEndEvent(will_retry=False),
+                    AgentSettledEvent(),
                 ]
             )
 
@@ -7528,9 +7535,42 @@ async def test_tui_prompt_worker_skips_retry_hint_for_context_overflow() -> None
 
     await app._run_prompt("break")
 
-    assert app.state.error == "prompt is too long: context window exceeded"
+    assert app.state.error is None
+    assert not any(item.role == "error" for item in app.state.items)
+    assert any(
+        item.role == "status" and "compacting and retrying" in item.text for item in app.state.items
+    )
+    assert app.state.items[-1].text == "Recovered answer"
+    assert app.state.running is False
+
+
+@pytest.mark.anyio
+async def test_tui_prompt_worker_surfaces_overflow_when_compaction_fails() -> None:
+    message = AssistantMessage(
+        stop_reason="error",
+        error_message="prompt is too long: context window exceeded",
+    )
+    session = FakeSession(
+        events=[
+            AgentStartEvent(),
+            MessageEndEvent(message=message),
+            SessionAgentEndEvent(will_retry=False),
+            CompactionStartEvent(reason="overflow"),
+            CompactionEndEvent(
+                reason="overflow",
+                error_message="Overflow compaction failed",
+            ),
+            AgentSettledEvent(),
+        ]
+    )
+    app = TauTuiApp(session)
+    app._refresh = lambda: None  # type: ignore[method-assign]
+
+    await app._run_prompt("break")
+
+    assert app.state.error is not None
+    assert "context window exceeded" in app.state.error
     assert app.state.items[-1].role == "error"
-    assert app.state.items[-1].text == "Error: prompt is too long: context window exceeded"
     assert app.state.running is False
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -716,9 +716,9 @@ def test_compact_session_info_renders_sidebar_facts() -> None:
     output = console.export_text()
     lines = output.splitlines()
     provider_line = next(index for index, line in enumerate(lines) if "openai:fake-model" in line)
-    context_line = next(index for index, line in enumerate(lines) if "12k/200k" in line)
+    context_line = next(index for index, line in enumerate(lines) if "~12k/200k" in line)
     assert "/workspace/project (--)" in output
-    assert "context 12k/200k" not in output
+    assert "context ~12k/200k" not in output
     assert "openai:fake-model" in lines[provider_line]
     assert "(medium)" in lines[provider_line]
     assert context_line == provider_line + 1

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -20,10 +20,18 @@ Context token breakdown: system=<count>, messages=<count>, tools=<count>
 Thinking mode: <mode>
 ```
 
-The estimate is deterministic (roughly `characters / 4` plus small per-message
-and per-tool overhead), not a provider tokenizer — treat it as approximate. It
-covers the system prompt, project context (`AGENTS.md`), skill metadata, the
-active message history, and tool schemas.
+After a successful model response, Tau uses the provider-reported token usage as
+the authoritative size of the context processed by that response, then estimates
+only messages added afterward. Before the first response, immediately after
+compaction, or when no valid usage is available, Tau falls back to a deterministic
+estimate (roughly `characters / 4` plus small per-message and per-tool overhead).
+The fallback covers the system prompt, project context (`AGENTS.md`), skill
+metadata, active message history, and tool schemas.
+
+`/session` reports `Context token basis: provider=<count>, estimated
+trailing=<count>` when provider usage anchors the active count. Otherwise it shows
+the fallback system/message/tool breakdown. Provider usage from errored or aborted
+responses is not trusted.
 
 This is different from **cumulative usage** in the sidebar. Cumulative usage adds
 the provider-reported input and output tokens from every request on the active
@@ -39,7 +47,8 @@ model's context window. It checks three moments:
 
 - before a new prompt (to catch context added out-of-band),
 - after a successful turn (to compact before your next turn), and
-- after a context-overflow error (compact and retry once).
+- after a context-overflow error (force compaction regardless of the local estimate,
+  then retry once).
 
 When it compacts, Tau asks the model to summarize older messages, keeps a recent
 suffix of the conversation, and continues. The original session file is never
@@ -55,8 +64,10 @@ You can override the resulting threshold for a run:
 tau --auto-compact-threshold 100000
 ```
 
-Automatic compaction is best-effort: if summarization fails, Tau logs it, keeps
-the original context, and carries on.
+Automatic compaction is best-effort: if summarization fails, Tau logs it and keeps
+the original context. During successful overflow recovery, the TUI shows compaction
+and retry progress instead of presenting the intermediate provider rejection as a
+terminal error. The error becomes visible only if recovery cannot complete.
 
 ## Manual compaction
 

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -9,9 +9,10 @@ history) and lets you tune how hard the model works with **thinking modes**.
 
 ## Seeing context usage
 
-The compact status below the TUI prompt shows the approximate active context as
-`~used/limit`; the `~` marks the count as approximate. Run `/session` to see its
-detailed basis or fallback breakdown:
+The compact status below the TUI prompt shows provider-anchored active context as
+`used/limit`. When no valid provider usage exists yet, it shows `?/limit` instead
+of presenting the fallback estimate as provider-confirmed usage. Run `/session`
+to see the detailed provider basis or fallback estimate:
 
 ```text
 Estimated context tokens: <count>

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -10,7 +10,8 @@ history) and lets you tune how hard the model works with **thinking modes**.
 ## Seeing context usage
 
 The compact status below the TUI prompt shows the approximate active context as
-`used/limit`. Run `/session` to see its detailed breakdown:
+`~used/limit`; the `~` marks the count as approximate. Run `/session` to see its
+detailed basis or fallback breakdown:
 
 ```text
 Estimated context tokens: <count>

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -179,8 +179,10 @@ the provider's cache. Tau hides the figure entirely for providers that do not
 report cache usage.
 
 The compact status block below the prompt puts `provider:model (thinking)` on its
-first line and the approximate active context as `used/limit` on the second.
-Unlike cumulative usage, this estimate describes the system prompt, tools,
+first line and the approximate active context as `~used/limit` on the second. The
+`~` makes clear that active usage can include estimated trailing content even when
+provider-reported usage anchors most of the count. Unlike cumulative usage, this
+estimate describes the system prompt, tools,
 and active messages Tau expects to send on the next request. It can decrease
 after compaction while cumulative usage continues to increase. The
 working-directory name and model are emphasized while the parent path, Git

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -179,10 +179,10 @@ the provider's cache. Tau hides the figure entirely for providers that do not
 report cache usage.
 
 The compact status block below the prompt puts `provider:model (thinking)` on its
-first line and the approximate active context as `~used/limit` on the second. The
-`~` makes clear that active usage can include estimated trailing content even when
-provider-reported usage anchors most of the count. Unlike cumulative usage, this
-estimate describes the system prompt, tools,
+first line and provider-anchored active context as `used/limit` on the second. When
+no valid provider usage exists yet, such as immediately after compaction, it shows
+`?/limit` until a fresh response reports usage. Unlike cumulative usage, this
+active count describes the system prompt, tools,
 and active messages Tau expects to send on the next request. It can decrease
 after compaction while cumulative usage continues to increase. The
 working-directory name and model are emphasized while the parent path, Git


### PR DESCRIPTION
## Problem

Tau used a rough `characters / 4` calculation for the entire active conversation. That estimate can be much too low for long, tool-heavy sessions, especially when the provider also replays token-dense JSON and opaque reasoning state.

This caused a real Codex session to behave badly:

1. Codex reported that the previous response had processed about 397K tokens.
2. Tau's lower local estimate did not trigger proactive compaction.
3. The next request exceeded the provider's context limit.
4. Tau automatically compacted and retried, but the TUI displayed the temporary provider rejection as a terminal error.
5. The user reasonably believed the run had stopped and sent an unnecessary `continue` message.

The TUI also treated a low-level `agent_end` event as the end of all work, even though session-level compaction and retry could still be running.

## Solution

### Use provider token usage as the source of truth

After a successful response, Tau now uses the provider-reported token usage as the authoritative size of the context processed by that response. It estimates only messages and dynamically added tools that came afterward.

The existing `characters / 4` calculation remains a fallback when provider usage is unavailable or cannot safely describe the active context, such as after compaction or after an errored/aborted response.

This follows Pi's hybrid accounting model:

```text
active context = latest valid provider usage + estimated trailing content
```

As a result, a large provider-reported context can trigger proactive compaction even when Tau's character estimate would have undercounted it.

### Present overflow recovery as recovery, not failure

A recognized context-overflow error is now provisional while Tau's existing automatic recovery runs. The TUI shows:

```text
… Context limit reached; compacting and retrying
```

If compaction and retry succeed, the intermediate provider error is never shown as a terminal error. If recovery fails, Tau still surfaces the relevant failure:

- the original overflow when compaction fails;
- the retry's error when compaction succeeded but the retry failed for another reason.

### Wait for full session settlement

For session-driven runs, the TUI no longer treats low-level `agent_end` as final. It remains active until `agent_settled`, which means no compaction, retry, or queued continuation remains.

### Show whether provider usage is known

The compact status follows Pi's behavior. Once a valid provider response supplies usage, it shows:

```text
31.9K/244.8K
```

When no valid provider usage exists yet, such as immediately after compaction, it shows:

```text
?/244.8K
```

This avoids presenting the character-based fallback as provider-confirmed usage. `/session` still exposes the detailed fallback estimate for diagnostics and compaction decisions.

## User experience

Long sessions should compact before reaching the provider limit more reliably. If an overflow still occurs, users see automatic recovery progress instead of a misleading red error, and they no longer need to send a message just to restart work that Tau is already continuing.

## Scope

Addresses the production Codex overflow investigated from session `a0864c44eacd4db4a9a9a9765907e9c3`. No numbered issue is currently linked.

## Manual validation

1. Start or resume a long Codex subscription session.
2. After a successful turn, run `/session`.
3. Confirm it reports:
   ```text
   Context token basis: provider=<count>, estimated trailing=<count>
   ```
4. Confirm the compact status uses `used/limit` when provider usage is valid and `?/limit` when it is unavailable.
5. Trigger a context overflow with automatic compaction enabled.
6. Confirm the TUI shows compaction/retry progress and no terminal error when recovery succeeds.
7. Make compaction fail and confirm the original overflow becomes visible.
8. Let compaction succeed but make the retry fail differently; confirm only the retry failure is shown.

## Validation performed

- `uv run pytest` — 1300 passed, 2 Windows-only tests skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- GitHub Python checks passed
- GitHub documentation build passed


