### PR TITLE
Add system prompt CLI controls

### DIFF
--- a/dev-notes/system-prompt-cli-controls.md
+++ b/dev-notes/system-prompt-cli-controls.md
@@ -1,0 +1,53 @@
+# Explicit system-prompt CLI controls
+
+Issue: https://github.com/huggingface/tau/issues/530
+
+## What changed
+
+Tau now exposes Pi-compatible startup controls:
+
+```bash
+tau --system-prompt "Custom base" \
+  --append-system-prompt ./shared-rules.md \
+  --append-system-prompt "Local rule" \
+  -p "review this"
+```
+
+`--system-prompt TEXT_OR_PATH` replaces the generated base. The repeatable
+`--append-system-prompt TEXT_OR_PATH` values retain command-line order and are
+joined with `\n\n` (exactly one blank line). As with Tau's other options, these
+recognized flags must precede positional prompt text.
+
+## Resolution and errors
+
+Each option value is resolved independently. Tau expands `~`; if the resulting
+path exists, Tau reads it as UTF-8. If it does not exist, the original value is
+literal prompt text. Existing directories, unreadable files, and invalid UTF-8
+files fail startup with a concise diagnostic containing both the option and
+path. This matches Pi's file-when-existing, literal-otherwise policy without
+adding automatic prompt-file discovery.
+
+## Architecture and resume behavior
+
+Resolution belongs to `tau_coding.cli`. The resolved values flow through print
+mode or the Textual adapter into `CodingSessionConfig.custom_system_prompt` and
+`append_system_prompt`. They deliberately do not use `CodingSessionConfig.system`,
+which is an exact low-level override. Therefore a custom base still receives
+append text, project context, eligible skills when `read` is available, date,
+and cwd from the existing prompt builder.
+
+The same values are supplied when `--session` resumes a TUI session, so its next
+provider request uses the startup override. Prompt controls are not written into
+session JSONL; callers must supply them again on a later resume.
+
+Out of scope: automatic `SYSTEM.md` discovery, extension runtime overrides, and
+export behavior.
+
+## Verification
+
+```bash
+uv run pytest tests/test_cli.py tests/test_tui_app.py tests/test_system_prompt.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -237,6 +237,22 @@ def main(
             help="Set the exact id for the newly created print-mode session.",
         ),
     ] = None,
+    system_prompt: Annotated[
+        str | None,
+        typer.Option(
+            "--system-prompt",
+            metavar="TEXT_OR_PATH",
+            help="Replace the default system-prompt base with literal text or a UTF-8 file.",
+        ),
+    ] = None,
+    append_system_prompt: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--append-system-prompt",
+            metavar="TEXT_OR_PATH",
+            help="Append literal text or a UTF-8 file to the system prompt (repeatable).",
+        ),
+    ] = None,
     auto_compact_threshold: Annotated[
         int | None,
         typer.Option(
@@ -368,6 +384,12 @@ def main(
         raise typer.Exit()
 
     extension_paths = tuple(extension or ())
+    custom_system_prompt = (
+        _resolve_prompt_input(system_prompt, option="--system-prompt")
+        if system_prompt is not None
+        else None
+    )
+    resolved_append_system_prompt = _resolve_append_system_prompts(append_system_prompt or ())
 
     if not print_requested:
         notice = _startup_update_notice()
@@ -385,6 +407,8 @@ def main(
                 extension_paths,
                 not no_extensions,
                 project_extensions,
+                custom_system_prompt,
+                resolved_append_system_prompt,
             )
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -416,6 +440,8 @@ def main(
             not no_extensions,
             project_extensions,
             session_id,
+            custom_system_prompt,
+            resolved_append_system_prompt,
         )
     except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -435,6 +461,8 @@ async def run_openai_tui(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    custom_system_prompt: str | None = None,
+    append_system_prompt: str | None = None,
 ) -> str | None:
     """Run the Textual TUI and return its resumable session id, if any."""
     release_notes_notice = startup_release_notes_notice(_current_version())
@@ -452,6 +480,8 @@ async def run_openai_tui(
         extension_paths=extension_paths,
         extensions_enabled=extensions_enabled,
         project_extensions_enabled=project_extensions_enabled,
+        custom_system_prompt=custom_system_prompt,
+        append_system_prompt=append_system_prompt,
     )
 
 
@@ -531,6 +561,33 @@ def _run_export_cli(args: list[str]) -> None:
         raise typer.BadParameter(str(exc)) from exc
     typer.echo(f"Exported session to {exported_path}")
     raise typer.Exit()
+
+
+def _resolve_prompt_input(value: str, *, option: str) -> str:
+    """Resolve an existing UTF-8 file, otherwise preserve literal prompt text."""
+    path = Path(value).expanduser()
+    try:
+        exists = path.exists()
+    except OSError:
+        exists = False
+    if not exists:
+        return value
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise typer.BadParameter(
+            f"Could not read {option} file {path}: {exc}",
+            param_hint=option,
+        ) from exc
+
+
+def _resolve_append_system_prompts(values: tuple[str, ...] | list[str]) -> str | None:
+    """Resolve repeated append inputs in order and separate them by one blank line."""
+    if not values:
+        return None
+    return "\n\n".join(
+        _resolve_prompt_input(value, option="--append-system-prompt") for value in values
+    )
 
 
 def _merge_stdin_prompt(prompt: str) -> str:
@@ -675,6 +732,8 @@ async def run_openai_print_mode(
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
     session_id: str | None = None,
+    custom_system_prompt: str | None = None,
+    append_system_prompt: str | None = None,
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     settings = load_provider_settings()
@@ -709,6 +768,8 @@ async def run_openai_print_mode(
             extension_paths=extension_paths,
             extensions_enabled=extensions_enabled,
             project_extensions_enabled=project_extensions_enabled,
+            custom_system_prompt=custom_system_prompt,
+            append_system_prompt=append_system_prompt,
         )
     finally:
         await provider.aclose()
@@ -743,6 +804,8 @@ async def run_print_mode(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    custom_system_prompt: str | None = None,
+    append_system_prompt: str | None = None,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -765,6 +828,8 @@ async def run_print_mode(
             extension_paths=extension_paths,
             extensions_enabled=extensions_enabled,
             project_extensions_enabled=project_extensions_enabled,
+            custom_system_prompt=custom_system_prompt,
+            append_system_prompt=append_system_prompt,
         )
     )
     session.extension_runtime.set_ui_bridge(StderrUiBridge())

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -565,7 +565,10 @@ def _run_export_cli(args: list[str]) -> None:
 
 def _resolve_prompt_input(value: str, *, option: str) -> str:
     """Resolve an existing UTF-8 file, otherwise preserve literal prompt text."""
-    path = Path(value).expanduser()
+    try:
+        path = Path(value).expanduser()
+    except RuntimeError:
+        return value
     try:
         exists = path.exists()
     except OSError as exc:

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -568,8 +568,11 @@ def _resolve_prompt_input(value: str, *, option: str) -> str:
     path = Path(value).expanduser()
     try:
         exists = path.exists()
-    except OSError:
-        exists = False
+    except OSError as exc:
+        raise typer.BadParameter(
+            f"Could not inspect {option} path {path}: {exc}",
+            param_hint=option,
+        ) from exc
     if not exists:
         return value
     try:

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -9,3 +9,22 @@ For current user-facing behavior in a Tau checkout, read:
 - `src/tau_coding/commands.py`
 
 Keep command parsing and application-specific resource loading in `tau_coding`, not the reusable `tau_agent` harness. When changing behavior, test both command results and the relevant print/TUI integration, then update published reference documentation.
+
+## System prompt startup controls
+
+`--system-prompt TEXT_OR_PATH` replaces the default base prompt.
+`--append-system-prompt TEXT_OR_PATH` is repeatable; values retain command-line
+order and are separated by exactly one blank line. Put recognized flags before
+the positional prompt.
+
+Each value is read as UTF-8 when it names an existing path (with `~` expanded),
+or used verbatim when the path does not exist. An existing directory, unreadable
+file, or invalid UTF-8 file stops startup with a diagnostic naming the option
+and path.
+
+Both flags apply to print and interactive TUI startup, including the next request
+of a session resumed with `--session`. They are not persisted, so pass them on
+each later resume that needs them. A custom base still goes through
+`build_system_prompt`: configured append text, project context, eligible skills,
+the current date, and cwd remain included. Do not route this CLI option through
+the lower-level exact `CodingSessionConfig.system` override.

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -4,7 +4,8 @@
     "date": "2026-07-31",
     "sections": {
       "New": [
-        "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees."
+        "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees.",
+        "Customize the generated system prompt in print or TUI sessions with `--system-prompt` and repeatable `--append-system-prompt` text-or-file inputs."
       ],
       "Changed": [
         "Cache Anthropic prompt prefixes to reduce repeated input billing, with auth-aware retention, compatibility overrides, and a sidebar cache hit rate.",

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6702,6 +6702,8 @@ async def run_tui_app(
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
     project_extensions_enabled: bool = False,
+    custom_system_prompt: str | None = None,
+    append_system_prompt: str | None = None,
 ) -> str | None:
     """Run the Textual app and return the active id when its session is persisted."""
     if new_session and session_id is not None:
@@ -6775,6 +6777,8 @@ async def run_tui_app(
                 extension_paths=extension_paths,
                 extensions_enabled=extensions_enabled,
                 project_extensions_enabled=project_extensions_enabled,
+                custom_system_prompt=custom_system_prompt,
+                append_system_prompt=append_system_prompt,
             )
         )
         custom_themes, theme_diagnostics = load_custom_tui_themes(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,122 @@ def test_version_command(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.stdout.strip() == "tau 1.2.3"
 
 
+def test_help_lists_system_prompt_options() -> None:
+    result = CliRunner().invoke(app, ["--help"], env={"COLUMNS": "160"})
+
+    output = re.sub(r"\s+", "", _strip_ansi(result.output))
+    assert result.exit_code == 0
+    assert "--system-promptTEXT_OR_PATH" in output
+    assert "--append-system-promptTEXT_OR_PATH" in output
+
+
+def test_prompt_inputs_resolve_files_literals_and_append_order(tmp_path: Path) -> None:
+    base_path = tmp_path / "base.md"
+    append_path = tmp_path / "append.md"
+    base_path.write_text("File base ü", encoding="utf-8")
+    append_path.write_text("File append", encoding="utf-8")
+
+    assert cli._resolve_prompt_input(str(base_path), option="--system-prompt") == "File base ü"
+    assert cli._resolve_prompt_input("literal base", option="--system-prompt") == "literal base"
+    assert (
+        cli._resolve_append_system_prompts(["first", str(append_path), "third"])
+        == "first\n\nFile append\n\nthird"
+    )
+
+
+def test_prompt_input_reports_invalid_utf8_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prompt_path = tmp_path / "invalid.md"
+    prompt_path.write_bytes(b"\xff")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        ["--system-prompt", prompt_path.name, "--new-session"],
+    )
+
+    assert result.exit_code == 2
+    output = _strip_ansi(result.output)
+    assert "--system-prompt" in output
+    assert prompt_path.name in output
+    assert "Could not read" in output
+
+
+def test_system_prompt_flags_are_parsed_before_positional_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base_path = tmp_path / "base.md"
+    append_path = tmp_path / "append.md"
+    base_path.write_text("Custom base", encoding="utf-8")
+    append_path.write_text("second", encoding="utf-8")
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    async def fake_run_openai_print_mode(*args: object) -> bool:
+        calls.append((str(args[0]), args[-2], args[-1]))  # type: ignore[arg-type]
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--print",
+            "--system-prompt",
+            str(base_path),
+            "--append-system-prompt",
+            "first",
+            "--append-system-prompt",
+            str(append_path),
+            "explain",
+            "this",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("explain this", "Custom base", "first\n\nsecond")]
+
+
+def test_prompt_input_reports_existing_unreadable_path(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["--append-system-prompt", str(tmp_path), "--new-session"],
+    )
+
+    assert result.exit_code == 2
+    output = _strip_ansi(result.output)
+    assert "--append-system-prompt" in output
+    assert "Could not read" in output
+
+
+def test_system_prompt_flags_forward_to_resumed_tui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str | None, str | None, str | None]] = []
+
+    async def fake_run_openai_tui(*args: object) -> None:
+        calls.append((args[2], args[-2], args[-1]))  # type: ignore[arg-type]
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--session",
+            "session-1",
+            "--system-prompt",
+            "Resume base",
+            "--append-system-prompt",
+            "Resume append",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("session-1", "Resume base", "Resume append")]
+
+
 def test_version_command_does_not_check_for_updates(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli, "_current_version", lambda: "1.2.3")
     monkeypatch.setattr(
@@ -362,11 +478,16 @@ def test_cli_positional_prompt_invokes_tui_runner(
 async def test_run_openai_tui_combines_release_notes_and_update_notice(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str | None, tuple[str, ...]]] = []
+    calls: list[tuple[str | None, tuple[str, ...], str | None, str | None]] = []
 
     async def fake_run_tui_app(**kwargs: object) -> None:
         calls.append(  # type: ignore[arg-type]
-            (kwargs["startup_update_notice"], kwargs["startup_notices"])
+            (
+                kwargs["startup_update_notice"],
+                kwargs["startup_notices"],
+                kwargs["custom_system_prompt"],
+                kwargs["append_system_prompt"],
+            )
         )
 
     monkeypatch.setattr(cli, "run_tui_app", fake_run_tui_app)
@@ -391,12 +512,16 @@ async def test_run_openai_tui_combines_release_notes_and_update_notice(
         model=None,
         cwd=tmp_path,
         update_notice=UpdateNotice(current_version="0.1.2", latest_version="0.1.3"),
+        custom_system_prompt="Custom base",
+        append_system_prompt="Custom append",
     )
 
     assert calls == [
         (
             "Tau 0.1.3 is available (installed: 0.1.2). Run `tau update` to upgrade.",
             ("Tau updated to 0.1.2\n\n**New**\n- Release note",),
+            "Custom base",
+            "Custom append",
         )
     ]
 
@@ -438,6 +563,43 @@ async def test_run_print_mode_prints_final_assistant_text(
         )
     )
     assert [tool.name for tool in provider.calls[0][3]] == ["read", "write", "edit", "bash"]
+
+
+@pytest.mark.anyio
+async def test_run_print_mode_uses_custom_and_appended_system_prompt(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    resource_root = tmp_path / "resources"
+    skill_dir = resource_root / "skills" / "testing"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\ndescription: Test code\n---\n# Testing",
+        encoding="utf-8",
+    )
+    (tmp_path / "AGENTS.md").write_text("Follow project rules.", encoding="utf-8")
+    provider = FakeProvider(
+        [[assistant_start(model="fake"), assistant_done(message=AssistantMessage(content="Done"))]]
+    )
+
+    ok = await run_print_mode(
+        prompt="Hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        custom_system_prompt="Custom base.",
+        append_system_prompt="First append.\n\nSecond append.",
+    )
+
+    _captured = capsys.readouterr()
+    system = provider.calls[0][1]
+    assert ok is True
+    assert system.startswith("Custom base.\n\nFirst append.\n\nSecond append.")
+    assert "You are an expert coding assistant operating inside Tau" not in system
+    assert "Follow project rules." in system
+    assert "<available_skills>" in system
+    assert "Current date:" in system
+    assert f"Current working directory: {tmp_path}" in system
 
 
 @pytest.mark.anyio
@@ -716,6 +878,8 @@ def test_print_mode_passes_exact_session_id_without_changing_output(
         extensions_enabled: bool,
         project_extensions_enabled: bool,
         session_id: str | None,
+        custom_system_prompt: str | None,
+        append_system_prompt: str | None,
     ) -> bool:
         del (
             prompt,
@@ -727,6 +891,8 @@ def test_print_mode_passes_exact_session_id_without_changing_output(
             extension_paths,
             extensions_enabled,
             project_extensions_enabled,
+            custom_system_prompt,
+            append_system_prompt,
         )
         calls.append(session_id)
         return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,6 +201,43 @@ def test_prompt_input_reports_existing_unreadable_path(tmp_path: Path) -> None:
     assert "Could not read" in output
 
 
+def test_prompt_input_reports_path_inspection_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prompt_path = tmp_path / "base.md"
+    prompt_path.write_text("Custom base", encoding="utf-8")
+    original_exists = Path.exists
+    tui_calls = 0
+
+    def fail_for_prompt_path(path: Path) -> bool:
+        if path == prompt_path:
+            raise PermissionError("permission denied")
+        return original_exists(path)
+
+    async def fake_run_openai_tui(*args: object) -> None:
+        nonlocal tui_calls
+        tui_calls += 1
+
+    monkeypatch.setattr(Path, "exists", fail_for_prompt_path)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(
+        app,
+        ["--system-prompt", str(prompt_path), "--new-session"],
+        env={"COLUMNS": "300"},
+    )
+
+    assert result.exit_code == 2
+    output = _strip_ansi(result.output)
+    compact_output = re.sub(r"\s+", "", output)
+    assert "--system-prompt" in output
+    assert str(prompt_path) in compact_output
+    assert "Could not inspect" in output
+    assert "permission denied" in output
+    assert tui_calls == 0
+
+
 def test_system_prompt_flags_forward_to_resumed_tui(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,42 @@ def test_prompt_inputs_resolve_files_literals_and_append_order(tmp_path: Path) -
     )
 
 
+@pytest.mark.parametrize(
+    ("option", "expected_base", "expected_append"),
+    [
+        ("--system-prompt", "~unknown-tau-user/base.md", None),
+        ("--append-system-prompt", None, "~unknown-tau-user/append.md"),
+    ],
+)
+def test_unknown_user_prompt_path_is_forwarded_as_literal(
+    monkeypatch: pytest.MonkeyPatch,
+    option: str,
+    expected_base: str | None,
+    expected_append: str | None,
+) -> None:
+    value = expected_base or expected_append
+    assert value is not None
+    calls: list[tuple[str | None, str | None]] = []
+    original_expanduser = Path.expanduser
+
+    def fail_for_unknown_user(path: Path) -> Path:
+        if str(path).startswith("~unknown-tau-user/"):
+            raise RuntimeError("Could not determine home directory")
+        return original_expanduser(path)
+
+    async def fake_run_openai_tui(*args: object) -> None:
+        calls.append((args[-2], args[-1]))  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "expanduser", fail_for_unknown_user)
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, [option, value, "--new-session"])
+
+    assert result.exit_code == 0
+    assert calls == [(expected_base, expected_append)]
+
+
 def test_prompt_input_reports_invalid_utf8_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8155,6 +8155,9 @@ async def test_run_tui_app_creates_new_session_by_default(
             assert config.provider_name == "local"  # type: ignore[attr-defined]
             assert config.auto_compact_token_threshold == 1000  # type: ignore[attr-defined]
             assert config.index_on_first_persist is True  # type: ignore[attr-defined]
+            assert config.system is None  # type: ignore[attr-defined]
+            assert config.custom_system_prompt == "Custom base"  # type: ignore[attr-defined]
+            assert config.append_system_prompt == "First\n\nSecond"  # type: ignore[attr-defined]
             calls.append("load")
             return "session"
 
@@ -8196,6 +8199,8 @@ async def test_run_tui_app_creates_new_session_by_default(
         auto_compact_token_threshold=1000,
         initial_prompt="explain this repo",
         session_manager=FakeManager(),
+        custom_system_prompt="Custom base",
+        append_system_prompt="First\n\nSecond",
     )
 
     assert calls == [
@@ -8417,6 +8422,9 @@ async def test_run_tui_app_resumes_explicit_session(
         async def load(cls, config: object) -> str:
             assert config.provider_name == "local"  # type: ignore[attr-defined]
             assert config.model == "fake-model"  # type: ignore[attr-defined]
+            assert config.system is None  # type: ignore[attr-defined]
+            assert config.custom_system_prompt == "Resume base"  # type: ignore[attr-defined]
+            assert config.append_system_prompt == "Resume append"  # type: ignore[attr-defined]
             calls.append("load")
             return "session"
 
@@ -8462,6 +8470,8 @@ async def test_run_tui_app_resumes_explicit_session(
         cwd=tmp_path,
         session_id="session-1",
         session_manager=FakeManager(),
+        custom_system_prompt="Resume base",
+        append_system_prompt="Resume append",
     )
 
     assert calls == [

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -48,11 +48,40 @@ features and fixes.
 | `--session TEXT` | Resume a session id in the TUI |
 | `--new-session` | Start a new session instead of resuming the default |
 | `--session-id TEXT` | Set the exact id for a newly created print-mode session; errors if it already exists |
+| `--system-prompt TEXT_OR_PATH` | Replace Tau's default system-prompt base with literal text or an existing UTF-8 file |
+| `--append-system-prompt TEXT_OR_PATH` | Append literal text or an existing UTF-8 file (repeatable) |
 | `--auto-compact-threshold INT` | Auto-compact above this rough token estimate |
 | `-e, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |
 | `--no-extensions` | Disable extension directory discovery (explicit `-e` paths still load) |
 | `--project-extensions` | Also load `<project>/.tau/extensions` (runs project-supplied code at startup) |
 | `-v, --version` | Print the version and exit |
+
+### System prompt input
+
+`--system-prompt` replaces Tau's default base prompt. Repeat
+`--append-system-prompt` to add sections in command-line order; Tau separates each
+resolved value with exactly one blank line. Put these flags before the positional
+prompt, like other recognized options:
+
+```bash
+tau --system-prompt "You are a focused reviewer." \
+  --append-system-prompt ./team-rules.md \
+  --append-system-prompt "Report risky changes first." \
+  -p "review this repository"
+```
+
+For either option, Tau reads the value as a UTF-8 file when that path exists.
+Otherwise it uses the value verbatim, so a nonexistent path is literal prompt
+text. Existing directories, unreadable files, and invalid UTF-8 files stop
+startup with an error naming the option and path. `~` is expanded when checking
+for a file.
+
+A custom base still receives appended text, discovered project instructions,
+eligible skills when the `read` tool is enabled, the current date, and the
+working directory. The options apply to print mode and interactive startup;
+when used with `--session`, they configure the resumed session's next provider
+request. They are startup controls and are not stored in session history, so
+pass them again on a later resume when needed.
 
 `--resume`, `--prompt`, `-o/--output`, and `-x` are removed; each now exits
 with an error naming its replacement (`--session`, `--print`, `--mode`, and


### PR DESCRIPTION
## Summary

- add Pi-compatible `--system-prompt TEXT_OR_PATH` and repeatable `--append-system-prompt TEXT_OR_PATH`
- resolve existing paths as UTF-8 files and preserve nonexisting values as literal text, with actionable path diagnostics
- forward custom and appended prompts through print mode and new/resumed TUI sessions while preserving Tau's normal prompt composition
- document syntax, ordering, resolution, resume behavior, and scope boundaries

## User experience

Users can replace Tau's generated system-prompt base or append ordered instructions from literal text and files. Existing project context, eligible skills, date, and cwd remain available with a custom base.

Closes #530.

## Validation

- `uv run pytest` (1306 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`

## Manual validation

```bash
tau --system-prompt "Custom base" \
  --append-system-prompt ./rules.md \
  --append-system-prompt "Local rules" \
  -p "review this repository"

tau --session <session-id> --system-prompt ./base.md \
  --append-system-prompt ./rules.md
```
