### PR TITLE
Load Tau-native system prompt files

### DIFF
--- a/dev-notes/system-prompt-files.md
+++ b/dev-notes/system-prompt-files.md
@@ -1,0 +1,63 @@
+# Tau-native system prompt files
+
+Issue: https://github.com/huggingface/tau/issues/531
+
+## What changed
+
+Tau now discovers optional replacement and append files:
+
+```text
+~/.tau/SYSTEM.md
+~/.tau/APPEND_SYSTEM.md
+<cwd>/.tau/SYSTEM.md
+<cwd>/.tau/APPEND_SYSTEM.md
+```
+
+Explicit `--system-prompt` or `--append-system-prompt` input wins over discovery.
+Otherwise a project file wins over its user counterpart. Replacement and append
+precedence are independent, so a project replacement can be paired with a user
+append. Project and user append files are alternatives rather than cumulative
+layers.
+
+The files use the existing custom-base prompt builder. Replacement content still
+receives selected append text, project context, eligible skills, date, and cwd.
+Prompt contents remain request configuration and are not added to session JSONL.
+
+## Why `.agents` is excluded
+
+Pi uses `.agents/skills` as a portable Agent Skills compatibility location, but
+keeps `SYSTEM.md` and `APPEND_SYSTEM.md` under its native `.pi` configuration.
+Tau follows the same boundary: existing `.agents` support for skills, templates,
+and instructions is unchanged, while system prompt files remain Tau-specific.
+
+## Reload and diagnostics
+
+`CodingSession` stores the discovered content and source paths separately from
+explicit startup values. `/reload` compares both source and content signatures,
+so adding, changing, removing, or shadowing a file rebuilds the next-turn prompt.
+Explicit startup values remain authoritative across reloads.
+
+Resource diagnostics identify selected, shadowed, and CLI-overridden files
+without exposing their contents. Missing files are ignored. A selected path that
+cannot be inspected, read, or decoded as UTF-8 fails startup/reload rather than
+silently weakening precedence. A failed reload leaves the previous prompt active.
+
+## Trust boundary
+
+Project prompt files load automatically in this phase, consistent with Tau's
+current project-resource behavior. They can change the model's highest-priority
+instructions, so published documentation tells users to inspect them. A unified
+Pi-compatible project trust boundary is tracked separately in issue #535; prompt
+file discovery is isolated in `tau_coding.resources` so that trust can later gate
+project candidates without changing `tau_agent` or prompt assembly.
+
+## Verification
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+cd website && hugo --minify
+cd website && npx --yes pagefind@latest --site public
+```

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -28,3 +28,21 @@ each later resume that needs them. A custom base still goes through
 `build_system_prompt`: configured append text, project context, eligible skills,
 the current date, and cwd remain included. Do not route this CLI option through
 the lower-level exact `CodingSessionConfig.system` override.
+
+## System prompt files
+
+Tau discovers replacement `SYSTEM.md` and append-only `APPEND_SYSTEM.md` files
+from `<cwd>/.tau/` and `~/.tau/`. Explicit CLI prompt input wins over a project
+file, which wins over a user file. Project and user append files are alternatives,
+not cumulative layers. `.agents/SYSTEM.md` and `.agents/APPEND_SYSTEM.md` are not
+supported because these are Tau-specific configuration resources.
+
+The selected replacement still receives append text, project context, eligible
+skills, date, and cwd. Run `/reload` after changing files; the next-turn prompt is
+rebuilt without adding prompt contents to session history. Selected, shadowed,
+and CLI-overridden sources appear in resource diagnostics. Unreadable or invalid
+UTF-8 selected files stop startup/reload with an actionable error.
+
+Project files currently load automatically. Users should inspect repository
+`.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md` files because they can replace or
+extend the model's highest-priority instructions.

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -5,7 +5,8 @@
     "sections": {
       "New": [
         "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees.",
-        "Customize the generated system prompt in print or TUI sessions with `--system-prompt` and repeatable `--append-system-prompt` text-or-file inputs."
+        "Customize the generated system prompt in print or TUI sessions with `--system-prompt` and repeatable `--append-system-prompt` text-or-file inputs.",
+        "Load Tau-native `SYSTEM.md` and `APPEND_SYSTEM.md` files from user or project `.tau` directories, with CLI and project precedence plus `/reload` support."
       ],
       "Changed": [
         "Cache Anthropic prompt prefixes to reduce repeated input billing, with auth-aware retention, compatibility overrides, and a sidebar cache hit rate.",

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -14,6 +14,17 @@ class ResourceError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class SystemPromptResources:
+    """Discovered Tau-native system-prompt file contents and sources."""
+
+    custom_prompt: str | None = None
+    custom_prompt_path: Path | None = None
+    append_prompt: str | None = None
+    append_prompt_path: Path | None = None
+    diagnostics: tuple[ResourceDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class ResourceDiagnostic:
     """A non-fatal resource discovery problem or precedence note."""
 
@@ -57,6 +68,16 @@ class TauResourcePaths:
     def prompts_dir(self) -> Path:
         """Return the primary Tau prompt templates directory."""
         return self.root / "prompts"
+
+    @property
+    def system_prompt_path(self) -> Path:
+        """Return the user-level replacement system-prompt file."""
+        return self.root / "SYSTEM.md"
+
+    @property
+    def append_system_prompt_path(self) -> Path:
+        """Return the user-level appended system-prompt file."""
+        return self.root / "APPEND_SYSTEM.md"
 
     @property
     def skills_dirs(self) -> tuple[Path, ...]:
@@ -123,6 +144,108 @@ def _dedupe_paths(paths: list[Path]) -> list[Path]:
         seen.add(resolved)
         deduped.append(resolved)
     return deduped
+
+
+def discover_system_prompt_resources(
+    paths: TauResourcePaths,
+    *,
+    custom_prompt_explicit: bool = False,
+    append_prompt_explicit: bool = False,
+    enabled: bool = True,
+) -> SystemPromptResources:
+    """Discover Tau-native prompt files with CLI/project/user precedence."""
+    if not enabled:
+        return SystemPromptResources()
+
+    diagnostics: list[ResourceDiagnostic] = []
+    custom_prompt, custom_path = _discover_system_prompt_file(
+        paths,
+        filename="SYSTEM.md",
+        label="replacement",
+        explicit=custom_prompt_explicit,
+        diagnostics=diagnostics,
+    )
+    append_prompt, append_path = _discover_system_prompt_file(
+        paths,
+        filename="APPEND_SYSTEM.md",
+        label="append",
+        explicit=append_prompt_explicit,
+        diagnostics=diagnostics,
+    )
+    return SystemPromptResources(
+        custom_prompt=custom_prompt,
+        custom_prompt_path=custom_path,
+        append_prompt=append_prompt,
+        append_prompt_path=append_path,
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _discover_system_prompt_file(
+    paths: TauResourcePaths,
+    *,
+    filename: str,
+    label: str,
+    explicit: bool,
+    diagnostics: list[ResourceDiagnostic],
+) -> tuple[str | None, Path | None]:
+    candidates: list[tuple[str, Path]] = []
+    if paths.cwd is not None:
+        candidates.append(("project", paths.cwd / ".tau" / filename))
+    candidates.append(("user", paths.root / filename))
+
+    existing: list[tuple[str, Path]] = []
+    for scope, path in candidates:
+        try:
+            if path.exists():
+                existing.append((scope, path))
+        except OSError as exc:
+            raise ResourceError(
+                f"Could not inspect {label} system prompt file {path}: {exc}"
+            ) from exc
+
+    if explicit:
+        for _scope, path in existing:
+            diagnostics.append(
+                ResourceDiagnostic(
+                    kind="system-prompt",
+                    name=label,
+                    path=path,
+                    severity="info",
+                    message="ignored because an explicit startup value takes precedence",
+                )
+            )
+        return None, None
+    if not existing:
+        return None, None
+
+    selected_scope, selected_path = existing[0]
+    try:
+        content = selected_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ResourceError(
+            f"Could not read {label} system prompt file {selected_path} as UTF-8: {exc}"
+        ) from exc
+
+    diagnostics.append(
+        ResourceDiagnostic(
+            kind="system-prompt",
+            name=label,
+            path=selected_path,
+            severity="info",
+            message=f"selected {selected_scope} system prompt file",
+        )
+    )
+    for _scope, path in existing[1:]:
+        diagnostics.append(
+            ResourceDiagnostic(
+                kind="system-prompt",
+                name=label,
+                path=path,
+                message=f"shadowed by higher-precedence file {selected_path}",
+            )
+        )
+    return content, selected_path
 
 
 def resource_paths_with_cwd(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1183,7 +1183,6 @@ class CodingSession:
         ``session_start(reason="reload")`` so startup-mounted UI is restored
         before the command reports completion.
         """
-        await self._extension_runtime.emit_session_shutdown("reload")
         before_skills = _skill_signatures(self._skills)
         before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
         before_context_files = _context_file_signatures(self._context_files)
@@ -1208,6 +1207,7 @@ class CodingSession:
             custom_system_prompt_explicit=self._config.custom_system_prompt is not None,
             append_system_prompt_explicit=self._config.append_system_prompt is not None,
         )
+        await self._extension_runtime.emit_session_shutdown("reload")
         self._reload_extensions()
 
         after_skills = _skill_signatures(resources.skills)
@@ -1468,6 +1468,10 @@ class CodingSession:
         self._skills = replacement._skills
         self._prompt_templates = replacement._prompt_templates
         self._context_files = replacement._context_files
+        self._custom_system_prompt = replacement._custom_system_prompt
+        self._custom_system_prompt_path = replacement._custom_system_prompt_path
+        self._append_system_prompt = replacement._append_system_prompt
+        self._append_system_prompt_path = replacement._append_system_prompt_path
         self._resource_diagnostics = replacement._resource_diagnostics
         self._command_registry = replacement._command_registry
         self._provider_name = replacement._provider_name

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -99,6 +99,7 @@ from tau_coding.resources import (
     ResourceDiagnostic,
     ResourceError,
     TauResourcePaths,
+    discover_system_prompt_resources,
     resource_paths_with_cwd,
 )
 from tau_coding.session_export import (
@@ -183,6 +184,10 @@ class SessionResources:
     skills: tuple[Skill, ...]
     prompt_templates: tuple[PromptTemplate, ...]
     context_files: tuple[ProjectContextFile, ...]
+    custom_system_prompt: str | None
+    custom_system_prompt_path: Path | None
+    append_system_prompt: str | None
+    append_system_prompt_path: Path | None
     diagnostics: tuple[ResourceDiagnostic, ...]
 
 
@@ -256,6 +261,10 @@ class CodingSession:
         skills: tuple[Skill, ...] = (),
         prompt_templates: tuple[PromptTemplate, ...] = (),
         context_files: tuple[ProjectContextFile, ...] = (),
+        custom_system_prompt: str | None = None,
+        custom_system_prompt_path: Path | None = None,
+        append_system_prompt: str | None = None,
+        append_system_prompt_path: Path | None = None,
         resource_diagnostics: tuple[ResourceDiagnostic, ...] = (),
         command_registry: CommandRegistry | None = None,
         pending_initial_entries: tuple[SessionEntry, ...] = (),
@@ -273,6 +282,10 @@ class CodingSession:
         self._skills = skills
         self._prompt_templates = prompt_templates
         self._context_files = context_files
+        self._custom_system_prompt = custom_system_prompt
+        self._custom_system_prompt_path = custom_system_prompt_path
+        self._append_system_prompt = append_system_prompt
+        self._append_system_prompt_path = append_system_prompt_path
         self._resource_diagnostics = resource_diagnostics
         self._command_registry = command_registry or create_default_command_registry()
         self._provider_name = config.provider_name
@@ -329,6 +342,9 @@ class CodingSession:
             resource_paths,
             config.context_files,
             skills_enabled=config.skills_enabled,
+            system_prompt_enabled=config.system is None,
+            custom_system_prompt_explicit=config.custom_system_prompt is not None,
+            append_system_prompt_explicit=config.append_system_prompt is not None,
         )
 
         extension_runtime = config.extension_runtime
@@ -365,8 +381,16 @@ class CodingSession:
                     cwd=config.cwd,
                     tools=tools,
                     skills=resources.skills,
-                    custom_prompt=config.custom_system_prompt,
-                    append_system_prompt=config.append_system_prompt,
+                    custom_prompt=(
+                        config.custom_system_prompt
+                        if config.custom_system_prompt is not None
+                        else resources.custom_system_prompt
+                    ),
+                    append_system_prompt=(
+                        config.append_system_prompt
+                        if config.append_system_prompt is not None
+                        else resources.append_system_prompt
+                    ),
                     context_files=resources.context_files,
                     extra_guidelines=extension_runtime.prompt_guidelines,
                 )
@@ -389,6 +413,10 @@ class CodingSession:
             skills=resources.skills,
             prompt_templates=resources.prompt_templates,
             context_files=resources.context_files,
+            custom_system_prompt=resources.custom_system_prompt,
+            custom_system_prompt_path=resources.custom_system_prompt_path,
+            append_system_prompt=resources.append_system_prompt,
+            append_system_prompt_path=resources.append_system_prompt_path,
             resource_diagnostics=resources.diagnostics,
             command_registry=config.command_registry or extension_runtime.build_command_registry(),
             pending_initial_entries=pending_initial_entries,
@@ -1163,6 +1191,10 @@ class CodingSession:
         before_system_prompt_inputs = _system_prompt_resource_signatures(
             skills=self._skills,
             context_files=self._context_files,
+            custom_system_prompt=self._custom_system_prompt,
+            custom_system_prompt_path=self._custom_system_prompt_path,
+            append_system_prompt=self._append_system_prompt,
+            append_system_prompt_path=self._append_system_prompt_path,
         )
         before_extensions = _extension_signatures(self._extension_runtime)
         before_tool_names = tuple(tool.name for tool in self._harness.config.tools)
@@ -1172,6 +1204,9 @@ class CodingSession:
             self._resource_paths,
             self._config.context_files,
             skills_enabled=self._config.skills_enabled,
+            system_prompt_enabled=self._config.system is None,
+            custom_system_prompt_explicit=self._config.custom_system_prompt is not None,
+            append_system_prompt_explicit=self._config.append_system_prompt is not None,
         )
         self._reload_extensions()
 
@@ -1181,6 +1216,10 @@ class CodingSession:
         after_system_prompt_inputs = _system_prompt_resource_signatures(
             skills=resources.skills,
             context_files=resources.context_files,
+            custom_system_prompt=resources.custom_system_prompt,
+            custom_system_prompt_path=resources.custom_system_prompt_path,
+            append_system_prompt=resources.append_system_prompt,
+            append_system_prompt_path=resources.append_system_prompt_path,
         )
         after_extensions = _extension_signatures(self._extension_runtime)
         after_tool_names = tuple(tool.name for tool in self._harness.config.tools)
@@ -1198,8 +1237,16 @@ class CodingSession:
                     cwd=self._config.cwd,
                     tools=self._harness.config.tools,
                     skills=resources.skills,
-                    custom_prompt=self._config.custom_system_prompt,
-                    append_system_prompt=self._config.append_system_prompt,
+                    custom_prompt=(
+                        self._config.custom_system_prompt
+                        if self._config.custom_system_prompt is not None
+                        else resources.custom_system_prompt
+                    ),
+                    append_system_prompt=(
+                        self._config.append_system_prompt
+                        if self._config.append_system_prompt is not None
+                        else resources.append_system_prompt
+                    ),
                     context_files=resources.context_files,
                     extra_guidelines=after_guidelines,
                 )
@@ -1209,6 +1256,10 @@ class CodingSession:
         self._skills = resources.skills
         self._prompt_templates = resources.prompt_templates
         self._context_files = resources.context_files
+        self._custom_system_prompt = resources.custom_system_prompt
+        self._custom_system_prompt_path = resources.custom_system_prompt_path
+        self._append_system_prompt = resources.append_system_prompt
+        self._append_system_prompt_path = resources.append_system_prompt_path
         self._resource_diagnostics = resources.diagnostics
         after_diagnostics = _diagnostic_signatures(self.resource_diagnostics)
         if rebuilt_system_prompt is not None:
@@ -2601,12 +2652,23 @@ def _system_prompt_resource_signatures(
     *,
     skills: tuple[Skill, ...],
     context_files: tuple[ProjectContextFile, ...],
-) -> tuple[tuple[object, ...], tuple[object, ...]]:
+    custom_system_prompt: str | None,
+    custom_system_prompt_path: Path | None,
+    append_system_prompt: str | None,
+    append_system_prompt_path: Path | None,
+) -> tuple[object, ...]:
     prompt_skills = tuple(
         (skill.name, str(skill.path), skill.description)
         for skill in sorted(skills, key=lambda item: item.name)
     )
-    return (prompt_skills, _context_file_signatures(context_files))
+    return (
+        prompt_skills,
+        _context_file_signatures(context_files),
+        custom_system_prompt,
+        str(custom_system_prompt_path) if custom_system_prompt_path is not None else None,
+        append_system_prompt,
+        str(append_system_prompt_path) if append_system_prompt_path is not None else None,
+    )
 
 
 def _load_session_resources(
@@ -2614,6 +2676,9 @@ def _load_session_resources(
     explicit_context_files: tuple[ProjectContextFile, ...],
     *,
     skills_enabled: bool = True,
+    system_prompt_enabled: bool = True,
+    custom_system_prompt_explicit: bool = False,
+    append_system_prompt_explicit: bool = False,
 ) -> SessionResources:
     loaded_skills: list[Skill]
     skill_diagnostics: list[ResourceDiagnostic]
@@ -2627,11 +2692,28 @@ def _load_session_resources(
     discovered_context, context_diagnostics = discover_project_context_with_diagnostics(
         resource_paths
     )
+    system_prompts = discover_system_prompt_resources(
+        resource_paths,
+        custom_prompt_explicit=custom_system_prompt_explicit,
+        append_prompt_explicit=append_system_prompt_explicit,
+        enabled=system_prompt_enabled,
+    )
     return SessionResources(
         skills=tuple(loaded_skills),
         prompt_templates=tuple(loaded_prompt_templates),
         context_files=_merge_context_files(explicit_context_files, discovered_context),
-        diagnostics=tuple([*skill_diagnostics, *prompt_diagnostics, *context_diagnostics]),
+        custom_system_prompt=system_prompts.custom_prompt,
+        custom_system_prompt_path=system_prompts.custom_prompt_path,
+        append_system_prompt=system_prompts.append_prompt,
+        append_system_prompt_path=system_prompts.append_prompt_path,
+        diagnostics=tuple(
+            [
+                *skill_diagnostics,
+                *prompt_diagnostics,
+                *context_diagnostics,
+                *system_prompts.diagnostics,
+            ]
+        ),
     )
 
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2602,6 +2602,37 @@ async def test_failed_system_prompt_file_reload_keeps_previous_prompt(tmp_path: 
 
 
 @pytest.mark.anyio
+async def test_new_session_adopts_system_prompt_resource_tracking(tmp_path: Path) -> None:
+    tau_home = tmp_path / "tau-home"
+    tau_home.mkdir()
+    prompt_path = tau_home / "SYSTEM.md"
+    prompt_path.write_text("Base A", encoding="utf-8")
+    manager = SessionManager(TauPaths(home=tau_home, agents_home=tmp_path / "agents-home"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(record.path),
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+            resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
+        )
+    )
+
+    prompt_path.write_text("Base B", encoding="utf-8")
+    await session.new_session()
+    assert session.system_prompt.startswith("Base B")
+
+    prompt_path.write_text("Base A", encoding="utf-8")
+    summary = await session.reload()
+
+    assert summary.system_prompt_rebuilt is True
+    assert session.system_prompt.startswith("Base A")
+
+
+@pytest.mark.anyio
 async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2464,6 +2464,144 @@ async def test_session_loads_with_resource_diagnostics_instead_of_failing(
 
 
 @pytest.mark.anyio
+async def test_session_loads_tau_native_system_prompt_files(tmp_path: Path) -> None:
+    tau_home = tmp_path / "tau-home"
+    project_tau = tmp_path / ".tau"
+    tau_home.mkdir()
+    project_tau.mkdir()
+    (tau_home / "SYSTEM.md").write_text("User base", encoding="utf-8")
+    (project_tau / "SYSTEM.md").write_text("Project base", encoding="utf-8")
+    (tau_home / "APPEND_SYSTEM.md").write_text("User append", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("Project instructions", encoding="utf-8")
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
+        )
+    )
+
+    assert session.system_prompt.startswith("Project base\n\nUser append")
+    assert "User base" not in session.system_prompt
+    assert "Project instructions" in session.system_prompt
+    assert "Current date:" in session.system_prompt
+    assert f"Current working directory: {tmp_path}" in session.system_prompt
+    prompt_diagnostics = [
+        item for item in session.resource_diagnostics if item.kind == "system-prompt"
+    ]
+    assert [item.severity for item in prompt_diagnostics] == ["info", "warning", "info"]
+
+
+@pytest.mark.anyio
+async def test_explicit_system_prompt_values_override_discovered_files(tmp_path: Path) -> None:
+    tau_home = tmp_path / "tau-home"
+    tau_home.mkdir()
+    (tau_home / "SYSTEM.md").write_bytes(b"\xff")
+    (tau_home / "APPEND_SYSTEM.md").write_bytes(b"\xff")
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
+            custom_system_prompt="Explicit base",
+            append_system_prompt="Explicit append",
+        )
+    )
+
+    assert session.system_prompt.startswith("Explicit base\n\nExplicit append")
+    assert all(
+        "explicit startup value" in item.message
+        for item in session.resource_diagnostics
+        if item.kind == "system-prompt"
+    )
+
+
+@pytest.mark.anyio
+async def test_session_reload_tracks_system_prompt_file_precedence(tmp_path: Path) -> None:
+    tau_home = tmp_path / "tau-home"
+    project_tau = tmp_path / ".tau"
+    tau_home.mkdir()
+    project_tau.mkdir()
+    user_prompt = tau_home / "SYSTEM.md"
+    project_prompt = project_tau / "SYSTEM.md"
+    append_prompt = tau_home / "APPEND_SYSTEM.md"
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
+        )
+    )
+    assert "You are an expert coding assistant operating inside Tau" in session.system_prompt
+
+    user_prompt.write_text("User base", encoding="utf-8")
+    summary = await session.reload()
+    assert summary.system_prompt_rebuilt is True
+    assert session.system_prompt.startswith("User base")
+
+    append_prompt.write_text("Reloaded append", encoding="utf-8")
+    summary = await session.reload()
+    assert summary.system_prompt_rebuilt is True
+    assert session.system_prompt.startswith("User base\n\nReloaded append")
+
+    project_prompt.write_text("Project base", encoding="utf-8")
+    summary = await session.reload()
+    assert summary.system_prompt_rebuilt is True
+    assert session.system_prompt.startswith("Project base")
+
+    project_prompt.write_text("Changed project base", encoding="utf-8")
+    await session.reload()
+    assert session.system_prompt.startswith("Changed project base")
+
+    project_prompt.unlink()
+    await session.reload()
+    assert session.system_prompt.startswith("User base\n\nReloaded append")
+
+    user_prompt.unlink()
+    await session.reload()
+    assert session.system_prompt.startswith(
+        "You are an expert coding assistant operating inside Tau"
+    )
+    assert "Reloaded append" in session.system_prompt
+
+    append_prompt.unlink()
+    await session.reload()
+    assert "Reloaded append" not in session.system_prompt
+
+
+@pytest.mark.anyio
+async def test_failed_system_prompt_file_reload_keeps_previous_prompt(tmp_path: Path) -> None:
+    tau_home = tmp_path / "tau-home"
+    tau_home.mkdir()
+    prompt_path = tau_home / "SYSTEM.md"
+    prompt_path.write_text("Valid base", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
+        )
+    )
+    previous = session.system_prompt
+
+    prompt_path.write_bytes(b"\xff")
+    with pytest.raises(ResourceError, match="Could not read replacement system prompt file"):
+        await session.reload()
+
+    assert session.system_prompt == previous
+
+
+@pytest.mark.anyio
 async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Path) -> None:
     resource_root = tmp_path / "resources"
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -15,7 +15,7 @@ from tau_agent.session import CustomEntry, JsonlSessionStorage, LeafEntry, Messa
 from tau_agent.tools import AgentTool, AgentToolResult
 from tau_agent.types import JSONValue
 from tau_ai import FakeProvider
-from tau_coding import CodingSession, CodingSessionConfig, TauResourcePaths
+from tau_coding import CodingSession, CodingSessionConfig, ResourceError, TauResourcePaths
 from tau_coding.extensions import (
     CustomMessageView,
     ExtensionAPI,
@@ -1932,6 +1932,29 @@ async def test_reload_invalidates_old_instance_and_new_instance_works(
     assert new_api is not old_api
     assert new_api.context.cwd == session.cwd
     new_api.send_user_message("fresh")  # the reloaded instance works normally
+
+
+async def test_failed_resource_reload_does_not_emit_extension_shutdown(tmp_path: Path) -> None:
+    body = (
+        "EVENTS = []\n\n"
+        "def setup(tau):\n"
+        "    tau.on('session_shutdown', "
+        "lambda event, context: EVENTS.append(('stop', event.reason)))\n"
+    )
+    paths = _paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    prompt_path = paths.root / "SYSTEM.md"
+    prompt_path.write_text("Valid base", encoding="utf-8")
+    session = await CodingSession.load(
+        _session_config(tmp_path, FakeProvider([]), extension_body=body)
+    )
+    module = _loaded_extension_module("integration")
+
+    prompt_path.write_bytes(b"\xff")
+    with pytest.raises(ResourceError, match="Could not read replacement system prompt file"):
+        await session.reload()
+
+    assert module.EVENTS == []  # type: ignore[attr-defined]
 
 
 async def test_reload_awaits_shutdown_before_invalidation_and_starts_new_generation(

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
+import pytest
+
 from tau_coding import TauPaths, TauResourcePaths
-from tau_coding.resources import derive_description, parse_markdown_resource
+from tau_coding.resources import (
+    ResourceError,
+    derive_description,
+    discover_system_prompt_resources,
+    parse_markdown_resource,
+)
 
 
 def test_resource_paths_use_tau_subdirectories(tmp_path: Path) -> None:
@@ -36,6 +43,64 @@ def test_resource_paths_include_agents_and_project_directories(tmp_path: Path) -
         cwd / ".tau" / "prompts",
         cwd / ".agents" / "prompts",
     )
+    assert paths.system_prompt_path == tau_home / "SYSTEM.md"
+    assert paths.append_system_prompt_path == tau_home / "APPEND_SYSTEM.md"
+
+
+def test_system_prompt_files_use_project_over_user_precedence(tmp_path: Path) -> None:
+    cwd = tmp_path / "project"
+    tau_home = tmp_path / "home" / ".tau"
+    agents_home = tmp_path / "home" / ".agents"
+    (cwd / ".tau").mkdir(parents=True)
+    tau_home.mkdir(parents=True)
+    agents_home.mkdir(parents=True)
+    (tau_home / "SYSTEM.md").write_text("User base", encoding="utf-8")
+    (cwd / ".tau" / "SYSTEM.md").write_text("Project base", encoding="utf-8")
+    (tau_home / "APPEND_SYSTEM.md").write_text("User append", encoding="utf-8")
+    # `.agents` is not a system-prompt configuration location.
+    (agents_home / "SYSTEM.md").write_text("Agents base", encoding="utf-8")
+
+    resources = discover_system_prompt_resources(
+        TauResourcePaths(root=tau_home, agents_root=agents_home, cwd=cwd)
+    )
+
+    assert resources.custom_prompt == "Project base"
+    assert resources.custom_prompt_path == cwd / ".tau" / "SYSTEM.md"
+    assert resources.append_prompt == "User append"
+    assert resources.append_prompt_path == tau_home / "APPEND_SYSTEM.md"
+    assert [(item.severity, item.path) for item in resources.diagnostics] == [
+        ("info", cwd / ".tau" / "SYSTEM.md"),
+        ("warning", tau_home / "SYSTEM.md"),
+        ("info", tau_home / "APPEND_SYSTEM.md"),
+    ]
+
+
+def test_explicit_prompt_values_shadow_files_without_reading_them(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    (tau_home / "SYSTEM.md").write_bytes(b"\xff")
+    (tau_home / "APPEND_SYSTEM.md").write_bytes(b"\xff")
+
+    resources = discover_system_prompt_resources(
+        TauResourcePaths(root=tau_home, agents_root=None),
+        custom_prompt_explicit=True,
+        append_prompt_explicit=True,
+    )
+
+    assert resources.custom_prompt is None
+    assert resources.append_prompt is None
+    assert len(resources.diagnostics) == 2
+    assert all("explicit startup value" in item.message for item in resources.diagnostics)
+
+
+def test_selected_system_prompt_file_must_be_readable_utf8(tmp_path: Path) -> None:
+    tau_home = tmp_path / ".tau"
+    tau_home.mkdir()
+    prompt_path = tau_home / "SYSTEM.md"
+    prompt_path.write_bytes(b"\xff")
+
+    with pytest.raises(ResourceError, match="Could not read replacement system prompt file"):
+        discover_system_prompt_resources(TauResourcePaths(root=tau_home, agents_root=None))
 
 
 def test_parse_frontmatter_description() -> None:

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -83,6 +83,13 @@ when used with `--session`, they configure the resumed session's next provider
 request. They are startup controls and are not stored in session history, so
 pass them again on a later resume when needed.
 
+Without flags, Tau also discovers `SYSTEM.md` and `APPEND_SYSTEM.md` under the
+project or user `.tau` directory. CLI values win over project files, and project
+files win over user files. Use `/reload` after changing a file. These are
+Tau-specific configuration files, not `.agents` resources. See
+[Configuration & files]({{< relref "./configuration.md#system-prompt-files" >}})
+for paths, precedence, diagnostics, and the project-resource security warning.
+
 `--resume`, `--prompt`, `-o/--output`, and `-x` are removed; each now exits
 with an error naming its replacement (`--session`, `--print`, `--mode`, and
 `-e/--extension`, respectively).

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -20,6 +20,8 @@ those locations and file formats.
 ├── skills/             # user-level skills
 ├── prompts/            # user-level prompt templates
 ├── themes/             # user-level TUI themes
+├── SYSTEM.md           # optional replacement system-prompt base
+├── APPEND_SYSTEM.md    # optional appended system-prompt instructions
 ├── AGENTS.md           # global project instructions
 └── logs/               # diagnostics
 ```
@@ -30,6 +32,36 @@ Tau also reads user-level `.agents` resources: `~/.agents/skills/`,
 Startup update checks cache their latest PyPI result in
 `~/.tau/cache/update-check.json` and refresh at most once per day. Set
 `TAU_NO_UPDATE_CHECK=1` to disable the check; Tau also skips it when `CI` is set.
+
+## System prompt files
+
+Tau can replace or extend its generated system prompt with Tau-native Markdown
+files:
+
+```text
+~/.tau/SYSTEM.md                 # user replacement
+~/.tau/APPEND_SYSTEM.md          # user append
+<project>/.tau/SYSTEM.md         # project replacement
+<project>/.tau/APPEND_SYSTEM.md  # project append
+```
+
+For each kind, precedence is explicit CLI input, then the project file, then the
+user file. A higher-precedence append file replaces the lower-precedence append
+file; Tau does not concatenate project and user files. Replacement content still
+receives the selected append text, project instructions, eligible skills, the
+current date, and the working directory. Empty files are valid explicit values.
+
+Run `/reload` after adding, changing, or removing a file. Tau rebuilds the prompt
+for the next model request without adding it to session history. `/session`
+resource diagnostics identify selected, shadowed, or CLI-overridden files. A
+selected file that cannot be inspected or decoded as UTF-8 stops startup or
+reload rather than silently falling back.
+
+System prompt files are Tau-specific and are not discovered from `.agents`.
+Project files currently load automatically, like Tau's other project instruction
+resources. Inspect a repository's `.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md`
+before starting Tau there: they can replace or extend the model's highest-priority
+instructions.
 
 ## Network proxies
 


### PR DESCRIPTION
## Summary

- discover Tau-native `SYSTEM.md` and `APPEND_SYSTEM.md` files from user and project `.tau` directories
- apply explicit CLI, project, then user precedence independently for replacement and append inputs
- rebuild the next-turn prompt when `/reload` adds, changes, removes, or shadows a prompt file
- report selected, shadowed, and CLI-overridden sources without exposing prompt contents
- fail safely when the selected file cannot be inspected, read, or decoded as UTF-8

## User experience

Users can keep persistent personal or repository-specific system instructions in files instead of repeating CLI flags. Existing prompt composition remains intact: replacement prompts still receive append text, project context, eligible skills, date, and cwd. Clear diagnostics explain which source won.

System prompt files remain Tau-native configuration; `.agents/SYSTEM.md` is intentionally not supported. Project files load automatically for now, and the documentation highlights their security impact. The future project-trust boundary is tracked separately in #535.

Closes #531.

## Manual validation

1. Put a replacement in `~/.tau/SYSTEM.md`, start Tau, and run `/system`.
2. Add `<project>/.tau/SYSTEM.md`, run `/reload`, and verify the project text replaces the user text.
3. Add either user or project `APPEND_SYSTEM.md`, run `/reload`, and verify its text follows the selected replacement.
4. Start Tau with `--system-prompt "CLI base"` and verify it overrides both files.
5. Run `/session` and inspect resource diagnostics for selected and shadowed paths.
6. Remove the project file, run `/reload`, and verify Tau falls back to the user file.

## Verification

- `uv run pytest` — 1325 passed, 2 skipped (Windows-only)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
