### PR TITLE
Include live system prompt in HTML exports

### DIFF
--- a/dev-notes/live-system-prompt-html-export.md
+++ b/dev-notes/live-system-prompt-html-export.md
@@ -1,0 +1,50 @@
+# Live system prompts in HTML session exports
+
+## What changed
+
+HTML created by a live `CodingSession` now contains its current
+`CodingSession.system_prompt`. The prompt appears in a labeled, collapsed
+**System Prompt** section above the transcript controls. It is escaped as plain
+text, keeps indentation and line breaks, and wraps long lines.
+
+Stored session JSONL still contains only session entries. Consequently:
+
+- `/export --format jsonl` does not add the prompt.
+- the JSONL download embedded in HTML does not add the prompt.
+- `tau export <session-id>` and `tau export <path.jsonl>` omit the HTML section,
+  because these offline paths only have stored entries and cannot recover the
+  live prompt.
+
+## Why the prompt is separate
+
+A system prompt configures provider requests; it is not a user, assistant, tool,
+or custom transcript event. Passing it as optional rendering context keeps the
+append-only session format unchanged and avoids inventing a synthetic entry.
+
+This behavior belongs in `tau_coding`: `CodingSession.export()` supplies the
+live value to the application-level HTML renderer. `tau_agent` remains unaware
+of CLI and HTML export policy.
+
+## Sharing and safety
+
+System prompts may include project instruction files, skill guidance, working
+directory paths, and other local context. The exported section warns about
+project instructions, but users should open and review live HTML before sharing
+it. HTML escaping prevents prompt text from becoming executable markup.
+
+## How to test
+
+Focused checks:
+
+```bash
+uv run pytest tests/test_session_export.py tests/test_coding_session.py tests/test_cli.py -k export
+```
+
+Full project checks:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -10,6 +10,7 @@
       "Changed": [
         "Cache Anthropic prompt prefixes to reduce repeated input billing, with auth-aware retention, compatibility overrides, and a sidebar cache hit rate.",
         "Redesign self-contained HTML session exports with compact accordions, entry filters and counts, expand/collapse controls, clearer tool labels, and offline JSONL download.",
+        "Include the current system prompt in live HTML session exports as a separate collapsed section; review exports before sharing because project instructions may be exposed, while JSONL and offline exports remain prompt-free.",
         "Show normal working indicators and unfocused completion notifications while manual `/compact` runs."
       ],
       "Fixed": [

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -629,6 +629,7 @@ class CodingSession:
             title=_session_export_title(self),
             source=str(session_path) if session_path is not None else self.session_id,
             format=export_format,
+            system_prompt=self.system_prompt,
         )
 
     @property

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -81,11 +81,17 @@ def export_session_html(
     *,
     title: str = "Tau Session Export",
     source: str | None = None,
+    system_prompt: str | None = None,
 ) -> Path:
     """Write a self-contained HTML session export and return its path."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
-        render_session_html(entries, title=title, source=source),
+        render_session_html(
+            entries,
+            title=title,
+            source=source,
+            system_prompt=system_prompt,
+        ),
         encoding="utf-8",
     )
     return output_path
@@ -98,12 +104,19 @@ def export_session_artifact(
     title: str = "Tau Session Export",
     source: str | None = None,
     format: str | None = None,
+    system_prompt: str | None = None,
 ) -> Path:
     """Write a session export in the requested or inferred format."""
     export_format = normalize_export_format(format or output_path.suffix.removeprefix("."))
     if export_format == "jsonl":
         return export_session_jsonl(entries, output_path)
-    return export_session_html(entries, output_path, title=title, source=source)
+    return export_session_html(
+        entries,
+        output_path,
+        title=title,
+        source=source,
+        system_prompt=system_prompt,
+    )
 
 
 def normalize_export_format(value: str | None) -> str:
@@ -135,6 +148,7 @@ def render_session_html(
     *,
     title: str = "Tau Session Export",
     source: str | None = None,
+    system_prompt: str | None = None,
 ) -> str:
     """Render a session transcript/tree as standalone HTML."""
     entry_list = list(entries)
@@ -144,6 +158,7 @@ def render_session_html(
     tree_html = _render_tree(visible_entries, active_path_ids, active_leaf_id)
     details_html = _render_entry_details(visible_entries, active_path_ids, active_leaf_id)
     source_html = f'<p class="source">Source: <code>{_escape(source)}</code></p>' if source else ""
+    system_prompt_html = _render_system_prompt(system_prompt)
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
     jsonl_b64 = base64.b64encode(_session_jsonl_text(entry_list).encode("utf-8")).decode("ascii")
     jsonl_filename = _jsonl_filename(title, source)
@@ -305,6 +320,33 @@ def render_session_html(
       flex-wrap: wrap;
       gap: 4px 18px;
       margin-top: 8px;
+    }}
+    details.system-prompt {{
+      margin-top: 16px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+    }}
+    .system-prompt-summary {{
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-family: var(--sans);
+      font-size: 0.78rem;
+      font-weight: 600;
+    }}
+    .system-prompt-warning {{
+      color: var(--muted);
+      font-size: 0.68rem;
+      font-weight: 400;
+    }}
+    .system-prompt-body {{ padding: 0 12px 12px; }}
+    .system-prompt-body pre {{
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }}
     .filter-bar {{
       display: flex;
@@ -674,6 +716,7 @@ def render_session_html(
         Generated: <time datetime="{_attr(generated_at)}">{_escape(generated_at)}</time>
       </p>
     </div>
+    {system_prompt_html}
     <div class="filter-bar" aria-label="Transcript filters">
       <span class="filter-label">View</span>
       <label class="chip">
@@ -821,6 +864,20 @@ def render_session_html(
 </body>
 </html>
 """
+
+
+def _render_system_prompt(system_prompt: str | None) -> str:
+    """Render live request configuration separately from transcript entries."""
+    if system_prompt is None:
+        return ""
+    return (
+        '<details class="system-prompt">'
+        '<summary class="system-prompt-summary">System Prompt'
+        '<span class="system-prompt-warning">May include project instructions</span>'
+        "</summary>"
+        f'<div class="system-prompt-body"><pre>{_escape(system_prompt)}</pre></div>'
+        "</details>"
+    )
 
 
 def _visible_entries(entries: Sequence[SessionEntry]) -> list[SessionEntry]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1434,6 +1434,7 @@ async def test_export_session_command_writes_html_for_indexed_session(tmp_path: 
     assert "<title>Exported Session</title>" in html
     assert "Export this" in html
     assert str(record.path) in html
+    assert '<details class="system-prompt">' not in html
 
 
 @pytest.mark.anyio
@@ -1456,6 +1457,7 @@ async def test_export_session_command_writes_html_for_jsonl_path(tmp_path: Path)
     assert output_path == tmp_path / "session.html"
     assert "<title>Tau session session</title>" in html
     assert "Path export" in html
+    assert '<details class="system-prompt">' not in html
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -237,6 +237,8 @@ async def test_session_export_defaults_to_cwd(tmp_path: Path) -> None:
     html = output_path.read_text(encoding="utf-8")
     assert "Export me" in html
     assert str(storage.path) in html
+    assert '<details class="system-prompt">' in html
+    assert "You are Tau." in html
 
 
 @pytest.mark.anyio
@@ -248,7 +250,10 @@ async def test_session_export_writes_jsonl_to_destination_directory(tmp_path: Pa
     output_path = await session.export(Path("exports"), format="jsonl")
 
     assert output_path == tmp_path / "exports" / "session-1.jsonl"
-    assert "Export me" in output_path.read_text(encoding="utf-8")
+    jsonl = output_path.read_text(encoding="utf-8")
+    assert "Export me" in jsonl
+    assert "You are Tau." not in jsonl
+    assert "system_prompt" not in jsonl
 
 
 @pytest.mark.anyio

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -88,6 +88,29 @@ def test_render_session_html_uses_static_document_layout() -> None:
     assert "http://" not in html and "https://" not in html
 
 
+def test_render_session_html_includes_escaped_readable_system_prompt() -> None:
+    entries = [MessageEntry(id="root", message=UserMessage(content="Hello"))]
+    system_prompt = "First line\n  indented <script>alert('x')</script>\n" + "long-word-" * 40
+
+    html = render_session_html(entries, system_prompt=system_prompt)
+
+    assert '<details class="system-prompt">' in html
+    assert "System Prompt" in html
+    assert "May include project instructions" in html
+    assert "First line\n  indented &lt;script&gt;alert('x')&lt;/script&gt;\n" in html
+    assert "<script>alert('x')</script>" not in html
+    assert "white-space: pre-wrap" in html
+    assert "overflow-wrap: anywhere" in html
+    assert html.index('class="system-prompt"') < html.index('<main class="session-shell">')
+
+
+def test_render_session_html_omits_unavailable_system_prompt() -> None:
+    html = render_session_html([])
+
+    assert '<details class="system-prompt">' not in html
+    assert "May include project instructions" not in html
+
+
 def test_render_session_html_syntax_highlights_tool_call_arguments() -> None:
     entries = [
         MessageEntry(
@@ -202,7 +225,10 @@ def test_render_session_html_includes_jsonl_download() -> None:
     ]
 
     html = render_session_html(
-        entries, title="Download Export", source="/home/user/.tau/sessions/abc123.jsonl"
+        entries,
+        title="Download Export",
+        source="/home/user/.tau/sessions/abc123.jsonl",
+        system_prompt="Private live prompt",
     )
 
     assert 'id="downloadJsonl"' in html
@@ -215,9 +241,12 @@ def test_render_session_html_includes_jsonl_download() -> None:
     assert match is not None
     decoded = base64.b64decode(match.group(1)).decode("utf-8")
     lines = decoded.splitlines()
-    # The download embeds every entry, including leaf pointers filtered from the view.
+    # The download embeds every entry, including leaf pointers filtered from the view,
+    # but keeps the live prompt outside persisted transcript data.
     assert len(lines) == 3
     assert '"id":"leaf"' in lines[2]
+    assert "Private live prompt" not in decoded
+    assert "system_prompt" not in decoded
 
 
 def test_render_session_html_jsonl_filename_falls_back_to_title_slug() -> None:

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -99,7 +99,18 @@ tau export <session-id> --format jsonl
 
 The source can be an indexed session id **or** a path to a JSONL session file.
 HTML exports are self-contained and include the preserved session tree plus the
-transcript in storage order. Every transcript entry is a compact accordion row
+transcript in storage order. When `/export` creates HTML from the live session,
+it also includes the current system prompt in a separate, collapsed **System
+Prompt** section. Review that section before sharing: the prompt may expose
+project instructions, skill guidance, paths, or other local context. Offline
+`tau export` of an indexed session or arbitrary JSONL file omits this section
+because session JSONL does not persist the prompt.
+
+The system prompt is display-only export metadata, not a transcript entry.
+Direct JSONL exports and JSONL downloaded from the HTML remain entry-only and do
+not contain it.
+
+Every transcript entry is a compact accordion row
 (icon, title, one-line preview, timestamp) that expands to reveal the full
 content; thinking blocks, tool-call arguments, and tool-result details are
 nested accordions. The export header includes controls to:

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -29,6 +29,13 @@ command palette with **Ctrl+K**.
 | `/skills` | Open a searchable picker of loaded skills and insert a selection into the prompt |
 | `/skill:<name> [request]` | Expand a loaded skill into your prompt |
 
+{{% note title="Live HTML exports include the system prompt" %}}
+`/export` includes the current system prompt in a collapsed section when it
+creates HTML. Review it before sharing because it may expose project
+instructions or other local context. JSONL exports do not include the prompt.
+Offline `tau export` from stored JSONL cannot recover it and omits the section.
+{{% /note %}}
+
 {{% note title="`/skill:` is special" %}}
 `/skill:<name>` is a *prompt-expansion* path, not a normal command — Tau expands
 the named skill into your prompt and runs it as a turn. Its optional request may


### PR DESCRIPTION
## Summary

- add the current `CodingSession.system_prompt` to live HTML exports in a separate collapsed, escaped section
- keep direct and embedded downloadable JSONL entry-only; omit unavailable prompts from indexed/arbitrary-file offline HTML exports
- document prompt exposure risk and add focused regression coverage plus implementation notes

## Testing

- `uv run pytest` (1320 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`

Closes #533
