### PR TITLE
Release Tau 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.5"
+version = "0.3.6"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,17 +1,33 @@
 [
   {
-    "version": "0.3.5",
-    "date": "2026-07-31",
+    "version": "0.3.6",
+    "date": "2026-08-03",
     "sections": {
       "New": [
-        "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees.",
         "Customize the generated system prompt in print or TUI sessions with `--system-prompt` and repeatable `--append-system-prompt` text-or-file inputs.",
         "Load Tau-native `SYSTEM.md` and `APPEND_SYSTEM.md` files from user or project `.tau` directories, with CLI and project precedence plus `/reload` support."
       ],
       "Changed": [
+        "Rebuild provider configuration from the current catalog during upgrades while preserving preferences and custom providers, so stale metadata cannot hide new capabilities or restore withdrawn models.",
+        "Include the current system prompt in live HTML session exports as a separate collapsed section; review exports before sharing because project instructions may be exposed, while JSONL and offline exports remain prompt-free."
+      ],
+      "Fixed": [
+        "Anchor context estimates to provider-reported token usage, proactively compact large sessions, and present automatic overflow recovery without misleading terminal errors.",
+        "Keep `@` file-reference completion available in skill arguments and custom prompt text.",
+        "Prevent direct `!` and `!!` shell commands from cancelling an active agent run."
+      ]
+    }
+  },
+  {
+    "version": "0.3.5",
+    "date": "2026-07-31",
+    "sections": {
+      "New": [
+        "Let print-mode automation choose a safe, durable session ID with `--session-id`, while preserving isolated-session guarantees."
+      ],
+      "Changed": [
         "Cache Anthropic prompt prefixes to reduce repeated input billing, with auth-aware retention, compatibility overrides, and a sidebar cache hit rate.",
         "Redesign self-contained HTML session exports with compact accordions, entry filters and counts, expand/collapse controls, clearer tool labels, and offline JSONL download.",
-        "Include the current system prompt in live HTML session exports as a separate collapsed section; review exports before sharing because project instructions may be exposed, while JSONL and offline exports remain prompt-free.",
         "Show normal working indicators and unfocused completion notifications while manual `/compact` runs."
       ],
       "Fixed": [

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -652,7 +652,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.5" in console.export_text()
+    assert "τ = 2π  0.3.6" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.3.5 to 0.3.6 in package and lock metadata
- add bundled 0.3.6 release highlights while restoring the published 0.3.5 notes
- update the version assertion backing the TUI sidebar brand

## Included changes

- add CLI and `.tau` file controls for replacing or appending the system prompt
- include the live system prompt in HTML exports with an explicit sharing warning
- rebuild provider configuration from the current catalog during upgrades
- anchor context recovery to provider-reported token usage
- restore `@` file completion in skill arguments and custom prompts
- prevent direct shell commands from cancelling active agent runs

## Validation

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 1,329 passed, 2 skipped (Windows-only)
- `uv build --out-dir /tmp/tau-release-0.3.6-dist`
- `uv run tau --version` — `tau 0.3.6`
- `hugo --source website --destination /tmp/tau-release-0.3.6-site --minify`
- `npx --yes pagefind@latest --site /tmp/tau-release-0.3.6-site`
- confirmed `tau-ai==0.3.6` is not already published on PyPI
