### PR TITLE
feat: enforce project input trust

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -16,6 +16,8 @@ User-facing documentation lives in `website/content/` and is published at
   - `03-tools.md` — built-in tool design
   - `04-sessions.md` — session tree / persistence design
   - `05-core-types-and-events.md` — provider-neutral types and events
+  - `project-trust.md` — researched, implementation-ready project-trust design
+    (design only; enforcement is not implemented)
   - `agent-loop.md`, `harness.md` — harness/loop reference notes
 - `architecture/` — per-phase implementation notes (`phase-1` … `phase-24`, plus
   hardening and feature notes). Each answers: what was added, why it exists, how

--- a/dev-notes/architecture/project-trust-runtime.md
+++ b/dev-notes/architecture/project-trust-runtime.md
@@ -1,0 +1,54 @@
+# Project-trust runtime
+
+Issue #535 adds a `tau_coding` input-loading guard around ambient project
+resources. The accepted policy and Pi compatibility research remain in
+`dev-notes/design/project-trust.md`.
+
+## Runtime shape
+
+- `project_trust.py` owns typed requests/resolutions, strict cwd
+  canonicalization, metadata-only detection, precedence, per-cwd caching, and
+  the locked version-1 atomic store.
+- `TauResourcePaths.project_resources_enabled` creates one coherent resource
+  plan. Existing skill, prompt, context, system-prompt, theme, and extension
+  loaders consume that plan rather than implementing policy.
+- `CodingSession.load` imports only user/explicit extensions first, resolves
+  trust, then loads protected Markdown/JSON and opted-in project extensions.
+- CLI entry points supply the user-global default and invocation override.
+  Structured/headless modes use no prompt. The TUI adapts the frontend-neutral
+  request to an accessible Textual modal.
+- Reload re-detects. Resume stages and resolves the destination cwd before
+  adoption. A cancelled reload/replacement keeps the current snapshot.
+
+`tau_agent` has no trust, path, Typer, or Textual dependency. Textual remains in
+`tau_coding.tui`.
+
+## Persistence and failure behavior
+
+`~/.tau/trust.json` has `version` and sorted `decisions`. Reads reject unknown
+fields/versions, duplicate or relative/non-normalized paths, and unknown
+values. Updates lock the store, write/fsync a mode-0600 same-directory temporary
+file, replace, and fsync the directory. Errors diagnose and fail closed; run-only
+explicit approval does not depend on storage.
+
+## Migration
+
+There is no legacy store. Existing projects are not auto-trusted. Interactive
+users decide when protected candidates exist; unresolved headless `ask` skips
+project inputs. User/global and explicit CLI resources continue to load.
+`--project-extensions` remains an additional executable-code opt-in.
+
+## Verification
+
+Use temporary homes/projects and fake extensions/providers. Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+cd website && hugo --minify
+cd website && npx --yes pagefind@latest --site public
+```
+
+Project trust is not a filesystem/process/network/tool/model sandbox.

--- a/dev-notes/architecture/project-trust-runtime.md
+++ b/dev-notes/architecture/project-trust-runtime.md
@@ -18,9 +18,10 @@ resources. The accepted policy and Pi compatibility research remain in
   Structured/headless modes use no prompt. The TUI adapts the frontend-neutral
   request to an accessible Textual modal.
 - Reload and destination replacement stage fresh cwd-bound extension runtimes,
-  resources, tools, commands, and prompts before adoption. Source-project
-  registrations never cross cwd boundaries; cancellation or preparation failure
-  keeps the current snapshot.
+  resources, tools, commands, prompts, and trust-cache entries before adoption.
+  Resource plans are unconditionally rebound to the canonical destination;
+  source-project registrations never cross cwd boundaries. Cancellation or any
+  preparation failure keeps the current snapshot and prior coordinator cache.
 
 `tau_agent` has no trust, path, Typer, or Textual dependency. Textual remains in
 `tau_coding.tui`.
@@ -29,9 +30,14 @@ resources. The accepted policy and Pi compatibility research remain in
 
 `~/.tau/trust.json` has `version` and sorted `decisions`. Reads reject unknown
 fields/versions, duplicate or relative/non-normalized paths, and unknown
-values. Updates lock the store, write/fsync a mode-0600 same-directory temporary
-file, replace, and fsync the directory. A post-replace failure restores the prior
-non-granting bytes before reporting failure. Errors diagnose and fail closed;
+values. Updates lock the store and first durably install a mode-0600 undo journal,
+then write/fsync a same-directory temporary file, replace `trust.json`, and fsync
+the directory. Readers reject any store with a pending journal. The journal is
+removed only after the destination commit point; failures attempt restoration,
+and a failed restoration leaves the journal in place so even combined commit and
+recovery failures cannot expose newly granting bytes. Journal-cleanup fsync
+failure is safe in either durable outcome: the committed store remains visible,
+or the journal reappears and reads fail closed. Errors diagnose and fail closed;
 run-only explicit approval does not depend on storage.
 
 ## Migration

--- a/dev-notes/architecture/project-trust-runtime.md
+++ b/dev-notes/architecture/project-trust-runtime.md
@@ -17,8 +17,10 @@ resources. The accepted policy and Pi compatibility research remain in
 - CLI entry points supply the user-global default and invocation override.
   Structured/headless modes use no prompt. The TUI adapts the frontend-neutral
   request to an accessible Textual modal.
-- Reload re-detects. Resume stages and resolves the destination cwd before
-  adoption. A cancelled reload/replacement keeps the current snapshot.
+- Reload and destination replacement stage fresh cwd-bound extension runtimes,
+  resources, tools, commands, and prompts before adoption. Source-project
+  registrations never cross cwd boundaries; cancellation or preparation failure
+  keeps the current snapshot.
 
 `tau_agent` has no trust, path, Typer, or Textual dependency. Textual remains in
 `tau_coding.tui`.
@@ -28,8 +30,9 @@ resources. The accepted policy and Pi compatibility research remain in
 `~/.tau/trust.json` has `version` and sorted `decisions`. Reads reject unknown
 fields/versions, duplicate or relative/non-normalized paths, and unknown
 values. Updates lock the store, write/fsync a mode-0600 same-directory temporary
-file, replace, and fsync the directory. Errors diagnose and fail closed; run-only
-explicit approval does not depend on storage.
+file, replace, and fsync the directory. A post-replace failure restores the prior
+non-granting bytes before reporting failure. Errors diagnose and fail closed;
+run-only explicit approval does not depend on storage.
 
 ## Migration
 

--- a/dev-notes/design/00-roadmap.md
+++ b/dev-notes/design/00-roadmap.md
@@ -31,6 +31,10 @@ context during automatic compaction, and can recover from a context-overflow
 provider error with one compact-and-retry attempt. See
 [Context Compaction](./context-compaction.md).
 
+Project-trust enforcement is not implemented. Its documentation-first design,
+Pi compatibility research, resource matrix, staged implementation, and test plan
+are recorded in [Project trust](./project-trust.md) for issue #535.
+
 ## Phase plan
 
 0. Project foundation and design docs.

--- a/dev-notes/design/project-trust.md
+++ b/dev-notes/design/project-trust.md
@@ -1,0 +1,720 @@
+# Project trust: compatibility research and Tau design
+
+Status: **design only**. Tau does not implement this policy yet.
+
+This note is the implementation plan for the documentation-first phase of
+[issue #535](https://github.com/huggingface/tau/issues/535). It explains the
+problem from first principles, records Pi's production behavior, audits Tau's
+current behavior, and fixes the intended Tau design before runtime code changes.
+
+A repository can currently influence Tau merely because Tau starts in that
+repository. Project trust will put a decision in front of that implicit input
+loading. It is not a judgment that every file in the repository is safe.
+
+## Compatibility baseline and research method
+
+Pi was inspected at the exact revision below on **2026-08-03**:
+
+- repository: [`earendil-works/pi`](https://github.com/earendil-works/pi)
+- commit: [`fa07e7bd92c90a0210a269354733c274e9fc11e6`](https://github.com/earendil-works/pi/commit/fa07e7bd92c90a0210a269354733c274e9fc11e6)
+- commit date: 2026-08-03 19:57:44 UTC
+
+The references below are commit-pinned and inspectable:
+
+- [`docs/security.md`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/docs/security.md)
+  is Pi's concise user-facing contract.
+- [`core/trust-manager.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/core/trust-manager.ts)
+  detects resources, canonicalizes keys, searches ancestors, and reads/writes
+  `trust.json`.
+- [`core/project-trust.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/core/project-trust.ts)
+  defines decision ordering, defaults, extension participation, and the startup
+  choices.
+- [`core/resource-loader.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/core/resource-loader.ts)
+  implements pre-trust and final resource-loading passes.
+- [`core/settings-manager.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/core/settings-manager.ts)
+  prevents project settings from loading while untrusted.
+- [`src/main.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/main.ts)
+  establishes bootstrap and session-cwd ordering.
+- [`cli/project-trust.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/cli/project-trust.ts)
+  limits trust UI exposed to extensions to interactive startup.
+- [`interactive-mode.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/modes/interactive/interactive-mode.ts)
+  contains `/trust`, reload, and resume integration.
+- [`core/agent-session-runtime.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/src/core/agent-session-runtime.ts)
+  recreates cwd-bound services when replacing a session.
+- [`examples/extensions/project-trust.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/examples/extensions/project-trust.ts)
+  demonstrates extension decisions and session-only results.
+- [`test/trust-manager.test.ts`](https://github.com/earendil-works/pi/blob/fa07e7bd92c90a0210a269354733c274e9fc11e6/packages/coding-agent/test/trust-manager.test.ts)
+  verifies persistence inheritance and trigger detection.
+
+These references describe that revision, not an assumed timeless Pi contract.
+
+## Pi's production behavior
+
+### What triggers a decision
+
+Pi first asks whether the cwd has a resource that needs trust. A bare `.pi`
+directory does not trigger anything. At the inspected revision, these entries do:
+
+- `<cwd>/.pi/settings.json`
+- `<cwd>/.pi/extensions`
+- `<cwd>/.pi/skills`
+- `<cwd>/.pi/prompts`
+- `<cwd>/.pi/themes`
+- `<cwd>/.pi/SYSTEM.md`
+- `<cwd>/.pi/APPEND_SYSTEM.md`
+- `.agents/skills` in the cwd or any ancestor, except the user's own
+  `~/.agents/skills`
+
+For the `.pi` directories, existence is enough; they need not contain a valid
+resource. This is why only a bare `.pi` directory is explicitly ignored.
+
+If no trigger exists, `resolveProjectTrusted()` returns true without consulting
+the store or prompting. Pi remembers this process-local outcome for that cwd.
+Its interactive reload has special handling: if a previously empty project gains
+a protected resource, Pi saves an implicit trusted decision after reload. Tau
+will deliberately differ here; see [Reload](#reload).
+
+### Gated and ungated inputs
+
+When trusted, Pi may load project settings, project `.pi` extensions, skills,
+prompts, themes, `SYSTEM.md`, `APPEND_SYSTEM.md`, project package resources, and
+install missing project packages. Project extensions and package extensions can
+therefore execute only after approval.
+
+Before the decision, Pi loads only:
+
+- global `AGENTS.md`/`CLAUDE.md` and ancestor context files;
+- user/global extensions;
+- extensions passed explicitly with CLI `-e`;
+- inline application extensions.
+
+Those pre-trust extensions can participate in the decision. Project extensions
+cannot decide whether they themselves should run.
+
+Pi deliberately leaves `AGENTS.md` and `CLAUDE.md` context ungated unless
+context loading is disabled. Explicit CLI resource paths also remain eligible;
+they represent a direct user instruction rather than ambient discovery.
+
+### Canonical paths, ancestors, and persistence
+
+Pi stores decisions in `~/.pi/agent/trust.json`. Keys are canonical absolute cwd
+paths. `resolvePath()` makes a path absolute and normalized; `canonicalizePath()`
+uses `realpathSync()` to follow symlinks, falling back to the normalized raw path
+if realpath fails.
+
+Lookup starts at the canonical cwd and walks to the filesystem root. The nearest
+entry whose value is `true` or `false` wins. Thus a child decision overrides a
+parent decision. Choosing “Trust parent folder” writes trust for the immediate
+canonical parent and removes an exact child decision so inheritance can apply.
+
+The file is a sorted JSON object whose values may be `true`, `false`, or `null`;
+lookup ignores `null` (normal removal deletes the key). Pi validates the whole
+object and uses a lock file for concurrent access. The inspected version writes
+the destination directly rather than by atomic replacement and has no
+schema-version field. Read/parse/validation/lock/write failures are errors; they
+are not converted into approval.
+
+### Decision order, scopes, and headless behavior
+
+Pi resolves in this order:
+
+1. one-run `--approve`/`-a` or `--no-approve`/`-na` override;
+2. no trigger means trusted;
+3. first decisive pre-trust extension result;
+4. nearest saved cwd/ancestor decision;
+5. global `defaultProjectTrust`, defaulting to `ask`;
+6. if still `ask`, prompt when UI exists, otherwise decline.
+
+The startup prompt offers:
+
+- trust this exact folder and save it;
+- trust the immediate parent and save it;
+- trust for this session only;
+- do not trust this exact folder and save it;
+- do not trust for this session only.
+
+Cancellation is a safe decline. The interactive `/trust` selector later edits
+saved exact/parent decisions, but says a restart is required; it does not mutate
+the current session's loaded set.
+
+Print, JSON, and RPC modes never prompt. With no extension or saved decision,
+`ask` and `never` decline, while `always` approves. The CLI overrides apply for
+one invocation and are not persisted. The argument parser rejects simultaneous
+approve and no-approve flags.
+
+### Bootstrap, extensions, and cwd changes
+
+Pi initially creates a settings manager with `projectTrusted: false`, so its
+first proxy bootstrap comes only from global settings. There is an important
+implementation caveat at this revision: after migrations, `main.ts` creates a
+second startup-cwd settings manager with the default `projectTrusted: true` and
+uses it for startup session-directory lookup before final trust resolution.
+Final cwd-bound runtime loading does enforce the trust split described below,
+but this early startup-settings read is not a pattern Tau should copy.
+
+Pi chooses a session—including a session from another project—before creating
+final cwd-bound runtime services. Final trust is therefore resolved against the
+session's actual cwd, not blindly against the process's startup directory.
+
+The resource loader's first pass forces project settings off and loads global,
+CLI, and inline extensions. It emits `project_trust`; the first extension to
+return yes/no wins, while `undecided` falls through. `remember: true` saves the
+exact cwd decision. Handler errors are diagnostics and do not approve. The
+second pass applies the decision, reloads settings, resolves packages, loads the
+final extension set, then loads skills, prompts, themes, context, and system
+prompt files.
+
+Session replacement recreates cwd-bound services. A TUI resume supplies an
+interactive trust context for the destination cwd. Pi also caches outcomes by
+cwd within the process, avoiding an unrelated cwd's decision while avoiding
+repeat prompts for one cwd.
+
+### Security boundary
+
+Pi's own security document is explicit: project trust is only an input-loading
+guard. Pi still runs with the user's permissions. It is not a filesystem,
+process, shell, tool, network, package-manager, extension, credential, model, or
+prompt-injection sandbox. Real isolation requires an OS, container, VM, or
+similar boundary.
+
+## Current Tau behavior on `main`
+
+This section describes what exists **now**, separately from the proposal.
+It was audited on 2026-08-03 at current Tau `main` commit
+[`9fffc6938e1873e5430b66117b7ade078d779030`](https://github.com/huggingface/tau/commit/9fffc6938e1873e5430b66117b7ade078d779030).
+The behavior-bearing source links below use its parent `cc179435`, before the
+release-only version commit.
+
+Tau has no unified project-trust decision or trust store. It does not expose
+`--approve`, `--no-approve`, or `defaultProjectTrust`. Starting, reloading, or
+resuming can load project Markdown without a trust prompt.
+
+The current sources are inspectable at:
+
+- [`resources.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/resources.py)
+- [`context.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/context.py)
+- [`session.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/session.py)
+- [`paths.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/paths.py)
+- [`extensions/loader.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/extensions/loader.py)
+- [`shell_config.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/shell_config.py)
+- [`cli.py`](https://github.com/huggingface/tau/blob/cc179435a4e4fb934d51c0032c36f8d46fcd811c/src/tau_coding/cli.py)
+
+### Current resource matrix
+
+| Input on current `main` | Current behavior |
+|---|---|
+| `~/.tau/settings.json` | User-only shell settings such as `shellCommandPrefix`; there is no project `.tau/settings.json` loader. |
+| `.agents` settings | Tau has no user or project `.agents` settings loader. |
+| Other user provider/TUI settings | Read from user `~/.tau` files; no project equivalents. |
+| `<cwd>/.tau/skills/*/SKILL.md` | Automatically discovered and loaded. |
+| `<cwd>/.agents/skills/*/SKILL.md` | Automatically discovered and loaded. Tau checks the cwd location, not every ancestor `.agents/skills` as Pi does. |
+| `<cwd>/.tau/prompts/*.md` | Automatically discovered and loaded. |
+| `<cwd>/.agents/prompts/*.md` | Automatically discovered and loaded. This is broader `.agents` support than Pi's trust trigger. |
+| `<cwd>/.tau/themes/*.json` | Loaded by the TUI and takes precedence over user themes. `.agents/themes` is not supported. |
+| `<cwd>/.tau/SYSTEM.md` | Automatically read and replaces the default prompt unless an explicit CLI system prompt wins. |
+| `<cwd>/.tau/APPEND_SYSTEM.md` | Automatically read and appended unless an explicit CLI append value wins. `.agents` system-prompt files are not supported. |
+| Plain `AGENTS.md` | Loaded from the detected project root through the cwd. |
+| `<cwd>/.tau/AGENTS.md` | Loaded as project context. |
+| `<cwd>/.agents/AGENTS.md` | Loaded as project context. |
+| `CLAUDE.md` | Not currently discovered by Tau. |
+| `<cwd>/.tau/extensions` | Python code, disabled by default and loaded only with `--project-extensions`. |
+| `~/.tau/extensions` | Python code, discovered by default unless `--no-extensions`. |
+| `-e/--extension PATH` | Loaded explicitly even with `--no-extensions`; not trust-gated. |
+| Extension `pyproject.toml` | `[tool.tau].extensions` is parsed only inside an extension directory being discovered; it is an extension manifest, not a general project package manager. |
+| Project packages | Tau has no Pi-style project package resource/install system today. |
+
+User `~/.tau` and `~/.agents` skills, prompts, and `AGENTS.md` are loaded as
+user-owned resources. Skills and prompts use increasing precedence: user
+`.tau`, user `.agents`, project `.tau`, project `.agents`. Project context layers
+root-to-cwd plain `AGENTS.md`, then cwd `.tau/AGENTS.md` and
+`.agents/AGENTS.md`. Project system prompt files take precedence over user files.
+
+`/reload` re-discovers resources and can execute opted-in project extensions
+without a trust check. `CodingSession.resume()` creates a replacement for the
+record's cwd and loads its resources before adopting it; there is no destination
+trust step. Explicit startup system-prompt text/path and explicit extension paths
+already express user intent and override or augment ambient discovery.
+
+The existing `--project-extensions` switch is a narrow safety opt-in, not a
+persisted project-trust system. Published docs correctly warn about project
+resources but must not claim enforcement exists until runtime phases land.
+
+## Proposed Tau policy
+
+Everything below is a future contract. Implementation PRs may stage it, but
+must not silently weaken it.
+
+### Goals and invariants
+
+1. No protected project file is read for content, parsed, imported, installed,
+   or executed before the decision for its canonical cwd.
+2. Detection may inspect file type/name/existence only. It must not parse a
+   project manifest merely to decide whether to ask.
+3. Decline yields one coherent unprotected resource snapshot, never a mixture
+   produced by a failed partial load.
+4. Global policy cannot come from project settings; a project cannot approve
+   itself.
+5. A trust outcome is scoped to a canonical cwd and may inherit only from the
+   nearest canonical ancestor decision.
+6. `tau_agent` remains unaware of trust, local paths, CLI, and Textual.
+7. Textual renders a Tau-owned decision request through the existing adapter
+   boundary; it does not own trust policy.
+
+### Protected-resource matrix
+
+“Project” means ambient resources discovered because of the active cwd, not a
+path the user explicitly supplied on this invocation.
+
+| Resource | Proposed policy | Trigger rule |
+|---|---|---|
+| Built-in packaged resources | Ungated | Never. |
+| User `~/.tau` and `~/.agents` resources | Ungated | Never; they are user-managed inputs. |
+| Explicit CLI system/append prompt, extension, and future explicit skill/prompt/theme paths | Ungated | Never; direct invocation is consent. Existing type/read/load errors still apply. |
+| `<cwd>/.tau/settings.json` if project settings are added | **Protected** | File exists. Only global settings can choose trust defaults. |
+| `<cwd>/.tau/skills` and `.agents/skills` | **Protected** | At least one candidate `*/SKILL.md` exists. |
+| `<cwd>/.tau/prompts` and `.agents/prompts` | **Protected** | At least one candidate non-reserved `*.md` exists. |
+| `<cwd>/.tau/themes` | **Protected** | At least one `*.json` candidate exists. |
+| `<cwd>/.tau/SYSTEM.md` and `APPEND_SYSTEM.md` | **Protected** | File exists. |
+| Plain ancestor-to-cwd `AGENTS.md`, cwd `.tau/AGENTS.md`, and cwd `.agents/AGENTS.md` | **Protected** | Any file Tau would include exists. |
+| `CLAUDE.md` | Not currently supported; if later discovered, **protected** like `AGENTS.md`. | File exists in the future discovery set. |
+| `<cwd>/.tau/extensions` | **Protected and still opt-in initially** | At least one candidate `.py`, `*/extension.py`, or extension-package manifest exists. |
+| Future project package declarations, package-managed resources, or auto-install metadata | **Protected** | The declaration/manifest exists; no resolution, download, or install before approval. |
+
+Empty `.tau`, `.agents`, and empty protected subdirectories do not trigger a
+decision. A broken or unreadable candidate that could otherwise load **does**
+trigger; detection must not treat inspection failure as proof that no protected
+input exists. Symlink candidates trigger based on the directory entry, while
+content access waits for approval.
+
+Directory scanners should share candidate predicates with the actual loaders so
+the trigger matrix cannot drift. Detection returns typed resource categories and
+paths for internal policy/diagnostics, but UI reports category/count—not file
+content. It must cap detailed paths to avoid startup floods.
+
+### Deliberate differences from Pi
+
+Tau should not copy Pi blindly:
+
+- **Protect all project `AGENTS.md`-style context.** Pi leaves `AGENTS.md` and
+  `CLAUDE.md` ungated. Tau will gate project plain, `.tau`, and `.agents`
+  instruction files because they become high-priority model input and can cause
+  actions indirectly. User-level context remains ungated. This is an
+  input-loading guard, not a claim that trusted context is safe.
+- **Protect `.agents/prompts` and `.agents/AGENTS.md` as well as
+  `.agents/skills`.** Tau intentionally supports more `.agents` locations than
+  Pi. Treating only skills as protected would leave equivalent project prompt
+  inputs outside the boundary.
+- **Do not broaden ancestor resource discovery as a side effect.** Initial trust
+  enforcement covers exactly what Tau loaders discover today: cwd `.tau` and
+  `.agents` resources plus existing root-to-cwd plain `AGENTS.md`. Adding Pi's
+  ancestor `.agents/skills` discovery is a separate compatibility change. If
+  added later, those ancestor resources are protected and become triggers.
+- **Keep `--project-extensions` during migration.** Initially a project
+  extension loads only when the project is trusted *and* the existing opt-in is
+  present. Trust must never make currently disabled executable code start
+  automatically. A later, separately documented release may reconsider this.
+- **Version and atomically replace Tau's store.** Pi's inspected store is an
+  unversioned object written directly. Tau should make migration explicit and
+  prevent torn writes.
+- **Never implicitly save trust on reload.** If a project had no protected
+  inputs and gains one, Tau asks (interactive) or follows deterministic
+  headless policy. Merely having started in an empty project is not durable
+  consent to future inputs.
+
+### `tau_coding` types and ownership
+
+Add a small `tau_coding.project_trust` policy layer. Suggested typed values:
+
+```python
+TrustDefault = Literal["ask", "always", "never"]
+TrustDecision = Literal["trusted", "untrusted"]
+TrustOverride = Literal["approve", "decline"]
+TrustScope = Literal["exact", "parent", "run"]
+
+@dataclass(frozen=True, slots=True)
+class CanonicalProjectPath:
+    value: Path
+
+@dataclass(frozen=True, slots=True)
+class ProtectedResourceSummary:
+    cwd: CanonicalProjectPath
+    categories: tuple[str, ...]
+    counts: Mapping[str, int]
+
+@dataclass(frozen=True, slots=True)
+class SavedTrustEntry:
+    path: CanonicalProjectPath
+    decision: TrustDecision
+
+@dataclass(frozen=True, slots=True)
+class ProjectTrustRequest:
+    cwd: CanonicalProjectPath
+    resources: ProtectedResourceSummary
+    inherited_entry: SavedTrustEntry | None
+    choices: tuple[TrustChoice, ...]
+
+@dataclass(frozen=True, slots=True)
+class ProjectTrustResolution:
+    trusted: bool
+    source: Literal["override", "empty", "extension", "saved", "default", "ui"]
+    saved_path: CanonicalProjectPath | None
+```
+
+Exact names may change, but keep these separations:
+
+- `ProjectTrustStore`: validate, lock, read, nearest lookup, and atomic update;
+- `ProtectedResourceDetector`: metadata-only trigger detection;
+- `ProjectTrustPolicy`: pure precedence/default resolution;
+- an async coordinator in `tau_coding` for extension/UI requests;
+- a resource plan/snapshot that filters project inputs before existing loaders.
+
+The coordinator receives abstract callbacks/protocols for decisions. TUI code
+maps `ProjectTrustRequest` to a Textual modal and returns a choice. No Textual
+imports enter the policy module. `tau_agent` receives only the already-built
+system prompt, tools, and resources as it does now.
+
+### Canonical path rules
+
+A trust key is not a repository root. It is the active cwd after session
+selection/replacement. Canonicalization must:
+
+1. expand `~`, make the path absolute against an explicitly supplied base, and
+   normalize `.`/`..`;
+2. require the active cwd to exist and be a directory;
+3. resolve all symlinks (`Path.resolve(strict=True)`);
+4. apply the platform's case normalization for comparison/storage where the
+   platform is case-insensitive, while retaining a display path separately if
+   useful;
+5. serialize one normalized native absolute path string.
+
+Do not use raw string-prefix tests: `/work/app2` is not a child of `/work/app`.
+Walk `Path.parent` from canonical cwd through the root. The first exact store
+entry wins. A child explicit decline therefore overrides trusted parent scope.
+Different symlink spellings resolve to one decision. A moved project has a new
+key; stale entries remain inspectable and harmless until an explicit cleanup
+feature exists.
+
+If canonicalization of the live cwd fails, protected resources are untrusted and
+startup emits an actionable error. Do not fall back to a noncanonical key as Pi
+does. Saved entries must be absolute and normalized; invalid entries make the
+store malformed rather than being silently skipped.
+
+### Versioned, inspectable persistence
+
+Use `~/.tau/trust.json` (equivalently `TauPaths.home / "trust.json"`) with this
+initial shape:
+
+```json
+{
+  "version": 1,
+  "decisions": [
+    {"path": "/home/alex/src", "decision": "trusted"},
+    {"path": "/home/alex/src/example", "decision": "untrusted"}
+  ]
+}
+```
+
+Requirements:
+
+- reject unknown versions, duplicate canonical paths, unknown fields, relative
+  paths, and unknown decisions;
+- sort decisions by path for stable diffs;
+- lock across read-modify-write so concurrent Tau processes cannot lose updates;
+- create the Tau home with user-only permissions where supported;
+- write a same-directory temporary file, flush and `fsync` it, set restrictive
+  permissions, `os.replace()` it over the destination, then `fsync` the parent
+  directory where supported;
+- clean up a failed temporary file without replacing the last valid store.
+
+Malformed/unreadable store means no saved decision can grant trust. Emit one
+clear diagnostic and fail closed for protected resources unless the user gives
+an explicit run-only approval through UI or `--approve`. A saved UI choice must
+be written successfully **before** it grants trust; if persistence is
+unwritable, report failure and remain untrusted, while offering the separate
+“this run only” choice. An extension result with `remember=True` follows the
+same rule. Explicit one-run approval never writes and remains usable, with a
+store-error diagnostic, because it is direct consent rather than inferred
+state.
+
+Do not rename a malformed store automatically or silently reset it; that hides
+why decisions disappeared. Future schema migration must parse the old complete
+document, write v1 atomically, preserve a backup, and report what changed.
+
+### Resolution precedence
+
+For each canonical destination cwd:
+
+1. explicit one-run CLI override;
+2. no protected resource candidates: allow ambient loading because there is
+   nothing protected, but record no durable decision;
+3. first decisive eligible pre-trust extension;
+4. nearest saved exact/ancestor decision;
+5. user-global `defaultProjectTrust` (`ask` when absent);
+6. interactive built-in choice for `ask`; otherwise safe decline.
+
+This matches Pi's meaningful order. A project setting can neither set
+`defaultProjectTrust` nor alter earlier steps. Cache a completed run resolution
+by canonical cwd, including declines, so one cwd does not repeatedly prompt.
+Never reuse it for another cwd. Re-run metadata detection on reload so an
+“empty” outcome does not become consent after new files appear.
+
+### Startup sequence
+
+The future bootstrap should be explicit and testable:
+
+1. Parse CLI arguments. Reject `--approve` with `--no-approve` before filesystem
+   resource loading.
+2. Load built-ins and user-global settings only. Read `defaultProjectTrust` only
+   here. Do not read `<cwd>/.tau/settings.json`.
+3. Resolve the final session target and canonical destination cwd using only
+   user-global session configuration. A resumed record's cwd wins after missing
+   cwd handling.
+4. Detect protected candidates by metadata only.
+5. Load a pre-trust extension runtime containing built-ins, user
+   `~/.tau/extensions`, and explicit `-e` paths. Never import project extensions
+   or resolve project packages in this pass.
+6. Resolve trust using the precedence above. Interactive startup asks through
+   the adapter; headless startup does not.
+7. Build a complete resource plan: global and explicit inputs always; project
+   inputs only if trusted; project extensions additionally require the existing
+   opt-in during migration.
+8. Only now parse project settings/manifests, resolve/install future project
+   packages, import project extensions, read project Markdown/JSON, create the
+   provider/runtime, and assemble the system prompt.
+9. Publish the new coding session only after the complete plan succeeds. Emit
+   bounded diagnostics for skipped categories or failures.
+
+Provider construction matters: a protected project setting must not influence
+provider, proxy, credentials, shell prefix, model, session directory, extension
+flags, or tool configuration before step 8.
+
+### Interactive TUI choices
+
+The built-in modal should state the canonical folder, explain the categories it
+would load, and say “This controls project inputs; it is not a sandbox.” Choices:
+
+- **Trust this folder** — atomically save exact trusted, then continue;
+- **Trust parent folder (`…`)** — save immediate parent trusted and remove an
+  exact child entry in one transaction, then continue;
+- **Trust for this run only** — continue without writing;
+- **Do not trust this folder** — atomically save exact untrusted, then continue
+  with protected resources skipped;
+- **Do not trust for this run only** — skip without writing.
+
+Escape/cancel equals run-only decline. Parent scope must never default to `$HOME`
+or filesystem root without displaying the exact broad scope and requiring the
+same explicit selection. Accessibility, focus, and key handling belong to the
+Textual adapter/modal; available choices and semantics belong to `tau_coding`.
+
+A future `/trust` command may inspect/edit decisions. Like Pi, edits should not
+quietly mutate already loaded resources. It should say restart or `/reload` is
+required. It must display inherited source and current run outcome separately.
+
+### Headless modes and explicit overrides
+
+Add `--approve`/`-a` and `--no-approve`/`-na` as mutually exclusive, invocation-
+only overrides. They do not write `trust.json`. They apply to every destination
+cwd entered by that invocation, including a resumed/replaced session, but each
+cwd still receives its own diagnostic and resource plan.
+
+Print, JSON, transcript, export-related runtime modes, and automation must never
+wait for UI. With no earlier decisive result:
+
+| Global default | Headless result |
+|---|---|
+| `ask` | untrusted |
+| `always` | trusted |
+| `never` | untrusted |
+
+Structured modes must send diagnostics to their established diagnostic channel,
+not corrupt stdout protocols. Extension participation is allowed in headless
+mode, but `has_ui` is false and UI methods cannot prompt. A handler that tries
+to prompt gets a deterministic error/undecided result, not stdin access.
+
+### Extension participation
+
+Add a Tau-owned `project_trust` event only after its result and ordering are
+tested. The event exposes canonical cwd, mode, `has_ui`, and category/count
+summary—never protected contents. Results are `approve`, `decline`, or `defer`,
+plus `remember: bool`.
+
+Only built-in, user-global, and explicit CLI extensions may receive it. First
+decisive result wins. Errors become diagnostics and resolution continues.
+Project extensions, project package extensions, and resources registered by
+them cannot load or participate before approval. Final loading should reuse
+already imported eligible extensions where practical so setup does not run
+twice.
+
+An extension cannot invent broader parent persistence: `remember` saves only the
+exact cwd. Built-in UI owns parent-scope selection. On malformed/unwritable
+storage, remembered extension approval fails closed as described above.
+
+### Reload
+
+`/reload` must be transactional:
+
+1. detect candidates again;
+2. if protected candidates now exist and this cwd has no cached non-empty
+   resolution, resolve trust before reading them;
+3. prepare all permitted resources and extensions in a replacement snapshot;
+4. swap only after preparation succeeds;
+5. emit reload/session lifecycle events from the accepted runtime.
+
+If the user cancels or a trust/storage/load error occurs, keep the previous valid
+resource/runtime snapshot. A deliberate decline may successfully replace it
+with the global/explicit-only snapshot, after confirmation. Never implicitly
+save trust because an empty project gained files. A saved decision changed by a
+future `/trust` command takes effect only on an explicit reload/restart.
+
+### Resume, replacement, and cwd changes
+
+Current Tau replacement loads before adoption but has no trust phase. Future
+resume/new-session/fork flows must derive and canonicalize the destination cwd,
+then run the same coordinator before any destination project resource is read.
+Do not carry source-cwd trust to the destination.
+
+For an interactive cross-cwd resume, stage destination selection and trust while
+the current session remains valid. Cancel leaves the existing session active.
+Only after destination resources and provider/runtime are ready should Tau tear
+down/adopt. Headless replacement uses the deterministic table and fails/skips
+without prompting. Cache keys are canonical cwd, not session id.
+
+### Diagnostics and observability
+
+Diagnostics should answer:
+
+- canonical cwd and whether a decision was exact or inherited;
+- outcome source (`override`, `extension`, `saved`, `default`, or `ui`);
+- protected categories skipped, with counts;
+- malformed/unreadable/unwritable store and remediation path;
+- pre-trust extension errors;
+- why project extensions remained disabled despite trust (missing existing
+  `--project-extensions` opt-in).
+
+Do not print trust-store contents, resource contents, credentials, or every path
+by default. Interactive status may summarize once. Text/JSON/transcript modes
+must preserve their output contracts. A debug view may expose bounded paths
+only after normal redaction rules.
+
+### Migration and compatibility rollout
+
+Enforcement changes existing behavior, so do not hide it in a refactor.
+Recommended first runtime release:
+
+- default global policy is `ask`;
+- interactive sessions ask when meaningful protected candidates exist;
+- headless unresolved `ask` declines and emits a concise migration diagnostic
+  suggesting a saved interactive decision or explicit `--approve`;
+- no existing repository is auto-trusted and no decision is inferred from
+  `--project-extensions` history;
+- user/global and explicit CLI resources continue working;
+- `--project-extensions` remains an additional requirement;
+- release notes and published security/configuration/CLI docs are updated only
+  when enforcement and flags actually ship.
+
+There is no legacy Tau trust store to import. If a prototype/unversioned file is
+ever released before v1, migration must be explicit, tested, and backed up.
+
+## Staged future implementation
+
+This design PR adds no runtime code. Follow-up changes should stay reviewable:
+
+1. **Pure policy and persistence.** Add types, strict canonicalization, detector,
+   versioned locked atomic store, nearest-ancestor lookup, and pure resolution.
+   No CLI/TUI integration yet.
+2. **Resource planning.** Introduce trusted/untrusted resource snapshots and gate
+   project settings, skills, prompts, themes, context, and system-prompt files.
+   Preserve existing precedence among permitted inputs.
+3. **CLI/headless integration.** Add mutually exclusive overrides, global default,
+   deterministic modes, structured diagnostics, startup/session-cwd ordering.
+4. **TUI adapter integration.** Add the accessible startup modal and scopes
+   without moving Textual into policy or `tau_agent`.
+5. **Extensions and replacement.** Add pre-trust extension event, two-pass reuse,
+   transactional reload, and cross-cwd resume/replacement.
+6. **Packages, only when Tau has them.** Gate project package declarations,
+   resolution, installs, and package resources before exposing the feature.
+7. **Published documentation/release notes.** Describe only behavior that has
+   landed, include migration guidance, and repeat the non-sandbox boundary.
+
+Each stage should update this note if implementation discovers an invalid
+assumption; deliberate policy changes need rationale, not accidental drift.
+
+## Deterministic test plan
+
+All tests must use temporary homes and projects; no test reads or writes the
+operator's real home or calls a live provider.
+
+### Policy and store
+
+- canonical aliases/symlinks map to one key; missing/non-directory cwd fails
+  closed;
+- exact beats nearest parent; parent beats global default; siblings do not
+  inherit;
+- broad parent trust plus exact child decline; removing child restores
+  inheritance;
+- v1 round trip is sorted and inspectable;
+- malformed JSON, wrong version/schema, duplicate/noncanonical paths, read
+  failure, lock failure, and write/replace/fsync failure do not grant trust;
+- interrupted atomic writes preserve the prior valid file;
+- concurrent fake writers do not lose decisions.
+
+### Detection and matrix
+
+Using temporary directories, cover every matrix row, both `.tau` and `.agents`,
+plain root-to-cwd `AGENTS.md`, empty directories, reserved/nonmatching files,
+unreadable entries, and symlinks. Assert detection reads no protected content.
+Assert current unsupported `CLAUDE.md` and package metadata do not accidentally
+load, while future package fixtures trigger once that feature exists.
+
+### Resolution and startup
+
+Table-test override, no-resource, extension, exact/ancestor saved decision, each
+default, UI choice, cancellation, and store-error precedence. Validate
+conflicting CLI flags before resource reads. Use a fake provider that records
+construction and calls; assert it sees no protected project setting/prompt
+before approval and receives no call on failed startup.
+
+### Resource and extension ordering
+
+Use fake extensions that record import/setup/events:
+
+- global and explicit extensions may handle trust;
+- project extensions never import before approval;
+- first decisive handler wins, defer continues, errors diagnose and continue;
+- remembered approval must persist before loading project code;
+- decline produces only global/explicit resources;
+- protected categories load as one final snapshot with existing precedence;
+- `--project-extensions` remains required in addition to trust.
+
+### Frontends, reload, and sessions
+
+- Textual pilot tests cover every scope, parent label, escape-as-decline, focus,
+  keyboard operation, persistence error, and non-sandbox copy;
+- print/JSON/transcript tests prove `ask` never prompts and stdout remains clean;
+- reload after an initially empty project asks/declines rather than auto-saving;
+- cancelled/failed reload preserves the old snapshot; accepted decline swaps to
+  global/explicit-only;
+- resume/replacement to a second cwd resolves independently before adoption;
+  cancellation retains the first session;
+- same canonical cwd uses its process cache, while symlink aliases and unrelated
+  cwd behavior are deterministic;
+- fake providers and fake extensions prove no live model, network, package
+  install, process, or real credential is needed.
+
+Run the repository's complete Python and website checks for every integration
+stage.
+
+## Non-sandbox boundary
+
+**Project trust is only an input-loading guard.** It does not restrict what Tau,
+the model, extensions, packages, or tools can do after loading. It is not a
+filesystem, write, process, shell, subprocess, network, tool, credential,
+provider, model, package-install, prompt-injection, or data-exfiltration
+boundary. A trusted project may still be malicious, and an untrusted repository
+may still influence the model through content the user explicitly asks Tau to
+read or through tool output.
+
+Users needing isolation must run Tau inside an appropriate OS sandbox,
+container, VM, micro-VM, remote environment, or policy-controlled tool boundary
+with limited files, credentials, and network access. This project-trust design
+must never be marketed as a substitute.

--- a/dev-notes/design/project-trust.md
+++ b/dev-notes/design/project-trust.md
@@ -421,10 +421,16 @@ Requirements:
 - sort decisions by path for stable diffs;
 - lock across read-modify-write so concurrent Tau processes cannot lose updates;
 - create the Tau home with user-only permissions where supported;
+- durably install a restrictive same-directory undo journal before replacing
+  the destination; readers fail closed whenever that journal remains;
 - write a same-directory temporary file, flush and `fsync` it, set restrictive
   permissions, `os.replace()` it over the destination, then `fsync` the parent
   directory where supported;
-- clean up a failed temporary file without replacing the last valid store.
+- remove the journal only after that commit point; on a reported failure restore
+  the prior store, and retain the fail-closed journal if any recovery operation
+  fails, so newly granting bytes can never become an effective saved decision;
+- clean up unrelated failed temporary files without replacing the last valid
+  store.
 
 Malformed/unreadable store means no saved decision can grant trust. Emit one
 clear diagnostic and fail closed for protected resources unless the user gives

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -23,6 +23,7 @@ from tau_coding.catalog_loader import user_catalog_path
 from tau_coding.commands import format_reload_summary
 from tau_coding.credentials import FileCredentialStore
 from tau_coding.extensions import StderrUiBridge
+from tau_coding.project_trust import TrustDefault, TrustOverride
 from tau_coding.provider_config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER_NAME,
@@ -294,8 +295,16 @@ def main(
         bool,
         typer.Option(
             "--project-extensions",
-            help="Also load project .tau/extensions (runs project-supplied code at startup).",
+            help="Also load trusted project .tau/extensions (additional code opt-in).",
         ),
+    ] = False,
+    approve: Annotated[
+        bool,
+        typer.Option("--approve", "-a", help="Trust protected project inputs for this run."),
+    ] = False,
+    no_approve: Annotated[
+        bool,
+        typer.Option("--no-approve", "-na", help="Decline protected project inputs for this run."),
     ] = False,
     version: Annotated[
         bool,
@@ -310,6 +319,12 @@ def main(
 
     if ctx.invoked_subcommand is not None:
         return
+
+    if approve and no_approve:
+        raise typer.BadParameter("--approve and --no-approve cannot be used together")
+    trust_override: TrustOverride | None = (
+        "approve" if approve else "decline" if no_approve else None
+    )
 
     if resume is not None:
         raise typer.BadParameter(
@@ -394,8 +409,7 @@ def main(
     if not print_requested:
         notice = _startup_update_notice()
         try:
-            resumable_session_id = anyio.run(
-                run_openai_tui,
+            tui_args = (
                 model,
                 cwd or Path.cwd(),
                 session,
@@ -409,6 +423,11 @@ def main(
                 project_extensions,
                 custom_system_prompt,
                 resolved_append_system_prompt,
+            )
+            resumable_session_id = (
+                anyio.run(run_openai_tui, *tui_args)
+                if trust_override is None
+                else anyio.run(run_openai_tui, *tui_args, trust_override)
             )
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -428,8 +447,7 @@ def main(
         typer.echo(notice.message, err=True)
 
     try:
-        ok = anyio.run(
-            run_openai_print_mode,
+        print_args = (
             prompt,
             model,
             cwd or Path.cwd(),
@@ -442,6 +460,11 @@ def main(
             session_id,
             custom_system_prompt,
             resolved_append_system_prompt,
+        )
+        ok = (
+            anyio.run(run_openai_print_mode, *print_args)
+            if trust_override is None
+            else anyio.run(run_openai_print_mode, *print_args, trust_override)
         )
     except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -463,6 +486,7 @@ async def run_openai_tui(
     project_extensions_enabled: bool = False,
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
+    trust_override: TrustOverride | None = None,
 ) -> str | None:
     """Run the Textual TUI and return its resumable session id, if any."""
     release_notes_notice = startup_release_notes_notice(_current_version())
@@ -482,6 +506,7 @@ async def run_openai_tui(
         project_extensions_enabled=project_extensions_enabled,
         custom_system_prompt=custom_system_prompt,
         append_system_prompt=append_system_prompt,
+        trust_override=trust_override,
     )
 
 
@@ -740,6 +765,7 @@ async def run_openai_print_mode(
     session_id: str | None = None,
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
+    trust_override: TrustOverride | None = None,
 ) -> bool:
     """Run print mode with the OpenAI-compatible provider configured from the environment."""
     settings = load_provider_settings()
@@ -776,6 +802,8 @@ async def run_openai_print_mode(
             project_extensions_enabled=project_extensions_enabled,
             custom_system_prompt=custom_system_prompt,
             append_system_prompt=append_system_prompt,
+            trust_override=trust_override,
+            trust_default=shell_settings.default_project_trust,
         )
     finally:
         await provider.aclose()
@@ -812,6 +840,8 @@ async def run_print_mode(
     project_extensions_enabled: bool = False,
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
+    trust_override: TrustOverride | None = None,
+    trust_default: TrustDefault = "always",
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -836,9 +866,14 @@ async def run_print_mode(
             project_extensions_enabled=project_extensions_enabled,
             custom_system_prompt=custom_system_prompt,
             append_system_prompt=append_system_prompt,
+            trust_override=trust_override,
+            trust_default=trust_default,
         )
     )
     session.extension_runtime.set_ui_bridge(StderrUiBridge())
+    for diagnostic in session.resource_diagnostics:
+        if diagnostic.kind == "project-trust":
+            typer.echo(diagnostic.format(), err=True)
     await session.emit_pending_session_start()
     renderer = create_event_renderer(
         output,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -841,7 +841,7 @@ async def run_print_mode(
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
-    trust_default: TrustDefault = "always",
+    trust_default: TrustDefault = "ask",
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 

--- a/src/tau_coding/context.py
+++ b/src/tau_coding/context.py
@@ -46,7 +46,7 @@ def _context_file_candidates(paths: TauResourcePaths) -> tuple[Path, ...]:
     if paths.agents_root is not None:
         candidates.append(paths.agents_root / "AGENTS.md")
 
-    if paths.cwd is not None:
+    if paths.cwd is not None and paths.project_resources_enabled:
         cwd = paths.cwd.expanduser().resolve()
         project_root = _find_project_root(cwd)
         candidates.extend(_ancestor_agents_files(project_root, cwd))

--- a/src/tau_coding/data/docs/README.md
+++ b/src/tau_coding/data/docs/README.md
@@ -6,6 +6,7 @@ Tau is a minimalist Python coding-agent harness inspired by Pi. Use these instal
 - [Skills](skills.md): install reusable task knowledge and prompt templates.
 - [Models](models.md): configure providers and models or change Tau's built-in catalog.
 - [CLI](cli.md): command-line and slash-command entry points.
+- [Security](security.md): project-input trust behavior and its non-sandbox boundary.
 - [TUI](tui.md): interactive interface behavior.
 - [Architecture](architecture.md): package boundaries and contributor design rules.
 

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -10,6 +10,14 @@ For current user-facing behavior in a Tau checkout, read:
 
 Keep command parsing and application-specific resource loading in `tau_coding`, not the reusable `tau_agent` harness. When changing behavior, test both command results and the relevant print/TUI integration, then update published reference documentation.
 
+## Project trust startup controls
+
+`--approve`/`-a` and `--no-approve`/`-na` are mutually exclusive run-only
+overrides. They are parsed before protected resource loading and never persist.
+Headless modes never prompt; user-global `defaultProjectTrust` controls unresolved
+projects. Keep diagnostics on stderr for structured stdout modes. See
+`security.md` and `website/content/guides/project-trust.md`.
+
 ## System prompt startup controls
 
 `--system-prompt TEXT_OR_PATH` replaces the default base prompt.
@@ -43,6 +51,6 @@ rebuilt without adding prompt contents to session history. Selected, shadowed,
 and CLI-overridden sources appear in resource diagnostics. Unreadable or invalid
 UTF-8 selected files stop startup/reload with an actionable error.
 
-Project files currently load automatically. Users should inspect repository
-`.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md` files because they can replace or
-extend the model's highest-priority instructions.
+Project files load only after the canonical cwd trust decision. Users should
+still inspect trusted `.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md`: project trust
+is an input-loading guard, not a sandbox or prompt-safety guarantee.

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -14,10 +14,14 @@ Installed examples are under `examples/extensions/` next to these docs. Read the
 ## Locations
 
 - `~/.tau/extensions/`: discovered by default.
-- `<project>/.tau/extensions/`: enabled explicitly with `--project-extensions`.
+- `<project>/.tau/extensions/`: requires project approval and `--project-extensions`.
 - `tau -e PATH`: explicitly load a file or directory.
 
-An extension defines `setup(tau)`. Project extensions execute arbitrary Python and are disabled by default; enable only trusted repositories.
+An extension defines `setup(tau)`. Built-in, user, and explicit extensions may
+handle `project_trust` before protected loading; first decisive result wins.
+Project extensions cannot approve themselves. They execute arbitrary Python and
+remain disabled without both approval and the explicit code opt-in. Trust is not
+a process/filesystem/network/tool/model sandbox.
 
 ## Development checklist
 

--- a/src/tau_coding/data/docs/security.md
+++ b/src/tau_coding/data/docs/security.md
@@ -1,0 +1,21 @@
+# Project trust and security
+
+Tau resolves trust for the canonical destination cwd before reading ambient
+project Markdown/JSON or importing project extensions. Protected inputs include
+project skills, prompts, themes, system-prompt files, AGENTS.md context,
+extension candidates, and reserved future project settings/package metadata.
+User/global and explicit CLI resources remain eligible.
+
+Interactive users can save exact or displayed-parent decisions or choose a
+run-only result. `~/.tau/trust.json` is a locked, atomically replaced version-1
+store. `defaultProjectTrust` in user `~/.tau/settings.json` is `ask`, `always`,
+or `never`; headless `ask`/`never` decline. `--approve` and `--no-approve` are
+run-only. Trusted project extensions additionally require
+`--project-extensions`.
+
+Project trust is only an input-loading guard. It is not a filesystem, process,
+shell, network, tool, credential, provider, model, package-install,
+prompt-injection, or exfiltration sandbox. Use OS/container/VM isolation and
+restricted credentials/network when isolation is required.
+
+Published details: `website/content/guides/project-trust.md`.

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.3.7",
+    "date": "2026-08-04",
+    "sections": {
+      "New": [
+        "Decide project-input trust before Tau reads ambient project instructions, skills, prompts, themes, system prompts, or opted-in extensions; save exact/parent decisions or choose run-only scopes.",
+        "Control automation with run-only `--approve`/`--no-approve` flags and user-global `defaultProjectTrust` ask/always/never policy."
+      ],
+      "Changed": [
+        "Unresolved headless `ask` now skips protected project inputs; user/global and explicit CLI resources remain available, and project extensions still additionally require `--project-extensions`.",
+        "Project trust is explicitly an input-loading guard, not a filesystem, process, network, tool, model, credential, or prompt-injection sandbox."
+      ]
+    }
+  },
+  {
     "version": "0.3.6",
     "date": "2026-08-03",
     "sections": {

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -51,6 +51,7 @@ LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset(
         "input",
         "tool_call",
         "tool_result",
+        "project_trust",
     }
 )
 

--- a/src/tau_coding/extensions/loader.py
+++ b/src/tau_coding/extensions/loader.py
@@ -48,6 +48,7 @@ def extension_dirs(
     paths: TauResourcePaths,
     *,
     include_project_dir: bool = False,
+    include_user_dir: bool = True,
 ) -> tuple[Path, ...]:
     """Return extension directories in load order (project first, then user).
 
@@ -57,9 +58,10 @@ def extension_dirs(
     project trust store, because they execute at session startup.
     """
     dirs: list[Path] = []
-    if include_project_dir and paths.cwd is not None:
+    if include_project_dir and paths.cwd is not None and paths.project_resources_enabled:
         dirs.append(paths.cwd / ".tau" / "extensions")
-    dirs.append(paths.root / "extensions")
+    if include_user_dir:
+        dirs.append(paths.root / "extensions")
     return tuple(_dedupe(dirs))
 
 
@@ -69,6 +71,7 @@ def discover_extensions(
     extra_paths: Sequence[Path] = (),
     include_resource_dirs: bool = True,
     include_project_dir: bool = False,
+    include_user_dir: bool = True,
 ) -> tuple[tuple[DiscoveredExtension, ...], tuple[ResourceDiagnostic, ...]]:
     """Discover extension entry files.
 
@@ -100,7 +103,11 @@ def discover_extensions(
         discovered.append(entry)
 
     if include_resource_dirs:
-        for directory in extension_dirs(paths, include_project_dir=include_project_dir):
+        for directory in extension_dirs(
+            paths,
+            include_project_dir=include_project_dir,
+            include_user_dir=include_user_dir,
+        ):
             for entry in _discover_in_dir(directory, diagnostics):
                 add(entry)
 
@@ -149,6 +156,7 @@ def load_extensions(
     extra_paths: Sequence[Path] = (),
     include_resource_dirs: bool = True,
     include_project_dir: bool = False,
+    include_user_dir: bool = True,
 ) -> ExtensionLoadResult:
     """Discover and import extensions, isolating per-extension failures."""
     discovered, diagnostics = discover_extensions(
@@ -156,6 +164,7 @@ def load_extensions(
         extra_paths=extra_paths,
         include_resource_dirs=include_resource_dirs,
         include_project_dir=include_project_dir,
+        include_user_dir=include_user_dir,
     )
     loaded: list[LoadedExtension] = []
     all_diagnostics = list(diagnostics)

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -146,11 +146,10 @@ class InputHookOutcome:
 class ExtensionRuntime:
     """Owns loaded extensions and dispatches events between them and a session.
 
-    The runtime outlives any single `CodingSession`: session replacement flows
-    (resume, new, branch) re-bind the same runtime rather than re-running
-    extension discovery and `setup`. `/reload`, by contrast, replaces the
-    registration set and invalidates the previous extension generation (see
-    `reset_for_reload`), so pre-reload API objects fail loudly.
+    Each runtime belongs to one prepared session snapshot. Reload and
+    destination replacement stage a fresh runtime, then retire the prior
+    generation only after preparation succeeds. This prevents project extension
+    registrations from crossing cwd trust boundaries.
     """
 
     def __init__(self, *, ui: UiBridge | None = None) -> None:
@@ -191,6 +190,13 @@ class ExtensionRuntime:
         self._load_diagnostics.extend(result.diagnostics)
         for extension in result.extensions:
             self._setup_extension(extension)
+
+    def retire(self) -> None:
+        """Invalidate a successfully replaced runtime without touching its successor."""
+        self._generation.invalidate()
+        if self._harness_unsubscribe is not None:
+            self._harness_unsubscribe()
+            self._harness_unsubscribe = None
 
     def reset_for_reload(self) -> None:
         """Drop all registrations and imported modules ahead of a re-load.

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -61,6 +61,7 @@ from tau_coding.extensions.loader import (
     load_extensions,
     unload_extension_modules,
 )
+from tau_coding.project_trust import ExtensionTrustResult, ProjectTrustEvent
 from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
 
 # Host callback that delivers a message through the frontend's serialized run
@@ -177,6 +178,7 @@ class ExtensionRuntime:
         extra_paths: Sequence[Path] = (),
         include_resource_dirs: bool = True,
         include_project_dir: bool = False,
+        include_user_dir: bool = True,
     ) -> None:
         """Discover extensions and run each `setup` with an isolated API."""
         result = load_extensions(
@@ -184,6 +186,7 @@ class ExtensionRuntime:
             extra_paths=extra_paths,
             include_resource_dirs=include_resource_dirs,
             include_project_dir=include_project_dir,
+            include_user_dir=include_user_dir,
         )
         self._load_diagnostics.extend(result.diagnostics)
         for extension in result.extensions:
@@ -767,6 +770,27 @@ class ExtensionRuntime:
         return handler
 
     # -- event dispatch -----------------------------------------------------------
+
+    async def decide_project_trust(self, event: ProjectTrustEvent) -> ExtensionTrustResult | None:
+        """Return the first decisive eligible extension trust result.
+
+        This runtime must contain only built-in, user, and explicit extensions;
+        callers load project extensions only after this method resolves.
+        """
+        for extension, handler in self._handlers_for("project_trust"):
+            try:
+                result = await _resolve(handler(event, self._fresh_context(extension)))
+            except Exception as exc:  # noqa: BLE001 - trust handlers fail closed/defer
+                self._record_runtime_failure(extension, "project_trust", exc)
+                continue
+            if result is None:
+                continue
+            if not isinstance(result, ExtensionTrustResult):
+                self._record_bad_result(extension, "project_trust", result)
+                continue
+            if result.decision != "defer":
+                return result
+        return None
 
     async def emit_session_start(self, reason: SessionLifecycleReason) -> None:
         """Dispatch `session_start` to subscribed extensions."""

--- a/src/tau_coding/project_trust.py
+++ b/src/tau_coding/project_trust.py
@@ -123,6 +123,21 @@ TrustPrompt = Callable[[ProjectTrustRequest], Awaitable[TrustChoice | None]]
 ExtensionDecider = Callable[[ProjectTrustEvent], Awaitable[ExtensionTrustResult | None]]
 
 
+def _darwin_filesystem_path(path: Path) -> Path:
+    """Return macOS's case-preserving path for an existing filesystem object."""
+    import fcntl
+
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        raw = fcntl.fcntl(descriptor, 50, b"\0" * 1024)  # F_GETPATH / MAXPATHLEN
+    finally:
+        os.close(descriptor)
+    value = raw.split(b"\0", 1)[0]
+    if not value:
+        raise OSError(f"Could not determine filesystem casing for {path}")
+    return Path(os.fsdecode(value))
+
+
 def canonicalize_project_path(path: Path, *, base: Path | None = None) -> CanonicalProjectPath:
     """Strictly canonicalize an existing destination cwd."""
     expanded = path.expanduser()
@@ -136,8 +151,19 @@ def canonicalize_project_path(path: Path, *, base: Path | None = None) -> Canoni
         raise ProjectTrustError(f"Could not canonicalize project cwd {expanded}: {exc}") from exc
     if not resolved.is_dir():
         raise ProjectTrustError(f"Project cwd is not a directory: {resolved}")
-    if sys.platform in {"win32", "darwin"}:
-        resolved = Path(os.path.normcase(str(resolved)))
+    try:
+        if sys.platform == "win32":
+            resolved = Path(os.path.normcase(str(resolved)))
+        elif sys.platform == "darwin":
+            # normcase() is a no-op on Darwin. F_GETPATH asks the mounted
+            # filesystem for its case-preserving spelling, so aliases on a
+            # case-insensitive volume share a key without collapsing distinct
+            # paths on a case-sensitive volume.
+            resolved = _darwin_filesystem_path(resolved)
+    except (OSError, UnicodeError) as exc:
+        raise ProjectTrustError(
+            f"Could not canonicalize project cwd casing {resolved}: {exc}"
+        ) from exc
     return CanonicalProjectPath(resolved)
 
 
@@ -319,14 +345,15 @@ class ProjectTrustStore:
 
     def _read_unlocked(self) -> dict[Path, TrustDecision]:
         # A pending journal means an update did not reach its commit point.
-        # Never inspect the possibly replaced destination in that state.
+        # Ordinary reads must never guess whether the interrupted operation was
+        # a grant or a revocation: either direction could resurrect trust.
+        # Recovery is attempted only by the writer that observed its own
+        # failure; a journal left by a crash remains visibly fail-closed.
         if self.pending_path.exists():
-            recovery_error = self._recover_unlocked()
-            if recovery_error is not None:
-                raise ProjectTrustError(
-                    f"Project trust store {self.path} has an incomplete update; "
-                    f"recovery failed: {recovery_error}"
-                )
+            raise ProjectTrustError(
+                f"Project trust store {self.path} has an incomplete update; "
+                f"pending journal requires explicit recovery: {self.pending_path}"
+            )
         if not self.path.exists():
             return {}
         try:
@@ -350,11 +377,18 @@ class ProjectTrustStore:
             candidate = Path(raw_path)
             if not candidate.is_absolute() or Path(os.path.normpath(raw_path)) != candidate:
                 raise ProjectTrustError(f"Noncanonical path in project trust store {self.path}")
-            normalized = (
-                Path(os.path.normcase(raw_path))
-                if sys.platform in {"win32", "darwin"}
-                else candidate
-            )
+            normalized = Path(os.path.normcase(raw_path)) if sys.platform == "win32" else candidate
+            if sys.platform == "darwin" and candidate.exists():
+                try:
+                    normalized = _darwin_filesystem_path(candidate)
+                except (OSError, UnicodeError) as exc:
+                    raise ProjectTrustError(
+                        f"Could not validate path casing in project trust store {self.path}: {exc}"
+                    ) from exc
+                if normalized != candidate:
+                    raise ProjectTrustError(
+                        f"Noncanonical path casing in project trust store {self.path}: {candidate}"
+                    )
             if normalized in result:
                 raise ProjectTrustError(f"Duplicate path in project trust store {self.path}")
             result[normalized] = decision

--- a/src/tau_coding/project_trust.py
+++ b/src/tau_coding/project_trust.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import IO, Literal
 
 from tau_coding.paths import TauPaths
+from tau_coding.prompt_templates import is_prompt_template_candidate
+from tau_coding.skills import is_skill_candidate
 
 TrustDefault = Literal["ask", "always", "never"]
 TrustDecision = Literal["trusted", "untrusted"]
@@ -148,10 +150,23 @@ class ProtectedResourceDetector:
     def detect(self, cwd: CanonicalProjectPath) -> ProtectedResourceSummary:
         root = cwd.value
         found: dict[str, list[Path]] = {category: [] for category in _RESOURCE_CATEGORIES}
-        self._file(found, "settings", root / ".tau" / "settings.json")
+        # Project settings are not supported by a Tau loader, so they cannot
+        # trigger trust until that loader exists.
         for namespace in (".tau", ".agents"):
-            self._glob(found, "skills", root / namespace / "skills", "*/SKILL.md")
-            self._glob(found, "prompts", root / namespace / "prompts", "*.md")
+            self._glob(
+                found,
+                "skills",
+                root / namespace / "skills",
+                "*/SKILL.md",
+                predicate=is_skill_candidate,
+            )
+            self._glob(
+                found,
+                "prompts",
+                root / namespace / "prompts",
+                "*.md",
+                predicate=is_prompt_template_candidate,
+            )
         self._glob(found, "themes", root / ".tau" / "themes", "*.json")
         self._file(found, "system-prompts", root / ".tau" / "SYSTEM.md")
         self._file(found, "system-prompts", root / ".tau" / "APPEND_SYSTEM.md")
@@ -182,14 +197,25 @@ class ProtectedResourceDetector:
             found[category].append(path)
 
     def _glob(
-        self, found: dict[str, list[Path]], category: str, directory: Path, pattern: str
+        self,
+        found: dict[str, list[Path]],
+        category: str,
+        directory: Path,
+        pattern: str,
+        *,
+        predicate: Callable[[Path], bool] | None = None,
     ) -> None:
         try:
             entries = tuple(directory.glob(pattern)) if directory.is_dir() else ()
         except OSError:
             # An unreadable protected directory is itself a meaningful trigger.
-            entries = (directory,)
-        found[category].extend(path for path in entries if self._is_candidate(path))
+            found[category].append(directory)
+            return
+        found[category].extend(
+            path
+            for path in entries
+            if self._is_candidate(path) and (predicate is None or predicate(path))
+        )
 
     def _context(self, found: dict[str, list[Path]], cwd: Path) -> None:
         # Match current Tau discovery: nearest project marker through cwd, then
@@ -334,7 +360,11 @@ class ProjectTrustStore:
         }
         fd = -1
         temporary: Path | None = None
+        replaced = False
+        prior_bytes: bytes | None = None
         try:
+            if self.path.exists():
+                prior_bytes = self.path.read_bytes()
             fd, raw_temporary = tempfile.mkstemp(
                 prefix=".trust-", suffix=".tmp", dir=self.paths.home
             )
@@ -347,10 +377,12 @@ class ProjectTrustStore:
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(temporary, self.path)
+            replaced = True
             temporary = None
-            os.chmod(self.path, 0o600)
             _fsync_directory(self.paths.home)
         except OSError as exc:
+            if replaced:
+                self._restore_prior_bytes(prior_bytes)
             raise ProjectTrustError(
                 f"Could not write project trust store {self.path}: {exc}"
             ) from exc
@@ -360,6 +392,33 @@ class ProjectTrustStore:
             if temporary is not None:
                 with suppress(OSError):
                     temporary.unlink(missing_ok=True)
+
+    def _restore_prior_bytes(self, prior_bytes: bytes | None) -> None:
+        """Best-effort rollback after a failure following destination replace."""
+        rollback: Path | None = None
+        try:
+            if prior_bytes is None:
+                self.path.unlink(missing_ok=True)
+            else:
+                fd, raw = tempfile.mkstemp(prefix=".trust-rollback-", dir=self.paths.home)
+                rollback = Path(raw)
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(prior_bytes)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.chmod(rollback, 0o600)
+                os.replace(rollback, self.path)
+                rollback = None
+            with suppress(OSError):
+                _fsync_directory(self.paths.home)
+        except OSError as exc:
+            raise ProjectTrustError(
+                f"Could not restore prior project trust store {self.path}: {exc}"
+            ) from exc
+        finally:
+            if rollback is not None:
+                with suppress(OSError):
+                    rollback.unlink(missing_ok=True)
 
 
 class ProjectTrustCoordinator:

--- a/src/tau_coding/project_trust.py
+++ b/src/tau_coding/project_trust.py
@@ -1,0 +1,552 @@
+"""Project-input trust policy, detection, persistence, and coordination.
+
+Project trust controls ambient project resources. It is deliberately not a
+filesystem, process, network, tool, model, or prompt-injection sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Literal
+
+from tau_coding.paths import TauPaths
+
+TrustDefault = Literal["ask", "always", "never"]
+TrustDecision = Literal["trusted", "untrusted"]
+TrustOverride = Literal["approve", "decline"]
+TrustScope = Literal["exact", "parent", "run"]
+TrustSource = Literal["override", "empty", "extension", "saved", "default", "ui"]
+TrustChoice = Literal["trust-exact", "trust-parent", "trust-run", "decline-exact", "decline-run"]
+
+_RESOURCE_CATEGORIES = (
+    "context",
+    "extensions",
+    "prompts",
+    "settings",
+    "skills",
+    "system-prompts",
+    "themes",
+)
+
+
+class ProjectTrustError(RuntimeError):
+    """A trust path, store, or persistence operation failed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalProjectPath:
+    """An existing, canonical project working directory."""
+
+    value: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectedResourceSummary:
+    """Bounded metadata-only summary of protected project inputs."""
+
+    cwd: CanonicalProjectPath
+    categories: tuple[str, ...]
+    counts: Mapping[str, int]
+    sample_paths: tuple[Path, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+
+@dataclass(frozen=True, slots=True)
+class SavedTrustEntry:
+    """A validated saved exact or inherited decision."""
+
+    path: CanonicalProjectPath
+    decision: TrustDecision
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectTrustRequest:
+    """Frontend-neutral request for an interactive trust decision."""
+
+    cwd: CanonicalProjectPath
+    resources: ProtectedResourceSummary
+    inherited_entry: SavedTrustEntry | None
+    choices: tuple[TrustChoice, ...] = (
+        "trust-exact",
+        "trust-parent",
+        "trust-run",
+        "decline-exact",
+        "decline-run",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectTrustResolution:
+    """Completed decision for one canonical cwd."""
+
+    trusted: bool
+    source: TrustSource
+    saved_path: CanonicalProjectPath | None = None
+    diagnostics: tuple[str, ...] = ()
+    had_candidates: bool = True
+    cancelled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionTrustResult:
+    """Result returned by an eligible pre-trust extension."""
+
+    decision: Literal["approve", "decline", "defer"] = "defer"
+    remember: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectTrustEvent:
+    """Content-free payload sent to eligible pre-trust extensions."""
+
+    cwd: Path
+    mode: Literal["interactive", "headless"]
+    has_ui: bool
+    categories: tuple[str, ...]
+    counts: Mapping[str, int]
+    type: Literal["project_trust"] = "project_trust"
+
+
+TrustPrompt = Callable[[ProjectTrustRequest], Awaitable[TrustChoice | None]]
+ExtensionDecider = Callable[[ProjectTrustEvent], Awaitable[ExtensionTrustResult | None]]
+
+
+def canonicalize_project_path(path: Path, *, base: Path | None = None) -> CanonicalProjectPath:
+    """Strictly canonicalize an existing destination cwd."""
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        if base is None:
+            raise ProjectTrustError("A base directory is required for a relative project cwd")
+        expanded = base.expanduser() / expanded
+    try:
+        resolved = expanded.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ProjectTrustError(f"Could not canonicalize project cwd {expanded}: {exc}") from exc
+    if not resolved.is_dir():
+        raise ProjectTrustError(f"Project cwd is not a directory: {resolved}")
+    if sys.platform in {"win32", "darwin"}:
+        resolved = Path(os.path.normcase(str(resolved)))
+    return CanonicalProjectPath(resolved)
+
+
+class ProtectedResourceDetector:
+    """Detect protected candidates using names and file metadata only."""
+
+    def __init__(self, *, max_sample_paths: int = 12) -> None:
+        self.max_sample_paths = max_sample_paths
+
+    def detect(self, cwd: CanonicalProjectPath) -> ProtectedResourceSummary:
+        root = cwd.value
+        found: dict[str, list[Path]] = {category: [] for category in _RESOURCE_CATEGORIES}
+        self._file(found, "settings", root / ".tau" / "settings.json")
+        for namespace in (".tau", ".agents"):
+            self._glob(found, "skills", root / namespace / "skills", "*/SKILL.md")
+            self._glob(found, "prompts", root / namespace / "prompts", "*.md")
+        self._glob(found, "themes", root / ".tau" / "themes", "*.json")
+        self._file(found, "system-prompts", root / ".tau" / "SYSTEM.md")
+        self._file(found, "system-prompts", root / ".tau" / "APPEND_SYSTEM.md")
+        self._context(found, root)
+        self._extensions(found, root / ".tau" / "extensions")
+        counts = {
+            category: len(found[category]) for category in _RESOURCE_CATEGORIES if found[category]
+        }
+        samples = tuple(path for category in _RESOURCE_CATEGORIES for path in found[category])[
+            : self.max_sample_paths
+        ]
+        return ProtectedResourceSummary(
+            cwd=cwd,
+            categories=tuple(counts),
+            counts=counts,
+            sample_paths=samples,
+        )
+
+    @staticmethod
+    def _is_candidate(path: Path) -> bool:
+        try:
+            return path.is_file() or path.is_symlink()
+        except OSError:
+            return True
+
+    def _file(self, found: dict[str, list[Path]], category: str, path: Path) -> None:
+        if self._is_candidate(path):
+            found[category].append(path)
+
+    def _glob(
+        self, found: dict[str, list[Path]], category: str, directory: Path, pattern: str
+    ) -> None:
+        try:
+            entries = tuple(directory.glob(pattern)) if directory.is_dir() else ()
+        except OSError:
+            # An unreadable protected directory is itself a meaningful trigger.
+            entries = (directory,)
+        found[category].extend(path for path in entries if self._is_candidate(path))
+
+    def _context(self, found: dict[str, list[Path]], cwd: Path) -> None:
+        # Match current Tau discovery: nearest project marker through cwd, then
+        # cwd-local namespace context files.
+        markers = (".git", "pyproject.toml", "uv.lock", "setup.py", "package.json")
+        project_root = cwd
+        for candidate in (cwd, *cwd.parents):
+            if any((candidate / marker).exists() for marker in markers):
+                project_root = candidate
+                break
+        try:
+            relative = cwd.relative_to(project_root)
+        except ValueError:
+            relative = Path()
+        current = project_root
+        self._file(found, "context", current / "AGENTS.md")
+        for part in relative.parts:
+            current /= part
+            self._file(found, "context", current / "AGENTS.md")
+        self._file(found, "context", cwd / ".tau" / "AGENTS.md")
+        self._file(found, "context", cwd / ".agents" / "AGENTS.md")
+
+    def _extensions(self, found: dict[str, list[Path]], directory: Path) -> None:
+        try:
+            entries = tuple(directory.iterdir()) if directory.is_dir() else ()
+        except OSError:
+            found["extensions"].append(directory)
+            return
+        for path in entries:
+            if path.name.startswith((".", "_")):
+                continue
+            if path.suffix == ".py" and self._is_candidate(path):
+                found["extensions"].append(path)
+            elif path.is_dir():
+                for candidate in (path / "extension.py", path / "pyproject.toml"):
+                    self._file(found, "extensions", candidate)
+
+
+class ProjectTrustStore:
+    """Versioned, locked, atomically replaced trust decision store."""
+
+    def __init__(self, paths: TauPaths | None = None) -> None:
+        self.paths = paths or TauPaths()
+        self.path = self.paths.home / "trust.json"
+        self.lock_path = self.paths.home / "trust.json.lock"
+
+    def nearest(self, cwd: CanonicalProjectPath) -> SavedTrustEntry | None:
+        decisions = self.read()
+        current = cwd.value
+        while True:
+            decision = decisions.get(current)
+            if decision is not None:
+                return SavedTrustEntry(CanonicalProjectPath(current), decision)
+            if current.parent == current:
+                return None
+            current = current.parent
+
+    def read(self) -> dict[Path, TrustDecision]:
+        with self._locked():
+            return self._read_unlocked()
+
+    def set(self, path: CanonicalProjectPath, decision: TrustDecision) -> None:
+        with self._locked():
+            decisions = self._read_unlocked()
+            decisions[path.value] = decision
+            self._write_unlocked(decisions)
+
+    def trust_parent(self, cwd: CanonicalProjectPath) -> CanonicalProjectPath:
+        parent = CanonicalProjectPath(cwd.value.parent)
+        with self._locked():
+            decisions = self._read_unlocked()
+            decisions.pop(cwd.value, None)
+            decisions[parent.value] = "trusted"
+            self._write_unlocked(decisions)
+        return parent
+
+    def remove(self, path: CanonicalProjectPath) -> None:
+        with self._locked():
+            decisions = self._read_unlocked()
+            decisions.pop(path.value, None)
+            self._write_unlocked(decisions)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        try:
+            self.paths.home.mkdir(mode=0o700, parents=True, exist_ok=True)
+            with self.lock_path.open("a+b") as handle:
+                os.chmod(self.lock_path, 0o600)
+                _lock(handle)
+                try:
+                    yield
+                finally:
+                    _unlock(handle)
+        except ProjectTrustError:
+            raise
+        except OSError as exc:
+            raise ProjectTrustError(
+                f"Could not lock project trust store {self.path}: {exc}"
+            ) from exc
+
+    def _read_unlocked(self) -> dict[Path, TrustDecision]:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ProjectTrustError(
+                f"Could not read project trust store {self.path}: {exc}"
+            ) from exc
+        if not isinstance(payload, dict) or set(payload) != {"version", "decisions"}:
+            raise ProjectTrustError(f"Malformed project trust store {self.path}: unknown schema")
+        if payload["version"] != 1 or not isinstance(payload["decisions"], list):
+            raise ProjectTrustError(f"Unsupported or malformed project trust store {self.path}")
+        result: dict[Path, TrustDecision] = {}
+        for raw in payload["decisions"]:
+            if not isinstance(raw, dict) or set(raw) != {"path", "decision"}:
+                raise ProjectTrustError(f"Malformed decision in project trust store {self.path}")
+            raw_path = raw["path"]
+            decision = raw["decision"]
+            if not isinstance(raw_path, str) or decision not in {"trusted", "untrusted"}:
+                raise ProjectTrustError(f"Malformed decision in project trust store {self.path}")
+            candidate = Path(raw_path)
+            if not candidate.is_absolute() or Path(os.path.normpath(raw_path)) != candidate:
+                raise ProjectTrustError(f"Noncanonical path in project trust store {self.path}")
+            normalized = (
+                Path(os.path.normcase(raw_path))
+                if sys.platform in {"win32", "darwin"}
+                else candidate
+            )
+            if normalized in result:
+                raise ProjectTrustError(f"Duplicate path in project trust store {self.path}")
+            result[normalized] = decision
+        return result
+
+    def _write_unlocked(self, decisions: Mapping[Path, TrustDecision]) -> None:
+        payload = {
+            "version": 1,
+            "decisions": [
+                {"path": str(path), "decision": decision}
+                for path, decision in sorted(decisions.items(), key=lambda item: str(item[0]))
+            ],
+        }
+        fd = -1
+        temporary: Path | None = None
+        try:
+            fd, raw_temporary = tempfile.mkstemp(
+                prefix=".trust-", suffix=".tmp", dir=self.paths.home
+            )
+            temporary = Path(raw_temporary)
+            os.chmod(temporary, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
+                json.dump(payload, handle, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            temporary = None
+            os.chmod(self.path, 0o600)
+            _fsync_directory(self.paths.home)
+        except OSError as exc:
+            raise ProjectTrustError(
+                f"Could not write project trust store {self.path}: {exc}"
+            ) from exc
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            if temporary is not None:
+                with suppress(OSError):
+                    temporary.unlink(missing_ok=True)
+
+
+class ProjectTrustCoordinator:
+    """Resolve and cache trust outcomes per canonical cwd for one invocation."""
+
+    def __init__(
+        self, store: ProjectTrustStore, detector: ProtectedResourceDetector | None = None
+    ) -> None:
+        self.store = store
+        self.detector = detector or ProtectedResourceDetector()
+        self._cache: dict[Path, ProjectTrustResolution] = {}
+
+    async def resolve(
+        self,
+        cwd: Path,
+        *,
+        override: TrustOverride | None = None,
+        default: TrustDefault = "ask",
+        interactive: bool = False,
+        prompt: TrustPrompt | None = None,
+        extension_deciders: Sequence[ExtensionDecider] = (),
+        refresh: bool = False,
+    ) -> tuple[ProtectedResourceSummary, ProjectTrustResolution]:
+        canonical = canonicalize_project_path(cwd, base=Path.cwd())
+        summary = self.detector.detect(canonical)
+        cached = self._cache.get(canonical.value)
+        if cached is not None and cached.had_candidates:
+            return summary, cached
+        if cached is not None and not refresh and not summary.categories:
+            return summary, cached
+        diagnostics: list[str] = []
+        if override is not None:
+            result = ProjectTrustResolution(
+                trusted=override == "approve",
+                source="override",
+                had_candidates=bool(summary.categories),
+            )
+            return summary, self._remember(canonical, result)
+        if not summary.categories:
+            result = ProjectTrustResolution(trusted=True, source="empty", had_candidates=False)
+            return summary, self._remember(canonical, result)
+
+        event = ProjectTrustEvent(
+            cwd=canonical.value,
+            mode="interactive" if interactive else "headless",
+            has_ui=interactive and prompt is not None,
+            categories=summary.categories,
+            counts=summary.counts,
+        )
+        for decide in extension_deciders:
+            try:
+                extension_result = await decide(event)
+            except Exception as exc:  # noqa: BLE001 - extensions safely defer on errors
+                diagnostics.append(f"project_trust extension failed: {type(exc).__name__}: {exc}")
+                continue
+            if extension_result is None or extension_result.decision == "defer":
+                continue
+            trusted = extension_result.decision == "approve"
+            saved_path: CanonicalProjectPath | None = None
+            if extension_result.remember:
+                try:
+                    self.store.set(canonical, "trusted" if trusted else "untrusted")
+                except ProjectTrustError as exc:
+                    diagnostics.append(str(exc))
+                    trusted = False
+                else:
+                    saved_path = canonical
+            result = ProjectTrustResolution(
+                trusted=trusted,
+                source="extension",
+                saved_path=saved_path,
+                diagnostics=tuple(diagnostics),
+            )
+            return summary, self._remember(canonical, result)
+
+        inherited: SavedTrustEntry | None = None
+        store_failed = False
+        try:
+            inherited = self.store.nearest(canonical)
+        except ProjectTrustError as exc:
+            store_failed = True
+            diagnostics.append(str(exc))
+        if inherited is not None:
+            result = ProjectTrustResolution(
+                trusted=inherited.decision == "trusted",
+                source="saved",
+                saved_path=inherited.path,
+                diagnostics=tuple(diagnostics),
+            )
+            return summary, self._remember(canonical, result)
+        if default != "ask":
+            result = ProjectTrustResolution(
+                trusted=default == "always" and not store_failed,
+                source="default",
+                diagnostics=tuple(diagnostics),
+            )
+            return summary, self._remember(canonical, result)
+        if not interactive or prompt is None:
+            result = ProjectTrustResolution(
+                trusted=False, source="default", diagnostics=tuple(diagnostics)
+            )
+            return summary, self._remember(canonical, result)
+
+        choice = await prompt(ProjectTrustRequest(canonical, summary, inherited))
+        trusted = choice in {"trust-exact", "trust-parent", "trust-run"}
+        saved_path = None
+        try:
+            if choice == "trust-exact":
+                self.store.set(canonical, "trusted")
+                saved_path = canonical
+            elif choice == "trust-parent":
+                saved_path = self.store.trust_parent(canonical)
+            elif choice == "decline-exact":
+                self.store.set(canonical, "untrusted")
+                saved_path = canonical
+        except ProjectTrustError as exc:
+            diagnostics.append(str(exc))
+            trusted = False
+            saved_path = None
+        result = ProjectTrustResolution(
+            trusted=trusted,
+            source="ui",
+            saved_path=saved_path,
+            diagnostics=tuple(diagnostics),
+            cancelled=choice is None,
+        )
+        return summary, self._remember(canonical, result)
+
+    def _remember(
+        self, cwd: CanonicalProjectPath, result: ProjectTrustResolution
+    ) -> ProjectTrustResolution:
+        self._cache[cwd.value] = result
+        return result
+
+
+def format_trust_diagnostic(
+    summary: ProtectedResourceSummary, resolution: ProjectTrustResolution
+) -> str:
+    """Return one bounded, content-free decision diagnostic."""
+    categories = (
+        ", ".join(f"{category}={summary.counts[category]}" for category in summary.categories)
+        or "none"
+    )
+    scope = f" via {resolution.saved_path.value}" if resolution.saved_path is not None else ""
+    outcome = "trusted" if resolution.trusted else "untrusted"
+    return (
+        f"Project inputs for {summary.cwd.value}: {outcome} "
+        f"(source={resolution.source}{scope}; {categories}). "
+        "Project trust is an input-loading guard, not a sandbox."
+    )
+
+
+def _lock(handle: IO[bytes]) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    except OSError as exc:
+        raise ProjectTrustError(f"Could not acquire project trust lock: {exc}") from exc
+
+
+def _unlock(handle: IO[bytes]) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def _fsync_directory(directory: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/src/tau_coding/project_trust.py
+++ b/src/tau_coding/project_trust.py
@@ -261,6 +261,7 @@ class ProjectTrustStore:
         self.paths = paths or TauPaths()
         self.path = self.paths.home / "trust.json"
         self.lock_path = self.paths.home / "trust.json.lock"
+        self.pending_path = self.paths.home / "trust.json.pending"
 
     def nearest(self, cwd: CanonicalProjectPath) -> SavedTrustEntry | None:
         decisions = self.read()
@@ -317,6 +318,15 @@ class ProjectTrustStore:
             ) from exc
 
     def _read_unlocked(self) -> dict[Path, TrustDecision]:
+        # A pending journal means an update did not reach its commit point.
+        # Never inspect the possibly replaced destination in that state.
+        if self.pending_path.exists():
+            recovery_error = self._recover_unlocked()
+            if recovery_error is not None:
+                raise ProjectTrustError(
+                    f"Project trust store {self.path} has an incomplete update; "
+                    f"recovery failed: {recovery_error}"
+                )
         if not self.path.exists():
             return {}
         try:
@@ -358,34 +368,54 @@ class ProjectTrustStore:
                 for path, decision in sorted(decisions.items(), key=lambda item: str(item[0]))
             ],
         }
+        data = (json.dumps(payload, indent=2) + "\n").encode()
+        prior_bytes = self.path.read_bytes() if self.path.exists() else None
+
+        # Persist a fail-closed undo journal before touching trust.json. Readers
+        # reject the store while this marker exists, so even failed recovery can
+        # never expose a newly granting destination.
+        journal = (b"present\n" + prior_bytes) if prior_bytes is not None else b"absent\n"
+        try:
+            self._atomic_replace(self.pending_path, journal, prefix=".trust-pending-")
+            self._atomic_replace(self.path, data, prefix=".trust-")
+        except OSError as exc:
+            recovery_error = self._recover_unlocked()
+            detail = f"; recovery failed: {recovery_error}" if recovery_error else ""
+            raise ProjectTrustError(
+                f"Could not write project trust store {self.path}: {exc}{detail}"
+            ) from exc
+
+        # The destination and its directory entry are durable. Failure to clear
+        # the journal is still a failed update and must restore the prior state.
+        try:
+            self.pending_path.unlink()
+        except OSError as exc:
+            recovery_error = self._recover_unlocked()
+            detail = f"; recovery failed: {recovery_error}" if recovery_error else ""
+            raise ProjectTrustError(
+                f"Could not commit project trust store {self.path}: {exc}{detail}"
+            ) from exc
+        # Journal cleanup is not part of the data commit. If this fsync fails,
+        # either the deletion persists (the durable destination grants) or the
+        # journal reappears after a crash (reads fail closed).
+        with suppress(OSError):
+            _fsync_directory(self.paths.home)
+
+    def _atomic_replace(self, destination: Path, data: bytes, *, prefix: str) -> None:
         fd = -1
         temporary: Path | None = None
-        replaced = False
-        prior_bytes: bytes | None = None
         try:
-            if self.path.exists():
-                prior_bytes = self.path.read_bytes()
-            fd, raw_temporary = tempfile.mkstemp(
-                prefix=".trust-", suffix=".tmp", dir=self.paths.home
-            )
-            temporary = Path(raw_temporary)
+            fd, raw = tempfile.mkstemp(prefix=prefix, suffix=".tmp", dir=self.paths.home)
+            temporary = Path(raw)
             os.chmod(temporary, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            with os.fdopen(fd, "wb") as handle:
                 fd = -1
-                json.dump(payload, handle, indent=2)
-                handle.write("\n")
+                handle.write(data)
                 handle.flush()
                 os.fsync(handle.fileno())
-            os.replace(temporary, self.path)
-            replaced = True
+            os.replace(temporary, destination)
             temporary = None
             _fsync_directory(self.paths.home)
-        except OSError as exc:
-            if replaced:
-                self._restore_prior_bytes(prior_bytes)
-            raise ProjectTrustError(
-                f"Could not write project trust store {self.path}: {exc}"
-            ) from exc
         finally:
             if fd >= 0:
                 os.close(fd)
@@ -393,32 +423,26 @@ class ProjectTrustStore:
                 with suppress(OSError):
                     temporary.unlink(missing_ok=True)
 
-    def _restore_prior_bytes(self, prior_bytes: bytes | None) -> None:
-        """Best-effort rollback after a failure following destination replace."""
-        rollback: Path | None = None
+    def _recover_unlocked(self) -> OSError | None:
+        """Restore the journaled state; retain the marker on every failure."""
+        if not self.pending_path.exists():
+            return None
         try:
-            if prior_bytes is None:
-                self.path.unlink(missing_ok=True)
+            journal = self.pending_path.read_bytes()
+            marker, separator, prior_bytes = journal.partition(b"\n")
+            if not separator or marker not in {b"present", b"absent"}:
+                raise OSError("malformed project trust recovery journal")
+            if marker == b"present":
+                self._atomic_replace(self.path, prior_bytes, prefix=".trust-rollback-")
             else:
-                fd, raw = tempfile.mkstemp(prefix=".trust-rollback-", dir=self.paths.home)
-                rollback = Path(raw)
-                with os.fdopen(fd, "wb") as handle:
-                    handle.write(prior_bytes)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                os.chmod(rollback, 0o600)
-                os.replace(rollback, self.path)
-                rollback = None
+                self.path.unlink(missing_ok=True)
+                _fsync_directory(self.paths.home)
+            self.pending_path.unlink()
             with suppress(OSError):
                 _fsync_directory(self.paths.home)
         except OSError as exc:
-            raise ProjectTrustError(
-                f"Could not restore prior project trust store {self.path}: {exc}"
-            ) from exc
-        finally:
-            if rollback is not None:
-                with suppress(OSError):
-                    rollback.unlink(missing_ok=True)
+            return exc
+        return None
 
 
 class ProjectTrustCoordinator:
@@ -441,9 +465,16 @@ class ProjectTrustCoordinator:
         prompt: TrustPrompt | None = None,
         extension_deciders: Sequence[ExtensionDecider] = (),
         refresh: bool = False,
+        cache_result: bool = True,
     ) -> tuple[ProtectedResourceSummary, ProjectTrustResolution]:
         canonical = canonicalize_project_path(cwd, base=Path.cwd())
         summary = self.detector.detect(canonical)
+
+        def finish(result: ProjectTrustResolution) -> ProjectTrustResolution:
+            if cache_result:
+                self._cache[canonical.value] = result
+            return result
+
         cached = self._cache.get(canonical.value)
         if cached is not None and cached.had_candidates:
             return summary, cached
@@ -456,10 +487,10 @@ class ProjectTrustCoordinator:
                 source="override",
                 had_candidates=bool(summary.categories),
             )
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
         if not summary.categories:
             result = ProjectTrustResolution(trusted=True, source="empty", had_candidates=False)
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
 
         event = ProjectTrustEvent(
             cwd=canonical.value,
@@ -492,7 +523,7 @@ class ProjectTrustCoordinator:
                 saved_path=saved_path,
                 diagnostics=tuple(diagnostics),
             )
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
 
         inherited: SavedTrustEntry | None = None
         store_failed = False
@@ -508,19 +539,19 @@ class ProjectTrustCoordinator:
                 saved_path=inherited.path,
                 diagnostics=tuple(diagnostics),
             )
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
         if default != "ask":
             result = ProjectTrustResolution(
                 trusted=default == "always" and not store_failed,
                 source="default",
                 diagnostics=tuple(diagnostics),
             )
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
         if not interactive or prompt is None:
             result = ProjectTrustResolution(
                 trusted=False, source="default", diagnostics=tuple(diagnostics)
             )
-            return summary, self._remember(canonical, result)
+            return summary, finish(result)
 
         choice = await prompt(ProjectTrustRequest(canonical, summary, inherited))
         trusted = choice in {"trust-exact", "trust-parent", "trust-run"}
@@ -545,13 +576,11 @@ class ProjectTrustCoordinator:
             diagnostics=tuple(diagnostics),
             cancelled=choice is None,
         )
-        return summary, self._remember(canonical, result)
+        return summary, finish(result)
 
-    def _remember(
-        self, cwd: CanonicalProjectPath, result: ProjectTrustResolution
-    ) -> ProjectTrustResolution:
+    def commit(self, cwd: CanonicalProjectPath, result: ProjectTrustResolution) -> None:
+        """Publish a staged resolution after its resource snapshot succeeds."""
         self._cache[cwd.value] = result
-        return result
 
 
 def format_trust_diagnostic(

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -17,7 +17,12 @@ from tau_coding.resources import (
 
 _TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
 _ARGUMENT_TEMPLATE_VARIABLES = {"arguments", "args"}
-_RESERVED_TEMPLATE_NAMES = frozenset({"prompts", "skills", "tools"})
+_RESERVED_TEMPLATE_NAMES = frozenset({"prompts", "skills", "tools", "reload"})
+
+
+def is_prompt_template_candidate(path: Path) -> bool:
+    """Return whether a directory entry is eligible for prompt loading."""
+    return path.suffix.lower() == ".md" and path.stem.casefold() not in _RESERVED_TEMPLATE_NAMES
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,7 +171,7 @@ def _load_prompt_templates_from_dir_with_diagnostics(
     seen: set[str] = set()
     for path in sorted(prompts_dir.glob("*.md"), key=lambda item: item.name):
         name = path.stem
-        if name.casefold() in _RESERVED_TEMPLATE_NAMES:
+        if not is_prompt_template_candidate(path):
             diagnostics.append(
                 ResourceDiagnostic(
                     kind="prompt",

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -256,8 +256,9 @@ def resource_paths_with_cwd(
     """Return resource paths with a cwd available for project-local discovery."""
     if paths is None:
         return TauResourcePaths(cwd=cwd)
-    if paths.cwd is not None:
-        return paths
+    # A resource plan is destination-bound. Replacement/resume callers may
+    # supply a plan created for the source session, but only its user/global
+    # roots and feature flags are reusable.
     return TauResourcePaths(
         root=paths.root,
         cwd=cwd,

--- a/src/tau_coding/resources.py
+++ b/src/tau_coding/resources.py
@@ -58,6 +58,7 @@ class TauResourcePaths:
     cwd: Path | None = None
     agents_root: Path | None = field(default_factory=lambda: Path.home() / ".agents")
     paths: TauPaths | None = None
+    project_resources_enabled: bool = True
 
     @property
     def skills_dir(self) -> Path:
@@ -91,7 +92,7 @@ class TauResourcePaths:
         dirs = [self.skills_dir]
         if self.agents_root is not None:
             dirs.append(self.agents_root / "skills")
-        if self.cwd is not None:
+        if self.cwd is not None and self.project_resources_enabled:
             dirs.extend(
                 [
                     paths.project_skills_dir(self.cwd),
@@ -109,7 +110,7 @@ class TauResourcePaths:
         """
         paths = self._paths()
         dirs = [self.root / "themes"]
-        if self.cwd is not None:
+        if self.cwd is not None and self.project_resources_enabled:
             dirs.append(paths.project_themes_dir(self.cwd))
         return tuple(_dedupe_paths(dirs))
 
@@ -120,7 +121,7 @@ class TauResourcePaths:
         dirs = [self.prompts_dir]
         if self.agents_root is not None:
             dirs.append(self.agents_root / "prompts")
-        if self.cwd is not None:
+        if self.cwd is not None and self.project_resources_enabled:
             dirs.extend(
                 [
                     paths.project_prompts_dir(self.cwd),
@@ -190,7 +191,7 @@ def _discover_system_prompt_file(
     diagnostics: list[ResourceDiagnostic],
 ) -> tuple[str | None, Path | None]:
     candidates: list[tuple[str, Path]] = []
-    if paths.cwd is not None:
+    if paths.cwd is not None and paths.project_resources_enabled:
         candidates.append(("project", paths.cwd / ".tau" / filename))
     candidates.append(("user", paths.root / filename))
 
@@ -262,6 +263,22 @@ def resource_paths_with_cwd(
         cwd=cwd,
         agents_root=paths.agents_root,
         paths=paths.paths,
+        project_resources_enabled=paths.project_resources_enabled,
+    )
+
+
+def resource_paths_with_project_trust(
+    paths: TauResourcePaths,
+    *,
+    trusted: bool,
+) -> TauResourcePaths:
+    """Return a coherent global-only or global-plus-project resource plan."""
+    return TauResourcePaths(
+        root=paths.root,
+        cwd=paths.cwd,
+        agents_root=paths.agents_root,
+        paths=paths.paths,
+        project_resources_enabled=trusted,
     )
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -72,6 +72,15 @@ from tau_coding.events import (
 )
 from tau_coding.extensions.runtime import ExtensionRuntime
 from tau_coding.paths import TauPaths
+from tau_coding.project_trust import (
+    ProjectTrustCoordinator,
+    ProjectTrustResolution,
+    ProjectTrustStore,
+    TrustDefault,
+    TrustOverride,
+    TrustPrompt,
+    format_trust_diagnostic,
+)
 from tau_coding.prompt_templates import (
     PromptTemplate,
     expand_prompt_template_command,
@@ -101,6 +110,7 @@ from tau_coding.resources import (
     TauResourcePaths,
     discover_system_prompt_resources,
     resource_paths_with_cwd,
+    resource_paths_with_project_trust,
 )
 from tau_coding.session_export import (
     default_session_export_artifact_path,
@@ -241,6 +251,11 @@ class CodingSessionConfig:
     extensions_enabled: bool = True
     project_extensions_enabled: bool = False
     extension_runtime: ExtensionRuntime | None = None
+    project_trust_coordinator: ProjectTrustCoordinator | None = None
+    trust_override: TrustOverride | None = None
+    trust_default: TrustDefault = "always"
+    trust_interactive: bool = False
+    trust_prompt: TrustPrompt | None = None
 
 
 class CodingSession:
@@ -270,6 +285,7 @@ class CodingSession:
         pending_initial_entries: tuple[SessionEntry, ...] = (),
         extension_runtime: ExtensionRuntime | None = None,
         image_support: ImageSupportState | None = None,
+        project_trust_resolution: ProjectTrustResolution | None = None,
     ) -> None:
         self._config = config
         self._state = state
@@ -308,6 +324,7 @@ class CodingSession:
         self._runtime_model_limits: RuntimeModelLimits | None = None
         self._runtime_model_limits_key: tuple[str, str] | None = None
         self._model_limits_discovery_error: str | None = None
+        self._project_trust_resolution = project_trust_resolution
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -337,7 +354,46 @@ class CodingSession:
             if latest_leaf is not None
             else linear_state
         )
-        resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
+        unfiltered_resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
+
+        extension_runtime = config.extension_runtime
+        fresh_extension_runtime = extension_runtime is None
+        if extension_runtime is None:
+            extension_runtime = ExtensionRuntime()
+            if config.extensions_enabled or config.extension_paths:
+                extension_runtime.load(
+                    unfiltered_resource_paths,
+                    extra_paths=config.extension_paths,
+                    include_resource_dirs=config.extensions_enabled,
+                    include_project_dir=False,
+                )
+
+        coordinator = config.project_trust_coordinator or ProjectTrustCoordinator(
+            ProjectTrustStore(
+                unfiltered_resource_paths.paths or TauPaths(home=unfiltered_resource_paths.root)
+            )
+        )
+        summary, trust_resolution = await coordinator.resolve(
+            config.cwd,
+            override=config.trust_override,
+            default=config.trust_default,
+            interactive=config.trust_interactive,
+            prompt=config.trust_prompt,
+            extension_deciders=(extension_runtime.decide_project_trust,)
+            if fresh_extension_runtime
+            else (),
+        )
+        canonical_cwd = summary.cwd.value
+        resource_paths = resource_paths_with_project_trust(
+            resource_paths_with_cwd(config.resource_paths, canonical_cwd),
+            trusted=trust_resolution.trusted,
+        )
+        config = replace(
+            config,
+            cwd=canonical_cwd,
+            resource_paths=resource_paths,
+            project_trust_coordinator=coordinator,
+        )
         resources = _load_session_resources(
             resource_paths,
             config.context_files,
@@ -346,18 +402,30 @@ class CodingSession:
             custom_system_prompt_explicit=config.custom_system_prompt is not None,
             append_system_prompt_explicit=config.append_system_prompt is not None,
         )
+        if summary.categories:
+            resources = replace(
+                resources,
+                diagnostics=(
+                    *resources.diagnostics,
+                    ResourceDiagnostic(
+                        kind="project-trust",
+                        message=format_trust_diagnostic(summary, trust_resolution),
+                        severity="info" if trust_resolution.trusted else "warning",
+                    ),
+                ),
+            )
 
-        extension_runtime = config.extension_runtime
-        fresh_extension_runtime = extension_runtime is None
-        if extension_runtime is None:
-            extension_runtime = ExtensionRuntime()
-            if config.extensions_enabled or config.extension_paths:
-                extension_runtime.load(
-                    resource_paths,
-                    extra_paths=config.extension_paths,
-                    include_resource_dirs=config.extensions_enabled,
-                    include_project_dir=config.project_extensions_enabled,
-                )
+        if (
+            fresh_extension_runtime
+            and trust_resolution.trusted
+            and config.project_extensions_enabled
+        ):
+            extension_runtime.load(
+                resource_paths,
+                include_resource_dirs=True,
+                include_project_dir=True,
+                include_user_dir=False,
+            )
 
         active_model = _runtime_model_for_state(config, state)
         image_support = ImageSupportState(
@@ -422,6 +490,7 @@ class CodingSession:
             pending_initial_entries=pending_initial_entries,
             extension_runtime=extension_runtime,
             image_support=image_support,
+            project_trust_resolution=trust_resolution,
         )
         await session._persist_loaded_interrupted_tool_repairs()
         session._sync_thinking_level_to_active_model()
@@ -747,9 +816,20 @@ class CodingSession:
         return self._command_registry
 
     @property
+    def project_trust_resolution(self) -> ProjectTrustResolution | None:
+        """Return this cwd's completed project-input trust resolution."""
+        return self._project_trust_resolution
+
+    @property
     def resource_diagnostics(self) -> tuple[ResourceDiagnostic, ...]:
         """Return non-fatal resource and extension diagnostics."""
-        return self._resource_diagnostics + self._extension_runtime.diagnostics
+        trust_diagnostics: tuple[ResourceDiagnostic, ...] = ()
+        if self._project_trust_resolution is not None:
+            trust_diagnostics = tuple(
+                ResourceDiagnostic(kind="project-trust", message=message, severity="error")
+                for message in self._project_trust_resolution.diagnostics
+            )
+        return self._resource_diagnostics + trust_diagnostics + self._extension_runtime.diagnostics
 
     @property
     def extension_runtime(self) -> ExtensionRuntime:
@@ -891,6 +971,14 @@ class CodingSession:
     def last_diagnostic_log_path(self) -> Path | None:
         """Return the last diagnostic log path written by this session."""
         return self._last_diagnostic_log_path
+
+    def set_project_trust_prompt(self, prompt: TrustPrompt) -> None:
+        """Install the active frontend's trust prompt for reload/replacement."""
+        self._config = replace(
+            self._config,
+            trust_interactive=True,
+            trust_prompt=prompt,
+        )
 
     def cancel(self) -> None:
         """Cancel the currently running agent turn, if any."""
@@ -1184,6 +1272,29 @@ class CodingSession:
         ``session_start(reason="reload")`` so startup-mounted UI is restored
         before the command reports completion.
         """
+        coordinator = self._config.project_trust_coordinator
+        if coordinator is not None:
+            summary, trust_resolution = await coordinator.resolve(
+                self.cwd,
+                override=self._config.trust_override,
+                default=self._config.trust_default,
+                interactive=self._config.trust_interactive,
+                prompt=self._config.trust_prompt,
+                refresh=True,
+            )
+            if trust_resolution.cancelled:
+                raise ValueError("Project trust decision cancelled; keeping current resources")
+            self._project_trust_resolution = trust_resolution
+            self._resource_paths = resource_paths_with_project_trust(
+                resource_paths_with_cwd(self._config.resource_paths, summary.cwd.value),
+                trusted=trust_resolution.trusted,
+            )
+            self._config = replace(
+                self._config,
+                cwd=summary.cwd.value,
+                resource_paths=self._resource_paths,
+            )
+
         before_skills = _skill_signatures(self._skills)
         before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
         before_context_files = _context_file_signatures(self._context_files)
@@ -1383,8 +1494,19 @@ class CodingSession:
                 extensions_enabled=self._config.extensions_enabled,
                 project_extensions_enabled=self._config.project_extensions_enabled,
                 extension_runtime=self._extension_runtime,
+                project_trust_coordinator=self._config.project_trust_coordinator,
+                trust_override=self._config.trust_override,
+                trust_default=self._config.trust_default,
+                trust_interactive=self._config.trust_interactive,
+                trust_prompt=self._config.trust_prompt,
             )
         )
+        if (
+            replacement.project_trust_resolution is not None
+            and replacement.project_trust_resolution.cancelled
+        ):
+            await replacement.aclose()
+            raise ValueError("Project trust decision cancelled; current session unchanged")
         if restore_record_model:
             if runtime_provider_config is None:
                 raise ProviderConfigError(f"Session provider is not configured: {provider_name}")
@@ -1485,6 +1607,7 @@ class CodingSession:
         self._pending_initial_entries = replacement._pending_initial_entries
         self._extension_runtime = replacement._extension_runtime
         self._image_support = replacement._image_support
+        self._project_trust_resolution = replacement._project_trust_resolution
         self._extension_runtime.bind(self)
         self._extension_runtime.attach_harness_listener(self._harness.subscribe)
         await self._extension_runtime.emit_session_start(reason)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -253,7 +253,7 @@ class CodingSessionConfig:
     extension_runtime: ExtensionRuntime | None = None
     project_trust_coordinator: ProjectTrustCoordinator | None = None
     trust_override: TrustOverride | None = None
-    trust_default: TrustDefault = "always"
+    trust_default: TrustDefault = "ask"
     trust_interactive: bool = False
     trust_prompt: TrustPrompt | None = None
 
@@ -356,17 +356,18 @@ class CodingSession:
         )
         unfiltered_resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
 
-        extension_runtime = config.extension_runtime
-        fresh_extension_runtime = extension_runtime is None
-        if extension_runtime is None:
-            extension_runtime = ExtensionRuntime()
-            if config.extensions_enabled or config.extension_paths:
-                extension_runtime.load(
-                    unfiltered_resource_paths,
-                    extra_paths=config.extension_paths,
-                    include_resource_dirs=config.extensions_enabled,
-                    include_project_dir=False,
-                )
+        # A runtime is cwd-bound because it may contain project registrations.
+        # Always stage a fresh eligible-only runtime for a destination snapshot;
+        # never reuse source-project code across replacement trust boundaries.
+        previous_runtime = config.extension_runtime
+        extension_runtime = ExtensionRuntime()
+        if config.extensions_enabled or config.extension_paths:
+            extension_runtime.load(
+                unfiltered_resource_paths,
+                extra_paths=config.extension_paths,
+                include_resource_dirs=config.extensions_enabled,
+                include_project_dir=False,
+            )
 
         coordinator = config.project_trust_coordinator or ProjectTrustCoordinator(
             ProjectTrustStore(
@@ -379,9 +380,7 @@ class CodingSession:
             default=config.trust_default,
             interactive=config.trust_interactive,
             prompt=config.trust_prompt,
-            extension_deciders=(extension_runtime.decide_project_trust,)
-            if fresh_extension_runtime
-            else (),
+            extension_deciders=(extension_runtime.decide_project_trust,),
         )
         canonical_cwd = summary.cwd.value
         resource_paths = resource_paths_with_project_trust(
@@ -393,6 +392,7 @@ class CodingSession:
             cwd=canonical_cwd,
             resource_paths=resource_paths,
             project_trust_coordinator=coordinator,
+            extension_runtime=extension_runtime,
         )
         resources = _load_session_resources(
             resource_paths,
@@ -415,11 +415,7 @@ class CodingSession:
                 ),
             )
 
-        if (
-            fresh_extension_runtime
-            and trust_resolution.trusted
-            and config.project_extensions_enabled
-        ):
+        if trust_resolution.trusted and config.project_extensions_enabled:
             extension_runtime.load(
                 resource_paths,
                 include_resource_dirs=True,
@@ -473,6 +469,8 @@ class CodingSession:
             ),
             messages=state.messages,
         )
+        if previous_runtime is not None:
+            extension_runtime.set_ui_bridge(previous_runtime.ui)
         session = cls(
             config,
             state=state,
@@ -496,18 +494,14 @@ class CodingSession:
         session._sync_thinking_level_to_active_model()
         session._refresh_runtime_provider()
         await session._refresh_runtime_model_limits()
-        if fresh_extension_runtime:
-            extension_runtime.bind(session)
-            # Attach to session._harness, not the local `harness`:
-            # _persist_loaded_interrupted_tool_repairs() above may have
-            # replaced the harness, and listeners on the discarded one would
-            # never see an agent event.
-            extension_runtime.attach_harness_listener(session._harness.subscribe)
-            # session_start is deferred: hosts emit it via
-            # emit_pending_session_start() after installing their UI bridge,
-            # so handlers can use notifications and dialogs (Pi starts the UI
-            # before initializing extensions for the same reason).
-            session._session_start_pending = True
+        extension_runtime.bind(session)
+        # Attach to session._harness, not the local `harness`:
+        # _persist_loaded_interrupted_tool_repairs() above may have replaced the
+        # harness, and listeners on the discarded one would never see an event.
+        extension_runtime.attach_harness_listener(session._harness.subscribe)
+        # session_start is deferred: hosts emit it via emit_pending_session_start()
+        # after installing their UI bridge.
+        session._session_start_pending = True
         return session
 
     @property
@@ -1264,37 +1258,7 @@ class CodingSession:
             self._model_limits_discovery_error = f"{type(exc).__name__}: {exc}"
 
     async def reload(self) -> CodingReloadSummary:
-        """Reload resources and extensions with an awaited lifecycle boundary.
-
-        Outgoing handlers finish ``session_shutdown(reason="reload")`` while
-        their API generation is still active. The runtime then clears UI,
-        invalidates/reloads registrations, and awaits the new generation's
-        ``session_start(reason="reload")`` so startup-mounted UI is restored
-        before the command reports completion.
-        """
-        coordinator = self._config.project_trust_coordinator
-        if coordinator is not None:
-            summary, trust_resolution = await coordinator.resolve(
-                self.cwd,
-                override=self._config.trust_override,
-                default=self._config.trust_default,
-                interactive=self._config.trust_interactive,
-                prompt=self._config.trust_prompt,
-                refresh=True,
-            )
-            if trust_resolution.cancelled:
-                raise ValueError("Project trust decision cancelled; keeping current resources")
-            self._project_trust_resolution = trust_resolution
-            self._resource_paths = resource_paths_with_project_trust(
-                resource_paths_with_cwd(self._config.resource_paths, summary.cwd.value),
-                trusted=trust_resolution.trusted,
-            )
-            self._config = replace(
-                self._config,
-                cwd=summary.cwd.value,
-                resource_paths=self._resource_paths,
-            )
-
+        """Stage and atomically publish a complete replacement snapshot."""
         before_skills = _skill_signatures(self._skills)
         before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
         before_context_files = _context_file_signatures(self._context_files)
@@ -1311,20 +1275,84 @@ class CodingSession:
         before_tool_names = tuple(tool.name for tool in self._harness.config.tools)
         before_guidelines = self._extension_runtime.prompt_guidelines
 
+        # Nothing below mutates the live session. Eligible extensions are loaded
+        # first so project code cannot import before the destination decision.
+        unfiltered_paths = resource_paths_with_cwd(self._config.resource_paths, self.cwd)
+        previous_ui = self._extension_runtime.ui
+        staged_runtime = ExtensionRuntime()
+        if self._config.extensions_enabled or self._config.extension_paths:
+            staged_runtime.load(
+                unfiltered_paths,
+                extra_paths=self._config.extension_paths,
+                include_resource_dirs=self._config.extensions_enabled,
+                include_project_dir=False,
+            )
+
+        staged_resolution = self._project_trust_resolution
+        staged_paths = self._resource_paths
+        coordinator = self._config.project_trust_coordinator
+        trust_summary = None
+        if coordinator is not None:
+            trust_summary, staged_resolution = await coordinator.resolve(
+                self.cwd,
+                override=self._config.trust_override,
+                default=self._config.trust_default,
+                interactive=self._config.trust_interactive,
+                prompt=self._config.trust_prompt,
+                extension_deciders=(staged_runtime.decide_project_trust,),
+                refresh=True,
+            )
+            if staged_resolution.cancelled:
+                raise ValueError("Project trust decision cancelled; keeping current resources")
+            staged_paths = resource_paths_with_project_trust(
+                resource_paths_with_cwd(self._config.resource_paths, trust_summary.cwd.value),
+                trusted=staged_resolution.trusted,
+            )
+
         resources = _load_session_resources(
-            self._resource_paths,
+            staged_paths,
             self._config.context_files,
             skills_enabled=self._config.skills_enabled,
             system_prompt_enabled=self._config.system is None,
             custom_system_prompt_explicit=self._config.custom_system_prompt is not None,
             append_system_prompt_explicit=self._config.append_system_prompt is not None,
         )
-        await self._extension_runtime.emit_session_shutdown("reload")
-        self._reload_extensions()
+        if trust_summary is not None and trust_summary.categories:
+            assert staged_resolution is not None
+            resources = replace(
+                resources,
+                diagnostics=(
+                    *resources.diagnostics,
+                    ResourceDiagnostic(
+                        kind="project-trust",
+                        message=format_trust_diagnostic(trust_summary, staged_resolution),
+                        severity="info" if staged_resolution.trusted else "warning",
+                    ),
+                ),
+            )
+        if (
+            staged_resolution is not None
+            and staged_resolution.trusted
+            and self._config.project_extensions_enabled
+        ):
+            staged_runtime.load(
+                staged_paths,
+                include_resource_dirs=True,
+                include_project_dir=True,
+                include_user_dir=False,
+            )
 
-        after_skills = _skill_signatures(resources.skills)
-        after_prompt_templates = _prompt_template_signatures(resources.prompt_templates)
-        after_context_files = _context_file_signatures(resources.context_files)
+        base_tools = (
+            self._config.tools
+            if self._config.tools is not None
+            else create_coding_tools(
+                cwd=self._config.cwd,
+                shell_command_prefix=self._config.shell_command_prefix,
+                image_support=self._image_support,
+            )
+        )
+        staged_tools = staged_runtime.compose_tools(base_tools)
+        staged_commands = self._config.command_registry or staged_runtime.build_command_registry()
         after_system_prompt_inputs = _system_prompt_resource_signatures(
             skills=resources.skills,
             context_files=resources.context_files,
@@ -1333,21 +1361,18 @@ class CodingSession:
             append_system_prompt=resources.append_system_prompt,
             append_system_prompt_path=resources.append_system_prompt_path,
         )
-        after_extensions = _extension_signatures(self._extension_runtime)
-        after_tool_names = tuple(tool.name for tool in self._harness.config.tools)
-        after_guidelines = self._extension_runtime.prompt_guidelines
-
-        rebuilt_system_prompt: str | None = None
-        system_prompt_rebuilt = False
-        if self._config.system is None and (
+        after_guidelines = staged_runtime.prompt_guidelines
+        system_prompt_rebuilt = self._config.system is None and (
             before_system_prompt_inputs != after_system_prompt_inputs
-            or before_tool_names != after_tool_names
+            or before_tool_names != tuple(tool.name for tool in staged_tools)
             or before_guidelines != after_guidelines
-        ):
-            rebuilt_system_prompt = build_system_prompt(
+        )
+        staged_system = self._harness.config.system
+        if system_prompt_rebuilt:
+            staged_system = build_system_prompt(
                 BuildSystemPromptOptions(
                     cwd=self._config.cwd,
-                    tools=self._harness.config.tools,
+                    tools=staged_tools,
                     skills=resources.skills,
                     custom_prompt=(
                         self._config.custom_system_prompt
@@ -1363,8 +1388,20 @@ class CodingSession:
                     extra_guidelines=after_guidelines,
                 )
             )
-            system_prompt_rebuilt = True
 
+        # Commit boundary: every fallible discovery/composition step succeeded.
+        old_runtime = self._extension_runtime
+        await old_runtime.emit_session_shutdown("reload")
+        old_runtime.clear_ui_components()
+        old_runtime.retire()
+        self._resource_paths = staged_paths
+        self._config = replace(
+            self._config,
+            cwd=staged_paths.cwd or self._config.cwd,
+            resource_paths=staged_paths,
+            extension_runtime=staged_runtime,
+        )
+        self._project_trust_resolution = staged_resolution
         self._skills = resources.skills
         self._prompt_templates = resources.prompt_templates
         self._context_files = resources.context_files
@@ -1373,54 +1410,31 @@ class CodingSession:
         self._append_system_prompt = resources.append_system_prompt
         self._append_system_prompt_path = resources.append_system_prompt_path
         self._resource_diagnostics = resources.diagnostics
-        after_diagnostics = _diagnostic_signatures(self.resource_diagnostics)
-        if rebuilt_system_prompt is not None:
-            self._harness.config.system = rebuilt_system_prompt
+        self._command_registry = staged_commands
+        self._extension_runtime = staged_runtime
+        staged_runtime.set_ui_bridge(previous_ui)
+        self._harness.config.tools = staged_tools
+        self._harness.config.system = staged_system
+        if system_prompt_rebuilt:
             self._invalidate_context_usage_cache()
-
-        await self._extension_runtime.emit_session_start("reload")
+        staged_runtime.bind(self)
+        staged_runtime.attach_harness_listener(self._harness.subscribe)
+        await staged_runtime.emit_session_start("reload")
 
         return CodingReloadSummary(
-            skills=_category_summary(before_skills, after_skills),
+            skills=_category_summary(before_skills, _skill_signatures(resources.skills)),
             prompt_templates=_category_summary(
-                before_prompt_templates,
-                after_prompt_templates,
+                before_prompt_templates, _prompt_template_signatures(resources.prompt_templates)
             ),
-            context_files=_category_summary(before_context_files, after_context_files),
-            extensions=_category_summary(before_extensions, after_extensions),
-            diagnostics=_category_summary(before_diagnostics, after_diagnostics),
+            context_files=_category_summary(
+                before_context_files, _context_file_signatures(resources.context_files)
+            ),
+            extensions=_category_summary(before_extensions, _extension_signatures(staged_runtime)),
+            diagnostics=_category_summary(
+                before_diagnostics, _diagnostic_signatures(self.resource_diagnostics)
+            ),
             system_prompt_rebuilt=system_prompt_rebuilt,
         )
-
-    def _reload_extensions(self) -> None:
-        """Re-discover extensions and rebuild dependent tools and commands.
-
-        Extension `setup` re-runs against freshly imported modules. Wrapped
-        tools are rebuilt in place on the live harness config, the session
-        command registry is rebuilt (unless the caller supplied its own), and
-        the harness event fan-out is re-subscribed.
-        """
-        self._extension_runtime.reset_for_reload()
-        if self._config.extensions_enabled or self._config.extension_paths:
-            self._extension_runtime.load(
-                self._resource_paths,
-                extra_paths=self._config.extension_paths,
-                include_resource_dirs=self._config.extensions_enabled,
-                include_project_dir=self._config.project_extensions_enabled,
-            )
-        base_tools = (
-            self._config.tools
-            if self._config.tools is not None
-            else create_coding_tools(
-                cwd=self._config.cwd,
-                shell_command_prefix=self._config.shell_command_prefix,
-                image_support=self._image_support,
-            )
-        )
-        self._harness.config.tools = self._extension_runtime.compose_tools(base_tools)
-        if self._config.command_registry is None:
-            self._command_registry = self._extension_runtime.build_command_registry()
-        self._extension_runtime.attach_harness_listener(self._harness.subscribe)
 
     def reload_provider_settings(self) -> None:
         """Reload provider settings for login and model-selection flows."""
@@ -1583,6 +1597,7 @@ class CodingSession:
         # run and before session_start fires, so start handlers can re-mount
         # into a clean frontend.
         self._extension_runtime.clear_ui_components()
+        self._extension_runtime.retire()
         self._config = replacement._config
         self._state = replacement._state
         self._harness = replacement._harness

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -819,6 +819,11 @@ class CodingSession:
         return self._project_trust_resolution
 
     @property
+    def theme_dirs(self) -> tuple[Path, ...]:
+        """Return theme directories permitted by this session's trust snapshot."""
+        return self._resource_paths.themes_dirs
+
+    @property
     def resource_diagnostics(self) -> tuple[ResourceDiagnostic, ...]:
         """Return non-fatal resource and extension diagnostics."""
         trust_diagnostics: tuple[ResourceDiagnostic, ...] = ()
@@ -1539,12 +1544,6 @@ class CodingSession:
                 trust_prompt=self._config.trust_prompt,
             )
         )
-        if (
-            replacement.project_trust_resolution is not None
-            and replacement.project_trust_resolution.cancelled
-        ):
-            await replacement.aclose()
-            raise ValueError("Project trust decision cancelled; current session unchanged")
         if restore_record_model:
             if runtime_provider_config is None:
                 raise ProviderConfigError(f"Session provider is not configured: {provider_name}")
@@ -1615,6 +1614,13 @@ class CodingSession:
         (transcript persistence, parent ids) mutates here, not on the discarded
         replacement instance.
         """
+        if (
+            replacement.project_trust_resolution is not None
+            and replacement.project_trust_resolution.cancelled
+        ):
+            await replacement.aclose()
+            raise ValueError("Project trust decision cancelled; current session unchanged")
+
         old_runtime = self._extension_runtime
         await old_runtime.emit_session_shutdown(reason)
         old_runtime.clear_ui_components()

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -73,6 +73,7 @@ from tau_coding.events import (
 from tau_coding.extensions.runtime import ExtensionRuntime
 from tau_coding.paths import TauPaths
 from tau_coding.project_trust import (
+    CanonicalProjectPath,
     ProjectTrustCoordinator,
     ProjectTrustResolution,
     ProjectTrustStore,
@@ -325,6 +326,7 @@ class CodingSession:
         self._runtime_model_limits_key: tuple[str, str] | None = None
         self._model_limits_discovery_error: str | None = None
         self._project_trust_resolution = project_trust_resolution
+        self._project_trust_commit_pending = False
 
     @classmethod
     async def load(cls, config: CodingSessionConfig) -> CodingSession:
@@ -503,8 +505,7 @@ class CodingSession:
         # session_start is deferred: hosts emit it via emit_pending_session_start()
         # after installing their UI bridge.
         session._session_start_pending = True
-        if not trust_resolution.cancelled:
-            coordinator.commit(summary.cwd, trust_resolution)
+        session._project_trust_commit_pending = not trust_resolution.cancelled
         return session
 
     @property
@@ -877,8 +878,19 @@ class CodingSession:
         """
         if not self._session_start_pending:
             return
-        self._session_start_pending = False
         await self._extension_runtime.emit_session_start("startup")
+        self._commit_project_trust_resolution()
+        self._session_start_pending = False
+
+    def _commit_project_trust_resolution(self) -> None:
+        """Publish staged trust only after the session becomes live."""
+        if not self._project_trust_commit_pending:
+            return
+        coordinator = self._config.project_trust_coordinator
+        resolution = self._project_trust_resolution
+        if coordinator is not None and resolution is not None:
+            coordinator.commit(CanonicalProjectPath(self.cwd), resolution)
+        self._project_trust_commit_pending = False
 
     def queue_steering_message(
         self,
@@ -1393,13 +1405,21 @@ class CodingSession:
                 )
             )
 
-        # Commit boundary: every fallible discovery/composition step succeeded.
+        # Cancellable lifecycle work stays before the publication boundary. The
+        # staged runtime may inspect the still-live session during session_start;
+        # cancellation leaves that prior snapshot/runtime/cache untouched.
         old_runtime = self._extension_runtime
         await old_runtime.emit_session_shutdown("reload")
+        old_runtime.clear_ui_components()
+        staged_runtime.set_ui_bridge(previous_ui)
+        staged_runtime.bind(self)
+        await staged_runtime.emit_session_start("reload")
+
+        # Publication is synchronous: cancellation can no longer report failure
+        # after only part of the live snapshot or trust cache was adopted.
         if coordinator is not None and trust_summary is not None:
             assert staged_resolution is not None
             coordinator.commit(trust_summary.cwd, staged_resolution)
-        old_runtime.clear_ui_components()
         old_runtime.retire()
         self._resource_paths = staged_paths
         self._config = replace(
@@ -1419,14 +1439,11 @@ class CodingSession:
         self._resource_diagnostics = resources.diagnostics
         self._command_registry = staged_commands
         self._extension_runtime = staged_runtime
-        staged_runtime.set_ui_bridge(previous_ui)
         self._harness.config.tools = staged_tools
         self._harness.config.system = staged_system
         if system_prompt_rebuilt:
             self._invalidate_context_usage_cache()
-        staged_runtime.bind(self)
         staged_runtime.attach_harness_listener(self._harness.subscribe)
-        await staged_runtime.emit_session_start("reload")
 
         return CodingReloadSummary(
             skills=_category_summary(before_skills, _skill_signatures(resources.skills)),
@@ -1598,13 +1615,16 @@ class CodingSession:
         (transcript persistence, parent ids) mutates here, not on the discarded
         replacement instance.
         """
-        await self._extension_runtime.emit_session_shutdown(reason)
-        # Tear down extension-owned UI (slot widgets, main views, key
-        # interceptors) from the outgoing session after its shutdown handlers
-        # run and before session_start fires, so start handlers can re-mount
-        # into a clean frontend.
-        self._extension_runtime.clear_ui_components()
-        self._extension_runtime.retire()
+        old_runtime = self._extension_runtime
+        await old_runtime.emit_session_shutdown(reason)
+        old_runtime.clear_ui_components()
+        await replacement._extension_runtime.emit_session_start(reason)
+        replacement._commit_project_trust_resolution()
+        replacement._session_start_pending = False
+
+        # Every cancellable boundary has completed. Adopt synchronously so a
+        # reported cancellation cannot expose only part of the destination.
+        old_runtime.retire()
         self._config = replacement._config
         self._state = replacement._state
         self._harness = replacement._harness
@@ -1630,9 +1650,10 @@ class CodingSession:
         self._extension_runtime = replacement._extension_runtime
         self._image_support = replacement._image_support
         self._project_trust_resolution = replacement._project_trust_resolution
+        self._project_trust_commit_pending = False
+        self._session_start_pending = False
         self._extension_runtime.bind(self)
         self._extension_runtime.attach_harness_listener(self._harness.subscribe)
-        await self._extension_runtime.emit_session_start(reason)
 
     async def compact(self, instructions: str | None = None) -> str:
         """Generate a manual compaction summary and rebuild active context."""

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -381,6 +381,7 @@ class CodingSession:
             interactive=config.trust_interactive,
             prompt=config.trust_prompt,
             extension_deciders=(extension_runtime.decide_project_trust,),
+            cache_result=False,
         )
         canonical_cwd = summary.cwd.value
         resource_paths = resource_paths_with_project_trust(
@@ -502,6 +503,8 @@ class CodingSession:
         # session_start is deferred: hosts emit it via emit_pending_session_start()
         # after installing their UI bridge.
         session._session_start_pending = True
+        if not trust_resolution.cancelled:
+            coordinator.commit(summary.cwd, trust_resolution)
         return session
 
     @property
@@ -1301,6 +1304,7 @@ class CodingSession:
                 prompt=self._config.trust_prompt,
                 extension_deciders=(staged_runtime.decide_project_trust,),
                 refresh=True,
+                cache_result=False,
             )
             if staged_resolution.cancelled:
                 raise ValueError("Project trust decision cancelled; keeping current resources")
@@ -1392,6 +1396,9 @@ class CodingSession:
         # Commit boundary: every fallible discovery/composition step succeeded.
         old_runtime = self._extension_runtime
         await old_runtime.emit_session_shutdown("reload")
+        if coordinator is not None and trust_summary is not None:
+            assert staged_resolution is not None
+            coordinator.commit(trust_summary.cwd, staged_resolution)
         old_runtime.clear_ui_components()
         old_runtime.retire()
         self._resource_paths = staged_paths

--- a/src/tau_coding/shell_config.py
+++ b/src/tau_coding/shell_config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from tau_coding.paths import TauPaths
+from tau_coding.project_trust import TrustDefault
 
 
 class ShellConfigError(ValueError):
@@ -19,12 +20,16 @@ class ShellSettings:
     """Shell execution settings loaded from Tau home."""
 
     shell_command_prefix: str | None = None
+    default_project_trust: TrustDefault = "ask"
 
     def to_json(self) -> dict[str, str]:
         """Serialize these settings to JSON-compatible data."""
-        if self.shell_command_prefix is None:
-            return {}
-        return {"shellCommandPrefix": self.shell_command_prefix}
+        result: dict[str, str] = {}
+        if self.default_project_trust != "ask":
+            result["defaultProjectTrust"] = self.default_project_trust
+        if self.shell_command_prefix is not None:
+            result["shellCommandPrefix"] = self.shell_command_prefix
+        return result
 
 
 def shell_settings_path(paths: TauPaths | None = None) -> Path:
@@ -53,10 +58,17 @@ def shell_settings_from_json(data: dict[str, Any]) -> ShellSettings:
     if "shellCommandPrefix" in data and "shell_command_prefix" in data:
         raise ShellConfigError("Use only one of shellCommandPrefix or shell_command_prefix")
 
+    raw_default = data.get("defaultProjectTrust", "ask")
+    if raw_default not in {"ask", "always", "never"}:
+        raise ShellConfigError("defaultProjectTrust must be ask, always, or never")
+
     raw_prefix = data.get("shellCommandPrefix", data.get("shell_command_prefix"))
     if raw_prefix is None:
-        return ShellSettings()
+        return ShellSettings(default_project_trust=raw_default)
     if not isinstance(raw_prefix, str):
         raise ShellConfigError("shellCommandPrefix must be a string")
     prefix = raw_prefix.strip()
-    return ShellSettings(shell_command_prefix=prefix or None)
+    return ShellSettings(
+        shell_command_prefix=prefix or None,
+        default_project_trust=raw_default,
+    )

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -26,6 +26,11 @@ class Skill:
     description: str | None = None
 
 
+def is_skill_candidate(path: Path) -> bool:
+    """Return whether an entry is a loader-eligible ``*/SKILL.md`` candidate."""
+    return path.name == "SKILL.md" and (path.is_file() or path.is_symlink())
+
+
 @dataclass(frozen=True, slots=True)
 class SkillInvocation:
     """Parsed expanded skill invocation message."""

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3143,8 +3143,13 @@ class TauTuiApp(App[None]):
 
     ExtensionSelectScreen,
     ExtensionConfirmScreen,
-    ExtensionInputScreen {
+    ExtensionInputScreen,
+    ProjectTrustScreen {
         align: center middle;
+    }
+
+    ProjectTrustScreen {
+        background: $tau-screen-background 60%;
     }
 
     #extension-select,
@@ -3193,6 +3198,40 @@ class TauTuiApp(App[None]):
         height: 1;
         margin-top: 1;
         color: $tau-muted-text;
+    }
+
+    #project-trust-dialog {
+        width: 76;
+        max-width: 92%;
+        height: auto;
+        max-height: 90%;
+        padding: 1 2;
+        background: $tau-chrome-background;
+        color: $tau-chrome-text;
+        border: tall $tau-border;
+    }
+
+    #project-trust-title {
+        color: $tau-chrome-text;
+    }
+
+    #project-trust-path-label,
+    #project-trust-summary-label,
+    #project-trust-boundary,
+    #project-trust-help {
+        color: $tau-muted-text;
+    }
+
+    #project-trust-list {
+        background: $tau-transcript-background;
+        color: $tau-screen-text;
+        border: tall $tau-border;
+    }
+
+    #project-trust-list ListItem.-highlight,
+    #project-trust-list ListItem.-highlight Label {
+        background: $tau-highlight-background;
+        color: $tau-highlight-text;
     }
 
     #command-output {
@@ -4858,7 +4897,8 @@ class TauTuiApp(App[None]):
             | LoginProviderPickerScreen
             | ThemePickerScreen
             | ExtensionSelectScreen
-            | ExtensionConfirmScreen,
+            | ExtensionConfirmScreen
+            | ProjectTrustScreen,
         ):
             self.screen.action_select_cursor()
             return
@@ -4888,7 +4928,8 @@ class TauTuiApp(App[None]):
             | ModelPickerScreen
             | ToolsReferenceScreen
             | ExtensionSelectScreen
-            | ExtensionConfirmScreen,
+            | ExtensionConfirmScreen
+            | ProjectTrustScreen,
         ):
             self.screen.action_cursor_down()
             return
@@ -4915,7 +4956,8 @@ class TauTuiApp(App[None]):
             | ModelPickerScreen
             | ToolsReferenceScreen
             | ExtensionSelectScreen
-            | ExtensionConfirmScreen,
+            | ExtensionConfirmScreen
+            | ProjectTrustScreen,
         ):
             self.screen.action_cursor_up()
             return

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -24,7 +24,6 @@ from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.events import Key, Resize
 from textual.screen import ModalScreen
-from textual.theme import Theme
 from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import (
@@ -157,9 +156,10 @@ from tau_coding.tui.terminal_notification import TerminalNotificationController
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.themes import (
     available_tui_theme_names,
-    get_tui_theme,
     load_custom_tui_themes,
     set_custom_tui_themes,
+    textual_theme_for_tui_theme,
+    theme_css_variables,
 )
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
@@ -168,6 +168,9 @@ from tau_coding.tui.widgets import (
     _custom_markup_to_text,
     render_completion_suggestions,
 )
+
+_textual_theme_for_tau_theme = textual_theme_for_tui_theme
+_theme_css_variables = theme_css_variables
 
 type BindingEntry = Binding | tuple[str, str] | tuple[str, str, str]
 SIDEBAR_MIN_WIDTH = 96
@@ -6363,62 +6366,6 @@ def _is_thinking_cycle_key(key: str, configured_key: str) -> bool:
     if key == configured_key:
         return True
     return configured_key == "shift+tab" and key == "backtab"
-
-
-def _textual_theme_for_tau_theme(theme_name: TuiThemeName) -> Theme:
-    """Map a Tau theme to Textual's native theme type."""
-    theme = get_tui_theme(theme_name)
-    return Theme(
-        name=theme.name,
-        primary=theme.accent,
-        secondary=theme.prompt_border,
-        warning=theme.markdown_bullet,
-        error=theme.error,
-        success=theme.success,
-        accent=theme.accent,
-        foreground=theme.screen_text,
-        background=theme.screen_background,
-        surface=theme.chrome_background,
-        panel=theme.sidebar_background,
-        dark=theme.dark,
-        variables=_theme_css_variables(theme),
-    )
-
-
-def _theme_css_variables(theme: TuiTheme) -> dict[str, str]:
-    """Return Textual CSS variables for a resolved Tau theme."""
-    return {
-        "tau-screen-background": theme.screen_background,
-        "tau-screen-text": theme.screen_text,
-        "tau-chrome-background": theme.chrome_background,
-        "tau-chrome-text": theme.chrome_text,
-        "tau-muted-text": theme.muted_text,
-        "tau-sidebar-background": theme.sidebar_background,
-        "tau-border": theme.border,
-        "tau-transcript-background": theme.transcript_background,
-        "tau-prompt-background": theme.prompt_background,
-        "tau-prompt-text": theme.prompt_text,
-        "tau-prompt-border": theme.prompt_border,
-        "tau-autocomplete-background": theme.autocomplete_background,
-        "tau-accent": theme.accent,
-        "tau-tool-running": theme.role_styles["tool"].border,
-        "tau-highlight-background": theme.highlight_background,
-        "tau-highlight-text": theme.highlight_text,
-        "tau-markdown-highlight": theme.markdown_heading,
-        "tau-markdown-table-header": theme.markdown_table_header,
-        "tau-markdown-table-border": theme.markdown_table_border,
-        "tau-markdown-inline-code": theme.markdown_inline_code,
-        "tau-markdown-code-block-background": theme.markdown_code_block_background,
-        "tau-markdown-link": theme.markdown_link,
-        "tau-markdown-bullet": theme.markdown_bullet,
-        "footer-background": theme.chrome_background,
-        "footer-foreground": theme.chrome_text,
-        "footer-description-background": theme.chrome_background,
-        "footer-description-foreground": theme.chrome_text,
-        "footer-key-background": theme.chrome_background,
-        "footer-key-foreground": theme.accent,
-        "footer-item-background": theme.chrome_background,
-    }
 
 
 def _render_queued_messages(state: TuiState, *, theme: TuiTheme) -> Group:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3569,6 +3569,47 @@ class TauTuiApp(App[None]):
         for theme_name in available_tui_theme_names():
             self.register_theme(_textual_theme_for_tau_theme(theme_name))
 
+    def _reload_session_themes(self) -> None:
+        """Rebind custom themes to the active session's accepted trust snapshot."""
+        theme_dirs = getattr(self.session, "theme_dirs", None)
+        if theme_dirs is None:
+            trust_resolution = getattr(self.session, "project_trust_resolution", None)
+            trusted = trust_resolution is None or trust_resolution.trusted
+            theme_dirs = TauResourcePaths(
+                cwd=self.session.cwd,
+                project_resources_enabled=trusted,
+            ).themes_dirs
+        try:
+            custom_themes, diagnostics = load_custom_tui_themes(theme_dirs)
+        except (OSError, RuntimeError) as exc:
+            # Theme discovery must fail closed after a trust/cwd transition:
+            # never retain themes from the previous project snapshot.
+            custom_themes = {}
+            diagnostics = []
+            self._notify(f"Could not reload custom themes: {exc}", severity="error")
+
+        set_custom_tui_themes(custom_themes)
+        self._register_tau_textual_themes()
+        resolved_theme = self.tui_settings.resolved_theme.name
+        self._applying_settings_theme = True
+        try:
+            if self.theme == resolved_theme:
+                # Re-apply CSS when a same-named custom theme changed in place.
+                self._watch_theme(resolved_theme)
+            else:
+                self.theme = resolved_theme
+        finally:
+            self._applying_settings_theme = False
+        for diagnostic in diagnostics:
+            severity: Literal["information", "warning", "error"] = (
+                "error"
+                if diagnostic.severity == "error"
+                else "warning"
+                if diagnostic.severity == "warning"
+                else "information"
+            )
+            self._notify(diagnostic.format(), severity=severity)
+
     def _watch_theme(self, theme_name: str) -> None:
         """Keep Textual theme changes synchronized with Tau's durable TUI theme."""
         super()._watch_theme(theme_name)
@@ -3819,6 +3860,7 @@ class TauTuiApp(App[None]):
                 except ValueError as exc:
                     command = replace(command, message=f"Could not reload: {exc}")
                 else:
+                    self._reload_session_themes()
                     command = replace(command, message=format_reload_summary(summary))
             if command.new_session_requested:
                 await self._new_session()
@@ -5130,6 +5172,7 @@ class TauTuiApp(App[None]):
     async def _resume_session(self, session_id: str) -> None:
         try:
             resume_message = await self.session.resume(session_id)
+            self._reload_session_themes()
             self.state.clear()
             self.state.set_skills(self.session.skills)
             self._load_session_messages_from_session()
@@ -5222,6 +5265,7 @@ class TauTuiApp(App[None]):
             return
         try:
             await new_session()
+            self._reload_session_themes()
             self.state.clear()
             self.state.set_skills(self.session.skills)
             self._load_session_messages_from_session()
@@ -6797,14 +6841,15 @@ async def run_tui_app(
                 trust_prompt=prompt_project_trust,
             )
         )
-        trust_resolution = getattr(session, "project_trust_resolution", None)
-        trusted = trust_resolution is None or trust_resolution.trusted
-        custom_themes, theme_diagnostics = load_custom_tui_themes(
-            TauResourcePaths(
+        theme_dirs = getattr(session, "theme_dirs", None)
+        if theme_dirs is None:
+            trust_resolution = getattr(session, "project_trust_resolution", None)
+            trusted = trust_resolution is None or trust_resolution.trusted
+            theme_dirs = TauResourcePaths(
                 cwd=record.cwd,
                 project_resources_enabled=trusted,
             ).themes_dirs
-        )
+        custom_themes, theme_diagnostics = load_custom_tui_themes(theme_dirs)
         set_custom_tui_themes(custom_themes)
         legacy_notices = (startup_notice,) if startup_notice else ()
         error_notices = (startup_error_notice,) if startup_error_notice else ()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -98,6 +98,7 @@ from tau_coding.oauth_types import (
     OAuthPrompt,
     OAuthSelectPrompt,
 )
+from tau_coding.project_trust import ProjectTrustRequest, TrustChoice, TrustOverride
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
@@ -150,6 +151,7 @@ from tau_coding.tui.config import (
     save_tui_settings,
 )
 from tau_coding.tui.file_drop import normalize_dropped_paths
+from tau_coding.tui.project_trust import ProjectTrustScreen, prompt_project_trust
 from tau_coding.tui.state import TuiState, format_terminal_command_result_block
 from tau_coding.tui.terminal_notification import TerminalNotificationController
 from tau_coding.tui.terminal_title import TerminalTitleController
@@ -3471,6 +3473,10 @@ class TauTuiApp(App[None]):
         self._supports_pyperclip: bool | None = None
         self._sync_session_title()
 
+    async def prompt_project_trust(self, request: ProjectTrustRequest) -> TrustChoice | None:
+        """Resolve a trust request through the active Textual modal stack."""
+        return await self.push_screen_wait(ProjectTrustScreen(request))
+
     def _sync_session_title(self) -> None:
         """Reflect the active session name in the terminal tab title."""
         self._sync_terminal_title()
@@ -6720,6 +6726,7 @@ async def run_tui_app(
     project_extensions_enabled: bool = False,
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
+    trust_override: TrustOverride | None = None,
 ) -> str | None:
     """Run the Textual app and return the active id when its session is persisted."""
     if new_session and session_id is not None:
@@ -6795,10 +6802,19 @@ async def run_tui_app(
                 project_extensions_enabled=project_extensions_enabled,
                 custom_system_prompt=custom_system_prompt,
                 append_system_prompt=append_system_prompt,
+                trust_override=trust_override,
+                trust_default=shell_settings.default_project_trust,
+                trust_interactive=True,
+                trust_prompt=prompt_project_trust,
             )
         )
+        trust_resolution = getattr(session, "project_trust_resolution", None)
+        trusted = trust_resolution is None or trust_resolution.trusted
         custom_themes, theme_diagnostics = load_custom_tui_themes(
-            TauResourcePaths(cwd=record.cwd).themes_dirs
+            TauResourcePaths(
+                cwd=record.cwd,
+                project_resources_enabled=trusted,
+            ).themes_dirs
         )
         set_custom_tui_themes(custom_themes)
         legacy_notices = (startup_notice,) if startup_notice else ()
@@ -6815,6 +6831,9 @@ async def run_tui_app(
             startup_notices=all_startup_notices,
             initial_prompt=initial_prompt,
         )
+        set_trust_prompt = getattr(session, "set_project_trust_prompt", None)
+        if set_trust_prompt is not None:
+            set_trust_prompt(app.prompt_project_trust)
         await app.run_async()
     finally:
         if session is not None:

--- a/src/tau_coding/tui/project_trust.py
+++ b/src/tau_coding/tui/project_trust.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from textual.app import App, ComposeResult
-from textual.binding import Binding
+from textual.binding import Binding, BindingType
 from textual.containers import Vertical
+from textual.events import Key
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static
+from textual.widgets import Label, ListItem, ListView, Static
 
 from tau_coding.project_trust import ProjectTrustRequest, TrustChoice
 
@@ -20,18 +23,64 @@ _LABELS: tuple[tuple[TrustChoice, str], ...] = (
 
 
 class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
-    """Keyboard-accessible modal rendering one policy-owned request."""
+    """Tau-style modal picker rendering one policy-owned request."""
 
-    BINDINGS = [Binding("escape", "cancel", "Decline for this run")]
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Decline for this run"),
+        Binding("up", "cursor_up", "Up", show=False),
+        Binding("down", "cursor_down", "Down", show=False),
+        Binding("enter", "select_cursor", "Select", show=False),
+    ]
     DEFAULT_CSS = """
-    ProjectTrustScreen { align: center middle; }
-    #project-trust-dialog {
-        width: 76; max-height: 90%; padding: 1 2;
-        border: round $accent; background: $panel;
+    ProjectTrustScreen {
+        align: center middle;
+        background: $background 60%;
     }
-    #project-trust-title { text-style: bold; margin-bottom: 1; }
-    #project-trust-copy { margin-bottom: 1; }
-    #project-trust-dialog Button { width: 100%; margin-top: 1; }
+    #project-trust-dialog {
+        width: 76;
+        max-width: 92%;
+        height: auto;
+        max-height: 90%;
+        padding: 1 2;
+        background: $panel;
+        color: $text;
+        border: tall $primary;
+    }
+    #project-trust-title {
+        height: 1;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    #project-trust-path-label,
+    #project-trust-summary-label {
+        height: 1;
+        color: $text-muted;
+    }
+    #project-trust-path,
+    #project-trust-summary,
+    #project-trust-boundary {
+        height: auto;
+        margin-bottom: 1;
+    }
+    #project-trust-boundary {
+        color: $text-muted;
+    }
+    #project-trust-list {
+        height: auto;
+        max-height: 7;
+        background: $surface;
+        border: tall $primary;
+    }
+    #project-trust-list ListItem.-highlight,
+    #project-trust-list ListItem.-highlight Label {
+        background: $accent;
+        color: $text;
+    }
+    #project-trust-help {
+        height: 1;
+        margin-top: 1;
+        color: $text-muted;
+    }
     """
 
     def __init__(self, request: ProjectTrustRequest) -> None:
@@ -44,22 +93,61 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
             for category in self.request.resources.categories
         )
         parent = self.request.cwd.value.parent
-        with Vertical(id="project-trust-dialog"):
-            yield Label("Project inputs require a decision", id="project-trust-title")
-            yield Static(
-                f"Folder: {self.request.cwd.value}\n"
-                f"Protected inputs: {categories}\n\n"
-                "This controls project inputs; it is not a sandbox.",
-                id="project-trust-copy",
+        choices = []
+        for choice, label in _LABELS:
+            displayed = f"{label} ({parent})" if choice == "trust-parent" else label
+            choices.append(
+                ListItem(
+                    Label(displayed, markup=False),
+                    id=f"trust-{choice}",
+                    name=choice,
+                    classes="project-trust-choice",
+                )
             )
-            for choice, label in _LABELS:
-                displayed = f"{label} ({parent})" if choice == "trust-parent" else label
-                yield Button(displayed, id=f"trust-{choice}", name=choice)
+        with Vertical(id="project-trust-dialog"):
+            yield Static("Project inputs require a decision", id="project-trust-title")
+            yield Static("Folder", id="project-trust-path-label")
+            yield Static(str(self.request.cwd.value), id="project-trust-path", markup=False)
+            yield Static("Protected inputs", id="project-trust-summary-label")
+            yield Static(categories, id="project-trust-summary", markup=False)
+            yield Static(
+                "This controls project inputs; it is not a sandbox.",
+                id="project-trust-boundary",
+            )
+            yield ListView(*choices, id="project-trust-list")
+            yield Static("↑/↓ choose · Enter selects · Escape declines", id="project-trust-help")
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        choice = event.button.name
+    def on_mount(self) -> None:
+        """Focus the first safe, explicit action for keyboard users."""
+        choices = self.query_one("#project-trust-list", ListView)
+        choices.index = 0
+        choices.focus()
+
+    def on_key(self, event: Key) -> None:
+        """Keep navigation local when hosted by Tau's globally bound app."""
+        if event.key == "up":
+            event.stop()
+            self.action_cursor_up()
+        elif event.key == "down":
+            event.stop()
+            self.action_cursor_down()
+        elif event.key == "enter":
+            event.stop()
+            self.action_select_cursor()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        choice = event.item.name
         if choice is not None:
             self.dismiss(choice)  # type: ignore[arg-type]
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#project-trust-list", ListView).action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        self.query_one("#project-trust-list", ListView).action_cursor_down()
+
+    def action_select_cursor(self) -> None:
+        self.query_one("#project-trust-list", ListView).action_select_cursor()
 
     def action_cancel(self) -> None:
         self.dismiss(None)

--- a/src/tau_coding/tui/project_trust.py
+++ b/src/tau_coding/tui/project_trust.py
@@ -12,6 +12,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Label, ListItem, ListView, Static
 
 from tau_coding.project_trust import ProjectTrustRequest, TrustChoice
+from tau_coding.tui.themes import TAU_DARK_THEME, textual_theme_for_tui_theme
 
 _LABELS: tuple[tuple[TrustChoice, str], ...] = (
     ("trust-exact", "Trust this folder"),
@@ -34,7 +35,7 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
     DEFAULT_CSS = """
     ProjectTrustScreen {
         align: center middle;
-        background: $background 60%;
+        background: #000000 70%;
     }
     #project-trust-dialog {
         width: 76;
@@ -42,9 +43,9 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
         height: auto;
         max-height: 90%;
         padding: 1 2;
-        background: $panel;
-        color: $text;
-        border: tall $primary;
+        background: #000000;
+        color: #d8dee9;
+        border: tall #141922;
     }
     #project-trust-title {
         height: 1;
@@ -54,7 +55,7 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
     #project-trust-path-label,
     #project-trust-summary-label {
         height: 1;
-        color: $text-muted;
+        color: #667085;
     }
     #project-trust-path,
     #project-trust-summary,
@@ -63,23 +64,24 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
         margin-bottom: 1;
     }
     #project-trust-boundary {
-        color: $text-muted;
+        color: #667085;
     }
     #project-trust-list {
         height: auto;
         max-height: 7;
-        background: $surface;
-        border: tall $primary;
+        background: #000000;
+        color: #d8dee9;
+        border: tall #141922;
     }
     #project-trust-list ListItem.-highlight,
     #project-trust-list ListItem.-highlight Label {
-        background: $accent;
-        color: $text;
+        background: #a7f3f0;
+        color: #061a1a;
     }
     #project-trust-help {
         height: 1;
         margin-top: 1;
-        color: $text-muted;
+        color: #667085;
     }
     """
 
@@ -156,6 +158,9 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
 class _ProjectTrustApp(App[TrustChoice | None]):
     def __init__(self, request: ProjectTrustRequest) -> None:
         super().__init__()
+        tau_dark = textual_theme_for_tui_theme(TAU_DARK_THEME.name)
+        self.register_theme(tau_dark)
+        self.theme = tau_dark.name
         self.request = request
 
     def on_mount(self) -> None:

--- a/src/tau_coding/tui/project_trust.py
+++ b/src/tau_coding/tui/project_trust.py
@@ -1,0 +1,79 @@
+"""Accessible Textual adapter for Tau-owned project-trust requests."""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+from tau_coding.project_trust import ProjectTrustRequest, TrustChoice
+
+_LABELS: tuple[tuple[TrustChoice, str], ...] = (
+    ("trust-exact", "Trust this folder"),
+    ("trust-parent", "Trust parent folder"),
+    ("trust-run", "Trust for this run only"),
+    ("decline-exact", "Do not trust this folder"),
+    ("decline-run", "Do not trust for this run only"),
+)
+
+
+class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
+    """Keyboard-accessible modal rendering one policy-owned request."""
+
+    BINDINGS = [Binding("escape", "cancel", "Decline for this run")]
+    DEFAULT_CSS = """
+    ProjectTrustScreen { align: center middle; }
+    #project-trust-dialog {
+        width: 76; max-height: 90%; padding: 1 2;
+        border: round $accent; background: $panel;
+    }
+    #project-trust-title { text-style: bold; margin-bottom: 1; }
+    #project-trust-copy { margin-bottom: 1; }
+    #project-trust-dialog Button { width: 100%; margin-top: 1; }
+    """
+
+    def __init__(self, request: ProjectTrustRequest) -> None:
+        super().__init__()
+        self.request = request
+
+    def compose(self) -> ComposeResult:
+        categories = ", ".join(
+            f"{category} ({self.request.resources.counts[category]})"
+            for category in self.request.resources.categories
+        )
+        parent = self.request.cwd.value.parent
+        with Vertical(id="project-trust-dialog"):
+            yield Label("Project inputs require a decision", id="project-trust-title")
+            yield Static(
+                f"Folder: {self.request.cwd.value}\n"
+                f"Protected inputs: {categories}\n\n"
+                "This controls project inputs; it is not a sandbox.",
+                id="project-trust-copy",
+            )
+            for choice, label in _LABELS:
+                displayed = f"{label} ({parent})" if choice == "trust-parent" else label
+                yield Button(displayed, id=f"trust-{choice}", name=choice)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        choice = event.button.name
+        if choice is not None:
+            self.dismiss(choice)  # type: ignore[arg-type]
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class _ProjectTrustApp(App[TrustChoice | None]):
+    def __init__(self, request: ProjectTrustRequest) -> None:
+        super().__init__()
+        self.request = request
+
+    def on_mount(self) -> None:
+        self.push_screen(ProjectTrustScreen(self.request), self.exit)
+
+
+async def prompt_project_trust(request: ProjectTrustRequest) -> TrustChoice | None:
+    """Run the frontend adapter and return the Tau policy choice."""
+    return await _ProjectTrustApp(request).run_async()

--- a/src/tau_coding/tui/themes/__init__.py
+++ b/src/tau_coding/tui/themes/__init__.py
@@ -20,6 +20,7 @@ from rich.errors import StyleSyntaxError
 from rich.style import Style
 from textual.color import Color as TextualColor
 from textual.color import ColorParseError as TextualColorParseError
+from textual.theme import Theme
 
 from tau_coding.resources import ResourceDiagnostic
 
@@ -400,6 +401,62 @@ def get_tui_theme(name: TuiThemeName = "tau-dark") -> TuiTheme:
     if name in _BUILTIN_THEMES:
         return _BUILTIN_THEMES[name]
     return _custom_themes[name]
+
+
+def textual_theme_for_tui_theme(theme_name: TuiThemeName) -> Theme:
+    """Map a Tau theme to Textual's native theme type."""
+    theme = get_tui_theme(theme_name)
+    return Theme(
+        name=theme.name,
+        primary=theme.accent,
+        secondary=theme.prompt_border,
+        warning=theme.markdown_bullet,
+        error=theme.error,
+        success=theme.success,
+        accent=theme.accent,
+        foreground=theme.screen_text,
+        background=theme.screen_background,
+        surface=theme.chrome_background,
+        panel=theme.sidebar_background,
+        dark=theme.dark,
+        variables=theme_css_variables(theme),
+    )
+
+
+def theme_css_variables(theme: TuiTheme) -> dict[str, str]:
+    """Return Textual CSS variables for a resolved Tau theme."""
+    return {
+        "tau-screen-background": theme.screen_background,
+        "tau-screen-text": theme.screen_text,
+        "tau-chrome-background": theme.chrome_background,
+        "tau-chrome-text": theme.chrome_text,
+        "tau-muted-text": theme.muted_text,
+        "tau-sidebar-background": theme.sidebar_background,
+        "tau-border": theme.border,
+        "tau-transcript-background": theme.transcript_background,
+        "tau-prompt-background": theme.prompt_background,
+        "tau-prompt-text": theme.prompt_text,
+        "tau-prompt-border": theme.prompt_border,
+        "tau-autocomplete-background": theme.autocomplete_background,
+        "tau-accent": theme.accent,
+        "tau-tool-running": theme.role_styles["tool"].border,
+        "tau-highlight-background": theme.highlight_background,
+        "tau-highlight-text": theme.highlight_text,
+        "tau-markdown-highlight": theme.markdown_heading,
+        "tau-markdown-table-header": theme.markdown_table_header,
+        "tau-markdown-table-border": theme.markdown_table_border,
+        "tau-markdown-inline-code": theme.markdown_inline_code,
+        "tau-markdown-code-block-background": theme.markdown_code_block_background,
+        "tau-markdown-link": theme.markdown_link,
+        "tau-markdown-bullet": theme.markdown_bullet,
+        "footer-background": theme.chrome_background,
+        "footer-foreground": theme.chrome_text,
+        "footer-description-background": theme.chrome_background,
+        "footer-description-foreground": theme.chrome_text,
+        "footer-key-background": theme.chrome_background,
+        "footer-key-foreground": theme.accent,
+        "footer-item-background": theme.chrome_background,
+    }
 
 
 def load_custom_tui_themes(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -662,6 +662,7 @@ async def test_run_print_mode_uses_custom_and_appended_system_prompt(
         resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
         custom_system_prompt="Custom base.",
         append_system_prompt="First append.\n\nSecond append.",
+        trust_default="always",
     )
 
     _captured = capsys.readouterr()
@@ -747,6 +748,7 @@ async def test_run_print_mode_includes_discovered_context(
         cwd=tmp_path,
         provider=provider,
         resource_paths=TauResourcePaths(root=tmp_path / "resources", agents_root=None),
+        trust_default="always",
     )
 
     _captured = capsys.readouterr()
@@ -1662,3 +1664,29 @@ def test_setup_command_warns_when_api_key_env_is_missing(
 
     assert result.exit_code == 0
     assert "Set MISSING_API_KEY before running Tau with this provider." in result.stderr
+
+
+@pytest.mark.parametrize("output", [PrintOutputMode.json, PrintOutputMode.transcript])
+@pytest.mark.anyio
+async def test_headless_ask_declines_without_corrupting_structured_stdout(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, output: PrintOutputMode
+) -> None:
+    (tmp_path / "AGENTS.md").write_text("PROTECTED-STRUCTURED-SECRET", encoding="utf-8")
+    provider = FakeProvider(
+        [[assistant_start(model="fake"), assistant_done(message=AssistantMessage(content="Done"))]]
+    )
+
+    ok = await run_print_mode(
+        prompt="Hello",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        output=output,
+        resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+    )
+
+    captured = capsys.readouterr()
+    assert ok is True
+    assert "PROTECTED-STRUCTURED-SECRET" not in provider.calls[0][1]
+    assert "Project inputs" not in captured.out
+    assert "Project inputs" in captured.err

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1861,6 +1861,7 @@ async def test_session_builds_system_prompt_when_system_is_omitted(tmp_path: Pat
         model="fake",
         storage=storage,
         cwd=tmp_path,
+        trust_default="always",
         resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
     )
     session = await CodingSession.load(config)
@@ -2214,6 +2215,7 @@ async def test_session_skills_disabled_suppresses_skill_index(tmp_path: Path) ->
         model="fake",
         storage=storage,
         cwd=tmp_path,
+        trust_default="always",
         skills_enabled=False,
         resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
     )
@@ -2485,6 +2487,7 @@ async def test_session_loads_tau_native_system_prompt_files(tmp_path: Path) -> N
             model="fake",
             storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
             cwd=tmp_path,
+            trust_default="always",
             resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
         )
     )
@@ -2542,6 +2545,7 @@ async def test_session_reload_tracks_system_prompt_file_precedence(tmp_path: Pat
             model="fake",
             storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
             cwd=tmp_path,
+            trust_default="always",
             resource_paths=TauResourcePaths(root=tau_home, agents_root=None),
         )
     )
@@ -2655,6 +2659,7 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
             model="fake",
             storage=storage,
             cwd=tmp_path,
+            trust_default="always",
             resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
         )
     )

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3418,7 +3418,9 @@ async def test_session_resume_preserves_shell_command_prefix(tmp_path: Path) -> 
 @pytest.mark.anyio
 async def test_session_resumes_indexed_session(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
-    first_record = manager.create_session(cwd=tmp_path / "first", model="fake", title="First")
+    first_cwd = tmp_path / "first"
+    first_cwd.mkdir()
+    first_record = manager.create_session(cwd=first_cwd, model="fake", title="First")
     second_cwd = tmp_path / "second"
     second_cwd.mkdir(parents=True)
     second_record = manager.create_session(cwd=second_cwd, model="fake", title="Second")
@@ -4009,8 +4011,10 @@ async def test_session_resume_uses_target_session_provider_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    first_cwd = tmp_path / "first"
+    first_cwd.mkdir()
     first_record = manager.create_session(
-        cwd=tmp_path / "first",
+        cwd=first_cwd,
         model="gpt-5",
         provider_name="openai",
         title="First",
@@ -4085,8 +4089,10 @@ async def test_session_resume_missing_provider_preserves_active_provider_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    first_cwd = tmp_path / "first"
+    first_cwd.mkdir()
     first_record = manager.create_session(
-        cwd=tmp_path / "first",
+        cwd=first_cwd,
         model="gpt-5",
         provider_name="openai",
         title="First",
@@ -4161,8 +4167,10 @@ async def test_session_resume_rejects_incompatible_provider_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    first_cwd = tmp_path / "first"
+    first_cwd.mkdir()
     first_record = manager.create_session(
-        cwd=tmp_path / "first",
+        cwd=first_cwd,
         model="gpt-5",
         provider_name="openai",
         title="First",
@@ -4232,7 +4240,9 @@ async def test_session_resume_rejects_incompatible_provider_model(
 @pytest.mark.anyio
 async def test_session_context_usage_recalculates_after_resume(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
-    first_record = manager.create_session(cwd=tmp_path / "first", model="fake", title="First")
+    first_cwd = tmp_path / "first"
+    first_cwd.mkdir()
+    first_record = manager.create_session(cwd=first_cwd, model="fake", title="First")
     second_cwd = tmp_path / "second"
     second_cwd.mkdir(parents=True)
     second_record = manager.create_session(cwd=second_cwd, model="fake", title="Second")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1794,13 +1794,14 @@ async def test_runtime_survives_new_session_swap(tmp_path: Path) -> None:
     config = dataclass_replace(config, session_manager=manager, session_id=record.id)
     session = await CodingSession.load(config)
     runtime_before = session.extension_runtime
+    module_before = _loaded_extension_module("integration")
 
     await session.new_session()
 
-    module = _loaded_extension_module("integration")
-    assert session.extension_runtime is runtime_before
-    assert ("stop", "new") in module.EVENTS
-    assert ("start", "new") in module.EVENTS
+    module_after = _loaded_extension_module("integration")
+    assert session.extension_runtime is not runtime_before
+    assert ("stop", "new") in module_before.EVENTS
+    assert ("start", "new") in module_after.EVENTS
 
 
 async def test_session_swap_clears_host_extension_components(tmp_path: Path) -> None:
@@ -1993,7 +1994,7 @@ async def test_reload_awaits_shutdown_before_invalidation_and_starts_new_generat
     ]
 
 
-async def test_session_rebinding_does_not_invalidate_extension_instances(
+async def test_session_replacement_rebuilds_and_invalidates_source_extensions(
     tmp_path: Path,
 ) -> None:
     from dataclasses import replace as dataclass_replace
@@ -2013,11 +2014,11 @@ async def test_session_rebinding_does_not_invalidate_extension_instances(
 
     await session.new_session()
 
-    # Same instance continues by design (setup did not re-run); its context
-    # views simply reflect the newly bound session.
-    assert len(module.APIS) == 1  # type: ignore[attr-defined]
-    assert api.context.session_id == session.session_id
-    api.send_user_message("still alive")  # must not raise
+    new_module = _loaded_extension_module("integration")
+    new_api = cast(ExtensionAPI, new_module.APIS[-1])  # type: ignore[attr-defined]
+    with pytest.raises(ExtensionError, match="stale after reload"):
+        _ = api.context
+    assert new_api.context.session_id == session.session_id
 
 
 async def test_inflight_handler_touching_stale_api_records_diagnostic(

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import cast
@@ -56,6 +57,30 @@ def test_canonical_project_path_requires_existing_directory_and_resolves_alias(
     assert canonicalize_project_path(alias).value == project.resolve()
     with pytest.raises(ProjectTrustError, match="canonicalize"):
         canonicalize_project_path(tmp_path / "missing")
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS filesystem casing regression")
+def test_macos_alternate_case_preserves_exact_child_decline(tmp_path: Path) -> None:
+    parent = tmp_path / "Parent"
+    child = parent / "MixedCase"
+    child.mkdir(parents=True)
+    alternate = parent / "mixedcase"
+    if not alternate.is_dir():
+        pytest.skip("temporary filesystem is case-sensitive")
+
+    store = ProjectTrustStore(_paths(tmp_path))
+    parent_key = canonicalize_project_path(parent)
+    child_key = canonicalize_project_path(child)
+    alternate_key = canonicalize_project_path(alternate)
+    assert alternate_key == child_key
+
+    store.set(parent_key, "trusted")
+    store.set(child_key, "untrusted")
+
+    saved = store.nearest(alternate_key)
+    assert saved is not None
+    assert saved.path == child_key
+    assert saved.decision == "untrusted"
 
 
 def test_detector_covers_protected_matrix_without_reading_contents(tmp_path: Path) -> None:
@@ -755,6 +780,26 @@ def test_combined_commit_and_recovery_failures_remain_fail_closed(
     assert store.pending_path.read_bytes() == b"present\n" + prior
     with pytest.raises(ProjectTrustError, match="incomplete update"):
         store.nearest(key)
+
+
+def test_pending_journal_after_revocation_never_restores_prior_trust(tmp_path: Path) -> None:
+    store = ProjectTrustStore(_paths(tmp_path))
+    project = tmp_path / "project"
+    project.mkdir()
+    key = canonicalize_project_path(project)
+    store.set(key, "trusted")
+    prior_trusted = store.path.read_bytes()
+    store.set(key, "untrusted")
+    revoked = store.path.read_bytes()
+
+    # Simulate a crash after trust.json was replaced with the revocation but
+    # before the writer removed its undo journal.
+    store.pending_path.write_bytes(b"present\n" + prior_trusted)
+
+    with pytest.raises(ProjectTrustError, match="explicit recovery"):
+        store.nearest(key)
+    assert store.path.read_bytes() == revoked
+    assert store.pending_path.read_bytes() == b"present\n" + prior_trusted
 
 
 def test_resource_plan_always_rebinds_to_destination(tmp_path: Path) -> None:

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -12,6 +12,7 @@ from typer.testing import CliRunner
 
 from tau_agent.provider import ModelProvider
 from tau_agent.session import SessionEntry
+from tau_coding import project_trust as project_trust_module
 from tau_coding.cli import app
 from tau_coding.paths import TauPaths
 from tau_coding.project_trust import (
@@ -24,7 +25,10 @@ from tau_coding.project_trust import (
     canonicalize_project_path,
     format_trust_diagnostic,
 )
-from tau_coding.resources import TauResourcePaths, resource_paths_with_project_trust
+from tau_coding.resources import (
+    TauResourcePaths,
+    resource_paths_with_project_trust,
+)
 from tau_coding.session import CodingSession, CodingSessionConfig
 from tau_coding.tui.project_trust import ProjectTrustScreen
 
@@ -78,7 +82,6 @@ def test_detector_covers_protected_matrix_without_reading_contents(tmp_path: Pat
         "context",
         "extensions",
         "prompts",
-        "settings",
         "skills",
         "system-prompts",
         "themes",
@@ -87,7 +90,6 @@ def test_detector_covers_protected_matrix_without_reading_contents(tmp_path: Pat
         "context": 3,
         "extensions": 3,
         "prompts": 2,
-        "settings": 1,
         "skills": 2,
         "system-prompts": 2,
         "themes": 1,
@@ -99,6 +101,8 @@ def test_detector_ignores_empty_and_unsupported_resources(tmp_path: Path) -> Non
     project = tmp_path / "project"
     (project / ".tau/skills").mkdir(parents=True)
     (project / ".agents/prompts").mkdir(parents=True)
+    (project / ".tau/settings.json").write_text("{}", encoding="utf-8")
+    (project / ".agents/prompts/reload.md").write_text("reserved", encoding="utf-8")
     (project / "CLAUDE.md").write_text("unsupported", encoding="utf-8")
     (project / "pyproject.toml").write_text("[project]", encoding="utf-8")
 
@@ -360,3 +364,302 @@ def test_cli_rejects_conflicting_overrides() -> None:
 
     assert result.exit_code != 0
     assert "cannot be used together" in result.output
+
+
+def test_store_failures_preserve_prior_non_granting_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _paths(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    key = canonicalize_project_path(project)
+
+    operations = ("chmod", "fsync", "replace", "directory-fsync")
+    for operation in operations:
+        store = ProjectTrustStore(paths)
+        monkeypatch.undo()
+        store.set(key, "untrusted")
+        before = store.path.read_bytes()
+
+        if operation == "chmod":
+            monkeypatch.setattr(
+                project_trust_module.os,
+                "chmod",
+                lambda *_args: (_ for _ in ()).throw(OSError("chmod")),
+            )
+        elif operation == "fsync":
+            monkeypatch.setattr(
+                project_trust_module.os,
+                "fsync",
+                lambda *_args: (_ for _ in ()).throw(OSError("fsync")),
+            )
+        elif operation == "replace":
+            monkeypatch.setattr(
+                project_trust_module.os,
+                "replace",
+                lambda *_args: (_ for _ in ()).throw(OSError("replace")),
+            )
+        else:
+            monkeypatch.setattr(
+                project_trust_module,
+                "_fsync_directory",
+                lambda *_args: (_ for _ in ()).throw(OSError("directory fsync")),
+            )
+
+        with pytest.raises(ProjectTrustError):
+            store.set(key, "trusted")
+        assert store.path.read_bytes() == before
+        assert json.loads(before)["decisions"][0]["decision"] == "untrusted"
+
+
+@pytest.mark.anyio
+async def test_session_default_declines_project_input_and_explicit_approval_loads_it(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("protected-default-probe", encoding="utf-8")
+    resources = TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None)
+    common = {
+        "provider": cast(ModelProvider, object()),
+        "model": "fake",
+        "cwd": project,
+        "resource_paths": resources,
+    }
+
+    declined = await CodingSession.load(CodingSessionConfig(**common, storage=_Storage()))
+    approved = await CodingSession.load(
+        CodingSessionConfig(**common, storage=_Storage(), trust_override="approve")
+    )
+
+    assert declined.project_trust_resolution is not None
+    assert declined.project_trust_resolution.trusted is False
+    assert "protected-default-probe" not in declined.system_prompt
+    assert "protected-default-probe" in approved.system_prompt
+
+
+@pytest.mark.anyio
+async def test_destination_rebuild_drops_source_project_extensions(tmp_path: Path) -> None:
+    home_extensions = tmp_path / "home/.tau/extensions"
+    source_extensions = tmp_path / "source/.tau/extensions"
+    destination = tmp_path / "destination"
+    home_extensions.mkdir(parents=True)
+    source_extensions.mkdir(parents=True)
+    destination.mkdir()
+    (destination / "AGENTS.md").write_text("destination protected", encoding="utf-8")
+    (home_extensions / "global.py").write_text(
+        "def setup(tau):\n    tau.add_prompt_guideline('GLOBAL-GUIDELINE')\n",
+        encoding="utf-8",
+    )
+    (source_extensions / "source.py").write_text(
+        "def setup(tau):\n    tau.add_prompt_guideline('SOURCE-PROJECT-GUIDELINE')\n",
+        encoding="utf-8",
+    )
+    resources = TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None)
+    source = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=tmp_path / "source",
+            resource_paths=resources,
+            trust_override="approve",
+            project_extensions_enabled=True,
+        )
+    )
+    replacement = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=destination,
+            resource_paths=resources,
+            trust_override="decline",
+            project_extensions_enabled=True,
+            extension_runtime=source._extension_runtime,
+        )
+    )
+
+    assert "GLOBAL-GUIDELINE" in replacement.system_prompt
+    assert "SOURCE-PROJECT-GUIDELINE" not in replacement.system_prompt
+    assert "destination protected" not in replacement.system_prompt
+
+
+@pytest.mark.anyio
+async def test_failed_reload_preserves_complete_live_snapshot(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    agents = project / "AGENTS.md"
+    agents.write_text("stable snapshot", encoding="utf-8")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=project,
+            resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+            trust_override="approve",
+        )
+    )
+    old_prompt = session.system_prompt
+    old_runtime = session._extension_runtime
+    old_tools = tuple(tool.name for tool in session._harness.config.tools)
+    old_resolution = session.project_trust_resolution
+    agents.write_bytes(b"\xff")
+
+    with pytest.raises(UnicodeDecodeError):
+        await session.reload()
+
+    assert session.system_prompt == old_prompt
+    assert session._extension_runtime is old_runtime
+    assert tuple(tool.name for tool in session._harness.config.tools) == old_tools
+    assert session.project_trust_resolution == old_resolution
+
+
+@pytest.mark.parametrize(
+    ("button_id", "expected"),
+    [
+        ("#trust-trust-exact", "trust-exact"),
+        ("#trust-trust-parent", "trust-parent"),
+        ("#trust-trust-run", "trust-run"),
+        ("#trust-decline-exact", "decline-exact"),
+        ("#trust-decline-run", "decline-run"),
+    ],
+)
+@pytest.mark.anyio
+async def test_tui_trust_modal_all_choices_are_keyboard_focusable(
+    tmp_path: Path, button_id: str, expected: str
+) -> None:
+    project = tmp_path / "parent/project"
+    project.mkdir(parents=True)
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
+    request = ProjectTrustRequest(canonicalize_project_path(project), summary, None)
+    results: list[object | None] = []
+
+    class Host(App[None]):
+        def on_mount(self) -> None:
+            self.push_screen(ProjectTrustScreen(request), results.append)
+
+    host = Host()
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(host.screen.focused, Button)
+        host.screen.query_one(button_id, Button).focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert results == [expected]
+
+
+@pytest.mark.anyio
+async def test_extension_order_errors_and_remember_failure_are_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    calls: list[str] = []
+
+    async def broken(_event: object) -> ExtensionTrustResult:
+        calls.append("broken")
+        raise RuntimeError("handler failure")
+
+    async def approve(_event: object) -> ExtensionTrustResult:
+        calls.append("approve")
+        return ExtensionTrustResult("approve", remember=True)
+
+    async def never_reached(_event: object) -> ExtensionTrustResult:
+        calls.append("late")
+        return ExtensionTrustResult("decline")
+
+    store = ProjectTrustStore(_paths(tmp_path))
+    monkeypatch.setattr(
+        store, "set", lambda *_args: (_ for _ in ()).throw(ProjectTrustError("write failed"))
+    )
+    _summary, resolution = await ProjectTrustCoordinator(store).resolve(
+        project, extension_deciders=(broken, approve, never_reached)
+    )
+
+    assert calls == ["broken", "approve"]
+    assert resolution.trusted is False
+    assert resolution.source == "extension"
+    assert any("handler failure" in item for item in resolution.diagnostics)
+    assert any("write failed" in item for item in resolution.diagnostics)
+
+
+def test_store_read_lock_and_write_permission_failures_are_safe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _paths(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    key = canonicalize_project_path(project)
+    store = ProjectTrustStore(paths)
+    store.set(key, "untrusted")
+    before = store.path.read_bytes()
+
+    original_read_text = Path.read_text
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda self, *args, **kwargs: (
+            (_ for _ in ()).throw(PermissionError("read denied"))
+            if self == store.path
+            else original_read_text(self, *args, **kwargs)
+        ),
+    )
+    with pytest.raises(ProjectTrustError, match="read"):
+        store.read()
+    monkeypatch.undo()
+
+    monkeypatch.setattr(
+        project_trust_module,
+        "_lock",
+        lambda _handle: (_ for _ in ()).throw(ProjectTrustError("lock denied")),
+    )
+    with pytest.raises(ProjectTrustError, match="lock"):
+        store.read()
+    monkeypatch.undo()
+
+    monkeypatch.setattr(
+        project_trust_module.tempfile,
+        "mkstemp",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("write denied")),
+    )
+    with pytest.raises(ProjectTrustError, match="write"):
+        store.set(key, "trusted")
+    assert store.path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("choice", "trusted", "saved_decision"),
+    [
+        ("trust-exact", True, "trusted"),
+        ("trust-run", True, None),
+        ("decline-exact", False, "untrusted"),
+        ("decline-run", False, None),
+        (None, False, None),
+    ],
+)
+@pytest.mark.anyio
+async def test_interactive_choices_have_exact_persistence_semantics(
+    tmp_path: Path, choice: object, trusted: bool, saved_decision: str | None
+) -> None:
+    project = tmp_path / "parent/project"
+    project.mkdir(parents=True)
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    store = ProjectTrustStore(_paths(tmp_path))
+
+    async def prompt(_request: ProjectTrustRequest) -> object:
+        return choice
+
+    _summary, resolution = await ProjectTrustCoordinator(store).resolve(
+        project,
+        interactive=True,
+        prompt=prompt,  # type: ignore[arg-type]
+    )
+
+    assert resolution.trusted is trusted
+    saved = store.nearest(canonicalize_project_path(project))
+    assert (saved.decision if saved else None) == saved_decision

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -27,6 +27,7 @@ from tau_coding.project_trust import (
 )
 from tau_coding.resources import (
     TauResourcePaths,
+    resource_paths_with_cwd,
     resource_paths_with_project_trust,
 )
 from tau_coding.session import CodingSession, CodingSessionConfig
@@ -663,3 +664,290 @@ async def test_interactive_choices_have_exact_persistence_semantics(
     assert resolution.trusted is trusted
     saved = store.nearest(canonicalize_project_path(project))
     assert (saved.decision if saved else None) == saved_decision
+
+
+@pytest.mark.parametrize(
+    "recovery_operation",
+    ["create", "write", "fsync", "chmod", "replace", "unlink"],
+)
+def test_combined_commit_and_recovery_failures_remain_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, recovery_operation: str
+) -> None:
+    store = ProjectTrustStore(_paths(tmp_path))
+    project = tmp_path / "project"
+    project.mkdir()
+    key = canonicalize_project_path(project)
+    store.set(key, "untrusted")
+    prior = store.path.read_bytes()
+
+    real_fsync_directory = project_trust_module._fsync_directory
+    directory_syncs = 0
+
+    def fail_target_directory_sync(directory: Path) -> None:
+        nonlocal directory_syncs
+        directory_syncs += 1
+        if directory_syncs == 2:
+            raise OSError("post-replace directory fsync")
+        real_fsync_directory(directory)
+
+    monkeypatch.setattr(project_trust_module, "_fsync_directory", fail_target_directory_sync)
+    if recovery_operation == "unlink":
+        real_unlink = Path.unlink
+
+        def fail_pending_unlink(path: Path, *args: object, **kwargs: object) -> None:
+            if path == store.pending_path:
+                raise OSError("rollback unlink")
+            real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_pending_unlink)
+    else:
+        real_atomic_replace = store._atomic_replace
+
+        def fail_rollback(destination: Path, data: bytes, *, prefix: str) -> None:
+            if prefix == ".trust-rollback-":
+                raise OSError(f"rollback {recovery_operation}")
+            real_atomic_replace(destination, data, prefix=prefix)
+
+        monkeypatch.setattr(store, "_atomic_replace", fail_rollback)
+
+    with pytest.raises(ProjectTrustError, match="recovery failed"):
+        store.set(key, "trusted")
+
+    assert store.pending_path.read_bytes() == b"present\n" + prior
+    with pytest.raises(ProjectTrustError, match="incomplete update"):
+        store.nearest(key)
+
+
+def test_resource_plan_always_rebinds_to_destination(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    original = TauResourcePaths(
+        root=tmp_path / "home/.tau",
+        cwd=source,
+        agents_root=tmp_path / "home/.agents",
+        paths=_paths(tmp_path),
+        project_resources_enabled=False,
+    )
+
+    rebound = resource_paths_with_cwd(original, destination.resolve())
+
+    assert rebound.cwd == destination.resolve()
+    assert rebound.root == original.root
+    assert rebound.agents_root == original.agents_root
+    assert rebound.paths == original.paths
+    assert rebound.project_resources_enabled is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("choice", "expected_text"),
+    [("trust-run", "DESTINATION-CONTEXT"), ("decline-run", None)],
+)
+async def test_source_bound_plan_uses_destination_resources_for_trust_choice(
+    tmp_path: Path, choice: str, expected_text: str | None
+) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    (source / "AGENTS.md").write_text("SOURCE-CONTEXT", encoding="utf-8")
+    (destination / "AGENTS.md").write_text("DESTINATION-CONTEXT", encoding="utf-8")
+    source_extension = source / ".tau/extensions/source.py"
+    destination_extension = destination / ".tau/extensions/destination.py"
+    source_extension.parent.mkdir(parents=True)
+    destination_extension.parent.mkdir(parents=True)
+    source_extension.write_text(
+        "def setup(tau):\n    tau.add_prompt_guideline('SOURCE-EXTENSION')\n",
+        encoding="utf-8",
+    )
+    destination_extension.write_text(
+        "def setup(tau):\n    tau.add_prompt_guideline('DESTINATION-EXTENSION')\n",
+        encoding="utf-8",
+    )
+    observed: list[Path] = []
+
+    async def prompt(request: ProjectTrustRequest) -> str:
+        observed.append(request.cwd.value)
+        return choice
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=destination,
+            resource_paths=TauResourcePaths(
+                root=tmp_path / "home/.tau", agents_root=None, cwd=source
+            ),
+            trust_interactive=True,
+            trust_prompt=prompt,  # type: ignore[arg-type]
+            project_extensions_enabled=True,
+        )
+    )
+
+    assert observed == [destination.resolve()]
+    assert session._resource_paths.cwd == destination.resolve()
+    assert "SOURCE-CONTEXT" not in session.system_prompt
+    assert "SOURCE-EXTENSION" not in session.system_prompt
+    assert ("DESTINATION-CONTEXT" in session.system_prompt) is (expected_text is not None)
+    assert ("DESTINATION-EXTENSION" in session.system_prompt) is (expected_text is not None)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("choice", ["trust-run", "decline-run"])
+async def test_failed_reload_does_not_commit_run_choice_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, choice: str
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    prompts = 0
+
+    async def prompt(_request: ProjectTrustRequest) -> str:
+        nonlocal prompts
+        prompts += 1
+        return choice
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=project,
+            resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=prompt,  # type: ignore[arg-type]
+        )
+    )
+    (project / "AGENTS.md").write_text("NEW-CONTEXT", encoding="utf-8")
+
+    from tau_coding import session as session_module
+
+    real_load = session_module._load_session_resources
+    attempts = 0
+
+    def fail_once(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError("resource preparation failed")
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(session_module, "_load_session_resources", fail_once)
+    with pytest.raises(ValueError, match="resource preparation failed"):
+        await session.reload()
+    assert prompts == 1
+    assert session.project_trust_resolution is not None
+    assert session.project_trust_resolution.source == "empty"
+
+    await session.reload()
+    assert prompts == 2
+    assert ("NEW-CONTEXT" in session.system_prompt) is (choice == "trust-run")
+
+
+@pytest.mark.anyio
+async def test_failed_project_extension_reload_re_resolves_trust(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    prompts = 0
+
+    async def prompt(_request: ProjectTrustRequest) -> str:
+        nonlocal prompts
+        prompts += 1
+        return "trust-run"
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=project,
+            resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+            project_trust_coordinator=coordinator,
+            project_extensions_enabled=True,
+            trust_interactive=True,
+            trust_prompt=prompt,
+        )
+    )
+    extension = project / ".tau/extensions/project.py"
+    extension.parent.mkdir(parents=True)
+    extension.write_text(
+        "def setup(tau):\n    tau.add_prompt_guideline('DESTINATION-EXTENSION')\n",
+        encoding="utf-8",
+    )
+    from tau_coding.extensions.runtime import ExtensionRuntime
+
+    real_load = ExtensionRuntime.load
+
+    def fail_project_setup(self: ExtensionRuntime, *args: object, **kwargs: object) -> None:
+        if kwargs.get("include_project_dir") is True:
+            raise RuntimeError("setup failed")
+        real_load(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ExtensionRuntime, "load", fail_project_setup)
+    with pytest.raises(RuntimeError, match="setup failed"):
+        await session.reload()
+    assert prompts == 1
+    assert session.project_trust_resolution is not None
+    assert session.project_trust_resolution.source == "empty"
+
+    monkeypatch.setattr(ExtensionRuntime, "load", real_load)
+    await session.reload()
+    assert prompts == 2
+    assert "DESTINATION-EXTENSION" in session.system_prompt
+
+
+@pytest.mark.anyio
+async def test_cancelled_destination_staging_leaves_source_session_and_cache_unchanged(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    (source / "AGENTS.md").write_text("SOURCE-ACTIVE", encoding="utf-8")
+    (destination / "AGENTS.md").write_text("DESTINATION-CANCELLED", encoding="utf-8")
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    resources = TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None)
+    active = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=source,
+            resource_paths=resources,
+            project_trust_coordinator=coordinator,
+            trust_override="approve",
+        )
+    )
+    source_prompt = active.system_prompt
+    source_runtime = active._extension_runtime
+
+    async def cancel(_request: ProjectTrustRequest) -> None:
+        return None
+
+    staged = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=destination,
+            resource_paths=active._resource_paths,
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=cancel,
+        )
+    )
+
+    assert staged.project_trust_resolution is not None
+    assert staged.project_trust_resolution.cancelled is True
+    assert active.cwd == source.resolve()
+    assert active.system_prompt == source_prompt
+    assert active._extension_runtime is source_runtime
+    assert destination.resolve() not in coordinator._cache

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -7,7 +8,7 @@ from typing import cast
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Static
+from textual.widgets import ListItem, ListView, Static
 from typer.testing import CliRunner
 
 from tau_agent.provider import ModelProvider
@@ -272,6 +273,7 @@ async def test_tui_trust_modal_shows_boundary_parent_and_keyboard_cancel(
 ) -> None:
     project = tmp_path / "parent/project"
     project.mkdir(parents=True)
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
     summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
     request = ProjectTrustRequest(canonicalize_project_path(project), summary, None)
     results: list[object | None] = []
@@ -283,10 +285,15 @@ async def test_tui_trust_modal_shows_boundary_parent_and_keyboard_cancel(
     host = Host()
     async with host.run_test() as pilot:
         await pilot.pause()
-        copy = str(host.screen.query_one("#project-trust-copy", Static).content)
-        parent_button = host.screen.query_one("#trust-trust-parent", Button)
-        assert "not a sandbox" in copy
-        assert str(project.parent.resolve()) in str(parent_button.label)
+        boundary = str(host.screen.query_one("#project-trust-boundary", Static).content)
+        displayed_path = str(host.screen.query_one("#project-trust-path", Static).content)
+        summary_copy = str(host.screen.query_one("#project-trust-summary", Static).content)
+        parent_choice = host.screen.query_one("#trust-trust-parent", ListItem)
+        assert "not a sandbox" in boundary
+        assert displayed_path == str(project.resolve())
+        assert "context (1)" in summary_copy
+        assert str(project.parent.resolve()) in str(parent_choice.query_one(Static).content)
+        assert parent_choice.has_class("project-trust-choice")
         await pilot.press("escape")
         await pilot.pause()
 
@@ -518,18 +525,18 @@ async def test_failed_reload_preserves_complete_live_snapshot(tmp_path: Path) ->
 
 
 @pytest.mark.parametrize(
-    ("button_id", "expected"),
+    ("choice_id", "index", "expected"),
     [
-        ("#trust-trust-exact", "trust-exact"),
-        ("#trust-trust-parent", "trust-parent"),
-        ("#trust-trust-run", "trust-run"),
-        ("#trust-decline-exact", "decline-exact"),
-        ("#trust-decline-run", "decline-run"),
+        ("#trust-trust-exact", 0, "trust-exact"),
+        ("#trust-trust-parent", 1, "trust-parent"),
+        ("#trust-trust-run", 2, "trust-run"),
+        ("#trust-decline-exact", 3, "decline-exact"),
+        ("#trust-decline-run", 4, "decline-run"),
     ],
 )
 @pytest.mark.anyio
-async def test_tui_trust_modal_all_choices_are_keyboard_focusable(
-    tmp_path: Path, button_id: str, expected: str
+async def test_tui_trust_modal_all_choices_support_arrow_navigation(
+    tmp_path: Path, choice_id: str, index: int, expected: str
 ) -> None:
     project = tmp_path / "parent/project"
     project.mkdir(parents=True)
@@ -545,8 +552,12 @@ async def test_tui_trust_modal_all_choices_are_keyboard_focusable(
     host = Host()
     async with host.run_test() as pilot:
         await pilot.pause()
-        assert isinstance(host.screen.focused, Button)
-        host.screen.query_one(button_id, Button).focus()
+        choice_list = host.screen.query_one("#project-trust-list", ListView)
+        assert host.screen.focused is choice_list
+        assert host.screen.query_one(choice_id, ListItem).has_class("project-trust-choice")
+        for _ in range(index):
+            await pilot.press("down")
+        assert choice_list.index == index
         await pilot.press("enter")
         await pilot.pause()
 
@@ -951,3 +962,184 @@ async def test_cancelled_destination_staging_leaves_source_session_and_cache_unc
     assert active.system_prompt == source_prompt
     assert active._extension_runtime is source_runtime
     assert destination.resolve() not in coordinator._cache
+
+
+@pytest.mark.anyio
+async def test_reload_cancellation_during_shutdown_preserves_snapshot_and_re_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    prompts = 0
+
+    async def prompt(_request: ProjectTrustRequest) -> str:
+        nonlocal prompts
+        prompts += 1
+        return "trust-run"
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=project,
+            resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=prompt,
+        )
+    )
+    await session.emit_pending_session_start()
+    old_runtime = session._extension_runtime
+    old_prompt = session.system_prompt
+    (project / "AGENTS.md").write_text("NEW-CONTEXT", encoding="utf-8")
+
+    async def cancel_shutdown(_reason: str) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(old_runtime, "emit_session_shutdown", cancel_shutdown)
+    with pytest.raises(asyncio.CancelledError):
+        await session.reload()
+
+    assert prompts == 1
+    assert session._extension_runtime is old_runtime
+    assert session.system_prompt == old_prompt
+    assert coordinator._cache[project.resolve()].source == "empty"
+
+    monkeypatch.undo()
+    await session.reload()
+    assert prompts == 2
+    assert "NEW-CONTEXT" in session.system_prompt
+
+
+@pytest.mark.anyio
+async def test_reload_cancellation_during_staged_start_preserves_snapshot_and_re_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tau_coding.extensions.runtime import ExtensionRuntime
+
+    project = tmp_path / "project"
+    project.mkdir()
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    prompts = 0
+
+    async def prompt(_request: ProjectTrustRequest) -> str:
+        nonlocal prompts
+        prompts += 1
+        return "trust-run"
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=project,
+            resource_paths=TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None),
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=prompt,
+        )
+    )
+    await session.emit_pending_session_start()
+    old_runtime = session._extension_runtime
+    old_prompt = session.system_prompt
+    (project / "AGENTS.md").write_text("NEW-CONTEXT", encoding="utf-8")
+    real_start = ExtensionRuntime.emit_session_start
+    cancelled = False
+
+    async def cancel_staged_start(self: ExtensionRuntime, reason: str) -> None:
+        nonlocal cancelled
+        if reason == "reload" and self is not old_runtime and not cancelled:
+            cancelled = True
+            raise asyncio.CancelledError
+        await real_start(self, reason)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ExtensionRuntime, "emit_session_start", cancel_staged_start)
+    with pytest.raises(asyncio.CancelledError):
+        await session.reload()
+
+    assert prompts == 1
+    assert session._extension_runtime is old_runtime
+    assert session.system_prompt == old_prompt
+    assert coordinator._cache[project.resolve()].source == "empty"
+
+    await session.reload()
+    assert prompts == 2
+    assert "NEW-CONTEXT" in session.system_prompt
+
+
+@pytest.mark.anyio
+async def test_destination_adoption_cancellation_keeps_source_and_retry_resolves_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tau_coding.extensions.runtime import ExtensionRuntime
+
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    (source / "AGENTS.md").write_text("SOURCE-CONTEXT", encoding="utf-8")
+    (destination / "AGENTS.md").write_text("DESTINATION-CONTEXT", encoding="utf-8")
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+    resources = TauResourcePaths(root=tmp_path / "home/.tau", agents_root=None)
+    active = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=source,
+            resource_paths=resources,
+            project_trust_coordinator=coordinator,
+            trust_override="approve",
+        )
+    )
+    await active.emit_pending_session_start()
+    source_runtime = active._extension_runtime
+    source_prompt = active.system_prompt
+    prompts = 0
+
+    async def prompt(_request: ProjectTrustRequest) -> str:
+        nonlocal prompts
+        prompts += 1
+        return "trust-run"
+
+    def replacement_config() -> CodingSessionConfig:
+        return CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=_Storage(),
+            cwd=destination,
+            resource_paths=resources,
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=prompt,
+            extension_runtime=active._extension_runtime,
+        )
+
+    replacement = await CodingSession.load(replacement_config())
+    real_start = ExtensionRuntime.emit_session_start
+    cancelled_runtime = replacement._extension_runtime
+
+    async def cancel_adoption(self: ExtensionRuntime, reason: str) -> None:
+        if self is cancelled_runtime:
+            raise asyncio.CancelledError
+        await real_start(self, reason)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ExtensionRuntime, "emit_session_start", cancel_adoption)
+    with pytest.raises(asyncio.CancelledError):
+        await active._adopt_replacement(replacement, reason="resume")
+
+    assert prompts == 1
+    assert active.cwd == source.resolve()
+    assert active.system_prompt == source_prompt
+    assert active._extension_runtime is source_runtime
+    assert destination.resolve() not in coordinator._cache
+
+    monkeypatch.setattr(ExtensionRuntime, "emit_session_start", real_start)
+    retry = await CodingSession.load(replacement_config())
+    await active._adopt_replacement(retry, reason="resume")
+    assert prompts == 2
+    assert active.cwd == destination.resolve()
+    assert "DESTINATION-CONTEXT" in active.system_prompt
+    assert coordinator._cache[destination.resolve()].source == "ui"

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -8,7 +8,9 @@ from typing import cast
 
 import pytest
 from textual.app import App
-from textual.widgets import ListItem, ListView, Static
+from textual.color import Color
+from textual.containers import Vertical
+from textual.widgets import Label, ListItem, ListView, Static
 from typer.testing import CliRunner
 
 from tau_agent.provider import ModelProvider
@@ -32,7 +34,8 @@ from tau_coding.resources import (
     resource_paths_with_project_trust,
 )
 from tau_coding.session import CodingSession, CodingSessionConfig
-from tau_coding.tui.project_trust import ProjectTrustScreen
+from tau_coding.tui.project_trust import ProjectTrustScreen, _ProjectTrustApp
+from tau_coding.tui.themes import TAU_DARK_THEME
 
 
 def _paths(tmp_path: Path) -> TauPaths:
@@ -562,6 +565,31 @@ async def test_tui_trust_modal_all_choices_support_arrow_navigation(
         await pilot.pause()
 
     assert results == [expected]
+
+
+@pytest.mark.anyio
+async def test_standalone_trust_modal_uses_tau_dark_palette(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
+    request = ProjectTrustRequest(canonicalize_project_path(project), summary, None)
+    host = _ProjectTrustApp(request)
+
+    async with host.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        dialog = host.screen.query_one("#project-trust-dialog", Vertical)
+        choice_list = host.screen.query_one("#project-trust-list", ListView)
+        highlighted_label = choice_list.query_one(ListItem).query_one(Label)
+
+        assert host.theme == TAU_DARK_THEME.name
+        assert dialog.styles.background == Color.parse(TAU_DARK_THEME.chrome_background)
+        assert dialog.styles.color == Color.parse(TAU_DARK_THEME.chrome_text)
+        assert choice_list.styles.background == Color.parse(TAU_DARK_THEME.transcript_background)
+        assert highlighted_label.styles.background == Color.parse(
+            TAU_DARK_THEME.highlight_background
+        )
+        assert highlighted_label.styles.color == Color.parse(TAU_DARK_THEME.highlight_text)
 
 
 @pytest.mark.anyio

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -16,6 +16,7 @@ from typer.testing import CliRunner
 
 from tau_agent.provider import ModelProvider
 from tau_agent.session import SessionEntry
+from tau_coding import SessionManager, jsonl_session_storage
 from tau_coding import project_trust as project_trust_module
 from tau_coding.cli import app
 from tau_coding.paths import TauPaths
@@ -1035,6 +1036,59 @@ async def test_cancelled_destination_staging_leaves_source_session_and_cache_unc
     assert active.system_prompt == source_prompt
     assert active._extension_runtime is source_runtime
     assert destination.resolve() not in coordinator._cache
+
+
+@pytest.mark.anyio
+async def test_new_session_trust_cancellation_preserves_active_session(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    paths = _paths(tmp_path)
+    manager = SessionManager(paths)
+    record = manager.create_session(cwd=project, model="fake")
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(paths))
+    prompts = 0
+
+    async def cancel(_request: ProjectTrustRequest) -> None:
+        nonlocal prompts
+        prompts += 1
+        return None
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=cast(ModelProvider, object()),
+            model="fake",
+            storage=jsonl_session_storage(record.path),
+            cwd=project,
+            session_id=record.id,
+            session_manager=manager,
+            resource_paths=TauResourcePaths(
+                root=paths.home,
+                agents_root=paths.agents_home,
+                paths=paths,
+            ),
+            project_trust_coordinator=coordinator,
+            trust_interactive=True,
+            trust_prompt=cancel,
+        )
+    )
+    await session.emit_pending_session_start()
+    old_id = session.session_id
+    old_runtime = session._extension_runtime
+    old_prompt = session.system_prompt
+    old_resolution = session.project_trust_resolution
+    (project / "AGENTS.md").write_text("NEW-PROTECTED-CONTEXT", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="current session unchanged"):
+        await session.new_session()
+
+    assert prompts == 1
+    assert session.session_id == old_id
+    assert session._extension_runtime is old_runtime
+    assert session.system_prompt == old_prompt
+    assert session.project_trust_resolution == old_resolution
+    assert project.resolve() in coordinator._cache
+    assert coordinator._cache[project.resolve()].source == "empty"
 
 
 @pytest.mark.anyio

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Static
+from typer.testing import CliRunner
+
+from tau_agent.provider import ModelProvider
+from tau_agent.session import SessionEntry
+from tau_coding.cli import app
+from tau_coding.paths import TauPaths
+from tau_coding.project_trust import (
+    ExtensionTrustResult,
+    ProjectTrustCoordinator,
+    ProjectTrustError,
+    ProjectTrustRequest,
+    ProjectTrustStore,
+    ProtectedResourceDetector,
+    canonicalize_project_path,
+    format_trust_diagnostic,
+)
+from tau_coding.resources import TauResourcePaths, resource_paths_with_project_trust
+from tau_coding.session import CodingSession, CodingSessionConfig
+from tau_coding.tui.project_trust import ProjectTrustScreen
+
+
+def _paths(tmp_path: Path) -> TauPaths:
+    return TauPaths(home=tmp_path / "home" / ".tau", agents_home=tmp_path / "home" / ".agents")
+
+
+def test_canonical_project_path_requires_existing_directory_and_resolves_alias(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(project, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks unavailable")
+
+    assert canonicalize_project_path(alias).value == project.resolve()
+    with pytest.raises(ProjectTrustError, match="canonicalize"):
+        canonicalize_project_path(tmp_path / "missing")
+
+
+def test_detector_covers_protected_matrix_without_reading_contents(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    candidates = (
+        project / ".tau/settings.json",
+        project / ".tau/skills/tau/SKILL.md",
+        project / ".agents/skills/agents/SKILL.md",
+        project / ".tau/prompts/tau.md",
+        project / ".agents/prompts/agents.md",
+        project / ".tau/themes/theme.json",
+        project / ".tau/SYSTEM.md",
+        project / ".tau/APPEND_SYSTEM.md",
+        project / "AGENTS.md",
+        project / ".tau/AGENTS.md",
+        project / ".agents/AGENTS.md",
+        project / ".tau/extensions/simple.py",
+        project / ".tau/extensions/package/extension.py",
+        project / ".tau/extensions/manifest/pyproject.toml",
+    )
+    for candidate in candidates:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text("protected content", encoding="utf-8")
+
+    summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
+
+    assert summary.categories == (
+        "context",
+        "extensions",
+        "prompts",
+        "settings",
+        "skills",
+        "system-prompts",
+        "themes",
+    )
+    assert summary.counts == {
+        "context": 3,
+        "extensions": 3,
+        "prompts": 2,
+        "settings": 1,
+        "skills": 2,
+        "system-prompts": 2,
+        "themes": 1,
+    }
+    assert len(summary.sample_paths) <= 12
+
+
+def test_detector_ignores_empty_and_unsupported_resources(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    (project / ".tau/skills").mkdir(parents=True)
+    (project / ".agents/prompts").mkdir(parents=True)
+    (project / "CLAUDE.md").write_text("unsupported", encoding="utf-8")
+    (project / "pyproject.toml").write_text("[project]", encoding="utf-8")
+
+    summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
+
+    assert summary.categories == ()
+
+
+def test_store_round_trip_is_sorted_and_nearest_decision_wins(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    store = ProjectTrustStore(paths)
+    parent = tmp_path / "projects"
+    child = parent / "app"
+    child.mkdir(parents=True)
+    parent_key = canonicalize_project_path(parent)
+    child_key = canonicalize_project_path(child)
+
+    store.set(child_key, "untrusted")
+    store.set(parent_key, "trusted")
+
+    assert store.nearest(child_key) is not None
+    assert store.nearest(child_key).decision == "untrusted"  # type: ignore[union-attr]
+    payload = json.loads(store.path.read_text(encoding="utf-8"))
+    assert payload == {
+        "version": 1,
+        "decisions": [
+            {"path": str(parent.resolve()), "decision": "trusted"},
+            {"path": str(child.resolve()), "decision": "untrusted"},
+        ],
+    }
+    assert store.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_parent_trust_removes_exact_child_for_inheritance(tmp_path: Path) -> None:
+    store = ProjectTrustStore(_paths(tmp_path))
+    child = tmp_path / "parent" / "child"
+    child.mkdir(parents=True)
+    child_key = canonicalize_project_path(child)
+    store.set(child_key, "untrusted")
+
+    saved_parent = store.trust_parent(child_key)
+
+    assert store.nearest(child_key).path == saved_parent  # type: ignore[union-attr]
+    assert store.nearest(child_key).decision == "trusted"  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-json",
+        '{"version": 2, "decisions": []}',
+        '{"version": 1, "decisions": [{"path": "relative", "decision": "trusted"}]}',
+        (
+            '{"version": 1, "decisions": ['
+            '{"path": "/tmp/a", "decision": "trusted"},'
+            '{"path": "/tmp/a", "decision": "untrusted"}]}'
+        ),
+    ],
+)
+def test_store_rejects_malformed_data(tmp_path: Path, payload: str) -> None:
+    store = ProjectTrustStore(_paths(tmp_path))
+    store.path.parent.mkdir(parents=True)
+    store.path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ProjectTrustError):
+        store.read()
+
+
+def test_concurrent_store_updates_do_not_lose_decisions(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    projects = [tmp_path / f"project-{index}" for index in range(8)]
+    for project in projects:
+        project.mkdir()
+
+    def save(project: Path) -> None:
+        ProjectTrustStore(paths).set(canonicalize_project_path(project), "trusted")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        tuple(pool.map(save, projects))
+
+    assert len(ProjectTrustStore(paths).read()) == len(projects)
+
+
+@pytest.mark.anyio
+async def test_policy_precedence_extension_before_saved_and_default(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    store = ProjectTrustStore(_paths(tmp_path))
+    store.set(canonicalize_project_path(project), "untrusted")
+    coordinator = ProjectTrustCoordinator(store)
+
+    async def approve(_event: object) -> ExtensionTrustResult:
+        return ExtensionTrustResult("approve")
+
+    _summary, resolution = await coordinator.resolve(
+        project,
+        default="never",
+        extension_deciders=(approve,),
+    )
+
+    assert resolution.trusted is True
+    assert resolution.source == "extension"
+
+
+@pytest.mark.anyio
+async def test_malformed_store_fails_closed_but_run_override_still_works(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("rules", encoding="utf-8")
+    store = ProjectTrustStore(_paths(tmp_path))
+    store.path.parent.mkdir(parents=True)
+    store.path.write_text("bad", encoding="utf-8")
+
+    summary, declined = await ProjectTrustCoordinator(store).resolve(project)
+    _summary, default_always = await ProjectTrustCoordinator(store).resolve(
+        project, default="always"
+    )
+    _summary, approved = await ProjectTrustCoordinator(store).resolve(project, override="approve")
+
+    assert declined.trusted is False
+    assert default_always.trusted is False
+    assert declined.diagnostics
+    assert approved.trusted is True
+    assert approved.source == "override"
+    assert "not a sandbox" in format_trust_diagnostic(summary, declined)
+
+
+@pytest.mark.anyio
+async def test_reload_rechecks_empty_result_but_reuses_nonempty_run_decision(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    coordinator = ProjectTrustCoordinator(ProjectTrustStore(_paths(tmp_path)))
+
+    _summary, empty = await coordinator.resolve(project)
+    (project / "AGENTS.md").write_text("new rules", encoding="utf-8")
+    _summary, declined = await coordinator.resolve(project, refresh=True)
+    _summary, still_declined = await coordinator.resolve(
+        project,
+        default="always",
+        refresh=True,
+    )
+
+    assert empty.source == "empty"
+    assert declined.trusted is False
+    assert still_declined == declined
+
+
+def test_untrusted_resource_plan_keeps_user_resources_only(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    paths = TauResourcePaths(root=tmp_path / "home/.tau", cwd=project, agents_root=None)
+
+    untrusted = resource_paths_with_project_trust(paths, trusted=False)
+
+    assert untrusted.skills_dirs == (paths.root / "skills",)
+    assert untrusted.prompts_dirs == (paths.root / "prompts",)
+    assert untrusted.themes_dirs == (paths.root / "themes",)
+
+
+@pytest.mark.anyio
+async def test_tui_trust_modal_shows_boundary_parent_and_keyboard_cancel(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "parent/project"
+    project.mkdir(parents=True)
+    summary = ProtectedResourceDetector().detect(canonicalize_project_path(project))
+    request = ProjectTrustRequest(canonicalize_project_path(project), summary, None)
+    results: list[object | None] = []
+
+    class Host(App[None]):
+        def on_mount(self) -> None:
+            self.push_screen(ProjectTrustScreen(request), results.append)
+
+    host = Host()
+    async with host.run_test() as pilot:
+        await pilot.pause()
+        copy = str(host.screen.query_one("#project-trust-copy", Static).content)
+        parent_button = host.screen.query_one("#trust-trust-parent", Button)
+        assert "not a sandbox" in copy
+        assert str(project.parent.resolve()) in str(parent_button.label)
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert results == [None]
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self.entries: list[SessionEntry] = []
+
+    async def append(self, entry: SessionEntry) -> None:
+        self.entries.append(entry)
+
+    async def read_all(self) -> list[SessionEntry]:
+        return list(self.entries)
+
+
+@pytest.mark.anyio
+async def test_project_extensions_need_trust_and_additional_opt_in(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    extension_dir = project / ".tau/extensions"
+    extension_dir.mkdir(parents=True)
+    marker = tmp_path / "imported"
+    (extension_dir / "project.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+        "def setup(tau):\n    pass\n",
+        encoding="utf-8",
+    )
+    resources = TauResourcePaths(
+        root=tmp_path / "home/.tau",
+        agents_root=tmp_path / "home/.agents",
+    )
+    common = {
+        "provider": cast(ModelProvider, object()),
+        "model": "fake",
+        "cwd": project,
+        "resource_paths": resources,
+    }
+
+    declined = await CodingSession.load(
+        CodingSessionConfig(
+            **common,
+            storage=_Storage(),
+            trust_override="decline",
+            project_extensions_enabled=True,
+        )
+    )
+    assert not marker.exists()
+    await declined.aclose()
+
+    trusted_without_opt_in = await CodingSession.load(
+        CodingSessionConfig(
+            **common,
+            storage=_Storage(),
+            trust_override="approve",
+            project_extensions_enabled=False,
+        )
+    )
+    assert not marker.exists()
+    await trusted_without_opt_in.aclose()
+
+    trusted = await CodingSession.load(
+        CodingSessionConfig(
+            **common,
+            storage=_Storage(),
+            trust_override="approve",
+            project_extensions_enabled=True,
+        )
+    )
+    assert marker.read_text(encoding="utf-8") == "imported"
+    await trusted.aclose()
+
+
+def test_cli_rejects_conflicting_overrides() -> None:
+    result = CliRunner().invoke(app, ["--approve", "--no-approve", "--print", "hello"])
+
+    assert result.exit_code != 0
+    assert "cannot be used together" in result.output

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2880,6 +2880,42 @@ def test_tui_app_registers_and_applies_custom_theme() -> None:
         set_custom_tui_themes({})
 
 
+@pytest.mark.anyio
+async def test_tui_app_removes_source_project_themes_after_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tau_coding.tui.themes import (
+        THEME_COLOR_FIELDS,
+        TRANSCRIPT_ROLES,
+        available_tui_theme_names,
+        parse_tui_theme_json,
+        set_custom_tui_themes,
+    )
+
+    theme_data = {
+        "name": "project-theme",
+        "colors": dict.fromkeys(THEME_COLOR_FIELDS, "#123456"),
+        "roles": {role: {"border": "#123456", "body": "#e0e0e0"} for role in TRANSCRIPT_ROLES},
+    }
+    project_theme = parse_tui_theme_json(theme_data)
+    set_custom_tui_themes({"project-theme": project_theme})
+    monkeypatch.setattr(tui_app, "load_custom_tui_themes", lambda _dirs: ({}, []))
+    session = FakeSession()
+    session.theme_dirs = ()
+    app = TauTuiApp(session, tui_settings=TuiSettings(theme="project-theme"))
+    try:
+        async with app.run_test() as pilot:
+            await app._resume_session("destination-session")
+            await pilot.pause()
+
+            assert app.theme == "tau-dark"
+            assert "project-theme" not in app.available_themes
+            assert "project-theme" not in available_tui_theme_names()
+            assert app.tui_settings.theme == "project-theme"
+    finally:
+        set_custom_tui_themes({})
+
+
 def test_tui_app_falls_back_to_tau_dark_when_theme_is_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -47,7 +47,7 @@ defining `setup(tau)`, which runs once at startup with the extension API.
 | Location | Loaded |
 |---|---|
 | `~/.tau/extensions/` | by default |
-| `<project>/.tau/extensions/` | only with `--project-extensions` |
+| `<project>/.tau/extensions/` | only after project approval **and** `--project-extensions` |
 | any file or directory | with `tau -e PATH` (repeatable) |
 
 Within a directory, `*.py` files are extensions, and a subdirectory
@@ -75,7 +75,15 @@ package, so relative imports fail. Once an extension has sibling
 modules, always pass a directory: the package directory itself, or the
 repo root when a manifest declares the entry.
 
-Extensions load project-first; on name conflicts (extension names, tool
+Before a project decision, built-in, user-global, and explicit `-e` extensions
+may handle the `project_trust` event. The event contains canonical cwd, mode,
+UI availability, and bounded category counts—never protected contents. Return
+`ExtensionTrustResult("approve" | "decline" | "defer", remember=...)`; the
+first decisive result wins, errors safely defer, and remembered results save
+only the exact cwd before project loading. Project extensions cannot approve
+themselves.
+
+Extensions load project-first after approval; on name conflicts (extension names, tool
 names, command names) the first registration wins. `--no-extensions`
 disables directory discovery entirely (explicit `-e` paths still load).
 `/reload` awaits `session_shutdown(reason="reload")` on the outgoing
@@ -84,8 +92,9 @@ extension generation, clears its UI, re-imports every extension and re-runs
 Use those lifecycle hooks to stop and restart background work and to remount UI.
 
 > **Security.** Extensions execute arbitrary Python inside your session.
-> Project extensions are therefore off by default — enable them with
-> `--project-extensions` only in repositories you trust.
+> Project extensions are therefore off by default. Trust approval and
+> `--project-extensions` are both required. Project trust is not a process,
+> filesystem, network, credential, tool, model, or prompt-injection sandbox.
 
 ## The extension API
 

--- a/website/content/guides/project-instructions.md
+++ b/website/content/guides/project-instructions.md
@@ -21,7 +21,9 @@ Keep it focused — it's part of the prompt budget for every turn.
 
 ## Where Tau looks
 
-Tau discovers instruction files in this order (all that exist are included):
+Tau discovers instruction files in this order. User files are always eligible;
+project files are included only after the active cwd's [project-trust decision]
+({{< relref "./project-trust.md" >}}):
 
 ```text
 ~/.tau/AGENTS.md
@@ -42,7 +44,9 @@ a subdirectory closer to where you're working.
 ## Reloading after edits
 
 If you change an `AGENTS.md` while the TUI is open, run **`/reload`** to refresh
-project context for future turns.
+project context for future turns. Adding the first protected file to an empty
+project triggers trust resolution rather than silently inheriting the old empty
+snapshot.
 
 {{% note %}}
 Tau itself uses an `AGENTS.md` at the repo root — a real example of the format

--- a/website/content/guides/project-trust.md
+++ b/website/content/guides/project-trust.md
@@ -1,0 +1,76 @@
+---
+title: Project trust
+description: Control ambient repository inputs before Tau loads them.
+---
+
+Tau asks before loading protected inputs discovered because of the active working
+directory. The decision is keyed to the canonical, existing cwd—not a guessed
+repository root. Symlink aliases therefore share a decision, and the nearest
+saved parent decision is inherited.
+
+## Protected inputs
+
+Tau gates project `.tau` and `.agents` skills and prompts, `.tau` themes,
+`SYSTEM.md` and `APPEND_SYSTEM.md`, plain and scoped `AGENTS.md`, project
+extension candidates, and project `settings.json` reserved for future support.
+Detection checks names and metadata only; Tau does not read, parse, or import a
+candidate before deciding.
+
+User resources under `~/.tau` and `~/.agents`, built-ins, and paths explicitly
+passed on the CLI remain eligible. Trusted project extensions still require the
+additional `--project-extensions` opt-in.
+
+## Decisions
+
+Interactive startup offers:
+
+- trust this exact folder and save it;
+- trust the displayed immediate parent and save it;
+- trust for this run only;
+- decline this exact folder and save it;
+- decline for this run only.
+
+Escape/cancel safely declines for startup. During `/reload` or cross-project
+session replacement, cancellation preserves the current session snapshot.
+Saved decisions live in `~/.tau/trust.json`, version 1. Tau validates the whole
+file and updates it under a lock with restrictive permissions and atomic
+replacement. A malformed, unreadable, locked, or unwritable store never grants
+saved trust. Run-only approval remains available with `--approve`.
+
+A child decision overrides an inherited parent decision. Parent trust is broad:
+Tau displays the exact parent before selection. There is no automatic cleanup
+when a project moves.
+
+## Headless and automation
+
+`--approve` (`-a`) and `--no-approve` (`-na`) are mutually exclusive, apply only
+to the invocation, and never edit the store. Print, JSON, transcript, and other
+headless paths never prompt. Their unresolved behavior follows the user-global
+`defaultProjectTrust` setting:
+
+| Value | Headless result |
+| --- | --- |
+| `ask` (default) | decline |
+| `always` | approve |
+| `never` | decline |
+
+Trust diagnostics use stderr in structured modes, so stdout remains machine
+readable. They report bounded category/count and decision-source information,
+not protected contents.
+
+## Reload and sessions
+
+`/reload` detects again. An initially empty project that gains protected inputs
+requires a new decision; Tau never infers durable trust from the earlier empty
+state. Resource preparation is coherent: decline builds a global/explicit-only
+snapshot. Resume and replacement resolve the destination record's canonical cwd
+instead of reusing the source project's outcome.
+
+## Security boundary
+
+**Project trust is an input-loading guard, not a sandbox.** It does not restrict
+filesystem reads/writes, processes, shell commands, tools, network access,
+credentials, providers, models, package installation, prompt injection, or data
+exfiltration. A trusted project may still be malicious. Use an OS sandbox,
+container, VM, remote environment, and restricted credentials/network when you
+need isolation.

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -53,8 +53,15 @@ features and fixes.
 | `--auto-compact-threshold INT` | Auto-compact above this rough token estimate |
 | `-e, --extension PATH` | Load an [extension]({{< relref "../guides/extensions.md" >}}) file or directory (repeatable) |
 | `--no-extensions` | Disable extension directory discovery (explicit `-e` paths still load) |
-| `--project-extensions` | Also load `<project>/.tau/extensions` (runs project-supplied code at startup) |
+| `--project-extensions` | Also load trusted `<project>/.tau/extensions`; project trust and this code opt-in are both required |
+| `-a, --approve` | Trust protected project inputs for this invocation only |
+| `-na, --no-approve` | Decline protected project inputs for this invocation only |
 | `-v, --version` | Print the version and exit |
+
+`--approve` and `--no-approve` are mutually exclusive and never write the
+trust store. See [Project trust]({{< relref "../guides/project-trust.md" >}})
+for interactive scopes, headless defaults, protected resources, and the
+non-sandbox boundary.
 
 ### System prompt input
 
@@ -84,8 +91,8 @@ request. They are startup controls and are not stored in session history, so
 pass them again on a later resume when needed.
 
 Without flags, Tau also discovers `SYSTEM.md` and `APPEND_SYSTEM.md` under the
-project or user `.tau` directory. CLI values win over project files, and project
-files win over user files. Use `/reload` after changing a file. These are
+project or user `.tau` directory. CLI values win over trusted project files, and
+project files win over user files. Use `/reload` after changing a file. These are
 Tau-specific configuration files, not `.agents` resources. See
 [Configuration & files]({{< relref "./configuration.md#system-prompt-files" >}})
 for paths, precedence, diagnostics, and the project-resource security warning.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -14,7 +14,8 @@ those locations and file formats.
 ├── catalog.toml        # optional provider/model catalog overlay
 ├── providers.json      # provider/model preferences
 ├── credentials.json    # saved API keys / OAuth tokens (0600, atomic writes)
-├── settings.json       # general settings (e.g. shell command prefix)
+├── settings.json       # general settings (trust default, shell prefix)
+├── trust.json          # versioned project-input trust decisions
 ├── tui.json            # TUI theme, keybindings, and layout
 ├── sessions/           # saved sessions, per project
 ├── skills/             # user-level skills
@@ -28,6 +29,13 @@ those locations and file formats.
 
 Tau also reads user-level `.agents` resources: `~/.agents/skills/`,
 `~/.agents/prompts/`, `~/.agents/AGENTS.md`.
+
+`settings.json` may contain `"defaultProjectTrust": "ask" | "always" |
+"never"`. It is user-global only; a project cannot choose its own trust
+policy. The default is `ask`. Interactive `ask` opens the trust modal; headless
+`ask` safely declines. `trust.json` is managed atomically by Tau; do not add
+relative paths or unknown fields. See [Project trust]({{< relref
+"../guides/project-trust.md" >}}).
 
 Startup update checks cache their latest PyPI result in
 `~/.tau/cache/update-check.json` and refresh at most once per day. Set
@@ -58,10 +66,10 @@ selected file that cannot be inspected or decoded as UTF-8 stops startup or
 reload rather than silently falling back.
 
 System prompt files are Tau-specific and are not discovered from `.agents`.
-Project files currently load automatically, like Tau's other project instruction
-resources. Inspect a repository's `.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md`
-before starting Tau there: they can replace or extend the model's highest-priority
-instructions.
+Project files load only after the destination cwd is trusted. User files and
+explicit CLI values remain available when project inputs are declined. Trust is
+an input-loading guard, not a sandbox; inspect trusted prompt files because they
+can replace or extend the model's highest-priority instructions.
 
 ## Network proxies
 


### PR DESCRIPTION
## Summary

Adds a fail-closed project-trust boundary before Tau reads or imports ambient repository inputs. Tau now detects protected project resources using metadata only, resolves trust for the canonical destination working directory, and builds one coherent resource/session snapshot from that result.

This is the runtime implementation for #535. It is a **draft stacked PR** targeting the accepted design branch in #540 rather than `main`.

## Why

Opening an unfamiliar repository could previously make project-local instructions, prompts, skills, themes, settings candidates, or extensions eligible before the user had explicitly trusted that project. This change makes that boundary visible and consistent across initial startup, headless use, reloads, resumed sessions, and cross-directory session replacement.

## What changes

### Protected project inputs

Trust is resolved before Tau reads, parses, or imports:

- project `.tau` and `.agents` skills and prompts;
- `.tau` themes;
- `SYSTEM.md`, `APPEND_SYSTEM.md`, and plain/scoped `AGENTS.md` files;
- project extension candidates;
- project settings/package metadata reserved for future support.

Built-ins, user-global resources under `~/.tau` and `~/.agents`, and paths explicitly supplied on the CLI remain eligible. Trusting a project does **not** enable its extensions by itself; executable project extensions still require `--project-extensions`.

### Decisions and precedence

- Decisions are keyed to the canonical, existing cwd rather than a guessed repository root.
- Symlink aliases and alternate casing on case-insensitive macOS volumes resolve to the same key.
- The nearest saved ancestor decision applies, while an exact child decision overrides inherited parent trust.
- Interactive users can save trust/decline for the exact folder, save trust for the displayed immediate parent, or choose a run-only result.
- `--approve` / `--no-approve` provide invocation-only automation overrides and never modify the trust store.
- Headless `ask` and `never` fail closed; `defaultProjectTrust = "always"` permits project inputs without prompting.

### Session lifecycle

`CodingSession.load` first loads only user/explicit extensions, resolves trust, then conditionally loads protected project inputs. Reload and destination replacement stage cwd-bound resources, extension runtimes, tools, commands, prompts, and trust state before adopting the new snapshot. Cancellation or preparation failure preserves the current session snapshot.

### Persistence and failure safety

Saved decisions use a versioned `~/.tau/trust.json` store with:

- strict schema and canonical-path validation;
- process locking around read/modify/write;
- restrictive permissions;
- same-directory temporary files and atomic replacement;
- a durable undo journal around replacement and directory `fsync`.

Malformed, unreadable, locked, or unwritable state never grants saved trust. Readers reject any pending journal rather than silently recovering it, preventing an interrupted revocation from restoring an older trusted decision. Writer-side recovery also remains fail closed when commit and rollback both fail.

### Frontends and architecture

- Core policy, detection, persistence, and typed request/result models live in `tau_coding.project_trust`.
- Resource loaders consume a single `project_resources_enabled` plan instead of reimplementing trust checks.
- The TUI adapts the frontend-neutral request into a Tau-dark Textual modal.
- Structured/headless modes never prompt and keep diagnostics on stderr so stdout remains machine-readable.
- `tau_agent` remains independent of trust policy, filesystem paths, Typer, and Textual.

## Security boundary

Project trust is an **input-loading guard, not a sandbox**. It does not restrict filesystem access, processes, shell commands, tools, network access, credentials, providers, models, package installation, prompt injection, or data exfiltration. Use an OS sandbox, container, VM, or remote environment when isolation is required.

## Documentation and tests

Adds runtime/design notes, CLI and security documentation, website guides/reference updates, release notes, and deterministic coverage for:

- decision precedence and exact-vs-parent persistence;
- metadata-only protected-resource detection;
- interactive and headless behavior;
- startup, reload, resume, and cross-cwd replacement;
- extension gating and resource-plan rebinding;
- malformed stores, locking, atomic writes, crash journals, and rollback failures;
- macOS case-preserving canonicalization;
- TUI behavior and Tau-dark styling.

## Validation

- `uv run pytest` — 1383 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
- GitHub CI: Python checks and documentation build passed

Addresses #535. This draft does not merge or close the issue.
