### PR TITLE
Track OpenAI Responses cache writes

### DIFF
--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -821,10 +821,8 @@ def _int_or_zero(value: object) -> int:
 def _usage_from_response(event: Mapping[str, Any]) -> Usage | None:
     """Parse billed usage from a Responses ``response.completed``-style event.
 
-    Ports Pi's openai-responses-shared.ts usage handling: ``cached_tokens`` are
-    cache reads and are subtracted from ``input_tokens`` to leave fresh input.
-    The Responses API does not report cache writes, so ``cache_write`` stays 0.
-    Cost is left unset (None) because Tau has no per-model pricing table.
+    Cache reads and writes are subtracted from ``input_tokens`` to leave fresh
+    input. Cost is left unset (None) because Tau has no per-model pricing table.
     """
     response = event.get("response")
     if not isinstance(response, Mapping):
@@ -838,6 +836,11 @@ def _usage_from_response(event: Mapping[str, Any]) -> Usage | None:
         if isinstance(input_details, Mapping)
         else 0
     )
+    cache_write = (
+        _int_or_zero(input_details.get("cache_write_tokens"))
+        if isinstance(input_details, Mapping)
+        else 0
+    )
     output_details = raw.get("output_tokens_details")
     # Leave reasoning None (not 0) when the provider reports no breakdown,
     # honoring the "None = not reported" contract on Usage.
@@ -847,10 +850,10 @@ def _usage_from_response(event: Mapping[str, Any]) -> Usage | None:
         else None
     )
     return Usage(
-        input=max(0, _int_or_zero(raw.get("input_tokens")) - cache_read),
+        input=max(0, _int_or_zero(raw.get("input_tokens")) - cache_read - cache_write),
         output=_int_or_zero(raw.get("output_tokens")),
         cache_read=cache_read,
-        cache_write=0,
+        cache_write=cache_write,
         reasoning=reasoning,
         total_tokens=_int_or_zero(raw.get("total_tokens")),
     )

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -1186,10 +1186,9 @@ def _parse_chunk_usage(raw: Mapping[str, Any]) -> Usage:
 def _usage_from_responses_event(chunk: Mapping[str, Any]) -> Usage | None:
     """Parse billed usage from a `/v1/responses` terminal event.
 
-    Mirrors the Codex adapter's ``_usage_from_response``: ``cached_tokens`` are
-    cache reads subtracted from ``input_tokens`` to leave fresh input, the
-    Responses API does not report cache writes (``cache_write`` stays 0), and
-    cost is left unset because Tau has no per-model pricing table.
+    Mirrors the Codex adapter's ``_usage_from_response``: cache reads and
+    writes are subtracted from ``input_tokens`` to leave fresh input. Cost is
+    left unset because Tau has no per-model pricing table.
     """
     response = chunk.get("response")
     if not isinstance(response, Mapping):
@@ -1203,6 +1202,11 @@ def _usage_from_responses_event(chunk: Mapping[str, Any]) -> Usage | None:
         if isinstance(input_details, Mapping)
         else 0
     )
+    cache_write = (
+        _int_or_zero(input_details.get("cache_write_tokens"))
+        if isinstance(input_details, Mapping)
+        else 0
+    )
     output_details = raw.get("output_tokens_details")
     # Leave reasoning None (not 0) when the provider reports no breakdown,
     # honoring the "None = not reported" contract on Usage.
@@ -1212,10 +1216,10 @@ def _usage_from_responses_event(chunk: Mapping[str, Any]) -> Usage | None:
         else None
     )
     return Usage(
-        input=max(0, _int_or_zero(raw.get("input_tokens")) - cache_read),
+        input=max(0, _int_or_zero(raw.get("input_tokens")) - cache_read - cache_write),
         output=_int_or_zero(raw.get("output_tokens")),
         cache_read=cache_read,
-        cache_write=0,
+        cache_write=cache_write,
         reasoning=reasoning,
         total_tokens=_int_or_zero(raw.get("total_tokens")),
     )

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -2350,7 +2350,7 @@ async def test_openai_codex_provider_reports_usage() -> None:
                 'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n'
                 'data: {"type":"response.completed","response":{"status":"completed",'
                 '"usage":{"input_tokens":50,"output_tokens":8,"total_tokens":58,'
-                '"input_tokens_details":{"cached_tokens":12},'
+                '"input_tokens_details":{"cached_tokens":12,"cache_write_tokens":8},'
                 '"output_tokens_details":{"reasoning_tokens":3}}}}\n\n'
             ),
             headers={"content-type": "text/event-stream"},
@@ -2377,10 +2377,10 @@ async def test_openai_codex_provider_reports_usage() -> None:
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None
-    assert usage.input == 38  # 50 input - 12 cached
+    assert usage.input == 30  # 50 input - 12 cached - 8 written
     assert usage.output == 8
     assert usage.cache_read == 12
-    assert usage.cache_write == 0
+    assert usage.cache_write == 8
     assert usage.reasoning == 3
     assert usage.total_tokens == 58
     assert usage.cost.total == 0
@@ -2395,7 +2395,7 @@ async def test_openai_compatible_responses_api_reports_usage() -> None:
                 'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n'
                 'data: {"type":"response.completed","response":{"status":"completed",'
                 '"usage":{"input_tokens":50,"output_tokens":8,"total_tokens":58,'
-                '"input_tokens_details":{"cached_tokens":12},'
+                '"input_tokens_details":{"cached_tokens":12,"cache_write_tokens":8},'
                 '"output_tokens_details":{"reasoning_tokens":3}}}}\n\n'
             ),
             headers={"content-type": "text/event-stream"},
@@ -2422,10 +2422,10 @@ async def test_openai_compatible_responses_api_reports_usage() -> None:
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None
-    assert usage.input == 38  # 50 input - 12 cached
+    assert usage.input == 30  # 50 input - 12 cached - 8 written
     assert usage.output == 8
     assert usage.cache_read == 12
-    assert usage.cache_write == 0
+    assert usage.cache_write == 8
     assert usage.reasoning == 3
     assert usage.total_tokens == 58
     assert usage.cost.total == 0


### PR DESCRIPTION
## Description

Parse `usage.input_tokens_details.cache_write_tokens` from OpenAI Responses API terminal events for both direct OpenAI-compatible requests and Codex OAuth requests. Cache writes are now separated from fresh input while preserving the provider-reported total token count.

Tests cover cache reads and writes reported together by both adapters.

## User experience

Tau's session statistics and cache hit indicator can now distinguish cold cache writes from ordinary fresh input on providers such as GPT-5.6. This also lets existing pricing and session-stat calculations account for reported cache-write tokens instead of silently treating them as uncached input.

## Issue

No linked issue. Addresses incorrect OpenAI Responses cache-write accounting discovered while validating Codex OAuth cache behavior.

## Manual validation

1. Start a sufficiently long OpenAI API or Codex OAuth session on a model that reports `cache_write_tokens`.
2. Inspect the assistant message usage in the saved session JSONL.
3. Confirm `cacheWrite` reflects the provider value and `input + cacheRead + cacheWrite` reconstructs the provider's total input tokens.
4. Continue the session and confirm the TUI's cumulative cache percentage incorporates both cold writes and later cache reads.

## Checks

- `uv sync --dev --locked`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`
