### PR TITLE
Show latest and session cache hit rates

### DIFF
--- a/dev-notes/prompt-caching.md
+++ b/dev-notes/prompt-caching.md
@@ -109,12 +109,14 @@ wiring makes that data live rather than inventing a parallel vocabulary.
 ## Observability
 
 Without a visible hit rate there is no way to tell caching is working except by
-watching a rate limit, so `SessionStats` now accumulates `cached_input_tokens` and
-`cache_write_tokens` and exposes a `cache_hit_rate` property. The session sidebar
-renders it between the token counts and the cost estimate. The rate is `None` —
-and the sidebar omits it — when no provider in the branch reported any cache
-activity at all, so backends without prompt caching are not shown a permanent
-misleading `0%`.
+watching a rate limit, so `SessionStats` accumulates `cached_input_tokens` and
+`cache_write_tokens` and exposes both cumulative and latest-request cache hit
+rates. The sidebar labels both: the latest rate diagnoses the most recent model
+request, while the session rate describes lifetime cache efficiency on the active
+branch. After tools run, latest means the final model continuation rather than the
+user's initial request. Both rates are omitted when no provider in the branch has
+reported cache activity, so backends without prompt caching are not shown a
+permanent misleading `0%`.
 
 ## Validate
 

--- a/dev-notes/tui-sidebar-session-insights.md
+++ b/dev-notes/tui-sidebar-session-insights.md
@@ -14,6 +14,7 @@ The sidebar now shows:
 - the session name
 - user turns and assistant tool calls on the active branch
 - cumulative provider-reported input and output tokens
+- latest-request and cumulative-session prompt-cache hit rates
 - estimated cost when complete pricing is available
 - automatic-compaction status and threshold
 - context files, tools, skills, prompt templates, and loaded extensions
@@ -45,9 +46,11 @@ not only from the compacted model context. Consequently, compaction does not era
 activity or billed usage. A turn is a user or extension-authored custom message.
 A tool call is each tool-call block requested by an assistant message.
 
-Input totals include fresh input, cache reads, and cache writes. Output totals use
-the provider's reported output count. Cost is calculated per assistant response
-from that response's provider/model metadata, including tiered rates and separate
+Input totals include fresh input, cache reads, and cache writes. The cache line
+shows the latest assistant request separately from the cumulative active-branch
+rate; after tool use, latest refers to the most recent model continuation.
+Output totals use the provider's reported output count. Cost is calculated per
+assistant response from that response's provider/model metadata, including tiered rates and separate
 input, output, cache-read, and cache-write prices. If any billed response lacks
 pricing, Tau displays `$N/A` rather than showing a misleading partial estimate.
 

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -23,6 +23,8 @@ class SessionStats:
     output_tokens: int = 0
     cached_input_tokens: int = 0
     cache_write_tokens: int = 0
+    latest_prompt_tokens: int = 0
+    latest_cached_input_tokens: int = 0
     estimated_cost: float | None = None
 
     @property
@@ -38,6 +40,15 @@ class SessionStats:
             return None
         return self.cached_input_tokens / self.input_tokens
 
+    @property
+    def latest_cache_hit_rate(self) -> float | None:
+        """Share of the latest request's prompt served from cache."""
+        if self.latest_prompt_tokens <= 0:
+            return None
+        if self.cached_input_tokens == 0 and self.cache_write_tokens == 0:
+            return None
+        return self.latest_cached_input_tokens / self.latest_prompt_tokens
+
 
 def calculate_session_stats(
     entries: Sequence[SessionEntry],
@@ -51,6 +62,8 @@ def calculate_session_stats(
     output_tokens = 0
     cached_input_tokens = 0
     cache_write_tokens = 0
+    latest_prompt_tokens = 0
+    latest_cached_input_tokens = 0
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
@@ -68,6 +81,8 @@ def calculate_session_stats(
         tool_call_count += len(message.tool_calls)
         usage = message.usage
         prompt_tokens = usage.input + usage.cache_read + usage.cache_write
+        latest_prompt_tokens = prompt_tokens
+        latest_cached_input_tokens = usage.cache_read
         input_tokens += prompt_tokens
         cached_input_tokens += usage.cache_read
         cache_write_tokens += usage.cache_write
@@ -98,6 +113,8 @@ def calculate_session_stats(
         output_tokens=output_tokens,
         cached_input_tokens=cached_input_tokens,
         cache_write_tokens=cache_write_tokens,
+        latest_prompt_tokens=latest_prompt_tokens,
+        latest_cached_input_tokens=latest_cached_input_tokens,
         estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
     )
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1498,15 +1498,19 @@ def render_session_sidebar(
     usage = Text(style=theme.completion_description)
     usage.append(f"{_compact_usage_count(stats.input_tokens)} in, ")
     usage.append(f"{_compact_usage_count(stats.output_tokens)} out")
-    hit_rate = stats.cache_hit_rate
-    if hit_rate is not None:
-        usage.append(" · ", style=theme.completion_description)
-        usage.append(f"{hit_rate:.0%} cached", style=theme.completion_description)
     usage.append(" · ", style=theme.completion_description)
     if stats.estimated_cost is None:
         usage.append("$N/A", style=theme.completion_description)
     else:
         usage.append(f"~{_format_cost(stats.estimated_cost)}")
+    cache_rates: list[str] = []
+    if (latest_hit_rate := stats.latest_cache_hit_rate) is not None:
+        cache_rates.append(f"{latest_hit_rate:.0%} latest")
+    if (session_hit_rate := stats.cache_hit_rate) is not None:
+        cache_rates.append(f"{session_hit_rate:.0%} session")
+    if cache_rates:
+        usage.append("\ncache: ", style=theme.completion_description)
+        usage.append(" · ".join(cache_rates), style=theme.completion_description)
 
     threshold = session.auto_compact_token_threshold
     compaction = Text(
@@ -1537,7 +1541,7 @@ def render_session_sidebar(
     sections = (
         Padding(title, (0, 0, 0, 1)),
         _sidebar_section("activity", activity, theme=theme),
-        _sidebar_section("cumulative usage", usage, theme=theme),
+        _sidebar_section("usage", usage, theme=theme),
         _sidebar_section("compaction", compaction, theme=theme),
         _sidebar_section("context", context, theme=theme),
         _sidebar_section("tools", tools, theme=theme),

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -3,6 +3,7 @@ from tau_agent.messages import (
     CustomMessage,
     TextContent,
     ToolCall,
+    ToolResultMessage,
     Usage,
     UserMessage,
 )
@@ -32,6 +33,88 @@ def test_cache_hit_rate_divides_reads_by_total_prompt_tokens() -> None:
     stats = SessionStats(input_tokens=1_000, cached_input_tokens=950, cache_write_tokens=50)
 
     assert stats.cache_hit_rate == 0.95
+
+
+def test_latest_cache_hit_rate_uses_latest_request_tokens() -> None:
+    stats = SessionStats(
+        input_tokens=2_000,
+        cached_input_tokens=1_400,
+        latest_prompt_tokens=1_000,
+        latest_cached_input_tokens=950,
+    )
+
+    assert stats.latest_cache_hit_rate == 0.95
+
+
+def test_latest_cache_hit_rate_is_hidden_without_reported_cache_activity() -> None:
+    stats = SessionStats(
+        input_tokens=1_000,
+        latest_prompt_tokens=1_000,
+    )
+
+    assert stats.latest_cache_hit_rate is None
+
+
+def test_calculate_session_stats_uses_latest_tool_continuation_cache_rate() -> None:
+    user = MessageEntry(message=UserMessage(content="Inspect it"))
+    tool_request = MessageEntry(
+        parent_id=user.id,
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-test",
+            content=[ToolCall(id="call-1", name="read", arguments={})],
+            usage=Usage(input=100, cache_write=100),
+        ),
+    )
+    tool_result = MessageEntry(
+        parent_id=tool_request.id,
+        message=ToolResultMessage(
+            tool_call_id="call-1",
+            tool_name="read",
+            content="result",
+        ),
+    )
+    continuation = MessageEntry(
+        parent_id=tool_result.id,
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-test",
+            usage=Usage(input=10, cache_read=190),
+        ),
+    )
+
+    stats = calculate_session_stats(
+        [user, tool_request, tool_result, continuation],
+        pricing=lambda _provider, _model, _input: {},
+    )
+
+    assert stats.cache_hit_rate == 0.475
+    assert stats.latest_cache_hit_rate == 0.95
+
+
+def test_latest_cache_hit_rate_reports_miss_after_earlier_cache_activity() -> None:
+    first = MessageEntry(
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-test",
+            usage=Usage(input=100, cache_write=100),
+        )
+    )
+    latest = MessageEntry(
+        parent_id=first.id,
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-test",
+            usage=Usage(input=200),
+        ),
+    )
+
+    stats = calculate_session_stats(
+        [first, latest],
+        pricing=lambda _provider, _model, _input: {},
+    )
+
+    assert stats.latest_cache_hit_rate == 0.0
 
 
 def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -202,6 +202,8 @@ class FakeSession:
             input_tokens=1_200_000,
             output_tokens=48_000,
             cached_input_tokens=1_140_000,
+            latest_prompt_tokens=1_200_000,
+            latest_cached_input_tokens=1_188_000,
             estimated_cost=1.24,
         )
         self.system_prompt = "You are Tau."
@@ -501,9 +503,10 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "location" not in output
     assert "branch" not in output
     assert "14 turns, 23 tool calls" in output
-    assert "cumulative usage" in output
-    assert "1.2m in, 48k out" in output
-    assert "1.2m in, 48k out · 95% cached · ~$1.24" in output
+    assert "usage" in output
+    assert "cumulative usage" not in output
+    assert "1.2m in, 48k out · ~$1.24" in output
+    assert "cache: 99% latest · 95% session" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert "• review" in output
@@ -645,6 +648,23 @@ def test_session_sidebar_omits_cache_rate_for_providers_without_caching() -> Non
     output = console.export_text()
     assert "cached" not in output
     assert "1.2k in, 300 out" in output
+
+
+def test_session_sidebar_shows_latest_cache_miss_with_session_rate() -> None:
+    session = FakeSession()
+    session.session_stats = SessionStats(
+        input_tokens=2_000,
+        output_tokens=300,
+        cached_input_tokens=500,
+        cache_write_tokens=500,
+        latest_prompt_tokens=1_000,
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "cache: 0% latest · 25% session" in output
 
 
 def test_session_sidebar_brand_includes_current_version() -> None:

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -35,8 +35,8 @@ trailing=<count>` when provider usage anchors the active count. Otherwise it sho
 the fallback system/message/tool breakdown. Provider usage from errored or aborted
 responses is not trusted.
 
-This is different from **cumulative usage** in the sidebar. Cumulative usage adds
-the provider-reported input and output tokens from every request on the active
+This is different from the cumulative token totals in the sidebar's **usage**
+section. Cumulative usage adds the provider-reported input and output tokens from every request on the active
 branch, including history later replaced by compaction. Repeatedly sending the
 same context therefore increases cumulative input usage, while active context
 consumption describes only what Tau expects to send next. The two figures are

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -147,9 +147,10 @@ when you want to reduce what is sent to the model.
 
 On wide-enough terminals Tau shows the session name prominently without a
 redundant section label, followed by active-branch
-turn and tool-call totals, provider-reported token usage under **cumulative usage**,
-prompt-cache hit rate, estimated cost, automatic-compaction threshold, and loaded tools, skills, prompt
-templates, extensions, and context files such as `AGENTS.md`. Tool, prompt, and extension
+turn and tool-call totals, provider-reported token usage, latest-request and
+session prompt-cache hit rates, estimated cost, automatic-compaction threshold,
+and loaded tools, skills, prompt templates, extensions, and context files such as
+`AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists limited to three rendered lines. Skills
 and context files use bullet lists, with one item or path per line, limited to
 five entries. Truncated sections end with `...(X more)` showing how many entries
@@ -171,12 +172,15 @@ provider request, so it can be much larger than the context used by the next
 request. Cost is an estimate based on provider-reported usage and configured
 catalog rates; the sidebar shows `$N/A` when Tau lacks complete pricing data.
 
-The cache hit rate is the share of those input tokens the provider served from its
-prompt cache instead of processing again. A healthy long coding session sits well
-above 90%; a low rate usually means something early in the request keeps changing,
-such as a reloaded tool list or a changed thinking level, or that a pause outlived
-the provider's cache. Tau hides the figure entirely for providers that do not
-report cache usage.
+The cache line separates the latest model request from the cumulative session.
+Both rates are the share of prompt tokens the provider served from its cache
+instead of processing again. The latest rate makes a cache miss immediately visible and,
+after tool use, describes the most recent model continuation. The session rate
+includes every request on the active branch, including the initial cold request.
+A low latest rate usually means something early in the request changed, such as
+a reloaded tool list or thinking level, or that a pause outlived the provider's
+cache.
+Tau hides both figures for providers that do not report cache usage.
 
 The compact status block below the prompt puts `provider:model (thinking)` on its
 first line and provider-anchored active context as `used/limit` on the second. When


### PR DESCRIPTION
## Summary

- show the latest model request's prompt-cache hit rate in the TUI sidebar
- keep the cumulative active-branch cache hit rate alongside it
- label both rates clearly and document tool-continuation semantics

## User experience

A healthy cache is now immediately visible after a short follow-up request. The initial cold request no longer obscures current cache behavior, while the session-wide rate remains available for lifetime efficiency and billing context.

## Issue

No linked issue.

## Manual validation

1. Start Tau in a wide terminal with a provider that reports prompt-cache usage.
2. Send an initial prompt and note the latest and session cache rates in the sidebar.
3. Send a short follow-up; confirm the latest rate reflects that model request while the session rate remains cumulative.
4. Trigger tool use; confirm the latest rate updates to the most recent model continuation.
5. Use a provider without reported cache usage and confirm the cache line is omitted.
