### PR TITLE
Add usage analysis tab to HTML session exports

### DIFF
--- a/dev-notes/architecture/phase-20-4-session-export.md
+++ b/dev-notes/architecture/phase-20-4-session-export.md
@@ -33,18 +33,21 @@ The export contains two coordinated views:
   entries
 
 The generated file is self-contained HTML, CSS, and JavaScript, so it can be
-opened without running Tau or the Textual app. Transcript entries render as
-compact, collapsed accordion rows (icon, title, one-line preview, timestamp),
-with thinking blocks, tool-call arguments, and result details nested as inner
+opened without running Tau or the Textual app. The export has separate
+**Transcript** and **Analysis** tabs. Transcript entries render as compact,
+collapsed accordion rows (icon, title, one-line preview, timestamp), with
+thinking blocks, tool-call arguments, and result details nested as inner
 accordions. Tool rows are titled `Tool: <name>`, and the session tree labels
 tool entries with just the tool name for readability. Chip-style header
 filters—with entry counts—can hide tool calls/results in both views or drop
 non-message session events for a user/assistant-focused transcript, and a
-single button expands or collapses every accordion at once. A download button
-reproduces the JSONL export from the entry data embedded (base64-encoded) in
-the page, so the HTML file alone round-trips the full session. The filters
-change only the exported view; the complete session remains embedded in the
-document.
+single button expands or collapses every accordion at once. The Analysis tab
+shows active-branch model request totals, cache hit rate, prompt/output/reasoning
+tokens, estimated cost, compactions, tool counts, a per-request table, and
+interactive SVG charts. A download button reproduces the JSONL export from the
+entry data embedded (base64-encoded) in the page, so the HTML file alone
+round-trips the full session. The filters change only the exported view; the
+complete session remains embedded in the document.
 
 ## Why it exists
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -658,6 +658,7 @@ class CodingSession:
             source=str(session_path) if session_path is not None else self.session_id,
             format=export_format,
             system_prompt=self.system_prompt,
+            pricing=self._pricing_for_response,
         )
 
     @property

--- a/src/tau_coding/session_analysis.py
+++ b/src/tau_coding/session_analysis.py
@@ -1,0 +1,199 @@
+"""Usage analysis for exported Tau sessions."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import cache
+
+from tau_agent.messages import AssistantMessage, Usage
+from tau_agent.session import CompactionEntry, LeafEntry, MessageEntry, SessionEntry
+from tau_agent.session.tree import SessionTreeError, path_to_entry
+from tau_coding.provider_catalog import (
+    ProviderCatalogEntry,
+    model_cost_for_input_tokens,
+)
+from tau_coding.session_stats import PricingResolver
+
+
+@dataclass(frozen=True, slots=True)
+class RequestUsage:
+    """Token usage and cost information for one assistant response."""
+
+    number: int
+    provider: str
+    model: str
+    fresh: int
+    cached: int
+    cache_write: int
+    output: int
+    reasoning: int
+    stop_reason: str
+    estimated_cost: float | None
+
+    @property
+    def prompt(self) -> int:
+        """Return all input tokens reported for the request."""
+        return self.fresh + self.cached + self.cache_write
+
+    @property
+    def hit_rate(self) -> float:
+        """Return the share of prompt tokens served from cache."""
+        return self.cached / self.prompt if self.prompt else 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class SessionAnalysis:
+    """Detailed usage analysis for the active branch of a session."""
+
+    requests: tuple[RequestUsage, ...]
+    compaction_count: int
+    tool_counts: tuple[tuple[str, int], ...]
+
+    @property
+    def total_fresh(self) -> int:
+        return sum(request.fresh for request in self.requests)
+
+    @property
+    def total_cached(self) -> int:
+        return sum(request.cached for request in self.requests)
+
+    @property
+    def total_cache_writes(self) -> int:
+        return sum(request.cache_write for request in self.requests)
+
+    @property
+    def total_prompt(self) -> int:
+        return sum(request.prompt for request in self.requests)
+
+    @property
+    def total_output(self) -> int:
+        return sum(request.output for request in self.requests)
+
+    @property
+    def total_reasoning(self) -> int:
+        return sum(request.reasoning for request in self.requests)
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Return the cumulative cache hit rate for the active branch."""
+        return self.total_cached / self.total_prompt if self.total_prompt else 0.0
+
+    @property
+    def estimated_cost(self) -> float | None:
+        """Return the total cost, or ``None`` if any request is unpriced."""
+        if not self.requests or any(request.estimated_cost is None for request in self.requests):
+            return None
+        return sum(request.estimated_cost or 0.0 for request in self.requests)
+
+
+def analyze_session(
+    entries: Sequence[SessionEntry],
+    *,
+    pricing: PricingResolver | None = None,
+) -> SessionAnalysis:
+    """Analyze assistant usage, tools, and compactions on the active branch.
+
+    A session export contains the complete tree. Usage is intentionally scoped to
+    the branch selected by the latest leaf pointer so abandoned branches do not
+    inflate the dashboard totals.
+    """
+    active_entries = _active_branch_entries(entries)
+    requests: list[RequestUsage] = []
+    tools: Counter[str] = Counter()
+    compactions = 0
+
+    for entry in active_entries:
+        if isinstance(entry, CompactionEntry):
+            compactions += 1
+        if not isinstance(entry, MessageEntry):
+            continue
+        message = entry.message
+        if not isinstance(message, AssistantMessage):
+            continue
+
+        for tool_call in message.tool_calls:
+            tools[tool_call.name] += 1
+        usage = message.usage
+        prompt_tokens = usage.input + usage.cache_read + usage.cache_write
+        rates = pricing(message.provider, message.model, prompt_tokens) if pricing else None
+        estimated_cost = (
+            _response_cost(usage=usage, rates=rates)
+            if rates is not None
+            else usage.cost.total
+            if usage.cost.total > 0
+            else None
+        )
+        requests.append(
+            RequestUsage(
+                number=len(requests) + 1,
+                provider=message.provider,
+                model=message.model,
+                fresh=usage.input,
+                cached=usage.cache_read,
+                cache_write=usage.cache_write,
+                output=usage.output,
+                reasoning=usage.reasoning or 0,
+                stop_reason=message.stop_reason,
+                estimated_cost=estimated_cost,
+            )
+        )
+
+    return SessionAnalysis(
+        requests=tuple(requests),
+        compaction_count=compactions,
+        tool_counts=tuple(sorted(tools.items(), key=lambda item: (-item[1], item[0]))),
+    )
+
+
+def _active_branch_entries(entries: Sequence[SessionEntry]) -> list[SessionEntry]:
+    entry_list = list(entries)
+    leaf_id = next(
+        (
+            entry.entry_id
+            for entry in reversed(entry_list)
+            if isinstance(entry, LeafEntry) and isinstance(entry.entry_id, str)
+        ),
+        None,
+    )
+    if leaf_id is None:
+        return [entry for entry in entry_list if not isinstance(entry, LeafEntry)]
+    try:
+        return path_to_entry(entry_list, leaf_id)
+    except SessionTreeError:
+        # Keep exports useful for partially written or externally edited JSONL.
+        return [entry for entry in entry_list if not isinstance(entry, LeafEntry)]
+
+
+def _response_cost(*, usage: Usage, rates: Mapping[str, float]) -> float:
+    return (
+        usage.input * rates.get("input", 0.0)
+        + usage.output * rates.get("output", 0.0)
+        + usage.cache_read * rates.get("cacheRead", 0.0)
+        + usage.cache_write * rates.get("cacheWrite", 0.0)
+    ) / 1_000_000
+
+
+@cache
+def default_pricing() -> PricingResolver:
+    """Return a resolver backed by Tau's packaged provider catalog."""
+    from tau_coding.catalog_loader import builtin_catalog
+
+    return catalog_pricing(builtin_catalog())
+
+
+def catalog_pricing(catalog: Sequence[ProviderCatalogEntry]) -> PricingResolver:
+    """Build a pricing resolver from provider catalog entries."""
+    providers = {provider.name: provider for provider in catalog}
+
+    def resolve(provider_name: str, model: str, input_tokens: int) -> dict[str, float] | None:
+        provider = providers.get(provider_name)
+        if provider is None:
+            return None
+        metadata = provider.model_metadata.get(model)
+        if metadata is None:
+            return None
+        return model_cost_for_input_tokens(metadata, input_tokens)
+
+    return resolve

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -886,6 +886,314 @@ def render_session_html(
       .analysis-card:nth-child(n + 3) {{ border-top: 1px solid var(--line); }}
       .analysis-heading {{ display: block; }}
     }}
+
+    /* Restrained application shell: flat surfaces, dense data, one quiet accent. */
+    :root {{
+      color-scheme: dark;
+      --canvas: #0d0e10;
+      --surface: #121416;
+      --surface-muted: #181a1d;
+      --text: #e7e7e5;
+      --muted: #8b8e93;
+      --line: #292c30;
+      --line-soft: #202327;
+      --line-strong: #3a3e42;
+      --accent: #a7c080;
+      --accent-soft: #1d241c;
+      --danger: #bd766f;
+      --code-bg: #0f1113;
+      --serif: "SF Pro Display", "Segoe UI", Inter, ui-sans-serif, system-ui, sans-serif;
+      --sans: "SF Pro Text", "Segoe UI", Inter, ui-sans-serif, system-ui, sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-family: var(--sans);
+    }}
+    :root[data-theme="light"] {{
+      color-scheme: light;
+      --canvas: #f2f2ee;
+      --surface: #fafaf7;
+      --surface-muted: #e9ebe5;
+      --text: #1b1d1b;
+      --muted: #73766f;
+      --line: #d5d8d0;
+      --line-soft: #e5e7e1;
+      --line-strong: #bfc4b9;
+      --accent: #61784c;
+      --accent-soft: #e6ece0;
+      --danger: #a84b44;
+      --code-bg: #eef0eb;
+    }}
+    html {{ background: var(--canvas); }}
+    body {{
+      background: var(--canvas);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 14px;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -.005em;
+    }}
+    header {{
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-template-areas: "eyebrow theme" "title meta";
+      align-items: end;
+      max-width: 1240px;
+      margin: 0 auto 30px;
+      padding: 38px 24px 22px;
+      border-bottom: 1px solid var(--line);
+    }}
+    h1 {{
+      grid-area: title;
+      margin: 7px 0 0;
+      color: var(--text);
+      font-size: 32px;
+      font-weight: 590;
+      letter-spacing: -.035em;
+      line-height: 1.1;
+    }}
+    h2 {{
+      color: var(--text);
+      font-size: 16px;
+      font-weight: 590;
+      letter-spacing: -.012em;
+      text-transform: none;
+    }}
+    h3, h4 {{ font-weight: 580; letter-spacing: -.01em; }}
+    .header-top {{ display: contents; }}
+    .eyebrow {{
+      grid-area: eyebrow;
+      color: var(--muted);
+      font: 600 10px/1.2 var(--mono);
+      letter-spacing: .12em;
+    }}
+    .theme-toggle {{
+      grid-area: theme;
+      width: 28px;
+      height: 28px;
+      color: var(--muted);
+      background: var(--surface);
+      border: 1px solid var(--line-strong);
+      border-radius: 5px;
+    }}
+    .theme-toggle:hover {{ color: var(--text); border-color: var(--accent); }}
+    .source, .generated {{
+      color: var(--muted);
+      font: 11px/1.7 var(--mono);
+    }}
+    .export-meta {{
+      display: block;
+      grid-area: meta;
+      max-width: 360px;
+      margin-top: 0;
+      text-align: right;
+    }}
+    .export-meta > * {{ margin: 0; }}
+    .source code, code {{ color: var(--accent); }}
+    details.system-prompt {{
+      grid-column: 1 / -1;
+      margin-top: 16px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+    }}
+    .system-prompt-summary {{
+      padding: 9px 12px;
+      font: 600 11px var(--mono);
+      text-transform: uppercase;
+      letter-spacing: .06em;
+    }}
+    .system-prompt-warning {{ color: var(--muted); font-size: 10px; }}
+    .system-prompt-body {{ padding: 0 12px 12px; }}
+    .system-prompt-body pre {{ background: var(--code-bg); }}
+    .view-tabs {{
+      grid-column: 1 / -1;
+      gap: 24px;
+      margin-top: 24px;
+      border-bottom: 1px solid var(--line);
+    }}
+    .view-tab {{
+      padding: 12px 1px 11px;
+      border: 0;
+      border-bottom: 2px solid transparent;
+      border-radius: 0;
+      background: transparent;
+      color: #777b81;
+      font-size: 12px;
+    }}
+    .view-tab:hover {{ background: transparent; color: #c7c9c6; }}
+    .view-tab[aria-selected="true"] {{ color: var(--text); border-bottom-color: var(--accent); }}
+    .filter-bar {{
+      grid-column: 1 / -1;
+      gap: 5px;
+      margin-top: 0;
+      padding: 10px 0 16px;
+      background: transparent;
+      border: 0;
+      border-radius: 0;
+    }}
+    .filter-label {{ font: 500 10px var(--mono); letter-spacing: .07em; }}
+    .chip-label, .jsonl-download, .expand-toggle {{
+      padding: 5px 10px;
+      color: #969a9f;
+      background: #17191c;
+      border: 1px solid #34373b;
+      border-radius: 5px;
+      font-size: 11px;
+    }}
+    .chip-label {{ gap: 6px; }}
+    .chip-label::before {{ width: 6px; height: 6px; border-radius: 1px; }}
+    .chip input:checked + .chip-label {{
+      color: #111315;
+      background: #e2e3df;
+      border-color: #e2e3df;
+    }}
+    .chip input:checked + .chip-label::before {{ background: var(--accent); }}
+    .chip-count {{ background: transparent; font-size: 10px; }}
+    .chip input:checked + .chip-label .chip-count {{ background: transparent; }}
+    .jsonl-download:hover, .expand-toggle:hover {{
+      color: var(--text);
+      background: #1e2124;
+      border-color: #45494e;
+    }}
+    .expand-toggle {{ color: var(--accent); border-color: var(--accent); }}
+    main, .analysis-shell {{
+      width: min(1240px, calc(100% - 48px));
+      max-width: 1240px;
+      padding: 28px 0 64px;
+    }}
+    main {{ gap: 24px; }}
+    aside {{
+      top: 14px;
+      padding-right: 18px;
+      border-right: 1px solid var(--line);
+    }}
+    aside h2 {{
+      color: var(--muted);
+      font: 500 10px/1.4 var(--mono);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }}
+    .tree .tree {{ border-color: var(--line); }}
+    .node-link {{ padding: 5px 7px; border-radius: 3px; }}
+    .node-link:hover {{ background: var(--surface-muted); }}
+    .active-path > .node-link {{ color: var(--accent); }}
+    .active-leaf > .node-link {{ background: var(--accent-soft); color: var(--text); }}
+    .node-type {{ font-size: 11px; }}
+    details.entry {{
+      margin-bottom: 7px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      box-shadow: none;
+    }}
+    details.entry.active-entry {{ background: var(--surface-muted); }}
+    details.entry.is-error {{ border-color: var(--danger); }}
+    .entry-summary {{ padding: 9px 12px; border-radius: 6px; }}
+    .entry-summary:hover {{ background: var(--accent-soft); }}
+    .entry-title {{ font-size: 11px; font-weight: 600; }}
+    .entry-preview {{ color: var(--muted); font-size: 11px; }}
+    .entry-status {{ color: var(--accent); font: 600 9px var(--mono); }}
+    .entry-time {{ color: var(--muted); font: 10px var(--mono); }}
+    .entry-body {{ padding: 10px 12px 12px 30px; border-top-color: var(--line); }}
+    .entry-meta-line {{ font-size: 10px; }}
+    details.block {{
+      background: var(--code-bg);
+      border-color: var(--line-soft, #202327);
+      border-radius: 4px;
+    }}
+    .block-summary {{ padding: 6px 9px; font-size: 10px; }}
+    .block-body {{ padding: 2px 9px 9px; }}
+    pre {{
+      background: var(--code-bg);
+      border-color: var(--line);
+      border-radius: 4px;
+      font-size: 11px;
+    }}
+    .highlight .p {{ color: var(--muted); }}
+    .highlight .nt {{ color: var(--accent); }}
+    .highlight .s2, .highlight .s1 {{ color: #9eaa8e; }}
+    .highlight .mi, .highlight .mf {{ color: #b89564; }}
+    .highlight .kc {{ color: #b58d9b; }}
+    .analysis-shell {{ padding-top: 28px; }}
+    .analysis-heading {{ margin: 0 2px 18px; }}
+    .analysis-heading p {{ color: var(--muted); font: 11px var(--mono); }}
+    .analysis-cards {{
+      gap: 0;
+      margin-bottom: 28px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }}
+    .analysis-card {{ padding: 17px 19px; border-right-color: var(--line); }}
+    .analysis-card span {{
+      font: 500 10px/1.3 var(--mono);
+      color: var(--muted);
+      letter-spacing: .07em;
+    }}
+    .analysis-card strong {{
+      color: var(--text);
+      font-size: 25px;
+      font-weight: 580;
+      letter-spacing: -.035em;
+    }}
+    .analysis-note {{ color: var(--muted); font-size: 11px; }}
+    .analysis-charts {{ gap: 12px; margin-top: 12px; }}
+    .analysis-charts svg {{
+      padding: 25px 27px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }}
+    .analysis-chart .grid {{ stroke: var(--line); }}
+    .analysis-chart .chart-title {{ fill: var(--text); font: 590 16px var(--sans); }}
+    .analysis-chart .tick, .analysis-chart .axis-label, .analysis-chart .legend {{
+      fill: var(--muted);
+      font: 10px var(--mono);
+    }}
+    .analysis-chart .point.active {{ stroke: var(--canvas); }}
+    .analysis-details {{
+      gap: 12px;
+      margin-top: 12px;
+      padding-top: 0;
+      border-top: 0;
+    }}
+    .analysis-details > div {{
+      min-width: 0;
+      padding: 25px 27px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }}
+    .analysis-table-wrap {{ border-top-color: var(--line); }}
+    .analysis-table th {{
+      background: var(--surface);
+      color: #74787e;
+      font: 500 9px/1.4 var(--mono);
+      letter-spacing: .07em;
+    }}
+    .analysis-table td {{ color: #c3c5c2; font-size: 11px; }}
+    .analysis-tool {{ border-top-color: var(--line-soft, #202327); font-size: 11px; }}
+    .chart-tooltip {{
+      background: #181a1d;
+      border: 1px solid #3a3e42;
+      border-radius: 6px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, .45);
+      color: #d4d5d2;
+    }}
+    :root:not([data-theme="light"]) .theme-toggle .theme-icon-light {{ display: none; }}
+    :root:not([data-theme="light"]) .theme-toggle .theme-icon-dark {{ display: inline-block; }}
+    @media (max-width: 820px) {{
+      header {{ display: block; padding-top: 24px; }}
+      .header-top {{ display: flex; }}
+      .export-meta {{ max-width: none; margin-top: 8px; text-align: left; }}
+      main, .analysis-shell {{ width: min(100% - 28px, 1240px); padding-top: 24px; }}
+      header {{ max-width: 100%; }}
+      .analysis-details > div {{ padding: 20px 17px; }}
+    }}
+    @media (max-width: 520px) {{
+      main, .analysis-shell {{ width: calc(100% - 28px); }}
+      .analysis-card {{ padding: 15px; }}
+    }}
   </style>
 </head>
 <body>
@@ -984,9 +1292,7 @@ def render_session_html(
       var toggle = document.getElementById("themeToggle");
       if (toggle) {{
         toggle.addEventListener("click", function () {{
-          var prefersDark =
-            window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-          var current = root.getAttribute("data-theme") || (prefersDark ? "dark" : "light");
+          var current = root.getAttribute("data-theme") || "dark";
           var next = current === "dark" ? "light" : "dark";
           root.setAttribute("data-theme", next);
           try {{

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -40,6 +40,12 @@ from tau_agent.session import (
     path_to_entry,
 )
 from tau_agent.types import JSONValue
+from tau_coding.session_analysis import (
+    SessionAnalysis,
+    analyze_session,
+    default_pricing,
+)
+from tau_coding.session_stats import PricingResolver
 
 
 class SessionExportError(ValueError):
@@ -82,6 +88,7 @@ def export_session_html(
     title: str = "Tau Session Export",
     source: str | None = None,
     system_prompt: str | None = None,
+    pricing: PricingResolver | None = None,
 ) -> Path:
     """Write a self-contained HTML session export and return its path."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,6 +98,7 @@ def export_session_html(
             title=title,
             source=source,
             system_prompt=system_prompt,
+            pricing=pricing,
         ),
         encoding="utf-8",
     )
@@ -105,6 +113,7 @@ def export_session_artifact(
     source: str | None = None,
     format: str | None = None,
     system_prompt: str | None = None,
+    pricing: PricingResolver | None = None,
 ) -> Path:
     """Write a session export in the requested or inferred format."""
     export_format = normalize_export_format(format or output_path.suffix.removeprefix("."))
@@ -116,6 +125,7 @@ def export_session_artifact(
         title=title,
         source=source,
         system_prompt=system_prompt,
+        pricing=pricing,
     )
 
 
@@ -149,9 +159,11 @@ def render_session_html(
     title: str = "Tau Session Export",
     source: str | None = None,
     system_prompt: str | None = None,
+    pricing: PricingResolver | None = None,
 ) -> str:
-    """Render a session transcript/tree as standalone HTML."""
+    """Render a session transcript/tree and usage analysis as standalone HTML."""
     entry_list = list(entries)
+    analysis = analyze_session(entry_list, pricing=pricing or default_pricing())
     active_leaf_id = _active_leaf_id(entry_list)
     active_path_ids = _active_path_ids(entry_list, active_leaf_id)
     visible_entries = _visible_entries(entry_list)
@@ -164,6 +176,7 @@ def render_session_html(
     jsonl_filename = _jsonl_filename(title, source)
     tool_count = sum(1 for entry in visible_entries if _entry_filter_kind(entry) == "tool")
     event_count = sum(1 for entry in visible_entries if _entry_filter_kind(entry) == "event")
+    analysis_html = _render_analysis(analysis)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -321,6 +334,29 @@ def render_session_html(
       gap: 4px 18px;
       margin-top: 8px;
     }}
+    .view-tabs {{
+      display: flex;
+      gap: 18px;
+      margin-top: 24px;
+      border-bottom: 1px solid var(--line);
+    }}
+    .view-tab {{
+      padding: 8px 2px 9px;
+      color: var(--muted);
+      background: transparent;
+      border: 0;
+      border-bottom: 2px solid transparent;
+      cursor: pointer;
+      font-family: var(--sans);
+      font-size: 0.76rem;
+      font-weight: 500;
+    }}
+    .view-tab:hover {{ color: var(--accent); }}
+    .view-tab[aria-selected="true"] {{
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }}
+    .view-panel[hidden] {{ display: none; }}
     details.system-prompt {{
       margin-top: 16px;
       background: var(--surface);
@@ -663,6 +699,150 @@ def render_session_html(
     .hide-tools .tool-content {{ display: none; }}
     .messages-only details.entry[data-entry-kind="event"] {{ display: none; }}
     .messages-only .tree-node[data-entry-kind="event"] > .node-link {{ display: none; }}
+    .analysis-shell {{
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 30px clamp(16px, 4vw, 44px) 56px;
+    }}
+    .analysis-heading {{
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 18px;
+    }}
+    .analysis-heading p {{
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-family: var(--sans);
+    }}
+    .analysis-cards {{
+      display: grid;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }}
+    .analysis-card {{
+      min-width: 0;
+      padding: 14px 14px 16px 0;
+      border-right: 1px solid var(--line);
+    }}
+    .analysis-card + .analysis-card {{ padding-left: 14px; }}
+    .analysis-card:nth-child(6) {{ border-right: 0; }}
+    .analysis-card span {{
+      color: var(--muted);
+      font-family: var(--sans);
+      font-size: 0.64rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }}
+    .analysis-card strong {{
+      display: block;
+      margin-top: 7px;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 1rem;
+      font-weight: 500;
+    }}
+    .analysis-note {{
+      margin: 14px 0 26px;
+      color: var(--muted);
+      font-family: var(--sans);
+      font-size: 0.72rem;
+    }}
+    .analysis-charts {{
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 34px;
+      margin-top: 26px;
+    }}
+    .analysis-charts svg {{
+      width: 100%;
+      height: auto;
+      overflow: visible;
+      border-bottom: 1px solid var(--line);
+    }}
+    .analysis-charts svg:first-child {{ grid-column: 1 / -1; }}
+    .analysis-chart {{ cursor: crosshair; touch-action: none; }}
+    .analysis-chart .grid {{ stroke: var(--line); stroke-width: 1; }}
+    .analysis-chart .chart-title {{
+      fill: var(--text);
+      font: 500 15px var(--serif);
+    }}
+    .analysis-chart .tick,
+    .analysis-chart .axis-label,
+    .analysis-chart .legend {{
+      fill: var(--muted);
+      font: 11px var(--mono);
+    }}
+    .analysis-chart .hover-line {{
+      stroke: var(--text);
+      stroke-width: 1;
+      stroke-dasharray: 3 4;
+      opacity: .55;
+      pointer-events: none;
+    }}
+    .analysis-chart .point {{ transition: r .12s ease, opacity .12s ease; }}
+    .analysis-chart .point.active {{ r: 6; stroke: var(--canvas); stroke-width: 2; }}
+    .analysis-chart .series {{ transition: opacity .15s ease; }}
+    .analysis-chart .series.is-hidden {{ opacity: .08; pointer-events: none; }}
+    .analysis-chart .series-toggle {{ cursor: pointer; outline: none; }}
+    .analysis-chart .series-toggle[aria-pressed="false"] {{ opacity: .3; }}
+    .analysis-chart .series-toggle:focus-visible text {{ text-decoration: underline; }}
+    .analysis-details {{
+      display: grid;
+      grid-template-columns: minmax(0, 3fr) minmax(180px, 1fr);
+      gap: 36px;
+      margin-top: 42px;
+      padding-top: 24px;
+      border-top: 2px solid var(--text);
+    }}
+    .analysis-table-wrap {{ overflow: auto; max-height: 560px; border-top: 1px solid var(--line); }}
+    .analysis-table {{
+      border-collapse: collapse;
+      width: 100%;
+      white-space: nowrap;
+      font: 11px var(--mono);
+    }}
+    .analysis-table th, .analysis-table td {{
+      padding: 8px 9px;
+      text-align: right;
+      border-bottom: 1px solid var(--line);
+    }}
+    .analysis-table th {{
+      position: sticky;
+      top: 0;
+      background: var(--canvas);
+      color: var(--muted);
+      font-size: 0.6rem;
+      font-weight: 600;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }}
+    .analysis-table th:first-child, .analysis-table td:first-child {{ padding-left: 0; }}
+    .analysis-table th:nth-child(2), .analysis-table th:nth-child(3),
+    .analysis-table td:nth-child(2), .analysis-table td:nth-child(3) {{ text-align: left; }}
+    .analysis-tool {{
+      display: flex;
+      justify-content: space-between;
+      padding: 9px 0;
+      border-top: 1px solid var(--line);
+    }}
+    .analysis-tool strong {{ font-family: var(--mono); font-weight: 500; }}
+    .chart-tooltip {{
+      position: fixed;
+      z-index: 10;
+      display: none;
+      min-width: 170px;
+      padding: 9px 11px;
+      background: rgba(19, 33, 60, .96);
+      color: #f4f6fa;
+      border-radius: 4px;
+      box-shadow: 0 5px 20px rgba(19, 33, 60, .16);
+      font: 11px/1.6 var(--mono);
+      white-space: pre-line;
+      pointer-events: none;
+    }}
     pre.highlight {{ padding: 9px 12px; }}
     .highlight .p {{ color: var(--muted); }}
     .highlight .nt {{ color: var(--accent); }}
@@ -682,6 +862,12 @@ def render_session_html(
     :root[data-theme="dark"] .highlight .mf {{ color: #e0a95e; }}
     :root[data-theme="dark"] .highlight .kc {{ color: #e58fc0; }}
     @media (max-width: 820px) {{
+      .analysis-cards {{ grid-template-columns: repeat(3, minmax(0, 1fr)); }}
+      .analysis-card:nth-child(3) {{ border-right: 0; }}
+      .analysis-card:nth-child(n + 4) {{ border-top: 1px solid var(--line); }}
+      .analysis-charts {{ grid-template-columns: 1fr; }}
+      .analysis-charts svg:first-child {{ grid-column: auto; }}
+      .analysis-details {{ grid-template-columns: 1fr; }}
       main {{ grid-template-columns: 1fr; }}
       aside {{
         position: static;
@@ -692,6 +878,13 @@ def render_session_html(
       }}
       .entry-preview {{ display: none; }}
       .entry-body {{ padding-left: 14px; }}
+    }}
+    @media (max-width: 520px) {{
+      .analysis-cards {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+      .analysis-card:nth-child(3) {{ border-right: 1px solid var(--line); }}
+      .analysis-card:nth-child(2n) {{ border-right: 0; }}
+      .analysis-card:nth-child(n + 3) {{ border-top: 1px solid var(--line); }}
+      .analysis-heading {{ display: block; }}
     }}
   </style>
 </head>
@@ -717,7 +910,19 @@ def render_session_html(
       </p>
     </div>
     {system_prompt_html}
-    <div class="filter-bar" aria-label="Transcript filters">
+    <nav class="view-tabs" aria-label="Export views">
+      <button
+        type="button" class="view-tab" id="transcriptTab" aria-selected="true"
+        aria-controls="transcriptView">
+        Transcript
+      </button>
+      <button
+        type="button" class="view-tab" id="analysisTab" aria-selected="false"
+        aria-controls="analysisView">
+        Analysis
+      </button>
+    </nav>
+    <div class="filter-bar" id="transcriptControls" aria-label="Transcript filters">
       <span class="filter-label">View</span>
       <label class="chip">
         <input type="checkbox" id="showTools" checked>
@@ -747,6 +952,7 @@ def render_session_html(
       </button>
     </div>
   </header>
+  <div class="view-panel" id="transcriptView">
   <main class="session-shell">
     <aside class="tree-rail">
       <h2>Session</h2>
@@ -757,6 +963,11 @@ def render_session_html(
       {details_html}
     </section>
   </main>
+  </div>
+  <section class="view-panel" id="analysisView" hidden aria-label="Session analysis">
+    {analysis_html}
+  </section>
+  <div class="chart-tooltip" role="status" aria-live="polite"></div>
   <script id="sessionJsonlData" type="application/octet-stream">{jsonl_b64}</script>
   <script>
     (function () {{
@@ -785,6 +996,22 @@ def render_session_html(
           }}
         }});
       }}
+
+      var transcriptTab = document.getElementById("transcriptTab");
+      var analysisTab = document.getElementById("analysisTab");
+      var transcriptView = document.getElementById("transcriptView");
+      var analysisView = document.getElementById("analysisView");
+      var transcriptControls = document.getElementById("transcriptControls");
+      function selectView(view) {{
+        var analysisSelected = view === "analysis";
+        transcriptTab.setAttribute("aria-selected", String(!analysisSelected));
+        analysisTab.setAttribute("aria-selected", String(analysisSelected));
+        transcriptView.hidden = analysisSelected;
+        analysisView.hidden = !analysisSelected;
+        transcriptControls.hidden = analysisSelected;
+      }}
+      transcriptTab.addEventListener("click", function () {{ selectView("transcript"); }});
+      analysisTab.addEventListener("click", function () {{ selectView("analysis"); }});
 
       var showTools = document.getElementById("showTools");
       var showEvents = document.getElementById("showEvents");
@@ -857,6 +1084,74 @@ def render_session_html(
       if (window.location.hash.indexOf("#entry-") === 0) {{
         openEntry(window.location.hash.slice(1));
       }}
+
+      var chartTooltip = document.querySelector(".chart-tooltip");
+      function hideChartTooltip(chart) {{
+        chartTooltip.style.display = "none";
+        chart.querySelector(".hover-line").setAttribute("visibility", "hidden");
+        chart.querySelectorAll(".point.active").forEach(function (point) {{
+          point.classList.remove("active");
+        }});
+      }}
+      document.querySelectorAll(".analysis-chart").forEach(function (chart) {{
+        var count = Number(chart.dataset.count);
+        var left = Number(chart.dataset.left);
+        var right = Number(chart.dataset.right);
+        var viewWidth = chart.viewBox.baseVal.width;
+        chart.addEventListener("pointermove", function (event) {{
+          var rect = chart.getBoundingClientRect();
+          var svgX = (event.clientX - rect.left) * viewWidth / rect.width;
+          var plotWidth = viewWidth - left - right;
+          if (svgX < left || svgX > viewWidth - right || count < 1) {{
+            hideChartTooltip(chart);
+            return;
+          }}
+          var index = Math.max(0, Math.min(count - 1, Math.round(
+            (svgX - left) / plotWidth * Math.max(count - 1, 1)
+          )));
+          var points = Array.from(chart.querySelectorAll('.point[data-index="' + index + '"]'))
+            .filter(function (point) {{
+              return !point.closest(".series").classList.contains("is-hidden");
+            }});
+          if (!points.length) return;
+          chart.querySelectorAll(".point.active").forEach(function (point) {{
+            point.classList.remove("active");
+          }});
+          points.forEach(function (point) {{ point.classList.add("active"); }});
+          var x = points[0].getAttribute("cx");
+          var line = chart.querySelector(".hover-line");
+          line.setAttribute("x1", x); line.setAttribute("x2", x);
+          line.setAttribute("visibility", "visible");
+          chartTooltip.textContent = "Request " + (index + 1) + "\\n" + points.map(
+            function (point) {{ return point.dataset.name + "  " + point.dataset.label; }}
+          ).join("\\n");
+          chartTooltip.style.display = "block";
+          var tooltipRect = chartTooltip.getBoundingClientRect();
+          chartTooltip.style.left = Math.min(
+            window.innerWidth - tooltipRect.width - 10, event.clientX + 14
+          ) + "px";
+          chartTooltip.style.top = Math.max(10, event.clientY - tooltipRect.height - 12) + "px";
+        }});
+        chart.addEventListener("pointerleave", function () {{ hideChartTooltip(chart); }});
+        function toggleSeries(control) {{
+          var series = chart.querySelector(
+            '.series[data-series-id="' + control.dataset.seriesId + '"]'
+          );
+          var visible = control.getAttribute("aria-pressed") === "true";
+          control.setAttribute("aria-pressed", String(!visible));
+          series.classList.toggle("is-hidden", visible);
+        }}
+        chart.querySelectorAll(".series-toggle").forEach(function (control) {{
+          control.addEventListener("click", function (event) {{
+            event.stopPropagation(); toggleSeries(control);
+          }});
+          control.addEventListener("keydown", function (event) {{
+            if (event.key === "Enter" || event.key === " ") {{
+              event.preventDefault(); toggleSeries(control);
+            }}
+          }});
+        }});
+      }});
       applyFilters();
       syncAccordionToggle();
     }})();
@@ -864,6 +1159,211 @@ def render_session_html(
 </body>
 </html>
 """
+
+
+def _render_analysis(analysis: SessionAnalysis) -> str:
+    """Render the active-branch usage dashboard for the analysis tab."""
+    requests = analysis.requests
+    if not requests:
+        return (
+            '<div class="analysis-shell">'
+            '<div class="analysis-heading"><h2>Usage analysis</h2></div>'
+            '<p class="empty">No assistant request usage was found on the active branch.</p>'
+            "</div>"
+        )
+
+    rates = [request.hit_rate for request in requests]
+    cumulative_rates: list[float] = []
+    cumulative_cached = cumulative_prompt = 0
+    for request in requests:
+        cumulative_cached += request.cached
+        cumulative_prompt += request.prompt
+        cumulative_rates.append(cumulative_cached / cumulative_prompt if cumulative_prompt else 0.0)
+
+    charts = "".join(
+        (
+            _line_chart(
+                "Prompt input by request",
+                [
+                    ("cached", [float(item.cached) for item in requests], "#3f6b61"),
+                    ("cache writes", [float(item.cache_write) for item in requests], "#9a7b3f"),
+                    ("fresh", [float(item.fresh) for item in requests], "#b56b45"),
+                ],
+            ),
+            _line_chart(
+                "Cache hit rate",
+                [("request", rates, "#a8644a"), ("cumulative", cumulative_rates, "#385d7a")],
+                y_max=1.0,
+                percent=True,
+            ),
+            _line_chart(
+                "Output and reasoning tokens",
+                [
+                    ("output", [float(item.output) for item in requests], "#6e5a7d"),
+                    ("reasoning", [float(item.reasoning) for item in requests], "#9a7b3f"),
+                ],
+            ),
+        )
+    )
+    table_rows = "".join(
+        "<tr>"
+        f"<td>{item.number}</td><td>{_escape(item.provider)}</td>"
+        f"<td>{_escape(item.model)}</td><td>{item.fresh:,}</td>"
+        f"<td>{item.cached:,}</td><td>{item.cache_write:,}</td>"
+        f"<td>{item.prompt:,}</td><td>{item.hit_rate:.1%}</td>"
+        f"<td>{item.output:,}</td><td>{item.reasoning:,}</td>"
+        f"<td>{_format_cost(item.estimated_cost)}</td>"
+        f"<td>{_escape(item.stop_reason)}</td></tr>"
+        for item in requests
+    )
+    tool_rows = (
+        "".join(
+            f'<div class="analysis-tool"><span>{_escape(name)}</span><strong>{count}</strong></div>'
+            for name, count in analysis.tool_counts
+        )
+        or '<p class="empty">No tool calls on active branch.</p>'
+    )
+    cost_note = (
+        "Costs use Tau's provider catalog rates. OAuth subscription estimates are API-rate "
+        "equivalents, not actual subscription charges. Unknown rates are shown as N/A."
+    )
+    return f"""<div class="analysis-shell">
+  <div class="analysis-heading">
+    <h2>Usage analysis</h2>
+    <p>Active branch only</p>
+  </div>
+  <div class="analysis-cards" aria-label="Usage summary">
+    <div class="analysis-card"><span>Model requests</span><strong>{len(requests):,}</strong></div>
+    <div class="analysis-card"><span>Cache hit rate</span>
+      <strong>{analysis.cache_hit_rate:.1%}</strong></div>
+    <div class="analysis-card"><span>Prompt input</span>
+      <strong>{analysis.total_prompt:,}</strong></div>
+    <div class="analysis-card"><span>Output tokens</span>
+      <strong>{analysis.total_output:,}</strong></div>
+    <div class="analysis-card"><span>Estimated cost</span>
+      <strong>{_format_cost(analysis.estimated_cost)}</strong></div>
+    <div class="analysis-card"><span>Compactions</span>
+      <strong>{analysis.compaction_count:,}</strong></div>
+  </div>
+  <p class="analysis-note">{_escape(cost_note)} Hover or tap a request for exact values.
+    Select a legend item to hide a series.</p>
+  <div class="analysis-charts">{charts}</div>
+  <div class="analysis-details">
+    <div>
+      <h2>Requests</h2>
+      <div class="analysis-table-wrap">
+        <table class="analysis-table">
+          <thead><tr><th>#</th><th>Provider</th><th>Model</th><th>Fresh</th>
+            <th>Cached</th><th>Written</th><th>Prompt</th><th>Hit rate</th>
+            <th>Output</th><th>Reasoning</th><th>Est. cost</th><th>Stop</th></tr></thead>
+          <tbody>{table_rows}</tbody>
+        </table>
+      </div>
+    </div>
+    <div>
+      <h2>Tool calls</h2>
+      {tool_rows}
+    </div>
+  </div>
+</div>"""
+
+
+def _line_chart(
+    title: str,
+    series: Sequence[tuple[str, Sequence[float], str]],
+    *,
+    y_max: float | None = None,
+    percent: bool = False,
+) -> str:
+    """Render a self-contained SVG line chart for the analysis dashboard."""
+    width, height = 900, 300
+    left, right, top, bottom = 62, 18, 38, 44
+    plot_width, plot_height = width - left - right, height - top - bottom
+    count = max((len(values) for _, values, _ in series), default=0)
+    observed_max = max((max(values, default=0.0) for _, values, _ in series), default=0.0)
+    maximum = y_max or max(observed_max, 1.0)
+    if not percent:
+        magnitude = 10 ** max(0, len(str(int(maximum))) - 1)
+        maximum = ((maximum + magnitude - 1) // magnitude) * magnitude
+
+    def point(index: int, value: float) -> tuple[float, float]:
+        x = left + (index / max(count - 1, 1)) * plot_width
+        y = top + plot_height - (value / maximum) * plot_height
+        return x, y
+
+    parts = [
+        f'<svg class="analysis-chart" viewBox="0 0 {width} {height}" role="img" '
+        f'aria-label="{_attr(title)}" data-left="{left}" data-right="{right}" '
+        f'data-count="{count}">',
+        f'<text class="chart-title" x="{left}" y="22">{_escape(title)}</text>',
+    ]
+    for tick in range(6):
+        value = maximum * tick / 5
+        y = top + plot_height - tick * plot_height / 5
+        label = f"{value:.0%}" if percent else _compact_number(value)
+        parts.append(
+            f'<line class="grid" x1="{left}" y1="{y:.1f}" x2="{width - right}" y2="{y:.1f}"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{left - 8}" y="{y + 4:.1f}" text-anchor="end">{label}</text>'
+        )
+    for index in range(count):
+        if count <= 20 or index % max(1, count // 12) == 0 or index == count - 1:
+            x, _ = point(index, 0)
+            parts.append(
+                f'<text class="tick" x="{x:.1f}" y="{height - 16}" '
+                f'text-anchor="middle">{index + 1}</text>'
+            )
+    parts.append(
+        f'<line class="hover-line" x1="{left}" y1="{top}" x2="{left}" '
+        f'y2="{top + plot_height}" visibility="hidden"/>'
+    )
+    for series_index, (name, values, color) in enumerate(series):
+        points = " ".join(
+            f"{x:.1f},{y:.1f}" for x, y in (point(i, value) for i, value in enumerate(values))
+        )
+        parts.append(f'<g class="series" data-series-id="{series_index}">')
+        parts.append(
+            f'<polyline points="{points}" fill="none" stroke="{color}" stroke-width="2.5"/>'
+        )
+        for index, value in enumerate(values):
+            x, y = point(index, value)
+            label = f"{value:.1%}" if percent else f"{int(value):,}"
+            parts.append(
+                f'<circle class="point" data-index="{index}" data-name="{_attr(name)}" '
+                f'data-label="{_attr(label)}" cx="{x:.1f}" cy="{y:.1f}" r="3.5" fill="{color}"/>'
+            )
+        parts.append("</g>")
+    legend_x = width - right
+    for series_index, (name, _, color) in reversed(list(enumerate(series))):
+        legend_x -= 18 + len(name) * 7
+        parts.append(
+            f'<g class="series-toggle" data-series-id="{series_index}" role="button" '
+            f'tabindex="0" aria-pressed="true"><circle cx="{legend_x}" cy="18" r="4" '
+            f'fill="{color}"/><text class="legend" x="{legend_x + 8}" y="22">'
+            f"{_escape(name)}</text></g>"
+        )
+    parts.append(
+        f'<text class="axis-label" x="{left + plot_width / 2}" y="{height - 2}" '
+        'text-anchor="middle">Model request</text></svg>'
+    )
+    return "".join(parts)
+
+
+def _format_cost(value: float | None) -> str:
+    if value is None:
+        return "$N/A"
+    if 0 < value < 0.01:
+        return f"${value:.3f}"
+    return f"${value:.2f}"
+
+
+def _compact_number(value: float) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}m"
+    if value >= 1_000:
+        return f"{value / 1_000:.0f}k"
+    return f"{value:.0f}"
 
 
 def _render_system_prompt(system_prompt: str | None) -> str:

--- a/tests/test_session_analysis.py
+++ b/tests/test_session_analysis.py
@@ -1,0 +1,55 @@
+from tau_agent import (
+    AssistantMessage,
+    LeafEntry,
+    MessageEntry,
+    TextContent,
+    ToolCall,
+    Usage,
+    UserMessage,
+)
+from tau_coding.session_analysis import analyze_session
+
+
+def test_analyze_session_reports_usage_for_active_branch_only() -> None:
+    root = MessageEntry(id="root", message=UserMessage(content="Start"))
+    kept = MessageEntry(
+        id="kept",
+        parent_id=root.id,
+        message=AssistantMessage(
+            provider="openai",
+            model="gpt-test",
+            content=[
+                TextContent(text="Done"),
+                ToolCall(id="call-1", name="read", arguments={"path": "README.md"}),
+            ],
+            usage=Usage(input=100, cache_read=300, cache_write=125, output=20, reasoning=5),
+        ),
+    )
+    abandoned = MessageEntry(
+        id="abandoned",
+        parent_id=root.id,
+        message=AssistantMessage(
+            provider="openai",
+            model="gpt-test",
+            usage=Usage(input=9_000, output=1),
+        ),
+    )
+    entries = [root, kept, abandoned, LeafEntry(id="leaf", entry_id=kept.id)]
+
+    analysis = analyze_session(
+        entries,
+        pricing=lambda _provider, _model, _input: {
+            "input": 1.0,
+            "output": 2.0,
+            "cacheRead": 0.5,
+            "cacheWrite": 0.25,
+        },
+    )
+
+    assert len(analysis.requests) == 1
+    assert analysis.requests[0].prompt == 525
+    assert analysis.requests[0].hit_rate == 300 / 525
+    assert analysis.requests[0].reasoning == 5
+    assert analysis.total_output == 20
+    assert analysis.estimated_cost == 0.00032125
+    assert analysis.tool_counts == (("read", 1),)

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -86,6 +86,9 @@ def test_render_session_html_uses_static_document_layout() -> None:
     assert 'id="transcriptTab"' in html
     assert 'id="analysisTab"' in html
     assert 'id="analysisView"' in html
+    assert "--canvas: #0d0e10" in html
+    assert "--accent: #a7c080" in html
+    assert "flat surfaces, dense data, one quiet accent" in html
     assert 'id="themeToggle"' in html
     assert "<link" not in html.lower()
     assert "http://" not in html and "https://" not in html
@@ -177,6 +180,7 @@ def test_render_session_html_includes_usage_analysis_tab() -> None:
     assert "Tool calls" in html
     assert 'class="analysis-chart"' in html
     assert 'selectView("analysis")' in html
+    assert 'root.getAttribute("data-theme") || "dark"' in html
 
 
 def test_render_session_html_includes_filter_bar_and_accordions() -> None:

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -83,6 +83,9 @@ def test_render_session_html_uses_static_document_layout() -> None:
     assert "Session" in html
     assert "Transcript" in html
     assert "border-right: 1px solid var(--line);" in html
+    assert 'id="transcriptTab"' in html
+    assert 'id="analysisTab"' in html
+    assert 'id="analysisView"' in html
     assert 'id="themeToggle"' in html
     assert "<link" not in html.lower()
     assert "http://" not in html and "https://" not in html
@@ -128,6 +131,52 @@ def test_render_session_html_syntax_highlights_tool_call_arguments() -> None:
 
     assert 'class="highlight"' in html
     assert '<span class="nt">' in html or '<span class="s2">' in html
+
+
+def test_render_session_html_includes_usage_analysis_tab() -> None:
+    entries = [
+        MessageEntry(id="root", message=UserMessage(content="Inspect")),
+        MessageEntry(
+            id="reply",
+            parent_id="root",
+            message=AssistantMessage(
+                provider="openai",
+                model="gpt-test",
+                content=assistant_content(
+                    "Done",
+                    [ToolCall(id="call-1", name="read", arguments={"path": "README.md"})],
+                ),
+                usage={
+                    "input": 100,
+                    "cacheRead": 300,
+                    "cacheWrite": 125,
+                    "output": 20,
+                    "reasoning": 5,
+                },
+            ),
+        ),
+        LeafEntry(id="leaf", entry_id="reply"),
+    ]
+
+    html = render_session_html(
+        entries,
+        pricing=lambda _provider, _model, _input: {
+            "input": 1.0,
+            "output": 2.0,
+            "cacheRead": 0.5,
+            "cacheWrite": 0.25,
+        },
+    )
+
+    assert 'id="analysisTab"' in html
+    assert 'id="analysisView" hidden' in html
+    assert "Active branch only" in html
+    assert "57.1%" in html
+    assert "Model requests</span><strong>1</strong>" in html
+    assert "Output and reasoning tokens" in html
+    assert "Tool calls" in html
+    assert 'class="analysis-chart"' in html
+    assert 'selectView("analysis")' in html
 
 
 def test_render_session_html_includes_filter_bar_and_accordions() -> None:

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -110,10 +110,15 @@ The system prompt is display-only export metadata, not a transcript entry.
 Direct JSONL exports and JSONL downloaded from the HTML remain entry-only and do
 not contain it.
 
-Every transcript entry is a compact accordion row
-(icon, title, one-line preview, timestamp) that expands to reveal the full
-content; thinking blocks, tool-call arguments, and tool-result details are
-nested accordions. The export header includes controls to:
+The HTML export has separate **Transcript** and **Analysis** tabs. Every
+transcript entry is a compact accordion row (icon, title, one-line preview,
+timestamp) that expands to reveal the full content; thinking blocks, tool-call
+arguments, and tool-result details are nested accordions. The Analysis tab
+summarizes the active branch with model request totals, cache hit rate,
+prompt/output/reasoning tokens, estimated cost, compactions, tool counts, a
+per-request table, and interactive charts. Unknown pricing is shown as `N/A`.
+
+The transcript view includes controls to:
 
 - show or hide tool calls and tool results in both the transcript and session
   tree—the chip filters show how many entries of each kind the session contains

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -110,8 +110,9 @@ The system prompt is display-only export metadata, not a transcript entry.
 Direct JSONL exports and JSONL downloaded from the HTML remain entry-only and do
 not contain it.
 
-The HTML export has separate **Transcript** and **Analysis** tabs. Every
-transcript entry is a compact accordion row (icon, title, one-line preview,
+The HTML export has separate **Transcript** and **Analysis** tabs and uses a
+compact dark, data-dashboard layout with a quiet green accent (the theme toggle
+can switch to light mode). Every transcript entry is a compact accordion row (icon, title, one-line preview,
 timestamp) that expands to reveal the full content; thinking blocks, tool-call
 arguments, and tool-result details are nested accordions. The Analysis tab
 summarizes the active branch with model request totals, cache hit rate,


### PR DESCRIPTION
## Summary

Add a self-contained **Analysis** tab to exported Tau HTML sessions, alongside the existing Transcript tab, and refine the complete export template with a restrained Tokenlog-inspired dashboard style.

The analysis view includes:

- active-branch request totals and cache hit rate
- prompt, output, and reasoning token totals
- estimated cost with unknown pricing shown as `N/A`
- compaction and tool-call counts
- per-request usage table
- inline interactive SVG charts for prompt input, cache hit rate, and output/reasoning tokens

The analysis calculations are shared in `tau_coding.session_analysis` and live exports use the session's configured pricing resolver.

## User experience

Users can inspect usage and cost trends directly from the standalone `/export` HTML file without running Tau again or opening a separate analysis command. The export now uses a compact, dark, data-oriented visual system inspired by Tokenlog: flat panels, restrained borders, dense tables, monospace metadata, and one quiet green accent. The theme toggle still supports light mode.

The existing transcript/tree layout and controls remain available in their own tab. Analysis is intentionally scoped to the active branch so abandoned branches do not inflate totals.

## Issue

No specific issue was provided; this addresses the requested session-export analysis and visual redesign features.

## Manual validation

1. Run Tau and create or resume a session with at least one assistant response.
2. Run `/export`.
3. Open the generated HTML file in a browser.
4. Switch between **Transcript** and **Analysis**.
5. In Analysis, verify the summary cards, request table, tool counts, chart tooltips, and clickable chart legends.
6. Verify the dark default styling, light/dark toggle, and responsive layout.
7. Verify the Transcript tab still supports filtering, accordions, theme switching, and JSONL download.
