### PR TITLE
Require an explicit startup trust choice

### DIFF
--- a/dev-notes/design/project-trust.md
+++ b/dev-notes/design/project-trust.md
@@ -507,7 +507,9 @@ would load, and say “This controls project inputs; it is not a sandbox.” Cho
   with protected resources skipped;
 - **Do not trust for this run only** — skip without writing.
 
-Escape/cancel equals run-only decline. Parent scope must never default to `$HOME`
+Escape/cancel exits Tau during initial startup; users must explicitly select a
+run-only decline to continue without project inputs. During reload or session
+replacement, cancellation preserves the active snapshot. Parent scope must never default to `$HOME`
 or filesystem root without displaying the exact broad scope and requiring the
 same explicit selection. Accessibility, focus, and key handling belong to the
 Textual adapter/modal; available choices and semantics belong to `tau_coding`.

--- a/src/tau_coding/data/docs/security.md
+++ b/src/tau_coding/data/docs/security.md
@@ -10,8 +10,9 @@ Interactive users can save exact or displayed-parent decisions or choose a
 run-only result. `~/.tau/trust.json` is a locked, atomically replaced version-1
 store. `defaultProjectTrust` in user `~/.tau/settings.json` is `ask`, `always`,
 or `never`; headless `ask`/`never` decline. `--approve` and `--no-approve` are
-run-only. Trusted project extensions additionally require
-`--project-extensions`.
+run-only. Cancelling the interactive startup decision exits Tau; continuing
+without project inputs requires selecting a decline option. Trusted project
+extensions additionally require `--project-extensions`.
 
 Project trust is only an input-loading guard. It is not a filesystem, process,
 shell, network, tool, credential, provider, model, package-install,

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6841,9 +6841,12 @@ async def run_tui_app(
                 trust_prompt=prompt_project_trust,
             )
         )
+        trust_resolution = getattr(session, "project_trust_resolution", None)
+        if trust_resolution is not None and trust_resolution.cancelled:
+            return None
+
         theme_dirs = getattr(session, "theme_dirs", None)
         if theme_dirs is None:
-            trust_resolution = getattr(session, "project_trust_resolution", None)
             trusted = trust_resolution is None or trust_resolution.trusted
             theme_dirs = TauResourcePaths(
                 cwd=record.cwd,

--- a/src/tau_coding/tui/project_trust.py
+++ b/src/tau_coding/tui/project_trust.py
@@ -27,7 +27,7 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
     """Tau-style modal picker rendering one policy-owned request."""
 
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("escape", "cancel", "Decline for this run"),
+        Binding("escape", "cancel", "Cancel"),
         Binding("up", "cursor_up", "Up", show=False),
         Binding("down", "cursor_down", "Down", show=False),
         Binding("enter", "select_cursor", "Select", show=False),
@@ -85,9 +85,15 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
     }
     """
 
-    def __init__(self, request: ProjectTrustRequest) -> None:
+    def __init__(
+        self,
+        request: ProjectTrustRequest,
+        *,
+        cancel_action: str = "cancels",
+    ) -> None:
         super().__init__()
         self.request = request
+        self.cancel_action = cancel_action
 
     def compose(self) -> ComposeResult:
         categories = ", ".join(
@@ -117,7 +123,10 @@ class ProjectTrustScreen(ModalScreen[TrustChoice | None]):
                 id="project-trust-boundary",
             )
             yield ListView(*choices, id="project-trust-list")
-            yield Static("↑/↓ choose · Enter selects · Escape declines", id="project-trust-help")
+            yield Static(
+                f"↑/↓ choose · Enter selects · Escape {self.cancel_action}",
+                id="project-trust-help",
+            )
 
     def on_mount(self) -> None:
         """Focus the first safe, explicit action for keyboard users."""
@@ -164,7 +173,10 @@ class _ProjectTrustApp(App[TrustChoice | None]):
         self.request = request
 
     def on_mount(self) -> None:
-        self.push_screen(ProjectTrustScreen(self.request), self.exit)
+        self.push_screen(
+            ProjectTrustScreen(self.request, cancel_action="exits Tau"),
+            self.exit,
+        )
 
 
 async def prompt_project_trust(request: ProjectTrustRequest) -> TrustChoice | None:

--- a/tests/test_project_trust.py
+++ b/tests/test_project_trust.py
@@ -315,10 +315,12 @@ async def test_tui_trust_modal_shows_boundary_parent_and_keyboard_cancel(
     async with host.run_test() as pilot:
         await pilot.pause()
         boundary = str(host.screen.query_one("#project-trust-boundary", Static).content)
+        help_text = str(host.screen.query_one("#project-trust-help", Static).content)
         displayed_path = str(host.screen.query_one("#project-trust-path", Static).content)
         summary_copy = str(host.screen.query_one("#project-trust-summary", Static).content)
         parent_choice = host.screen.query_one("#trust-trust-parent", ListItem)
         assert "not a sandbox" in boundary
+        assert "Escape cancels" in help_text
         assert displayed_path == str(project.resolve())
         assert "context (1)" in summary_copy
         assert str(project.parent.resolve()) in str(parent_choice.query_one(Static).content)
@@ -607,8 +609,10 @@ async def test_standalone_trust_modal_uses_tau_dark_palette(tmp_path: Path) -> N
         dialog = host.screen.query_one("#project-trust-dialog", Vertical)
         choice_list = host.screen.query_one("#project-trust-list", ListView)
         highlighted_label = choice_list.query_one(ListItem).query_one(Label)
+        help_text = str(host.screen.query_one("#project-trust-help", Static).content)
 
         assert host.theme == TAU_DARK_THEME.name
+        assert "Escape exits Tau" in help_text
         assert dialog.styles.background == Color.parse(TAU_DARK_THEME.chrome_background)
         assert dialog.styles.color == Color.parse(TAU_DARK_THEME.chrome_text)
         assert choice_list.styles.background == Color.parse(TAU_DARK_THEME.transcript_background)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7944,6 +7944,79 @@ async def test_run_tui_app_falls_back_to_first_credentialed_provider(
 
 
 @pytest.mark.anyio
+async def test_run_tui_app_exits_when_startup_trust_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    calls: list[str] = []
+    record = CodingSessionRecord(
+        id="new-session",
+        path=tmp_path / "new-session.jsonl",
+        cwd=tmp_path,
+        model="gpt-5",
+        title=None,
+        created_at=1.0,
+        updated_at=1.0,
+        provider_name="openai",
+    )
+
+    class FakeProvider:
+        async def aclose(self) -> None:
+            calls.append("provider_closed")
+
+    class FakeManager:
+        def prepare_session(
+            self,
+            *,
+            cwd: Path,
+            model: str,
+            provider_name: str | None = None,
+        ) -> CodingSessionRecord:
+            calls.append("prepare")
+            return record
+
+        def get_session(self, session_id: str) -> CodingSessionRecord | None:
+            return None
+
+    class CancelledSession:
+        project_trust_resolution = SimpleNamespace(cancelled=True)
+
+        async def aclose(self) -> None:
+            calls.append("session_closed")
+
+    class FakeCodingSession:
+        @classmethod
+        async def load(cls, config: object) -> CancelledSession:
+            calls.append("load")
+            return CancelledSession()
+
+    class UnexpectedApp:
+        def __init__(self, session: object, **kwargs: object) -> None:
+            raise AssertionError("main TUI must not open after startup trust cancellation")
+
+    settings = ProviderSettings(
+        default_provider="openai",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="openai",
+                models=("gpt-5",),
+                default_model="gpt-5",
+            ),
+        ),
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "stored-key")
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(tui_app, "create_model_provider", lambda *args, **kwargs: FakeProvider())
+    monkeypatch.setattr(tui_app, "CodingSession", FakeCodingSession)
+    monkeypatch.setattr(tui_app, "TauTuiApp", UnexpectedApp)
+
+    result = await tui_app.run_tui_app(cwd=tmp_path, model=None, session_manager=FakeManager())
+
+    assert result is None
+    assert calls == ["prepare", "load", "session_closed", "provider_closed"]
+
+
+@pytest.mark.anyio
 async def test_run_tui_app_surfaces_startup_provider_error_in_login_message(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/content/guides/project-trust.md
+++ b/website/content/guides/project-trust.md
@@ -30,8 +30,9 @@ Interactive startup offers:
 - decline this exact folder and save it;
 - decline for this run only.
 
-Escape/cancel safely declines for startup. During `/reload` or cross-project
-session replacement, cancellation preserves the current session snapshot.
+Escape/cancel exits Tau during startup without loading the project. During
+`/reload` or cross-project session replacement, cancellation preserves the
+current session snapshot and keeps Tau open.
 Saved decisions live in `~/.tau/trust.json`, version 1. Tau validates the whole
 file and updates it under a lock with restrictive permissions and atomic
 replacement. A malformed, unreadable, locked, or unwritable store never grants


### PR DESCRIPTION
## Summary

- exit Tau when the initial project-trust modal is cancelled with Escape
- require users who want to continue without project inputs to explicitly select a decline option
- preserve existing cancellation behavior during reload and session replacement
- make startup and in-session modal help text describe their distinct Escape behavior

## User experience

The startup trust boundary no longer treats Escape as an implicit run-only decline. Escape closes Tau before the main TUI opens. During an already-running session, Escape still cancels the trust transition and preserves the active snapshot.

Follow-up to #541.

## Validation

- `uv run pytest` — 1391 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`

## Manual validation

1. Start Tau in a project with protected inputs and no saved trust decision.
2. Press Escape in the startup trust modal; Tau should exit without opening the main TUI.
3. Start again and explicitly select “Do not trust for this run only”; Tau should open without project inputs.
4. Trigger a trust prompt during reload or session replacement and press Escape; Tau should remain open with the prior session snapshot.
