### PR TITLE
Improve OpenAI prompt-cache affinity

### DIFF
--- a/dev-notes/prompt-caching.md
+++ b/dev-notes/prompt-caching.md
@@ -8,15 +8,15 @@ key. Tau carries its durable coding-session id through `AgentHarness` into every
 model request, including tool continuations, and clamps it to OpenAI's 64-character
 `prompt_cache_key` limit.
 
-Direct OpenAI Responses requests send the same value in three places:
+Direct OpenAI Responses requests send the same value as `prompt_cache_key` in
+the request body and `session_id` in the request headers. Codex OAuth uses the
+same body field, but its subscription backend spells the header `session-id`.
+Direct Chat Completions sends only `prompt_cache_key`.
 
-- `prompt_cache_key` in the request body;
-- `session_id` in the request headers;
-- `x-client-request-id` in the request headers.
-
-Codex OAuth uses the same body field and `x-client-request-id`, but its subscription
-backend spells the other header `session-id`. Direct Chat Completions sends only
-`prompt_cache_key`. This remains stateless operation: Tau keeps `store: false` and
+Tau deliberately omits the optional `x-client-request-id` header. OpenAI defines
+it as a unique per-request diagnostic identifier, not a stable cache-affinity key;
+reusing the session id there would make individual requests ambiguous in provider
+logs. This remains stateless operation: Tau keeps `store: false` and
 resends the complete transcript. The id helps routing and grouping; it cannot make
 a changed system prompt, tool schema, or transcript prefix cacheable.
 

--- a/dev-notes/prompt-caching.md
+++ b/dev-notes/prompt-caching.md
@@ -1,4 +1,33 @@
-# Anthropic prompt caching
+# Prompt caching
+
+## OpenAI cache affinity
+
+OpenAI automatically caches matching prompt prefixes, but successive requests are
+more likely to reuse the same cache when the client supplies one stable affinity
+key. Tau carries its durable coding-session id through `AgentHarness` into every
+model request, including tool continuations, and clamps it to OpenAI's 64-character
+`prompt_cache_key` limit.
+
+Direct OpenAI Responses requests send the same value in three places:
+
+- `prompt_cache_key` in the request body;
+- `session_id` in the request headers;
+- `x-client-request-id` in the request headers.
+
+Codex OAuth uses the same body field and `x-client-request-id`, but its subscription
+backend spells the other header `session-id`. Direct Chat Completions sends only
+`prompt_cache_key`. This remains stateless operation: Tau keeps `store: false` and
+resends the complete transcript. The id helps routing and grouping; it cannot make
+a changed system prompt, tool schema, or transcript prefix cacheable.
+
+Compatible gateways default to the old payload and header shape because support is
+not universal. `supportsPromptCacheKey`, `sendSessionAffinityHeaders`, and
+`sessionAffinityFormat` catalog compat values can opt a known route in. New and
+branched sessions receive a new key; resumed sessions retain theirs. Summary and
+compaction calls intentionally omit the id because their one-off prompts do not
+share the conversation prefix.
+
+## Anthropic breakpoint caching
 
 Tau's Anthropic provider parsed and priced cache usage from the very first
 release — `Usage.cache_read`, `Usage.cache_write`, and `cache_write_1h` are all

--- a/src/tau_agent/harness.py
+++ b/src/tau_agent/harness.py
@@ -43,6 +43,7 @@ class AgentHarnessConfig:
     tools: list[AgentTool] = field(default_factory=list)
     max_turns: int | None = None
     queue_mode: QueueMode = "one_at_a_time"
+    session_id: str | None = None
     before_tool_call: BeforeToolCall | None = None
     after_tool_call: AfterToolCall | None = None
 
@@ -175,6 +176,7 @@ class AgentHarness:
                 tools=self._config.tools,
                 max_turns=self._config.max_turns,
                 signal=signal,
+                session_id=self._config.session_id,
                 get_steering_messages=self._drain_steering_messages,
                 get_follow_up_messages=self._drain_follow_up_messages,
                 before_tool_call=self._config.before_tool_call,

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -51,6 +51,7 @@ async def run_agent_loop(
     prompts: Sequence[AgentMessage] = (),
     max_turns: int | None = None,
     signal: CancellationToken | None = None,
+    session_id: str | None = None,
     get_steering_messages: Callable[[], Sequence[AgentMessage]] | None = None,
     get_follow_up_messages: Callable[[], Sequence[AgentMessage]] | None = None,
     before_tool_call: BeforeToolCall | None = None,
@@ -117,6 +118,7 @@ async def run_agent_loop(
                 messages=_provider_context(messages),
                 tools=tools,
                 signal=signal,
+                session_id=session_id,
             ):
                 yield event
                 if isinstance(event, MessageEndEvent) and isinstance(
@@ -194,6 +196,7 @@ async def _assistant_events(
     messages: list[AgentMessage],
     tools: list[AgentTool],
     signal: CancellationToken | None,
+    session_id: str | None,
 ) -> AsyncIterator[AgentEvent]:
     source: AsyncIterator[AssistantMessageEvent] = provider.stream_response(
         model=model,
@@ -201,6 +204,7 @@ async def _assistant_events(
         messages=messages,
         tools=tools,
         signal=signal,
+        session_id=session_id,
     )
     started = False
     async for event in source:

--- a/src/tau_agent/provider.py
+++ b/src/tau_agent/provider.py
@@ -27,6 +27,11 @@ class ModelProvider(Protocol):
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
-        """Stream one model response as assistant message events."""
+        """Stream one model response as assistant message events.
+
+        Providers may use ``session_id`` for request routing or prompt-cache
+        affinity. Unsupported providers ignore it.
+        """
         ...

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -96,8 +96,10 @@ class AnthropicProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Stream one response as Pi-compatible assistant message events."""
+        del session_id
         raw = self._stream_provider_events(
             model=model, system=system, messages=messages, tools=tools, signal=signal
         )

--- a/src/tau_ai/fake.py
+++ b/src/tau_ai/fake.py
@@ -16,6 +16,7 @@ class FakeProvider:
     def __init__(self, streams: Iterable[Iterable[AssistantMessageEvent]]) -> None:
         self._streams = [list(stream) for stream in streams]
         self.calls: list[tuple[str, str, list[AgentMessage], list[AgentTool]]] = []
+        self.session_ids: list[str | None] = []
 
     def stream_response(
         self,
@@ -25,8 +26,10 @@ class FakeProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         self.calls.append((model, system, list(messages), list(tools)))
+        self.session_ids.append(session_id)
         stream = self._streams.pop(0) if self._streams else []
 
         async def iterator() -> AsyncIterator[AssistantMessageEvent]:

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -70,8 +70,10 @@ class GoogleGenerativeAIProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Stream one response as Pi-compatible assistant message events."""
+        del session_id
         raw = self._stream_provider_events(
             model=model, system=system, messages=messages, tools=tools, signal=signal
         )

--- a/src/tau_ai/mistral.py
+++ b/src/tau_ai/mistral.py
@@ -70,8 +70,10 @@ class MistralConversationsProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Stream one response as Pi-compatible assistant message events."""
+        del session_id
         raw = self._stream_provider_events(
             model=model, system=system, messages=messages, tools=tools, signal=signal
         )

--- a/src/tau_ai/openai_cache.py
+++ b/src/tau_ai/openai_cache.py
@@ -1,0 +1,20 @@
+"""Shared OpenAI prompt-cache affinity helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+OPENAI_API_HOST = "api.openai.com"
+OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64
+
+
+def openai_prompt_cache_key(session_id: str | None) -> str | None:
+    """Return a non-empty session-derived key within OpenAI's 64-char limit."""
+    if not session_id:
+        return None
+    return session_id[:OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH]
+
+
+def is_direct_openai_url(base_url: str) -> bool:
+    """Return whether a URL targets OpenAI's first-party API host."""
+    return urlsplit(base_url).hostname == OPENAI_API_HOST

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -46,6 +46,7 @@ from tau_ai.events import AssistantMessageEvent
 from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
 from tau_ai.model_limits import RuntimeModelLimits
+from tau_ai.openai_cache import openai_prompt_cache_key
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
@@ -139,10 +140,16 @@ class OpenAICodexProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Stream one response as Pi-compatible assistant message events."""
         raw = self._stream_provider_events(
-            model=model, system=system, messages=messages, tools=tools, signal=signal
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            signal=signal,
+            session_id=session_id,
         )
         return canonicalize_provider_stream(
             raw, api="openai-codex-responses", provider="openai-codex", model=model
@@ -156,11 +163,13 @@ class OpenAICodexProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one Codex Responses request as provider-neutral events."""
 
         async def iterator() -> AsyncIterator[ProviderEvent]:
             client = self._get_client()
+            cache_key = openai_prompt_cache_key(session_id)
             payload = _build_codex_payload(
                 model=model,
                 system=system,
@@ -169,6 +178,7 @@ class OpenAICodexProvider:
                 reasoning_effort=self._config.reasoning_effort,
                 reasoning_summary=self._config.reasoning_summary,
                 supports_images=self._config.supports_images,
+                prompt_cache_key=cache_key,
             )
             url = _resolve_codex_url(self._config.base_url)
 
@@ -183,6 +193,7 @@ class OpenAICodexProvider:
                         access_token=credentials.access_token,
                         account_id=credentials.account_id,
                         originator=self._config.originator,
+                        session_id=cache_key,
                     )
                     async with client.stream(
                         "POST",
@@ -367,6 +378,7 @@ def _build_codex_payload(
     reasoning_effort: str | None = None,
     reasoning_summary: str = "auto",
     supports_images: bool = False,
+    prompt_cache_key: str | None = None,
 ) -> dict[str, JSONValue]:
     payload: dict[str, JSONValue] = {
         "model": model,
@@ -379,6 +391,8 @@ def _build_codex_payload(
         "tool_choice": "auto",
         "parallel_tool_calls": True,
     }
+    if prompt_cache_key is not None:
+        payload["prompt_cache_key"] = prompt_cache_key
     if reasoning_effort is not None:
         payload["reasoning"] = {
             "effort": reasoning_effort,
@@ -952,6 +966,7 @@ def _build_codex_headers(
     access_token: str,
     account_id: str,
     originator: str,
+    session_id: str | None = None,
 ) -> dict[str, str]:
     headers = {
         **dict(configured_headers or {}),
@@ -963,6 +978,9 @@ def _build_codex_headers(
         "accept": "text/event-stream",
         "content-type": "application/json",
     }
+    if session_id is not None:
+        headers["session-id"] = session_id
+        headers["x-client-request-id"] = session_id
     return headers
 
 

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -980,7 +980,6 @@ def _build_codex_headers(
     }
     if session_id is not None:
         headers["session-id"] = session_id
-        headers["x-client-request-id"] = session_id
     return headers
 
 

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -48,6 +48,7 @@ from tau_ai.env import OpenAICompatibleConfig
 from tau_ai.events import AssistantMessageEvent
 from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
+from tau_ai.openai_cache import is_direct_openai_url, openai_prompt_cache_key
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
@@ -95,10 +96,16 @@ class OpenAICompatibleProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Stream one response as Pi-compatible assistant message events."""
         raw = self._stream_provider_events(
-            model=model, system=system, messages=messages, tools=tools, signal=signal
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            signal=signal,
+            session_id=session_id,
         )
         return canonicalize_provider_stream(
             raw,
@@ -115,6 +122,7 @@ class OpenAICompatibleProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one model response as provider-neutral events."""
         if self._config.api == "openai-responses" or _use_responses_api(model):
@@ -124,6 +132,7 @@ class OpenAICompatibleProvider:
                 messages=messages,
                 tools=tools,
                 signal=signal,
+                session_id=session_id,
             )
         return self._stream_chat_completions(
             model=model,
@@ -131,6 +140,7 @@ class OpenAICompatibleProvider:
             messages=messages,
             tools=tools,
             signal=signal,
+            session_id=session_id,
         )
 
     def _stream_chat_completions(
@@ -141,8 +151,11 @@ class OpenAICompatibleProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one chat completion response as provider-neutral events."""
+        affinity_id = openai_prompt_cache_key(session_id)
+        cache_key = self._prompt_cache_key(affinity_id)
         payload = _build_chat_payload(
             model=model,
             system=system,
@@ -155,12 +168,15 @@ class OpenAICompatibleProvider:
             max_tokens=self._config.max_tokens,
             include_reasoning_effort_none=self._config.include_reasoning_effort_none,
             supports_images=self._config.supports_images,
+            prompt_cache_key=cache_key,
         )
         return self._stream(
             model=model,
             url=f"{self._config.base_url.rstrip('/')}/chat/completions",
             payload=payload,
             parser_factory=_ChatStreamParser,
+            session_id=affinity_id,
+            session_affinity_format=self._session_affinity_format(responses=False),
             has_images=(self._config.supports_images and messages_have_images(messages)),
             signal=signal,
         )
@@ -173,8 +189,11 @@ class OpenAICompatibleProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one `/v1/responses` response as provider-neutral events."""
+        affinity_id = openai_prompt_cache_key(session_id)
+        cache_key = self._prompt_cache_key(affinity_id)
         payload = _build_responses_payload(
             model=model,
             system=system,
@@ -183,12 +202,15 @@ class OpenAICompatibleProvider:
             reasoning_effort=self._config.reasoning_effort,
             max_tokens=self._config.max_tokens,
             supports_images=self._config.supports_images,
+            prompt_cache_key=cache_key,
         )
         return self._stream(
             model=model,
             url=f"{self._config.base_url.rstrip('/')}/responses",
             payload=payload,
             parser_factory=_ResponsesStreamParser,
+            session_id=affinity_id,
+            session_affinity_format=self._session_affinity_format(responses=True),
             has_images=(self._config.supports_images and messages_have_images(messages)),
             signal=signal,
         )
@@ -200,6 +222,8 @@ class OpenAICompatibleProvider:
         url: str,
         payload: Mapping[str, JSONValue],
         parser_factory: Callable[[], _StreamParser],
+        session_id: str | None = None,
+        session_affinity_format: str | None = None,
         has_images: bool = False,
         signal: CancellationToken | None = None,
     ) -> AsyncIterator[ProviderEvent]:
@@ -233,6 +257,7 @@ class OpenAICompatibleProvider:
                 has_authorization = any(key.casefold() == "authorization" for key in headers)
                 if not has_authorization:
                     headers["Authorization"] = f"Bearer {api_key}"
+            _apply_session_affinity_headers(headers, session_id, session_affinity_format)
 
             attempt = 0
             while True:
@@ -327,6 +352,23 @@ class OpenAICompatibleProvider:
 
         return iterator()
 
+    def _prompt_cache_key(self, affinity_id: str | None) -> str | None:
+        supports = self._config.compat.get("supportsPromptCacheKey")
+        if supports is not True and not (
+            supports is None and is_direct_openai_url(self._config.base_url)
+        ):
+            return None
+        return affinity_id
+
+    def _session_affinity_format(self, *, responses: bool) -> str | None:
+        sends_headers = self._config.compat.get("sendSessionAffinityHeaders")
+        if sends_headers is not True and not (
+            sends_headers is None and responses and is_direct_openai_url(self._config.base_url)
+        ):
+            return None
+        value = self._config.compat.get("sessionAffinityFormat")
+        return value if isinstance(value, str) else "openai"
+
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = create_async_client(timeout=self._config.timeout_seconds)
@@ -336,6 +378,22 @@ class OpenAICompatibleProvider:
         if attempt >= self._config.max_retries:
             return False
         return status_code is None or _is_transient_status(status_code)
+
+
+def _apply_session_affinity_headers(
+    headers: dict[str, str],
+    session_id: str | None,
+    affinity_format: str | None,
+) -> None:
+    if session_id is None or affinity_format is None:
+        return
+    if affinity_format == "openrouter":
+        headers["x-session-id"] = session_id
+        return
+    if affinity_format == "openai":
+        headers["session_id"] = session_id
+    if affinity_format in {"openai", "openai-nosession"}:
+        headers["x-client-request-id"] = session_id
 
 
 class _StreamParser(Protocol):
@@ -681,6 +739,7 @@ def _build_chat_payload(
     max_tokens: int | None = None,
     include_reasoning_effort_none: bool = False,
     supports_images: bool = False,
+    prompt_cache_key: str | None = None,
 ) -> dict[str, JSONValue]:
     resolved_compat = dict(compat or {})
     supports_store = bool(resolved_compat.get("supportsStore", True))
@@ -697,6 +756,8 @@ def _build_chat_payload(
             *_messages_to_openai_chat(messages, supports_images=supports_images),
         ],
     }
+    if prompt_cache_key is not None:
+        payload["prompt_cache_key"] = prompt_cache_key
     if supports_usage:
         payload["stream_options"] = {"include_usage": True}
     if supports_store:
@@ -773,6 +834,7 @@ def _build_responses_payload(
     reasoning_effort: str | None = None,
     max_tokens: int | None = None,
     supports_images: bool = False,
+    prompt_cache_key: str | None = None,
 ) -> dict[str, JSONValue]:
     payload: dict[str, JSONValue] = {
         "model": model,
@@ -784,6 +846,8 @@ def _build_responses_payload(
         "instructions": system,
         "input": _messages_to_responses_input(messages, supports_images=supports_images),
     }
+    if prompt_cache_key is not None:
+        payload["prompt_cache_key"] = prompt_cache_key
     if max_tokens is not None:
         payload["max_output_tokens"] = max_tokens
     effort = _normalize_responses_effort(reasoning_effort)

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -392,8 +392,6 @@ def _apply_session_affinity_headers(
         return
     if affinity_format == "openai":
         headers["session_id"] = session_id
-    if affinity_format in {"openai", "openai-nosession"}:
-        headers["x-client-request-id"] = session_id
 
 
 class _StreamParser(Protocol):

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1503,6 +1503,10 @@ def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
     is_deepseek = provider.name == "deepseek" or "deepseek.com" in base_url
     is_cerebras = provider.name == "cerebras" or "cerebras.ai" in base_url
     is_openrouter = provider.name == "openrouter" or "openrouter.ai" in base_url
+    is_openai_api = (
+        urlsplit(base_url).hostname == urlsplit(DEFAULT_OPENAI_COMPATIBLE_BASE_URL).hostname
+    )
+    is_openai_responses = _provider_api(provider, model) == "openai-responses"
     is_nonstandard = is_cerebras or is_grok or is_together or is_deepseek or is_zai or is_moonshot
     use_max_tokens = is_moonshot or is_together
     is_anthropic_api = urlsplit(base_url).hostname == urlsplit(DEFAULT_ANTHROPIC_BASE_URL).hostname
@@ -1524,6 +1528,12 @@ def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
         ),
         "supportsStrictMode": not (is_moonshot or is_together),
         "supportsLongCacheRetention": not is_together,
+        # OpenAI's prompt-cache fields and affinity headers are not universally
+        # accepted by compatible gateways. Default them on only for the official
+        # endpoint; provider/model compat can opt another route in explicitly.
+        "supportsPromptCacheKey": is_openai_api,
+        "sendSessionAffinityHeaders": is_openai_api and is_openai_responses,
+        "sessionAffinityFormat": "openrouter" if is_openrouter else "openai",
         # Only first-party Anthropic is known to accept cache_control. Several
         # catalog providers speak the Anthropic protocol through a gateway, and one
         # proxies to non-Anthropic models, so they default to no breakpoints. This

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -469,6 +469,7 @@ class CodingSession:
                 model=active_model,
                 system=system,
                 tools=tools,
+                session_id=config.session_id,
             ),
             messages=state.messages,
         )
@@ -2012,6 +2013,7 @@ class CodingSession:
                 tools=self._harness.config.tools,
                 max_turns=self._harness.config.max_turns,
                 queue_mode=self._harness.config.queue_mode,
+                session_id=self._config.session_id,
             ),
             messages=self._state.messages,
         )

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -206,9 +206,10 @@ class LoginRequiredProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
         """Surface a login-needed provider error."""
-        del system, messages, tools, signal
+        del system, messages, tools, signal, session_id
 
         async def iterator() -> AsyncIterator[AssistantMessageEvent]:
             error = AssistantMessage(

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -61,7 +61,12 @@ async def test_subscribers_receive_nested_message_updates_and_unsubscribe() -> N
         ]
     )
     harness = AgentHarness(
-        AgentHarnessConfig(provider=provider, model="fake", system="You are Tau.")
+        AgentHarnessConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            session_id="session-123",
+        )
     )
     seen: list[str] = []
     unsubscribe = harness.subscribe(lambda event: seen.append(event.type))
@@ -73,6 +78,7 @@ async def test_subscribers_receive_nested_message_updates_and_unsubscribe() -> N
     assert "message_update" in seen
     assert seen[-1] == "agent_end"
     assert len(provider.calls) == 2
+    assert provider.session_ids == ["session-123", "session-123"]
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -129,8 +129,9 @@ class RaisingProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
-        del model, system, messages, tools, signal
+        del model, system, messages, tools, signal, session_id
         self.call_count += 1
         should_fail = self.call_count == self.fail_on_call
 
@@ -158,8 +159,9 @@ class WaitingProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
-        del model, system, tools, signal
+        del model, system, tools, signal, session_id
         call_index = self.call_count
         self.call_count += 1
         self.calls.append(list(messages))
@@ -191,8 +193,9 @@ class CancellableWaitingProvider:
         messages: list[AgentMessage],
         tools: list[AgentTool],
         signal: CancellationToken | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[AssistantMessageEvent]:
-        del model, system, tools
+        del model, system, tools, session_id
         self.calls.append(list(messages))
 
         async def iterator() -> AsyncIterator[AssistantMessageEvent]:
@@ -320,6 +323,7 @@ async def test_prompt_logs_error_event_diagnostic_data(tmp_path: Path) -> None:
 
     await _collect_session_events(session.prompt("Hello"))
 
+    assert provider.session_ids == ["session-1"]
     log_path = tau_paths.agent_calls_log_path
     assert session.last_diagnostic_log_path == log_path
     entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[-1])

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -49,6 +49,36 @@ def test_create_model_provider_uses_codex_model_image_capability(tmp_path) -> No
     assert text_provider._config.supports_images is False
 
 
+def test_direct_openai_runtime_enables_responses_cache_affinity(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key("openai", "sk-test")
+
+    provider = create_model_provider(
+        provider_config_from_catalog_entry("openai"),
+        credential_store=store,
+        model="gpt-5.4",
+    )
+
+    assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider._config.compat["supportsPromptCacheKey"] is True
+    assert provider._config.compat["sendSessionAffinityHeaders"] is True
+    assert provider._config.compat["sessionAffinityFormat"] == "openai"
+
+
+def test_compatible_gateway_defaults_to_no_openai_cache_affinity(tmp_path) -> None:
+    store = FileCredentialStore(tmp_path / "credentials.json")
+    store.set_api_key("together", "gateway-key")
+
+    provider = create_model_provider(
+        provider_config_from_catalog_entry("together"),
+        credential_store=store,
+    )
+
+    assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider._config.compat["supportsPromptCacheKey"] is False
+    assert provider._config.compat["sendSessionAffinityHeaders"] is False
+
+
 def test_create_model_provider_uses_anthropic_oauth_runtime_auth(tmp_path) -> None:
     store = FileCredentialStore(tmp_path / "credentials.json")
     store.set_oauth(

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -177,6 +177,7 @@ async def test_openai_compatible_provider_formats_request_and_streams_text() -> 
                 system="You are Tau.",
                 messages=[UserMessage(content="Say hello")],
                 tools=[],
+                session_id="unsupported-session",
             )
         )
 
@@ -200,11 +201,49 @@ async def test_openai_compatible_provider_formats_request_and_streams_text() -> 
     payload = loads(request.content)
     assert payload["model"] == "test-model"
     assert payload["stream"] is True
+    assert "prompt_cache_key" not in payload
+    assert "session_id" not in request.headers
+    assert "x-client-request-id" not in request.headers
     assert "reasoning_effort" not in payload
     assert payload["messages"] == [
         {"role": "system", "content": "You are Tau."},
         {"role": "user", "content": "Say hello"},
     ]
+
+
+@pytest.mark.anyio
+async def test_openai_chat_completions_sends_prompt_cache_key_without_affinity_headers() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://api.openai.com/v1",
+            ),
+            client=client,
+        )
+        await _collect(
+            provider.stream_response(
+                model="gpt-4.1",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+                session_id="chat-session",
+            )
+        )
+
+    assert loads(requests[0].content)["prompt_cache_key"] == "chat-session"
+    assert "session_id" not in requests[0].headers
+    assert "x-client-request-id" not in requests[0].headers
 
 
 @pytest.mark.anyio
@@ -2339,11 +2378,14 @@ async def test_openai_compatible_provider_reports_usage() -> None:
 
 
 @pytest.mark.anyio
-async def test_openai_codex_provider_reports_usage() -> None:
+async def test_openai_codex_provider_reports_usage_and_sends_cache_affinity() -> None:
+    requests: list[httpx.Request] = []
+
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
 
-    def handler(_request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(
             200,
             text=(
@@ -2371,9 +2413,14 @@ async def test_openai_codex_provider_reports_usage() -> None:
                 system="You are Tau.",
                 messages=[UserMessage(content="Say hi")],
                 tools=[],
+                session_id="c" * 70,
             )
         )
 
+    cache_key = "c" * 64
+    assert loads(requests[0].content)["prompt_cache_key"] == cache_key
+    assert requests[0].headers["session-id"] == cache_key
+    assert requests[0].headers["x-client-request-id"] == cache_key
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None
@@ -2387,8 +2434,11 @@ async def test_openai_codex_provider_reports_usage() -> None:
 
 
 @pytest.mark.anyio
-async def test_openai_compatible_responses_api_reports_usage() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:
+async def test_openai_compatible_responses_reports_usage_and_sends_cache_affinity() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(
             200,
             text=(
@@ -2405,7 +2455,7 @@ async def test_openai_compatible_responses_api_reports_usage() -> None:
         provider = OpenAICompatibleProvider(
             OpenAICompatibleConfig(
                 api_key="test-key",
-                base_url="https://example.test/v1",
+                base_url="https://api.openai.com/v1",
             ),
             client=client,
         )
@@ -2416,9 +2466,13 @@ async def test_openai_compatible_responses_api_reports_usage() -> None:
                 system="You are Tau.",
                 messages=[UserMessage(content="Say hi")],
                 tools=[],
+                session_id="responses-session",
             )
         )
 
+    assert loads(requests[0].content)["prompt_cache_key"] == "responses-session"
+    assert requests[0].headers["session_id"] == "responses-session"
+    assert requests[0].headers["x-client-request-id"] == "responses-session"
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -2420,7 +2420,7 @@ async def test_openai_codex_provider_reports_usage_and_sends_cache_affinity() ->
     cache_key = "c" * 64
     assert loads(requests[0].content)["prompt_cache_key"] == cache_key
     assert requests[0].headers["session-id"] == cache_key
-    assert requests[0].headers["x-client-request-id"] == cache_key
+    assert "x-client-request-id" not in requests[0].headers
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None
@@ -2472,7 +2472,7 @@ async def test_openai_compatible_responses_reports_usage_and_sends_cache_affinit
 
     assert loads(requests[0].content)["prompt_cache_key"] == "responses-session"
     assert requests[0].headers["session_id"] == "responses-session"
-    assert requests[0].headers["x-client-request-id"] == "responses-session"
+    assert "x-client-request-id" not in requests[0].headers
     assert isinstance(events[-1], AssistantDoneEvent)
     usage = events[-1].message.usage
     assert usage is not None

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -60,6 +60,22 @@ OAuth tokens refresh automatically. `/logout` removes Tau's local credential,
 but does not revoke the grant remotely; use the provider's account settings for
 remote revocation.
 
+#### OpenAI prompt caching
+
+For direct OpenAI API and Codex OAuth sessions, Tau sends a stable session-derived
+prompt-cache key with every model request, including continuations after tool
+calls. OpenAI can use that key to keep successive append-only requests on the same
+cache path, improving reuse of the system prompt, tool schemas, and conversation
+prefix. Resuming a Tau session reuses its key; starting or branching a session
+creates a new one.
+
+Requests remain stateless: Tau keeps provider storage disabled and resends the
+complete transcript. The key improves cache affinity but cannot preserve a hit if
+the prefix changes or the provider cache expires. OpenAI-compatible gateways do
+not receive these fields unless their catalog compatibility settings explicitly
+opt in. The TUI sidebar's latest-request cache rate shows whether the most recent
+request actually hit.
+
 #### Anthropic prompt caching
 
 Tau marks cache breakpoints on Anthropic requests so the system prompt, tool

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -160,7 +160,7 @@ or model:
 | --- | --- |
 | `supportsPromptCacheKey` | Sends the stable session-derived `prompt_cache_key` body field |
 | `sendSessionAffinityHeaders` | Sends headers using `sessionAffinityFormat` |
-| `sessionAffinityFormat` | `openai` sends `session_id` and `x-client-request-id`; `openai-nosession` sends only `x-client-request-id`; `openrouter` sends `x-session-id` |
+| `sessionAffinityFormat` | `openai` sends `session_id`; `openrouter` sends `x-session-id` |
 
 Unknown gateways retain their existing request shape by default. Enable only fields
 documented by the target service. Codex uses its dedicated `session-id` header

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -150,6 +150,22 @@ default references after merging. Bundled tombstones therefore prevent stale
 user overlays from restoring models that Tau previously advertised for the wrong
 provider. They do not affect the same model ID on another provider.
 
+### OpenAI prompt-cache compat keys
+
+Tau enables OpenAI cache affinity automatically only for `api.openai.com` and the
+dedicated Codex OAuth provider. OpenAI-compatible gateways can opt in per provider
+or model:
+
+| Key | Effect |
+| --- | --- |
+| `supportsPromptCacheKey` | Sends the stable session-derived `prompt_cache_key` body field |
+| `sendSessionAffinityHeaders` | Sends headers using `sessionAffinityFormat` |
+| `sessionAffinityFormat` | `openai` sends `session_id` and `x-client-request-id`; `openai-nosession` sends only `x-client-request-id`; `openrouter` sends `x-session-id` |
+
+Unknown gateways retain their existing request shape by default. Enable only fields
+documented by the target service. Codex uses its dedicated `session-id` header
+mapping and does not read these OpenAI-compatible settings.
+
 ### Anthropic prompt-cache compat keys
 
 Providers using the `anthropic-messages` API accept three `compat` booleans


### PR DESCRIPTION
## Description

Carry Tau's stable coding-session ID through the provider-neutral agent request boundary and use it for OpenAI prompt-cache affinity.

- Direct OpenAI Responses sends one aligned value as `prompt_cache_key` and `session_id`.
- OpenAI Codex OAuth sends `prompt_cache_key` and `session-id`.
- The optional `x-client-request-id` is omitted because OpenAI defines it as a unique per-request diagnostic ID, not a stable affinity key.
- Direct OpenAI Chat Completions sends `prompt_cache_key` without undocumented affinity headers.
- OpenAI-compatible gateways retain their current request shape unless catalog compatibility flags opt them in.
- OpenAI cache keys are clamped to the provider's 64-character limit.
- Compaction and summary requests intentionally omit conversation affinity.

Requests remain stateless (`store: false`) and continue sending the full transcript. The session ID only improves cache grouping/routing for matching prefixes.

## User experience

Successive requests in an append-only OpenAI or Codex session—including continuations after tool calls—are more likely to reuse cached system instructions, tool schemas, and conversation history. Resumed sessions keep their affinity key, while new and branched sessions receive a new one. Tau's latest-request and cumulative cache-rate indicators make the result visible.

## Issue

Addresses the OpenAI affinity phase of #545.

## Manual validation

1. Start Tau with direct OpenAI Responses or Codex OAuth in a wide terminal.
2. Send an initial prompt and note the latest cache rate in the sidebar.
3. Send a short follow-up or trigger a tool continuation.
4. Confirm later requests report cache reads and the latest cache rate rises while the session rate remains cumulative.
5. Resume the session and confirm follow-up requests continue using the same cache path.
6. Start a new session and confirm its first request is cold.

For request-shape inspection, confirm the same clamped session-derived value appears in the OpenAI/Codex body and session header, while `x-client-request-id` is absent.

## Validation

- `uv run pytest` — 1,394 passed, 2 Windows-only tests skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-openai-cache-dist`
- `hugo --destination /tmp/tau-openai-cache-site --minify`
- `npx --yes pagefind@latest --site /tmp/tau-openai-cache-site`
