### PR TITLE
fix: restore Chinese/IME input in TUI on iTerm2 by opting out of kitty keyboard protocol

### DIFF
--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Importing this module opts iTerm2 out of Textual's kitty keyboard protocol
+# (whose DISABLE_KITTY_KEY constant is read once at import time) before any
+# of the imports below load `textual`; without it, iTerm2 mangles IME
+# composition and Chinese/Japanese/Korean input breaks. See tau_coding._kitty.
+import tau_coding._kitty  # noqa: F401  (import for its import-time side effect)
 from tau_coding.commands import (
     CommandRegistry,
     CommandResult,

--- a/src/tau_coding/_kitty.py
+++ b/src/tau_coding/_kitty.py
@@ -1,0 +1,36 @@
+"""Early process setup for Textual's kitty keyboard protocol.
+
+Importing this module immediately opts iTerm2 out of the kitty keyboard
+protocol, before any ``textual`` import runs and its ``DISABLE_KITTY_KEY``
+constant is locked in. It must stay free of ``textual`` imports so the call
+below runs before the protocol flag is read.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["opt_out_kitty_keyboard_protocol"]
+
+
+def opt_out_kitty_keyboard_protocol(environ: dict[str, str] | None = None) -> None:
+    """Disable the kitty keyboard protocol on terminals that break IME input.
+
+    Textual's terminal driver arms the kitty keyboard protocol, enabling
+    "report all keys + associated text" by default. Terminals that only
+    partially implement that protocol (notably iTerm2 on macOS) relay IME
+    composition poorly, which breaks Chinese/Japanese/Korean input. Opt out
+    here -- before any ``textual`` import runs -- so those terminals fall
+    back to delivering IME text as plain UTF-8.
+
+    ``environ`` defaults to ``os.environ``. An explicit ``TEXTUAL_DISABLE_KITTY_KEY``
+    value set by the user is always respected.
+    """
+    target = os.environ if environ is None else environ
+    if "TEXTUAL_DISABLE_KITTY_KEY" not in target and target.get("TERM_PROGRAM") == "iTerm.app":
+        target["TEXTUAL_DISABLE_KITTY_KEY"] = "1"
+
+
+# Running at module import keeps the opt-out ahead of every other package
+# import, which is the whole point of this module.
+opt_out_kitty_keyboard_protocol()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from tau_ai import (
     FakeProvider,
 )
 from tau_coding import CodingSessionRecord, SessionManager, cli
+from tau_coding._kitty import opt_out_kitty_keyboard_protocol
 from tau_coding.cli import app, run_print_mode
 from tau_coding.paths import TauPaths
 from tau_coding.provider_config import (
@@ -56,6 +57,34 @@ def _panel_text(value: str) -> str:
     no_ansi = _strip_ansi(value)
     borders = str.maketrans({ch: " " for ch in "│╭╮╰╯─"})
     return _collapse_ws(no_ansi.translate(borders))
+
+
+def test_opt_out_kitty_keyboard_protocol_on_iterm() -> None:
+    """iTerm2 arms the kitty keyboard protocol, breaking IME; opt out there."""
+    environ: dict[str, str] = {"TERM_PROGRAM": "iTerm.app"}
+    opt_out_kitty_keyboard_protocol(environ)
+    assert environ["TEXTUAL_DISABLE_KITTY_KEY"] == "1"
+    assert environ["TERM_PROGRAM"] == "iTerm.app"
+
+
+def test_opt_out_kitty_keyboard_protocol_ignores_other_terminals() -> None:
+    """Other terminals keep the kitty protocol enabled (Textual's default)."""
+    for term in ("ghostty", "Apple_Terminal", "tmux", "kitty", None):
+        environ: dict[str, str] = {}
+        if term is not None:
+            environ["TERM_PROGRAM"] = term
+        opt_out_kitty_keyboard_protocol(environ)
+        assert "TEXTUAL_DISABLE_KITTY_KEY" not in environ, term
+
+
+def test_opt_out_kitty_keyboard_protocol_respects_explicit_setting() -> None:
+    """A user-set TEXTUAL_DISABLE_KITTY_KEY is never overridden."""
+    environ = {
+        "TERM_PROGRAM": "iTerm.app",
+        "TEXTUAL_DISABLE_KITTY_KEY": "0",
+    }
+    opt_out_kitty_keyboard_protocol(environ)
+    assert environ["TEXTUAL_DISABLE_KITTY_KEY"] == "0"
 
 
 def test_force_utf8_streams_reconfigures_non_utf8_streams() -> None:


### PR DESCRIPTION
## Summary

Fixes the inability to type Chinese (and other CJK/IME-composed) text in the Tau TUI inside **iTerm2**.

## Root cause

Textual's terminal driver arms the [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) (`\x1b[>1u`) with `KITTY_REPORT_ALL_KEYS | KITTY_REPORT_ASSOCIATED_TEXT`. iTerm2 only partially implements that protocol, so it mangles IME composition and the composed characters never reach the prompt widget. The failure is upstream of Tau's own `PromptInput` key handling (which does not block printable characters).

## Why the env var must be set early

`textual.constants.DISABLE_KITTY_KEY` is a `Final` value read **once at import time**. Merely importing `tau_coding.cli` already pulls in `textual` via the parent `tau_coding/__init__.py`, so the opt-out must happen as the very first statement of the package import.

## Changes

- **`src/tau_coding/_kitty.py`** (new): dependency-light module (no `textual` imports) that sets `TEXTUAL_DISABLE_KITTY_KEY=1` on import, but only when `TERM_PROGRAM == "iTerm.app"`. It never overrides an explicit user value.
- **`src/tau_coding/__init__.py`**: imports `tau_coding._kitty` as the first import so the opt-out runs before any `textual` import.
- **`tests/test_cli.py`**: three tests covering iTerm opt-out, other terminals untouched, and explicit user overrides respected.

## Verification

- On iTerm2: env set to `1` and Textual reports `DISABLE_KITTY_KEY: True`.
- On ghostty/kitty/Apple_Terminal/tmux: behavior unchanged (protocol stays default).
- `ruff check`, `mypy`, and the full relevant test suite (469 tests) pass.

Users who want the kitty protocol back on a terminal can still override with `TEXTUAL_DISABLE_KITTY_KEY=0`.
