### PR TITLE
Release Tau 0.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.6"
+version = "0.3.7"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "0.3.7",
-    "date": "2026-08-04",
+    "date": "2026-08-05",
     "sections": {
       "New": [
         "Decide project-input trust before Tau reads ambient project instructions, skills, prompts, themes, system prompts, or opted-in extensions; save exact/parent decisions or choose run-only scopes.",
@@ -9,7 +9,11 @@
       ],
       "Changed": [
         "Unresolved headless `ask` now skips protected project inputs; user/global and explicit CLI resources remain available, and project extensions still additionally require `--project-extensions`.",
-        "Project trust is explicitly an input-loading guard, not a filesystem, process, network, tool, model, credential, or prompt-injection sandbox."
+        "Project trust is explicitly an input-loading guard, not a filesystem, process, network, tool, model, credential, or prompt-injection sandbox.",
+        "Show latest-request and session prompt-cache hit rates in the sidebar, track OpenAI Responses cache writes, and improve OpenAI prompt-cache affinity."
+      ],
+      "Fixed": [
+        "Exit Tau when the initial project-trust prompt is cancelled instead of continuing untrusted."
       ]
     }
   },

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -672,7 +672,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.6" in console.export_text()
+    assert "τ = 2π  0.3.7" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release Tau 0.3.7

Prepares the v0.3.7 patch release.

### Changes

- Bump `tau-ai` version to 0.3.7 in `pyproject.toml` and `uv.lock`
- Update TUI sidebar brand test expectation
- Finalize `releases.json` 0.3.7 entry (date, prompt-cache improvements, startup trust cancellation fix)

### Highlights since v0.3.6

- Project-input trust enforcement with persisted decisions and `--approve`/`--no-approve` flags (#541, #548)
- Prompt-cache visibility: latest/session hit rates, OpenAI Responses cache writes, improved cache affinity (#543, #544, #549)

### Checks

- `uv run mypy` ✅
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest` ✅ (1395 passed, 2 skipped)
