### PR TITLE
fix: keep TUI completion box height stable to prevent viewport jumping

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3502,6 +3502,7 @@ class TauTuiApp(App[None]):
         self._optimistic_user_messages: list[tuple[int, str]] = []
         self._completion_state = CompletionState()
         self._completion_visible_line_budget: int | None = None
+        self._completion_box_height: int | None = None
         self._activity_frame = 0
         self._activity_timer: Timer | None = None
         self._last_tool_timer_refresh_at = 0.0
@@ -5859,6 +5860,8 @@ class TauTuiApp(App[None]):
         suggestions.display = bool(self._completion_state.items)
         if not self._completion_state.items:
             self._completion_visible_line_budget = None
+            self._completion_box_height = None
+            suggestions.styles.height = "auto"
             suggestions.update(
                 render_completion_suggestions(
                     CompletionState(),
@@ -5868,16 +5871,25 @@ class TauTuiApp(App[None]):
             self._refresh_footer_bindings()
             return
         max_lines = self._completion_window_line_budget(suggestions)
-        suggestions.update(
-            render_completion_suggestions(
-                _visible_completion_state(
-                    self._completion_state,
-                    max_lines=max_lines,
-                    width=max(suggestions.content_size.width or suggestions.size.width, 1),
-                ),
-                theme=self.tui_settings.resolved_theme,
-            )
+        width = max(suggestions.content_size.width or suggestions.size.width, 1)
+        visible = _visible_completion_state(
+            self._completion_state,
+            max_lines=max_lines,
+            width=width,
         )
+        suggestions.update(
+            render_completion_suggestions(visible, theme=self.tui_settings.resolved_theme)
+        )
+        # Keep the box height stable while a completion session is active: it
+        # grows monotonically to the largest content seen so far and never
+        # shrinks as the user filters (e.g. "/" -> "/m"). Because the box is a
+        # flex child of #main-pane, shrinking it would resize the transcript
+        # above and make the viewport jump on every keystroke, especially with
+        # long transcripts.
+        content_lines = _completion_render_line_count(visible, width=width)
+        if self._completion_box_height is None or content_lines > self._completion_box_height:
+            self._completion_box_height = content_lines
+        suggestions.styles.height = self._completion_box_height
         self._refresh_footer_bindings()
 
     def _completion_window_line_budget(self, suggestions: Static) -> int:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -5556,6 +5556,71 @@ async def test_tui_app_keeps_completion_window_height_stable_after_edit(
 
 
 @pytest.mark.anyio
+async def test_typing_command_does_not_oscillate_transcript_via_completion_box() -> None:
+    """Filtering the completion list must not resize the box / jump the transcript.
+
+    The autocomplete box sits inside the #main-pane flex layout. If it shrank as
+    the user refined a command (e.g. "/" -> "/p"), the transcript (height: 1fr)
+    would regrow/shrink on every keystroke, making a long transcript visibly jump
+    and flicker. The box height must grow monotonically while a completion session
+    is active and never shrink.
+    """
+    from tau_agent import AssistantMessage, TextContent
+
+    session = FakeSession()
+    session.prompt_templates = tuple(
+        PromptTemplate(
+            name=f"prompt-{index:02d}",
+            path=Path(f"prompt-{index:02d}.md"),
+            content="Run.",
+        )
+        for index in range(30)
+    )
+    session.messages = tuple(  # enough content that the transcript really scrolls
+        AssistantMessage(
+            content=[
+                TextContent(
+                    type="text",
+                    text=(
+                        f"answer {index} - a fairly long line so the transcript has "
+                        "real vertical extent and wraps across several rows"
+                    ),
+                )
+            ]
+        )
+        for index in range(40)
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        app._refresh()
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert transcript.max_scroll_y > 0  # long transcript really scrolls
+
+        autocomplete = app.query_one("#autocomplete")
+        prompt = app.query_one("#prompt")
+        prompt.text = "/"
+        app._completion_state = app._build_completion_state("/")
+        app._refresh_completions()
+        await pilot.pause()
+        assert autocomplete.display
+        height_on_cmd = app._completion_box_height
+        max_on_cmd = transcript.max_scroll_y
+
+        # Refine the command; the list shrinks drastically, but the box must not
+        # shrink and the transcript viewport must stay pinned to where it was.
+        prompt.text = "/pro"
+        app._completion_state = app._build_completion_state("/pro")
+        app._refresh_completions()
+        await pilot.pause()
+        assert autocomplete.display
+        assert app._completion_box_height == height_on_cmd
+        assert transcript.max_scroll_y == max_on_cmd
+
+
+@pytest.mark.anyio
 async def test_tui_app_cycles_completion_selection() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
## Summary

Fix the TUI so typing commands with a lot of content on screen no longer makes the UI jump/flicker.

## Problem

The autocomplete box (`#autocomplete`) is a flex child of `#main-pane` with `height: auto; max-height: 18`. Every keystroke re-runs `_refresh_completions()`, and the suggestion list length changes as you type (e.g. `/` shows many items, `/m` collapses to a few). Because the box's rendered height shrank/grew with the list, the `#transcript` (`height: 1fr`) above it was resized on every keystroke, clamping/re-anchoring the scroll viewport. With a long transcript this produced visible jumping and flickering.

Reproduction confirmed this with measurements: `transcript.max_scroll_y` oscillated (e.g. `106 -> 103 -> ...`) while typing `/` through `/model`.

## Root cause

- `#autocomplete` participates in the `#main-pane` vertical flex layout (there is no true overlay support in Textual's `position: absolute` — absolute positioning does not remove a widget from flex flow).
- Its height was derived from the filtered item count, so it changed on every keystroke.

## Fix

Keep the completion box height **monotonic** during an active completion session — it grows only to the largest content height seen so far and never shrinks while filtering. The box is pinned to that height (`suggestions.styles.height`), so the transcript's layout allocation stays constant while typing. It resets to `auto` (and hides) when the completion session ends.

```python
content_lines = _completion_render_line_count(visible, width=width)
if self._completion_box_height is None or content_lines > self._completion_box_height:
    self._completion_box_height = content_lines
suggestions.styles.height = self._completion_box_height
```

After the fix, `transcript.max_scroll_y` stays stable (e.g. `108 -> 108 -> ...`) while typing a command, so the viewport no longer jumps.

## Tests

- Added regression test `test_typing_command_does_not_oscillate_transcript_via_completion_box` in `tests/test_tui_app.py` verifying that filtering the completion list neither shrinks the box nor moves the transcript viewport.
- Full TUI test suites pass: `test_tui_app.py` + `test_tui_autocomplete.py` (384), and the other TUI modules (`test_tui_components`, `test_tui_adapter`, `test_tui_config`, `test_tui_themes`, `test_coding_session`).
- `ruff` and `mypy` pass on the changed files.
