### PR TITLE
Bill Anthropic 1-hour cache writes at their own rate

### DIFF
--- a/src/tau_coding/catalog_loader.py
+++ b/src/tau_coding/catalog_loader.py
@@ -63,6 +63,10 @@ class _CatalogCostTier(BaseModel):
     output: _NonNegativeFloat
     cacheRead: _NonNegativeFloat
     cacheWrite: _NonNegativeFloat
+    # Optional 1-hour TTL cache-write rate (Anthropic bills those above the
+    # 5-minute cacheWrite rate). Omitted from the cost dict when unset so
+    # consumers can fall back to cacheWrite.
+    cacheWrite1h: _NonNegativeFloat | None = None
 
 
 class _CatalogModelMetadata(BaseModel):
@@ -431,12 +435,7 @@ def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatal
         cost_tiers=tuple(
             ModelCostTier(
                 max_input_tokens=tier.max_input_tokens,
-                cost={
-                    "input": tier.input,
-                    "output": tier.output,
-                    "cacheRead": tier.cacheRead,
-                    "cacheWrite": tier.cacheWrite,
-                },
+                cost=_cost_tier_rates(tier),
             )
             for tier in metadata.cost_tiers
         ),
@@ -446,6 +445,18 @@ def _model_metadata_from_provider(metadata: _CatalogModelMetadata) -> ModelCatal
         compat=_json_object(metadata.compat, "model_metadata.compat"),
         thinking_level_map=thinking_level_map,
     )
+
+
+def _cost_tier_rates(tier: _CatalogCostTier) -> dict[str, float]:
+    rates = {
+        "input": tier.input,
+        "output": tier.output,
+        "cacheRead": tier.cacheRead,
+        "cacheWrite": tier.cacheWrite,
+    }
+    if tier.cacheWrite1h is not None:
+        rates["cacheWrite1h"] = tier.cacheWrite1h
+    return rates
 
 
 def _json_object(value: Mapping[str, Any], field_name: str) -> dict[str, JSONValue]:

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -574,7 +574,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 10, output = 50, cacheRead = 1, cacheWrite = 12.5 }
+cost = { input = 10, output = 50, cacheRead = 1, cacheWrite = 12.5, cacheWrite1h = 20 }
 unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.claude-haiku-4-5]
@@ -583,7 +583,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25, cacheWrite1h = 2 }
 
 [providers.model_metadata.claude-haiku-4-5-20251001]
 name = "Claude Haiku 4.5"
@@ -591,7 +591,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25, cacheWrite1h = 2 }
 
 [providers.model_metadata.claude-opus-4-1]
 name = "Claude Opus 4.1 (latest)"
@@ -599,7 +599,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 32000
-cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75, cacheWrite1h = 30 }
 
 [providers.model_metadata.claude-opus-4-1-20250805]
 name = "Claude Opus 4.1"
@@ -607,7 +607,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 32000
-cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75 }
+cost = { input = 15, output = 75, cacheRead = 1.5, cacheWrite = 18.75, cacheWrite1h = 30 }
 
 [providers.model_metadata.claude-opus-4-5]
 name = "Claude Opus 4.5 (latest)"
@@ -615,7 +615,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25, cacheWrite1h = 10 }
 
 [providers.model_metadata.claude-opus-4-5-20251101]
 name = "Claude Opus 4.5"
@@ -623,7 +623,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25, cacheWrite1h = 10 }
 
 [providers.model_metadata.claude-opus-4-6]
 name = "Claude Opus 4.6"
@@ -632,7 +632,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25, cacheWrite1h = 10 }
 thinking_level_map = { xhigh = "max" }
 unsupported_thinking_levels = ["minimal"]
 
@@ -643,7 +643,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25, cacheWrite1h = 10 }
 thinking_level_map = { xhigh = "xhigh" }
 unsupported_thinking_levels = ["minimal"]
 
@@ -654,7 +654,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25, cacheWrite1h = 10 }
 thinking_level_map = { xhigh = "max" }
 unsupported_thinking_levels = ["minimal"]
 
@@ -664,7 +664,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75, cacheWrite1h = 6 }
 
 [providers.model_metadata.claude-sonnet-4-5-20250929]
 name = "Claude Sonnet 4.5"
@@ -672,7 +672,7 @@ reasoning = true
 input = ["text", "image"]
 context_window = 200000
 max_tokens = 64000
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75, cacheWrite1h = 6 }
 
 [providers.model_metadata.claude-sonnet-4-6]
 name = "Claude Sonnet 4.6"
@@ -681,7 +681,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 64000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75, cacheWrite1h = 6 }
 unsupported_thinking_levels = ["minimal"]
 
 [providers.model_metadata.claude-sonnet-5]
@@ -691,7 +691,7 @@ input = ["text", "image"]
 context_window = 1000000
 max_tokens = 128000
 compat = { forceAdaptiveThinking = true }
-cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75, cacheWrite1h = 6 }
 unsupported_thinking_levels = ["minimal"]
 
 [[providers]]

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -2365,13 +2365,24 @@ def _cost_tiers(value: object, field_name: str) -> tuple[ModelCostTier, ...]:
         if not isinstance(item, dict):
             raise ProviderConfigError(f"Provider cost tiers must be objects: {field_name}")
         tier_field = f"{field_name}.{index}"
-        allowed = {"max_input_tokens", "input", "output", "cacheRead", "cacheWrite"}
+        allowed = {
+            "max_input_tokens",
+            "input",
+            "output",
+            "cacheRead",
+            "cacheWrite",
+            "cacheWrite1h",
+        }
         if set(item) - allowed:
             raise ProviderConfigError(f"Provider cost tier has unknown fields: {tier_field}")
         cost = {
             key: _non_negative_float(item.get(key), f"{tier_field}.{key}")
             for key in ("input", "output", "cacheRead", "cacheWrite")
         }
+        if item.get("cacheWrite1h") is not None:
+            cost["cacheWrite1h"] = _non_negative_float(
+                item.get("cacheWrite1h"), f"{tier_field}.cacheWrite1h"
+            )
         tiers.append(
             ModelCostTier(
                 max_input_tokens=_optional_positive_int(

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -103,6 +103,7 @@ def calculate_session_stats(
             output_tokens=usage.output,
             cache_read_tokens=usage.cache_read,
             cache_write_tokens=usage.cache_write,
+            cache_write_1h_tokens=usage.cache_write_1h or 0,
             rates=rates,
         )
 
@@ -125,12 +126,21 @@ def _response_cost(
     output_tokens: int,
     cache_read_tokens: int,
     cache_write_tokens: int,
+    cache_write_1h_tokens: int,
     rates: Mapping[str, float],
 ) -> float:
-    """Calculate one response's estimated USD cost from per-million-token rates."""
+    """Calculate one response's estimated USD cost from per-million-token rates.
+
+    ``cache_write_tokens`` is the provider-reported total, which already
+    includes any 1-hour TTL writes. Anthropic bills those at a higher rate, so
+    they are priced at ``cacheWrite1h`` when the catalog provides it, falling
+    back to the 5-minute ``cacheWrite`` rate otherwise.
+    """
+    write_1h = min(cache_write_1h_tokens, cache_write_tokens)
     return (
         input_tokens * rates.get("input", 0.0)
         + output_tokens * rates.get("output", 0.0)
         + cache_read_tokens * rates.get("cacheRead", 0.0)
-        + cache_write_tokens * rates.get("cacheWrite", 0.0)
+        + (cache_write_tokens - write_1h) * rates.get("cacheWrite", 0.0)
+        + write_1h * rates.get("cacheWrite1h", rates.get("cacheWrite", 0.0))
     ) / _TOKENS_PER_MILLION

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -133,6 +133,8 @@ def test_builtin_catalog_golden_anthropic_entry() -> None:
     assert opus_5.cost is not None
     assert opus_5.cost["input"] == 5
     assert opus_5.cost["output"] == 25
+    assert opus_5.cost["cacheWrite"] == 6.25
+    assert opus_5.cost["cacheWrite1h"] == 10
     assert opus_5.compat == {"forceAdaptiveThinking": True}
     assert opus_5.thinking_level_map == {"minimal": None, "xhigh": "max"}
     assert entry.thinking_levels == ("off", "minimal", "low", "medium", "high", "xhigh")
@@ -595,6 +597,38 @@ cost_tiers = [
         model_cost_for_input_tokens(reloaded.model_metadata["MiniMax-M3"], 400_001)
         == long_context_cost
     )
+
+
+def test_user_catalog_cost_tier_accepts_one_hour_cache_write_rate(tmp_path: Path) -> None:
+    paths = _write_user_catalog(
+        tmp_path / ".tau",
+        """
+[[providers]]
+name = "minimax"
+
+[providers.model_metadata."MiniMax-M3"]
+cost_tiers = [
+  { max_input_tokens = 400000, input = 0.2, output = 1.0, cacheRead = 0.04, cacheWrite = 0.25 },
+  { input = 0.5, output = 2.0, cacheRead = 0.1, cacheWrite = 0.6, cacheWrite1h = 1.0 },
+]
+""",
+    )
+    entry = next(e for e in effective_catalog(paths) if e.name == "minimax")
+    metadata = entry.model_metadata["MiniMax-M3"]
+    assert model_cost_for_input_tokens(metadata, 400_001) == {
+        "input": 0.5,
+        "output": 2.0,
+        "cacheRead": 0.1,
+        "cacheWrite": 0.6,
+        "cacheWrite1h": 1.0,
+    }
+    # Tiers without the key omit it, so billing can fall back to cacheWrite.
+    assert model_cost_for_input_tokens(metadata, 400_000) == {
+        "input": 0.2,
+        "output": 1.0,
+        "cacheRead": 0.04,
+        "cacheWrite": 0.25,
+    }
 
 
 def test_user_catalog_rejects_bounded_final_cost_tier(tmp_path: Path) -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -421,6 +421,55 @@ def test_legacy_provider_model_cost_tiers_round_trip() -> None:
     )
 
 
+def test_legacy_provider_cost_tier_accepts_one_hour_cache_write_rate() -> None:
+    raw = {
+        "default_provider": "local",
+        "providers": [
+            {
+                "type": "openai-compatible",
+                "name": "local",
+                "base_url": "http://localhost:11434/v1",
+                "api_key_env": "LOCAL_API_KEY",
+                "models": ["qwen"],
+                "default_model": "qwen",
+                "model_metadata": {
+                    "qwen": {
+                        "cost_tiers": [
+                            {
+                                "max_input_tokens": 512000,
+                                "input": 0.3,
+                                "output": 1.2,
+                                "cacheRead": 0.06,
+                                "cacheWrite": 0.375,
+                                "cacheWrite1h": 0.6,
+                            },
+                            {
+                                "input": 0.6,
+                                "output": 2.4,
+                                "cacheRead": 0.12,
+                                "cacheWrite": 0.75,
+                            },
+                        ],
+                    }
+                },
+            }
+        ],
+        "scoped_models": [],
+    }
+
+    settings = provider_settings_from_json(raw)
+    provider = settings.get_provider("local")
+    assert isinstance(provider, OpenAICompatibleProviderConfig)
+    tiers = provider.model_metadata["qwen"].cost_tiers
+    assert tiers[0].cost["cacheWrite1h"] == 0.6
+    # Tiers without the key omit it, so billing can fall back to cacheWrite.
+    assert "cacheWrite1h" not in tiers[1].cost
+    assert (
+        provider.model_metadata["qwen"].to_json()["cost_tiers"]
+        == raw["providers"][0]["model_metadata"]["qwen"]["cost_tiers"]
+    )
+
+
 @pytest.mark.parametrize(
     ("cost_tiers", "match"),
     [

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -173,3 +173,53 @@ def test_calculate_session_stats_marks_cost_unavailable_when_pricing_is_missing(
     assert stats.input_tokens == 100
     assert stats.output_tokens == 20
     assert stats.estimated_cost is None
+
+
+def test_calculate_session_stats_prices_one_hour_cache_writes() -> None:
+    """Anthropic's cache_write total includes 1h writes, billed at cacheWrite1h."""
+    entry = MessageEntry(
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            usage=Usage(input=1_000, output=100, cache_write=800, cache_write_1h=400),
+        )
+    )
+
+    stats = calculate_session_stats(
+        [entry],
+        pricing=lambda _provider, _model, _input: {
+            "input": 3.0,
+            "output": 15.0,
+            "cacheRead": 0.3,
+            "cacheWrite": 3.75,
+            "cacheWrite1h": 6.0,
+        },
+    )
+
+    assert stats.cache_write_tokens == 800
+    # 1000*3 + 100*15 + 400*3.75 (5m writes) + 400*6 (1h writes) = 8400 per 1M
+    assert stats.estimated_cost == 0.0084
+
+
+def test_calculate_session_stats_falls_back_to_cache_write_rate_without_1h_rate() -> None:
+    """Catalogs without cacheWrite1h keep billing all writes at the 5m rate."""
+    entry = MessageEntry(
+        message=AssistantMessage(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            usage=Usage(input=1_000, output=100, cache_write=800, cache_write_1h=400),
+        )
+    )
+
+    stats = calculate_session_stats(
+        [entry],
+        pricing=lambda _provider, _model, _input: {
+            "input": 3.0,
+            "output": 15.0,
+            "cacheRead": 0.3,
+            "cacheWrite": 3.75,
+        },
+    )
+
+    # 1000*3 + 100*15 + 800*3.75 = 7500 per 1M
+    assert stats.estimated_cost == 0.0075

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -219,6 +219,11 @@ Limits are inclusive, must increase strictly, and the final tier must omit
 tiers should select the first tier whose limit includes the input-token count;
 older callers continue to see `cost` as the base rate.
 
+All rates are per million tokens. `cacheWrite` is the 5-minute cache-write
+rate; entries may add an optional `cacheWrite1h` rate for Anthropic's 1-hour
+TTL cache writes, which Anthropic bills higher. When `cacheWrite1h` is absent,
+1-hour writes fall back to the `cacheWrite` rate.
+
 ### Provider preferences
 
 Provider preferences live in `~/.tau/providers.json`:


### PR DESCRIPTION
## Summary

Anthropic's `usage.cache_creation_input_tokens` is a total that already includes 1-hour TTL writes, and Tau records it as `usage.cache_write` alongside the 1-hour subset in `usage.cache_write_1h`. But every pricing consumer billed the whole amount at the 5-minute `cacheWrite` catalog rate. Anthropic prices 1-hour writes at 2x the input rate (vs 1.25x for 5-minute writes), and Tau defaults OAuth sessions to the 1-hour retention (`anthropic_cache_settings`: `CACHE_RETENTION_LONG if oauth`), so subscription sessions — exactly the ones that produce 1-hour writes — systematically understated estimated cost.

## What changed

- `catalog.toml`: new optional `cacheWrite1h` rate, set to 2x input for all first-party Anthropic models (Sonnet 6, Opus 10, Haiku 2, Opus 4.1 30, Fable 20)
- `session_stats._response_cost`: splits `cache_write` into 5m/1h portions and bills the 1h portion at `cacheWrite1h`, falling back to `cacheWrite` when a catalog entry has no such key (so gateway and user catalogs are unaffected)
- `catalog_loader` / `provider_config`: cost tiers accept `cacheWrite1h`; the key is omitted from the rates dict when unset so the fallback engages
- docs: `website/content/reference/configuration.md` documents the new rate key and its fallback

## User-experience improvement

Estimated cost in the session footer/stats is no longer ~37% low on the cache-write portion for OAuth (Claude subscription) sessions, which default to 1-hour cache retention.

## Validation

- `uv run pytest` — 1400 passed, 2 skipped (Windows-only)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run mypy` — clean
- New tests: 1h pricing + fallback in `test_session_stats.py`, tier acceptance/omission in `test_provider_catalog.py` (+ golden-catalog assertion for `claude-opus-5`), runtime tier round-trip in `test_provider_config.py`

## Notes

- All sessions on disk today have `cache_write = 0` (every local Anthropic session predates the cache-breakpoint PR #502, and OpenAI/Kimi use automatic caching with no billed writes), so this only becomes visible on new Anthropic sessions — where it would otherwise have been wrong.
- Gateway Claude entries (openrouter, vercel-ai-gateway) intentionally got no `cacheWrite1h`: they default to 5-minute retention, and the fallback keeps their billing identical to today.
