### PR TITLE
Retry transient Anthropic stream errors

### DIFF
--- a/dev-notes/anthropic-stream-error-recovery.md
+++ b/dev-notes/anthropic-stream-error-recovery.md
@@ -1,0 +1,43 @@
+# Anthropic in-stream error recovery
+
+## What changed
+
+The Anthropic adapter now retries transient errors delivered inside an HTTP 200
+Server-Sent Events response. It recognizes Anthropic's `api_error`,
+`overloaded_error`, and `rate_limit_error` types and uses the provider's existing
+retry count, backoff delay, progress event, and cancellation behavior.
+
+## Why it exists
+
+A production Claude Opus 5 session ended immediately after Anthropic sent an
+`overloaded_error` SSE event. The provider was configured for two retries, but
+the old adapter applied that budget only to retryable HTTP statuses and transport
+exceptions. Every SSE `error` event was terminal, even before any response
+content arrived.
+
+## Architecture
+
+Retry classification remains in `tau_ai.anthropic`, where the provider-specific
+error type is available. The adapter wraps final stream diagnostics as an
+`event` plus the number of attempts, matching the safe extraction performed by
+`tau_coding.diagnostics`. The portable agent layer does not gain Anthropic-specific
+logic.
+
+Only errors received before text, thinking, or tool payload starts are retried.
+Once partial content exists, Tau surfaces the error rather than risking duplicate
+output or tool execution.
+
+## How to test
+
+```bash
+uv run pytest tests/test_tau_ai.py -k anthropic_provider
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+A manual check can use an Anthropic provider with `max_retries` greater than zero.
+During a brief overload before any response content, Tau should retry quietly and
+continue when a later attempt succeeds. Persistent overloads should surface the
+final `Overloaded` error after the configured attempts are exhausted.

--- a/dev-notes/architecture/provider-retries.md
+++ b/dev-notes/architecture/provider-retries.md
@@ -22,14 +22,18 @@ transient status codes such as `408`, `409`, `429`, and `5xx` responses before
 surfacing a final provider error. The default is two retries, for three total
 request attempts.
 
-The OpenAI Codex adapter also retries transient *in-stream* failures. The Codex
-Responses endpoint can return HTTP 200 and then send an SSE `error` or
-`response.failed` event (for example `server_is_overloaded`). When such an event
-arrives before any content or thinking deltas, the adapter classifies it against
-transient markers (overloaded, service unavailable, rate limit, internal/server
-errors, timeouts), emits `ProviderRetryEvent`, and reissues the request under
-the same `max_retries` budget. Errors after partial content, and non-transient
-errors such as `invalid_api_key`, stay terminal.
+The Anthropic and OpenAI Codex adapters also retry transient *in-stream*
+failures. Both APIs can return HTTP 200 and then send an SSE error event. For
+Anthropic, retryable error types are `api_error`, `overloaded_error`, and
+`rate_limit_error`. Codex classifies `error` and `response.failed` events against
+transient markers such as overloaded, service unavailable, rate limit,
+internal/server errors, and timeouts.
+
+When an in-stream error arrives before content or thinking deltas, the adapter
+emits `ProviderRetryEvent` and reissues the request under the same `max_retries`
+budget. Errors after partial content, and non-transient errors such as
+`authentication_error` or `invalid_api_key`, stay terminal to avoid replaying
+visible output or tool calls.
 
 Backoff is short, exponential, and capped by `max_retry_delay_seconds`.
 Cancellation is checked during the backoff delay so Escape/TUI cancellation does

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -208,6 +208,7 @@ class AnthropicProvider:
                             return
 
                         yield ProviderResponseStartEvent(model=model)
+                        stream_error: dict[str, JSONValue] | None = None
                         content_parts: list[str] = []
                         thinking_parts: list[str] = []
                         thinking_signature: str | None = None
@@ -284,12 +285,37 @@ class AnthropicProvider:
                                     )
                                 usage = _apply_message_delta_usage(usage, chunk.get("usage"))
                             elif event_type == "error":
-                                error = chunk.get("error")
-                                message = "Provider returned an error"
-                                if isinstance(error, Mapping):
-                                    message = _string_or_empty(error.get("message")) or message
-                                yield ProviderErrorEvent(message=message, data=chunk)
+                                error_type, message = _anthropic_stream_error_details(chunk)
+                                if (
+                                    not emitted_content
+                                    and self._should_retry(attempt)
+                                    and _retryable_anthropic_stream_error(error_type)
+                                ):
+                                    stream_error = chunk
+                                    break
+                                yield ProviderErrorEvent(
+                                    message=message,
+                                    data={"event": chunk, "attempts": attempt + 1},
+                                )
                                 return
+
+                        if stream_error is not None:
+                            error_type, _message = _anthropic_stream_error_details(stream_error)
+                            delay = retry_delay_seconds(
+                                attempt,
+                                max_delay_seconds=self._config.max_retry_delay_seconds,
+                            )
+                            yield provider_retry_event(
+                                attempt=attempt,
+                                max_retries=self._config.max_retries,
+                                delay_seconds=delay,
+                                reason=f"stream error ({error_type or 'unknown'})",
+                                data={"event": stream_error},
+                            )
+                            attempt += 1
+                            if not await wait_for_retry(delay, signal=signal):
+                                return
+                            continue
 
                         tool_calls = [
                             builder.build(index) for index, builder in sorted(tool_builders.items())
@@ -351,6 +377,30 @@ class AnthropicProvider:
         if attempt >= self._config.max_retries:
             return False
         return status_code is None or status_code in {408, 409, 425, 429} or status_code >= 500
+
+
+_TRANSIENT_ANTHROPIC_STREAM_ERROR_TYPES = frozenset(
+    {
+        "api_error",
+        "overloaded_error",
+        "rate_limit_error",
+    }
+)
+
+
+def _anthropic_stream_error_details(event: Mapping[str, JSONValue]) -> tuple[str, str]:
+    """Return the provider classification and message from an Anthropic SSE error."""
+    error = event.get("error")
+    if not isinstance(error, Mapping):
+        return "", "Provider returned an error"
+    error_type = _string_or_empty(error.get("type"))
+    message = _string_or_empty(error.get("message")) or "Provider returned an error"
+    return error_type, message
+
+
+def _retryable_anthropic_stream_error(error_type: str) -> bool:
+    """Return whether an Anthropic SSE error is transient and safe to retry."""
+    return error_type.lower() in _TRANSIENT_ANTHROPIC_STREAM_ERROR_TYPES
 
 
 class _AnthropicToolBuilder:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1842,6 +1842,240 @@ async def test_anthropic_provider_retries_overloaded_529() -> None:
 
 
 @pytest.mark.anyio
+async def test_anthropic_provider_retries_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=(
+                    'data: {"type":"error","error":{"type":"overloaded_error",'
+                    '"message":"Overloaded"}}\n\n'
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 2
+    assert [event.type for event in events] == [
+        "start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "done",
+    ]
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_surfaces_stream_error_after_retry_exhaustion() -> None:
+    requests: list[httpx.Request] = []
+    error_event = {
+        "type": "error",
+        "error": {"type": "overloaded_error", "message": "Overloaded"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"error","error":{"type":"overloaded_error",'
+                '"message":"Overloaded"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 3
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Overloaded"
+    assert events[-1].error.diagnostics[0].details == {
+        "event": error_event,
+        "attempts": 3,
+    }
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_does_not_retry_non_transient_stream_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"error","error":{"type":"authentication_error",'
+                '"message":"Invalid API key"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Invalid API key"
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_does_not_retry_stream_error_after_content() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"partial"}}\n\n'
+                'data: {"type":"error","error":{"type":"overloaded_error",'
+                '"message":"Overloaded"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.text == "partial"
+    assert events[-1].error.error_message == "Overloaded"
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_cancellation_stops_stream_error_retry_backoff() -> None:
+    requests: list[httpx.Request] = []
+
+    class CancelDuringBackoff(SimpleCancellationToken):
+        def __init__(self) -> None:
+            super().__init__()
+            self.checks = 0
+
+        def is_cancelled(self) -> bool:
+            self.checks += 1
+            return self.checks >= 2
+
+    signal = CancelDuringBackoff()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"error","error":{"type":"overloaded_error",'
+                '"message":"Overloaded"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://api.anthropic.test/v1",
+                max_retries=2,
+                max_retry_delay_seconds=1,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+                signal=signal,
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Provider stream ended without a terminal event"
+
+
+@pytest.mark.anyio
 async def test_anthropic_provider_includes_http_error_detail_in_message() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -257,9 +257,11 @@ Provider preferences live in `~/.tau/providers.json`:
   their session history. `timeout_seconds` defaults to `60` (> 0); `max_retries`
   defaults to `2`; `max_retry_delay_seconds` defaults to `1` (both ≥ 0).
   Retries cover transient HTTP statuses (`408`, `409`, `425`, `429`, `5xx`),
-  transport errors, and — for the OpenAI Codex provider — transient in-stream
-  SSE error events such as `server_is_overloaded` that arrive on an otherwise
-  successful HTTP 200 response.
+  transport errors, and transient in-stream SSE errors that arrive on an
+  otherwise successful HTTP 200 response. Anthropic retries `api_error`,
+  `overloaded_error`, and `rate_limit_error`; OpenAI Codex retries transient
+  events such as `server_is_overloaded`. In-stream errors remain terminal after
+  partial content to prevent duplicate output or tool calls.
 - API keys and OAuth credentials are **not** stored here — they live in
   `~/.tau/credentials.json` (private but not encrypted). OAuth objects may contain
   provider metadata such as a GitHub Enterprise domain and are refreshed


### PR DESCRIPTION
## Description

Retry transient Anthropic errors delivered inside an otherwise successful HTTP 200 SSE stream. The adapter now recognizes `api_error`, `overloaded_error`, and `rate_limit_error`, applies the configured retry budget and backoff, and records structured terminal diagnostics after exhaustion.

Retries remain provider-local and only occur before text, thinking, or tool payload begins. Non-transient errors and errors after partial output remain terminal to avoid duplicate content or tool execution.

This also adds regression coverage and updates architecture, configuration, and implementation notes.

## User experience

Brief Anthropic overloads no longer end an active coding run immediately when Anthropic reports them as stream events instead of HTTP 529 responses. Users get consistent retry behavior across both error delivery forms, while persistent failures still surface the provider's original message and classification.

## Issue

Closes #555.

## Manual validation

1. Configure Anthropic with `max_retries` greater than zero.
2. Start a request during a brief Anthropic overload before any response content arrives.
3. Confirm Tau retries and continues if a later attempt succeeds.
4. Confirm a persistent overload becomes a terminal `Overloaded` error only after exhausting the configured attempts.
5. Confirm errors after partial output are not replayed.

The behavior can also be reproduced deterministically with the new `httpx.MockTransport` tests:

```bash
uv run pytest tests/test_tau_ai.py -k anthropic_provider
```

## Validation

- `uv run pytest` — 1403 passed, 2 skipped (Windows-only)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
