### PR TITLE
Fix tool history across provider switches

### DIFF
--- a/dev-notes/portable-tool-call-ids.md
+++ b/dev-notes/portable-tool-call-ids.md
@@ -1,0 +1,70 @@
+# Portable tool-call IDs across provider switches
+
+## Problem
+
+Provider transcripts contain tool-call identifiers that correlate an assistant's
+request with the later tool result. Those identifiers are not portable by
+default. OpenAI Codex, for example, needs both a `call_id` and a response item ID,
+so Tau's persisted compatibility representation joins them with `|`:
+
+```text
+call_XwFnGCtoQNIN2ID9ahtpLvsI|fc_0ca1b059695ff22f
+```
+
+Anthropic only accepts letters, digits, `_`, and `-` in `tool_use.id`. Switching a
+session with Codex tool history to Claude therefore produced an HTTP 400 before
+Claude could answer.
+
+## Implementation
+
+`src/tau_ai/tool_call_ids.py` defines the common outbound correlation format.
+Already-portable IDs remain unchanged. IDs containing provider-specific syntax,
+or exceeding the conservative shared length, become a deterministic ID derived
+from SHA-256:
+
+```text
+tc_<40 lowercase hex characters>
+```
+
+Hashing rather than replacing punctuation prevents IDs such as `a|b` and `a_b`
+from collapsing to the same value. Because conversion is deterministic, each
+provider adapter can translate a tool call and its later result independently
+and still emit matching IDs. Parallel calls remain distinct.
+
+The Anthropic, Google, Mistral, OpenAI Responses, and OpenAI-compatible Chat
+serializers apply this conversion at their provider boundary. Persisted JSONL is
+not rewritten, so old sessions remain intact and are repaired in memory whenever
+they are sent to a target provider. Native IDs that already fit the shared format
+retain same-provider replay behavior.
+
+Anthropic compilation also drops thinking blocks from non-Anthropic assistant
+messages. Thinking signatures are opaque provider-owned state; forwarding an
+OpenAI or Google signature as an Anthropic signature would simply move the
+cross-provider validation failure from the tool ID to the thinking block.
+
+## Architecture
+
+The provider-neutral transcript remains in `tau_agent`. Provider constraints and
+history translation stay in `tau_ai`, where wire payloads are built. This keeps
+the agent loop and session storage independent of any vendor's identifier regex.
+
+## Verification
+
+Focused regression tests build Codex-style history entirely in memory and compile
+it for Anthropic. They verify that:
+
+- call and result IDs match after conversion;
+- parallel calls remain distinct;
+- generated IDs satisfy Anthropic's accepted alphabet;
+- foreign thinking signatures are omitted;
+- native Anthropic thinking and already-safe IDs remain unchanged.
+
+Run:
+
+```bash
+uv run pytest tests/test_cross_provider_history.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -50,6 +50,7 @@ from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
+from tau_ai.tool_call_ids import portable_tool_call_id
 
 ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_MAX_TOKENS = 4096
@@ -621,6 +622,11 @@ def _anthropic_message(message: AgentMessage, *, supports_images: bool) -> dict[
             if isinstance(block, TextContent):
                 content.append({"type": "text", "text": block.text})
             elif isinstance(block, ThinkingContent):
+                # Thinking signatures are provider-owned opaque state. Replaying
+                # an OpenAI/Google signature as an Anthropic thinking block makes
+                # an otherwise portable model switch fail validation.
+                if message.api != "anthropic-messages":
+                    continue
                 thinking: dict[str, JSONValue] = {
                     "type": "thinking",
                     "thinking": block.thinking,
@@ -632,7 +638,7 @@ def _anthropic_message(message: AgentMessage, *, supports_images: bool) -> dict[
                 content.append(
                     {
                         "type": "tool_use",
-                        "id": block.id,
+                        "id": portable_tool_call_id(block.id),
                         "name": block.name,
                         "input": block.arguments,
                     }
@@ -653,7 +659,7 @@ def _anthropic_message(message: AgentMessage, *, supports_images: bool) -> dict[
             "content": [
                 {
                     "type": "tool_result",
-                    "tool_use_id": message.tool_call_id,
+                    "tool_use_id": portable_tool_call_id(message.tool_call_id),
                     "content": result_content,
                     "is_error": bool(message.is_error),
                 }

--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -441,9 +441,14 @@ def _build_messages_payload(
     if thinking_budget_tokens is not None:
         resolved_max_tokens = max(resolved_max_tokens, thinking_budget_tokens + 1024)
     cache_control = _cache_control(cache_retention)
-    payload_messages = [
-        _anthropic_message(message, supports_images=supports_images) for message in messages
-    ]
+    payload_messages = []
+    for message in messages:
+        converted = _anthropic_message(message, supports_images=supports_images)
+        # Dropping foreign provider reasoning can empty a reasoning-only turn.
+        # Anthropic rejects empty assistant content, so omit that inert turn too.
+        if converted.get("role") == "assistant" and not converted.get("content"):
+            continue
+        payload_messages.append(converted)
     _apply_message_cache_breakpoints(payload_messages, cache_control)
     payload: dict[str, JSONValue] = {
         "model": model,

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -41,6 +41,7 @@ from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
+from tau_ai.tool_call_ids import portable_tool_call_id
 
 
 class GoogleGenerativeAIProvider:
@@ -389,7 +390,7 @@ def _messages_to_google(
             elif isinstance(block, ToolCall):
                 part = {
                     "functionCall": {
-                        "id": block.id,
+                        "id": portable_tool_call_id(block.id),
                         "name": block.name,
                         "args": dict(block.arguments),
                     }
@@ -409,7 +410,7 @@ def _messages_to_google(
             "response": {"output" if not message.is_error else "error": text},
         }
         if message.tool_call_id:
-            response["id"] = message.tool_call_id
+            response["id"] = portable_tool_call_id(message.tool_call_id)
         image_parts: list[JSONValue] = [_google_image(image) for image in images]
         if image_parts and _supports_multimodal_function_response(model):
             response["parts"] = image_parts

--- a/src/tau_ai/mistral.py
+++ b/src/tau_ai/mistral.py
@@ -41,6 +41,7 @@ from tau_ai.http_errors import provider_http_error_message
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
+from tau_ai.tool_call_ids import portable_tool_call_id
 
 
 class MistralConversationsProvider:
@@ -379,7 +380,7 @@ def _messages_to_mistral(
             converted.append(
                 {
                     "role": "tool",
-                    "tool_call_id": message.tool_call_id,
+                    "tool_call_id": portable_tool_call_id(message.tool_call_id),
                     "name": message.tool_name,
                     "content": text or ("(see attached image)" if images else "(no tool output)"),
                 }
@@ -419,7 +420,7 @@ def _message_to_mistral(message: AgentMessage) -> dict[str, JSONValue]:
     if isinstance(message, ToolResultMessage):
         return {
             "role": "tool",
-            "tool_call_id": message.tool_call_id,
+            "tool_call_id": portable_tool_call_id(message.tool_call_id),
             "name": message.tool_name,
             "content": message.text,
         }
@@ -440,7 +441,7 @@ def _tool_to_mistral(tool: AgentTool) -> dict[str, JSONValue]:
 
 def _tool_call_to_mistral(tool_call: ToolCall) -> dict[str, JSONValue]:
     return {
-        "id": tool_call.id,
+        "id": portable_tool_call_id(tool_call.id),
         "type": "function",
         "function": {"name": tool_call.name, "arguments": dumps(tool_call.arguments)},
     }

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -52,6 +52,7 @@ from tau_ai.openai_cache import is_direct_openai_url, openai_prompt_cache_key
 from tau_ai.provider import CancellationToken
 from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_retry
 from tau_ai.stream import canonicalize_provider_stream
+from tau_ai.tool_call_ids import portable_tool_call_id
 
 # Models that reject function tools + reasoning_effort on /chat/completions and
 # must use the /v1/responses endpoint instead.
@@ -903,7 +904,7 @@ def _messages_to_responses_input(
                 items.append(
                     {
                         "type": "function_call",
-                        "call_id": tool_call.id,
+                        "call_id": portable_tool_call_id(tool_call.id),
                         "name": tool_call.name,
                         "arguments": dumps(tool_call.arguments),
                     }
@@ -926,7 +927,7 @@ def _messages_to_responses_input(
             items.append(
                 {
                     "type": "function_call_output",
-                    "call_id": message.tool_call_id,
+                    "call_id": portable_tool_call_id(message.tool_call_id),
                     "output": output,
                 }
             )
@@ -1099,7 +1100,7 @@ def _messages_to_openai_chat(
             converted.append(
                 {
                     "role": "tool",
-                    "tool_call_id": message.tool_call_id,
+                    "tool_call_id": portable_tool_call_id(message.tool_call_id),
                     "name": message.tool_name,
                     "content": text or ("(see attached image)" if images else "(no tool output)"),
                 }
@@ -1144,7 +1145,7 @@ def _message_to_openai(message: AgentMessage) -> dict[str, JSONValue]:
     if isinstance(message, ToolResultMessage):
         return {
             "role": "tool",
-            "tool_call_id": message.tool_call_id,
+            "tool_call_id": portable_tool_call_id(message.tool_call_id),
             "name": message.tool_name,
             "content": message.text,
         }
@@ -1164,7 +1165,7 @@ def _tool_to_openai(tool: AgentTool) -> dict[str, JSONValue]:
 
 def _tool_call_to_openai(tool_call: ToolCall) -> dict[str, JSONValue]:
     return {
-        "id": tool_call.id,
+        "id": portable_tool_call_id(tool_call.id),
         "type": "function",
         "function": {
             "name": tool_call.name,

--- a/src/tau_ai/tool_call_ids.py
+++ b/src/tau_ai/tool_call_ids.py
@@ -1,0 +1,24 @@
+"""Portable tool-call identifiers for cross-provider history replay."""
+
+from __future__ import annotations
+
+import re
+from hashlib import sha256
+
+# Anthropic has the strictest documented identifier alphabet among Tau's
+# providers. Keeping translated IDs within this common subset also avoids
+# provider-specific punctuation and length constraints elsewhere.
+_PORTABLE_TOOL_CALL_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def portable_tool_call_id(value: str) -> str:
+    """Return a deterministic provider-safe correlation ID.
+
+    Provider-native IDs that already fit the common format remain unchanged,
+    preserving same-provider cache/replay behavior. Other IDs are hashed rather
+    than character-replaced so distinct native IDs cannot collapse together.
+    """
+    if _PORTABLE_TOOL_CALL_ID.fullmatch(value):
+        return value
+    digest = sha256(value.encode("utf-8")).hexdigest()
+    return f"tc_{digest[:40]}"

--- a/tests/test_cross_provider_history.py
+++ b/tests/test_cross_provider_history.py
@@ -1,0 +1,112 @@
+"""Cross-provider transcript compilation tests."""
+
+from __future__ import annotations
+
+import re
+
+from tau_agent import (
+    AssistantMessage,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+from tau_ai.anthropic import _build_messages_payload
+from tau_ai.env import CACHE_RETENTION_NONE
+from tau_ai.tool_call_ids import portable_tool_call_id
+
+
+def test_portable_tool_call_id_preserves_safe_ids_and_hashes_native_ids() -> None:
+    assert portable_tool_call_id("call_safe-1") == "call_safe-1"
+
+    first = portable_tool_call_id("call_1|fc_1")
+    second = portable_tool_call_id("call_1|fc_2")
+
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", first)
+    assert first == portable_tool_call_id("call_1|fc_1")
+    assert first != second
+    assert len(first) <= 64
+
+
+def test_anthropic_compiles_codex_tool_history_with_portable_ids() -> None:
+    first_native_id = "call_first|fc_first"
+    second_native_id = "call_second|fc_second"
+    messages = [
+        UserMessage(content="Inspect two files"),
+        AssistantMessage(
+            api="openai-codex-responses",
+            provider="openai-codex",
+            model="gpt-test",
+            content=[
+                ThinkingContent(
+                    thinking="private reasoning",
+                    thinking_signature='{"type":"reasoning","id":"rs_1"}',
+                ),
+                ToolCall(id=first_native_id, name="read", arguments={"path": "a.py"}),
+                ToolCall(id=second_native_id, name="read", arguments={"path": "b.py"}),
+            ],
+        ),
+        ToolResultMessage(
+            tool_call_id=first_native_id,
+            tool_name="read",
+            content=[TextContent(text="a")],
+        ),
+        ToolResultMessage(
+            tool_call_id=second_native_id,
+            tool_name="read",
+            content=[TextContent(text="b")],
+        ),
+        UserMessage(content="Summarize"),
+    ]
+
+    payload = _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        messages=messages,
+        tools=[],
+        cache_retention=CACHE_RETENTION_NONE,
+    )
+
+    payload_messages = payload["messages"]
+    assert isinstance(payload_messages, list)
+    assistant_content = payload_messages[1]["content"]
+    assert isinstance(assistant_content, list)
+    assert [block["type"] for block in assistant_content] == ["tool_use", "tool_use"]
+
+    tool_use_ids = [block["id"] for block in assistant_content]
+    result_ids = [payload_messages[index]["content"][0]["tool_use_id"] for index in (2, 3)]
+    assert tool_use_ids == result_ids
+    assert len(set(tool_use_ids)) == 2
+    assert all(re.fullmatch(r"[A-Za-z0-9_-]+", value) for value in tool_use_ids)
+
+
+def test_anthropic_preserves_native_anthropic_thinking_and_safe_tool_ids() -> None:
+    messages = [
+        AssistantMessage(
+            api="anthropic-messages",
+            provider="anthropic",
+            model="claude-test",
+            content=[
+                ThinkingContent(thinking="reasoning", thinking_signature="signature"),
+                ToolCall(id="toolu_safe_1", name="read", arguments={}),
+            ],
+        )
+    ]
+
+    payload = _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        messages=messages,
+        tools=[],
+        cache_retention=CACHE_RETENTION_NONE,
+    )
+
+    payload_messages = payload["messages"]
+    assert isinstance(payload_messages, list)
+    content = payload_messages[0]["content"]
+    assert isinstance(content, list)
+    assert content == [
+        {"type": "thinking", "thinking": "reasoning", "signature": "signature"},
+        {"type": "tool_use", "id": "toolu_safe_1", "name": "read", "input": {}},
+    ]

--- a/tests/test_cross_provider_history.py
+++ b/tests/test_cross_provider_history.py
@@ -81,6 +81,38 @@ def test_anthropic_compiles_codex_tool_history_with_portable_ids() -> None:
     assert all(re.fullmatch(r"[A-Za-z0-9_-]+", value) for value in tool_use_ids)
 
 
+def test_anthropic_omits_foreign_thinking_only_assistant_turn() -> None:
+    messages = [
+        UserMessage(content="Think about this"),
+        AssistantMessage(
+            api="openai-responses",
+            provider="openai",
+            model="gpt-test",
+            content=[
+                ThinkingContent(
+                    thinking="private reasoning",
+                    thinking_signature='{"type":"reasoning","id":"rs_1"}',
+                )
+            ],
+            stop_reason="length",
+        ),
+        UserMessage(content="Continue with Claude"),
+    ]
+
+    payload = _build_messages_payload(
+        model="claude-test",
+        system="You are Tau.",
+        messages=messages,
+        tools=[],
+        cache_retention=CACHE_RETENTION_NONE,
+    )
+
+    assert payload["messages"] == [
+        {"role": "user", "content": "Think about this"},
+        {"role": "user", "content": "Continue with Claude"},
+    ]
+
+
 def test_anthropic_preserves_native_anthropic_thinking_and_safe_tool_ids() -> None:
     messages = [
         AssistantMessage(

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -225,6 +225,13 @@ list before creating or refreshing a runtime provider. This prevents accidental
 provider/model mismatches, such as trying to send an API-only OpenAI model to the
 separate `openai-codex` subscription provider.
 
+When a switch crosses provider APIs, Tau compiles existing tool history for the
+target provider. Provider-specific tool-call IDs are deterministically translated
+to a portable format, with the same translated ID used for each call and result.
+When compiling history for Anthropic, Tau also omits opaque reasoning signatures
+created by other APIs. This lets a session continue after tools have run without
+exposing users to provider validation errors or rewriting the saved JSONL history.
+
 ### Claude Opus 5
 
 Tau supports Anthropic's `claude-opus-5` through the direct `anthropic`


### PR DESCRIPTION
## Summary

- translate provider-specific tool-call IDs into deterministic, collision-resistant IDs accepted across provider APIs
- preserve already-portable IDs and compile matching call/result IDs without rewriting saved session JSONL
- omit foreign opaque reasoning signatures when compiling OpenAI/Google history for Anthropic
- add cross-provider regression coverage and user/developer documentation

## User experience

Users can switch from OpenAI Codex to Claude after tools have run without Anthropic rejecting the retained conversation with an HTTP 400. Existing sessions containing Codex's legacy `call_id|item_id` representation work without manual cleanup or session-file mutation.

Closes #385.

## Manual validation

1. Start a session with `openai-codex`.
2. Ask the model to invoke one or more tools.
3. Switch to an Anthropic model with `/model`.
4. Send another prompt.
5. Confirm Claude continues from the retained history instead of reporting an invalid `tool_use.id`.

The regression was also validated against session `c051d276f6e74cc998843c74209d7087`: compiling its pre-failure history produced 73 Anthropic messages with no invalid tool IDs or foreign thinking blocks.

## Checks

- `uv run pytest` (1406 passed, 2 platform skips)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
