### PR TITLE
feat: update Kimi K3 reasoning effort levels (low, high, max)

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3891,7 +3891,7 @@ models = ["k3", "kimi-for-coding"]
 default_model = "kimi-for-coding"
 docs_url = "https://www.kimi.com/code/docs/en/kimi-code/models"
 api = "openai-completions"
-thinking_levels = ["medium", "xhigh"]
+thinking_levels = ["low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
@@ -3906,8 +3906,8 @@ input = ["text", "image"]
 context_window = 1048576
 compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = true, maxTokensField = "max_tokens", supportsStrictMode = false }
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
-thinking_level_map = { xhigh = "max" }
-unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_level_map = { low = "low", high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["off", "minimal", "medium"]
 
 [providers.model_metadata.kimi-for-coding]
 name = "Kimi for Coding (latest)"

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3892,7 +3892,7 @@ default_model = "kimi-for-coding"
 docs_url = "https://www.kimi.com/code/docs/en/kimi-code/models"
 api = "openai-completions"
 thinking_levels = ["low", "medium", "high", "xhigh"]
-thinking_default = "medium"
+thinking_default = "xhigh"
 thinking_parameter = "reasoning_effort"
 
 [providers.context_windows]
@@ -3917,6 +3917,7 @@ context_window = 262144
 max_tokens = 32768
 compat = { supportsStore = false, supportsDeveloperRole = false, supportsReasoningEffort = false, maxTokensField = "max_tokens", supportsStrictMode = false }
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal", "low", "high", "xhigh"]
 
 [[providers]]
 name = "moonshotai-cn"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -419,9 +419,9 @@ def test_builtin_catalog_golden_kimi_entries() -> None:
     assert k3.thinking_level_map == {
         "off": None,
         "minimal": None,
-        "low": None,
+        "low": "low",
         "medium": None,
-        "high": None,
+        "high": "high",
         "xhigh": "max",
     }
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -409,6 +409,7 @@ def test_builtin_catalog_golden_kimi_entries() -> None:
     assert coding.credential_name == "kimi-code"
     assert coding.models == ("k3", "kimi-for-coding")
     assert coding.default_model == "kimi-for-coding"
+    assert coding.thinking_default == "xhigh"
     assert coding.context_windows == {"k3": 1_048_576, "kimi-for-coding": 262_144}
 
     k3 = coding.model_metadata["k3"]
@@ -429,6 +430,13 @@ def test_builtin_catalog_golden_kimi_entries() -> None:
     assert latest.name == "Kimi for Coding (latest)"
     assert latest.reasoning is True
     assert latest.context_window == 262_144
+    assert latest.thinking_level_map == {
+        "off": None,
+        "minimal": None,
+        "low": None,
+        "high": None,
+        "xhigh": None,
+    }
 
 
 def test_builtin_minimax_m3_has_tiered_pricing() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -32,6 +32,7 @@ from tau_coding.provider_config import (
     set_provider_thinking_level,
     upsert_openai_compatible_provider,
 )
+from tau_coding.thinking import ThinkingLevel
 
 
 def test_stale_preferences_cannot_restore_removed_codex_alias(tmp_path: Path) -> None:
@@ -677,7 +678,7 @@ def _kimi_code_like_provider() -> OpenAICompatibleProviderConfig:
         models=("k3", "kimi-for-coding"),
         default_model="k3",
         thinking_levels=("low", "medium", "high", "xhigh"),
-        thinking_default="medium",
+        thinking_default="xhigh",
         thinking_parameter="reasoning_effort",
         model_metadata={
             "k3": ProviderModelMetadata(
@@ -691,17 +692,26 @@ def _kimi_code_like_provider() -> OpenAICompatibleProviderConfig:
                     "xhigh": "max",
                 },
             ),
+            "kimi-for-coding": ProviderModelMetadata(
+                reasoning=True,
+                thinking_level_map={
+                    "off": None,
+                    "minimal": None,
+                    "low": None,
+                    "high": None,
+                    "xhigh": None,
+                },
+            ),
         },
     )
 
 
-def test_resolve_startup_thinking_level_falls_back_when_default_unsupported() -> None:
+def test_resolve_startup_thinking_level_uses_k3_max_default() -> None:
     provider = _kimi_code_like_provider()
 
-    # k3 no longer supports xhigh only: low, high, xhigh are all available.
-    # The global "medium" default is unsupported, so it falls back to the
-    # first available level ("low") instead of crashing startup.
-    assert resolve_startup_thinking_level(provider, "k3") == "low"
+    # K3 does not support the global "medium" default, so startup uses its
+    # catalog default (xhigh, sent as "max") instead of the first level.
+    assert resolve_startup_thinking_level(provider, "k3") == "xhigh"
 
 
 def test_resolve_startup_thinking_level_prefers_remembered_model_default() -> None:
@@ -723,7 +733,8 @@ def test_resolve_startup_thinking_level_prefers_remembered_model_default() -> No
 def test_resolve_startup_thinking_level_keeps_supported_default() -> None:
     provider = _kimi_code_like_provider()
 
-    # kimi-for-coding supports the provider default (medium).
+    # kimi-for-coding supports global medium but not K3's xhigh default.
+    assert provider_thinking_levels(provider, model="kimi-for-coding") == ("medium",)
     assert resolve_startup_thinking_level(provider, "kimi-for-coding") == "medium"
 
 
@@ -910,7 +921,15 @@ def test_openai_compatible_config_from_provider_sets_reasoning_effort(
     assert plain.reasoning_effort is None
 
 
-def test_kimi_k3_maps_xhigh_thinking_to_max(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("level", "expected_effort"),
+    [("low", "low"), ("high", "high"), ("xhigh", "max")],
+)
+def test_kimi_k3_maps_thinking_levels_to_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    level: ThinkingLevel,
+    expected_effort: str,
+) -> None:
     monkeypatch.setenv("KIMI_CODE_API_KEY", "test-key")
     settings = load_provider_settings(TauPaths(home=Path("/missing")))
     provider = settings.get_provider("kimi-code")
@@ -918,11 +937,11 @@ def test_kimi_k3_maps_xhigh_thinking_to_max(monkeypatch: pytest.MonkeyPatch) -> 
     config = openai_compatible_config_from_provider(
         provider,
         model="k3",
-        thinking_level="xhigh",
+        thinking_level=level,
     )
 
     assert provider_thinking_levels(provider, model="k3") == ("low", "high", "xhigh")
-    assert config.reasoning_effort == "max"
+    assert config.reasoning_effort == expected_effort
 
 
 def test_openai_compatible_config_from_provider_rejects_unsupported_thinking_level(

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -670,13 +670,13 @@ def test_resolve_provider_selection_rejects_unknown_provider() -> None:
 
 
 def _kimi_code_like_provider() -> OpenAICompatibleProviderConfig:
-    # Mirrors the catalog kimi-code entry: k3 only supports xhigh (mapped to
-    # "max"); every other level is marked unsupported (None) in the map.
+    # Mirrors the catalog kimi-code entry: k3 supports low, high, and xhigh
+    # mapped to "low", "high", "max" respectively.
     return OpenAICompatibleProviderConfig(
         name="kimi-code",
         models=("k3", "kimi-for-coding"),
         default_model="k3",
-        thinking_levels=("medium", "xhigh"),
+        thinking_levels=("low", "medium", "high", "xhigh"),
         thinking_default="medium",
         thinking_parameter="reasoning_effort",
         model_metadata={
@@ -685,9 +685,9 @@ def _kimi_code_like_provider() -> OpenAICompatibleProviderConfig:
                 thinking_level_map={
                     "off": None,
                     "minimal": None,
-                    "low": None,
+                    "low": "low",
                     "medium": None,
-                    "high": None,
+                    "high": "high",
                     "xhigh": "max",
                 },
             ),
@@ -698,9 +698,10 @@ def _kimi_code_like_provider() -> OpenAICompatibleProviderConfig:
 def test_resolve_startup_thinking_level_falls_back_when_default_unsupported() -> None:
     provider = _kimi_code_like_provider()
 
-    # k3 only supports xhigh, so the global "medium" default must be coerced
-    # instead of crashing startup.
-    assert resolve_startup_thinking_level(provider, "k3") == "xhigh"
+    # k3 no longer supports xhigh only: low, high, xhigh are all available.
+    # The global "medium" default is unsupported, so it falls back to the
+    # first available level ("low") instead of crashing startup.
+    assert resolve_startup_thinking_level(provider, "k3") == "low"
 
 
 def test_resolve_startup_thinking_level_prefers_remembered_model_default() -> None:
@@ -920,7 +921,7 @@ def test_kimi_k3_maps_xhigh_thinking_to_max(monkeypatch: pytest.MonkeyPatch) -> 
         thinking_level="xhigh",
     )
 
-    assert provider_thinking_levels(provider, model="k3") == ("xhigh",)
+    assert provider_thinking_levels(provider, model="k3") == ("low", "high", "xhigh")
     assert config.reasoning_effort == "max"
 
 

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -301,7 +301,7 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
 ) -> None:
     # Regression: startup used to pass the global default ("medium") straight
     # to create_model_provider, which crashed for models like kimi-code:k3
-    # that only support xhigh.
+    # that only support xhigh. Now k3 also supports low and high.
     monkeypatch.setenv("TAU_TEST_KIMI_CODE_API_KEY", "test-key")
     store = FileCredentialStore(tmp_path / "credentials.json")
     provider_config = OpenAICompatibleProviderConfig(
@@ -309,7 +309,7 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
         api_key_env="TAU_TEST_KIMI_CODE_API_KEY",
         models=("k3",),
         default_model="k3",
-        thinking_levels=("medium", "xhigh"),
+        thinking_levels=("low", "medium", "high", "xhigh"),
         thinking_default="medium",
         thinking_parameter="reasoning_effort",
         model_metadata={
@@ -318,9 +318,9 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
                 thinking_level_map={
                     "off": None,
                     "minimal": None,
-                    "low": None,
+                    "low": "low",
                     "medium": None,
-                    "high": None,
+                    "high": "high",
                     "xhigh": "max",
                 },
             ),
@@ -346,7 +346,7 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
     )
 
     assert isinstance(provider, OpenAICompatibleProvider)
-    assert provider._config.reasoning_effort == "max"
+    assert provider._config.reasoning_effort == "low"
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -310,7 +310,7 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
         models=("k3",),
         default_model="k3",
         thinking_levels=("low", "medium", "high", "xhigh"),
-        thinking_default="medium",
+        thinking_default="xhigh",
         thinking_parameter="reasoning_effort",
         model_metadata={
             "k3": ProviderModelMetadata(
@@ -346,7 +346,7 @@ def test_create_model_provider_coerces_unsupported_startup_thinking_level(
     )
 
     assert isinstance(provider, OpenAICompatibleProvider)
-    assert provider._config.reasoning_effort == "low"
+    assert provider._config.reasoning_effort == "max"
 
 
 @pytest.mark.anyio

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -111,8 +111,8 @@ isn't listed). Custom providers can opt in via `thinking_levels` in their config
 
 At startup Tau picks a valid level for the selected model automatically: a
 remembered per-model choice wins, then `medium`, then the provider's own
-default, then the first level the model supports. So a model that only supports
-`xhigh` (for example `kimi-code:k3`) opens at `xhigh` instead of failing with
-"Thinking mode medium is not available". Picking an unsupported level
-explicitly (via `/think` or the thinking picker) still shows an error listing
-the available modes.
+default, then the first level the model supports. For example, `kimi-code:k3`
+supports `low`, `high`, and `xhigh`; because `medium` is unavailable, it opens
+at its `xhigh` catalog default instead of failing with "Thinking mode medium is
+not available". Picking an unsupported level explicitly (via `/think` or the
+thinking picker) still shows an error listing the available modes.

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -159,9 +159,10 @@ different endpoints, and charge against different billing plans:
 | `kimi-code` | Subscription key from the [Kimi Code console](https://www.kimi.com/code/console) | `k3` or rolling `kimi-for-coding` alias | `https://api.kimi.com/coding/v1` | `KIMI_CODE_API_KEY` |
 
 Kimi K3 uses the `k3` model ID, accepts text and image input, and supports up to
-a 1,048,576-token context window on eligible plans. Its reasoning effort is
-currently fixed at `max`,
-which Tau exposes as the `xhigh` thinking level. Start a new session when
+a 1,048,576-token context window on eligible plans. It supports three
+reasoning-effort levels via the `reasoning_effort` field: `low`, `high`, and
+`max` (default). Tau exposes these as the `low`, `high`, and `xhigh` thinking
+levels respectively. Start a new session when
 switching to K3 so the previous model's context cache is not re-prefilled. See
 [Kimi's model documentation](https://www.kimi.com/code/docs/en/kimi-code/models)
 for current plan availability and context limits.

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -162,8 +162,9 @@ Kimi K3 uses the `k3` model ID, accepts text and image input, and supports up to
 a 1,048,576-token context window on eligible plans. It supports three
 reasoning-effort levels via the `reasoning_effort` field: `low`, `high`, and
 `max` (default). Tau exposes these as the `low`, `high`, and `xhigh` thinking
-levels respectively. Start a new session when
-switching to K3 so the previous model's context cache is not re-prefilled. See
+levels respectively, and starts new K3 sessions at `xhigh` unless a remembered
+per-model choice exists. Start a new session when switching to K3 so the
+previous model's context cache is not re-prefilled. See
 [Kimi's model documentation](https://www.kimi.com/code/docs/en/kimi-code/models)
 for current plan availability and context limits.
 


### PR DESCRIPTION
## Description

Update Kimi K3's reasoning effort levels to match the upstream API. According to [Kimi's Reasoning Effort docs](https://platform.kimi.ai/docs/guide/use-reasoning-effort), K3 supports three values for the `reasoning_effort` parameter: `low`, `high`, and `max` (default).

Previously Tau only exposed `xhigh` (mapped to `max`). Now all three levels are available: `low` → `"low"`, `high` → `"high"`, `xhigh` → `"max"`.

## User Experience Improvement

Users of the `kimi-code` provider with the `k3` model can now choose between light (`low`), deep (`high`), and maximum (`xhigh`) reasoning effort instead of being limited to maximum effort only. The `/think` command will cycle through all three levels.

## Changes

- **`src/tau_coding/data/catalog.toml`**: Added `low` and `high` to the `kimi-code` provider's `thinking_levels`. Updated `k3` model metadata: `thinking_level_map` now maps `low` → `"low"`, `high` → `"high"`, `xhigh` → `"max"`; `unsupported_thinking_levels` updated to `["off", "minimal", "medium"]`.
- **`website/content/guides/providers-and-models.md`**: Updated docs to describe the three reasoning effort levels instead of the previous fixed-`max` description.
- **Test mocks**: Updated `_kimi_code_like_provider` mocks and assertions in `test_provider_config.py`, `test_provider_catalog.py`, and `test_provider_runtime.py`.

## Manual Validation

1. Configure the `kimi-code` provider with a valid KIMI_CODE_API_KEY.
2. Start a session with `k3`: `tau kimi-code --model k3`
3. Cycle thinking levels with `/think` and observe that `low`, `high`, and `xhigh` are available.
4. Verify the correct `reasoning_effort` value is sent by checking logs or provider behavior.
