### PR TITLE
Expose resolved Hugging Face response provider

### DIFF
--- a/dev-notes/hugging-face-response-provider-metadata.md
+++ b/dev-notes/hugging-face-response-provider-metadata.md
@@ -1,0 +1,39 @@
+# Hugging Face response-provider metadata
+
+Tau's built-in `huggingface` provider uses Hugging Face's OpenAI-compatible
+router. An unsuffixed model leaves provider selection automatic, so the backing
+Inference Provider can differ between requests and can change after a failure.
+
+Hugging Face reports the provider that handled an HTTP response in the
+`x-inference-provider` header. Tau now preserves that value on the resulting
+`AssistantMessage` as `response_provider` (`responseProvider` in serialized
+messages). The existing `provider` field remains the logical Tau provider,
+`huggingface`.
+
+This is intentionally per-response metadata rather than session metadata. The
+OpenAI-compatible adapter reads the header only when the runtime configuration
+enables it, and the built-in Hugging Face configuration is the only configuration
+that does so. The provider-neutral stream bridge copies the resolved value to
+streaming partials and the final persisted assistant message. Failed responses
+also retain the value when the header is present.
+
+Because the value comes from each successful HTTP response, a retry or future
+session-level failover records the replacement provider on the response it
+actually served. Tau does not infer a provider from the requested model and does
+not expose provider selection or pinning controls in this change.
+
+## Validation
+
+Focused tests use an `httpx.MockTransport` to simulate one failed response from
+one Inference Provider followed by a successful response from another. They
+verify that only the provider from the successful request becomes the final
+message's `response_provider`, while `provider` remains `huggingface`.
+
+Run:
+
+```bash
+uv run pytest tests/test_tau_ai.py tests/test_provider_config.py tests/test_agent_types.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -125,6 +125,7 @@ class AssistantMessage(WireModel):
     provider: str = "unknown"
     model: str = "unknown"
     response_model: str | None = None
+    response_provider: str | None = None
     response_id: str | None = None
     diagnostics: list[AssistantMessageDiagnostic] | None = None
     usage: Usage = Usage()

--- a/src/tau_ai/_provider_events.py
+++ b/src/tau_ai/_provider_events.py
@@ -18,6 +18,7 @@ class ProviderResponseStartEvent(BaseModel):
 
     type: Literal["response_start"] = "response_start"
     model: str
+    response_provider: str | None = None
 
 
 class ProviderRetryEvent(BaseModel):
@@ -78,6 +79,7 @@ class ProviderErrorEvent(BaseModel):
     type: Literal["error"] = "error"
     message: str
     data: dict[str, JSONValue] | None = None
+    response_provider: str | None = None
 
 
 type ProviderEvent = (

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -56,6 +56,7 @@ class OpenAICompatibleConfig:
     compat: Mapping[str, JSONValue] = field(default_factory=dict)
     include_reasoning_effort_none: bool = False
     provider_name: str = "OpenAI-compatible provider"
+    response_provider_header: str | None = None
     omit_authorization_header: bool = False
     credential_resolver: RuntimeProviderAuthResolver | None = None
 

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -266,6 +266,10 @@ class OpenAICompatibleProvider:
                     async with client.stream(
                         "POST", request_url, json=payload, headers=headers
                     ) as response:
+                        response_provider = _response_header_value(
+                            response,
+                            self._config.response_provider_header,
+                        )
                         if response.status_code >= 400:
                             body = await response.aread()
                             body_text = body.decode(errors="replace")
@@ -300,10 +304,14 @@ class OpenAICompatibleProvider:
                                     "body": body_text,
                                     "attempts": attempt + 1,
                                 },
+                                response_provider=response_provider,
                             )
                             return
 
-                        yield ProviderResponseStartEvent(model=model)
+                        yield ProviderResponseStartEvent(
+                            model=model,
+                            response_provider=response_provider,
+                        )
 
                         async for line in response.aiter_lines():
                             if signal is not None and signal.is_cancelled():
@@ -378,6 +386,17 @@ class OpenAICompatibleProvider:
         if attempt >= self._config.max_retries:
             return False
         return status_code is None or _is_transient_status(status_code)
+
+
+def _response_header_value(response: httpx.Response, header_name: str | None) -> str | None:
+    """Return one normalized response metadata header when configured."""
+    if header_name is None:
+        return None
+    value = response.headers.get(header_name)
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
 
 
 def _apply_session_affinity_headers(

--- a/src/tau_ai/stream.py
+++ b/src/tau_ai/stream.py
@@ -108,6 +108,8 @@ async def canonicalize_provider_stream(
             # Retries are provider-internal at the Pi AI boundary.
             continue
         if isinstance(event, ProviderResponseStartEvent):
+            if event.response_provider is not None:
+                partial.response_provider = event.response_provider
             if not started:
                 started = True
                 yield AssistantStartEvent(partial=_snapshot(partial))
@@ -178,6 +180,7 @@ async def canonicalize_provider_stream(
             final.api = api
             final.provider = provider
             final.model = model
+            final.response_provider = event.message.response_provider or partial.response_provider
             final.content = [block.model_copy(deep=True) for block in partial.content]
             if not final.content and event.message.content:
                 final.content = [block.model_copy(deep=True) for block in event.message.content]
@@ -190,6 +193,7 @@ async def canonicalize_provider_stream(
             terminal = True
         elif isinstance(event, ProviderErrorEvent):
             error = partial.model_copy(deep=True)
+            error.response_provider = event.response_provider or partial.response_provider
             error.stop_reason = "error"
             error.error_message = event.message
             error.diagnostics = [

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1631,6 +1631,9 @@ def openai_compatible_config_from_provider(
         reasoning_effort_parameter=provider.thinking_parameter or "reasoning_effort",
         thinking_format=_thinking_format(provider, selected_model),
         compat=compat,
+        response_provider_header=(
+            "x-inference-provider" if provider.name == "huggingface" else None
+        ),
         include_reasoning_effort_none=_include_reasoning_effort_none(
             provider,
             model=selected_model,

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -48,6 +48,20 @@ def test_assistant_message_keeps_ordered_content_blocks() -> None:
     }
 
 
+def test_assistant_message_serializes_resolved_response_provider() -> None:
+    message = AssistantMessage(
+        provider="huggingface",
+        model="test-model",
+        response_provider="test-inference-provider",
+        timestamp=123,
+    )
+
+    payload = message.model_dump(by_alias=True)
+
+    assert payload["provider"] == "huggingface"
+    assert payload["responseProvider"] == "test-inference-provider"
+
+
 def test_assistant_message_persists_thinking_blocks_and_signatures() -> None:
     message = AssistantMessage(
         content=[

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -818,6 +818,24 @@ def test_openai_compatible_config_from_provider_uses_configured_env_var(
     assert config.timeout_seconds == 60.0
     assert config.max_retries == 2
     assert config.max_retry_delay_seconds == 1.0
+    assert config.response_provider_header is None
+
+
+def test_huggingface_runtime_config_captures_inference_provider_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HF_TEST_TOKEN", "test-key")
+    provider = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        base_url="https://router.huggingface.co/v1",
+        api_key_env="HF_TEST_TOKEN",
+        models=("test-model",),
+        default_model="test-model",
+    )
+
+    config = openai_compatible_config_from_provider(provider)
+
+    assert config.response_provider_header == "x-inference-provider"
 
 
 def test_openai_compatible_config_from_provider_preserves_openai_base_url_env(

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -662,6 +662,60 @@ async def test_openai_compatible_provider_streams_tool_calls() -> None:
 
 
 @pytest.mark.anyio
+async def test_openai_compatible_provider_reports_resolved_response_provider() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                503,
+                text="temporarily unavailable",
+                headers={"x-inference-provider": "provider-before-failover"},
+            )
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+            headers={
+                "content-type": "text/event-stream",
+                "x-inference-provider": "provider-after-failover",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://router.huggingface.co/v1",
+                provider_name="huggingface",
+                response_provider_header="x-inference-provider",
+                max_retries=1,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="You are Tau.",
+                messages=[UserMessage(content="hello")],
+                tools=[],
+            )
+        )
+
+    assert attempts == 2
+    assert isinstance(events[0], AssistantStartEvent)
+    assert events[0].partial.response_provider == "provider-after-failover"
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].message.provider == "huggingface"
+    assert events[-1].message.response_provider == "provider-after-failover"
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_retries_transient_status() -> None:
     requests: list[httpx.Request] = []
 

--- a/website/content/internals/agent-loop.md
+++ b/website/content/internals/agent-loop.md
@@ -59,6 +59,10 @@ payload table.
 The final `AssistantMessage` is authoritative: it persists text, thinking, and tool
 calls as ordered content blocks. Nested update events provide responsive rendering,
 while saved sessions and provider history replay use the finalized structured message.
+Its `provider` field names Tau's configured provider. When a gateway reports a
+more specific backend, `response_provider` records the backend that served that
+request. For example, Hugging Face responses expose the selected Inference
+Provider there while `provider` remains `huggingface`.
 
 Because the contract is *events*, a frontend's job is reduced to: send a prompt,
 consume the stream, draw what you see.


### PR DESCRIPTION
## Summary

- add optional per-response `responseProvider` metadata to `AssistantMessage`
- capture Hugging Face Router's `x-inference-provider` header on streaming success and failure responses
- preserve the resolved provider through provider-neutral streaming partials and final persisted messages
- keep automatic routing unchanged and add no provider selection, configuration, or pinning controls

## Why

Tau's logical `provider` remains `huggingface`, but callers currently cannot tell which backing Hugging Face Inference Provider served a request. That distinction becomes especially important when automatic routing selects a provider on the first successful request or changes providers after a failure.

The metadata is sourced from each HTTP response rather than inferred from model or session state, so the final assistant message records the provider that actually served that request, including after retry or failover.

This branch merges cleanly with the currently open routing work in #561.

## User/developer impact

Custom frontends and SDK callers can read `AssistantMessage.response_provider` (`responseProvider` on the wire) while continuing to use `AssistantMessage.provider == "huggingface"` as the logical Tau provider. Existing sessions remain readable because the new field is optional.

## Validation

- `uv run pytest` — 1406 passed, 2 skipped (Windows-only)
- `uv run pytest tests/test_tau_ai.py tests/test_provider_config.py tests/test_agent_types.py` — 138 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify` — passed with the existing taxonomy layout warning
- `git merge-tree --write-tree --messages origin/feature/hf-sticky-routing HEAD` — clean synthetic merge with PR #561
