### PR TITLE
Release Tau 0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.7"
+version = "0.3.8"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,25 @@
 [
   {
+    "version": "0.3.8",
+    "date": "2026-08-06",
+    "sections": {
+      "New": [
+        "Add a reactive cache analytics tab to live self-contained HTML session exports.",
+        "Pin a Hugging Face model to an explicit backing Inference Provider for the lifetime of a session.",
+        "Expose the resolved Hugging Face response provider in session metadata and diagnostics."
+      ],
+      "Changed": [
+        "Update Kimi K3 reasoning effort levels to low, high, and max.",
+        "Add request timestamps to the cache tab tooltip and cache statistics table.",
+        "Bill Anthropic 1-hour cache writes at their own independent rate instead of blending with input token rates."
+      ],
+      "Fixed": [
+        "Retry transient Anthropic stream errors instead of failing the entire turn.",
+        "Fix tool history reset across provider switches so the active provider sees the correct prior tool results."
+      ]
+    }
+  },
+  {
     "version": "0.3.7",
     "date": "2026-08-05",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -673,7 +673,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.7" in console.export_text()
+    assert "τ = 2π  0.3.8" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release Tau 0.3.8

Prepares the v0.3.8 patch release.

### Changes

- Bump `tau-ai` version to 0.3.8 in `pyproject.toml` and `uv.lock`
- Update TUI sidebar brand test expectation
- Finalize `releases.json` 0.3.8 entry (cache analytics tab, HF provider pinning, Anthropic retries, tool history fix)

### Highlights since v0.3.7

- Reactive cache analytics tab in self-contained HTML session exports (#558)
- Pin Hugging Face model routing to an explicit Inference Provider per session (#561, #562)
- Retry transient Anthropic stream errors instead of failing (#556)
- Fix tool history across provider switches

### Checks

- `uv run mypy` ✅
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest` ✅ (1434 passed, 2 skipped)
