### PR TITLE
Autocomplete dot-prefixed paths

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -214,9 +214,7 @@ def _is_ignored_file_completion_path(path: Path, *, cwd: Path) -> bool:
         relative_parts = path.relative_to(cwd).parts
     except ValueError:
         return True
-    return any(
-        part.startswith(".") or part in IGNORED_FILE_COMPLETION_DIRS for part in relative_parts
-    )
+    return any(part in IGNORED_FILE_COMPLETION_DIRS for part in relative_parts)
 
 
 def _shell_path_completions(*, text: str, cwd: Path) -> tuple[CompletionItem, ...] | None:

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -470,6 +470,29 @@ def test_file_reference_completion_matches_workspace_files(tmp_path: Path) -> No
     assert state.selected.apply("please read @app") == "please read @src/app.py"
 
 
+def test_file_reference_completion_includes_dotfiles_and_dot_directories(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".env").write_text("TOKEN=value\n", encoding="utf-8")
+    (tmp_path / ".agents").mkdir()
+    (tmp_path / ".agents" / "rules.md").write_text("# Rules\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+
+    state = build_completion_state(
+        "please read @.",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert {item.display for item in state.items} == {
+        "@.agents/",
+        "@.agents/rules.md",
+        "@.env",
+    }
+
+
 def test_file_reference_completion_works_in_custom_prompt_arguments(tmp_path: Path) -> None:
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
@@ -532,6 +555,33 @@ def test_file_reference_completion_stays_off_for_slash_commands(tmp_path: Path) 
     )
 
     assert state.items == ()
+
+
+def test_shell_path_completion_includes_dotfiles_and_dot_directories(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("TOKEN=value\n", encoding="utf-8")
+    (tmp_path / ".agents").mkdir()
+    (tmp_path / ".agents" / "rules.md").write_text("# Rules\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+
+    root_state = build_completion_state(
+        "!cat .",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+    child_state = build_completion_state(
+        "!!cat .agents/ru",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=tmp_path,
+    )
+
+    assert {item.display for item in root_state.items} == {".agents/", ".env"}
+    assert [item.display for item in child_state.items] == [".agents/rules.md"]
+    assert child_state.selected is not None
+    assert child_state.selected.apply("!!cat .agents/ru") == "!!cat .agents/rules.md"
 
 
 def test_shell_path_completion_preserves_bang_prefix(tmp_path: Path) -> None:

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -78,7 +78,7 @@ prefix becomes a matching `$`, so you can tell at a glance that submitting will
 execute a shell command instead of messaging the model.
 
 While typing a path after `!`/`!!`, press **Tab** to complete filenames from the
-working directory.
+working directory. Dot-prefixed paths such as `.env` and `.agents/` are included.
 
 {{% note title="Aliases" %}}
 These commands (and the agent's `bash` tool) run in a non-interactive shell, so
@@ -90,8 +90,9 @@ aliases, set a `shellCommandPrefix` — see
 ## Referencing files with `@`
 
 Type `@` in the prompt to open file suggestions from the project tree, and insert
-a path like `@src/app.py`. Tau skips hidden and generated directories (`.git`,
-`.venv`, `node_modules`, `__pycache__`, `build`, `dist`).
+a path like `@src/app.py`. Dot-prefixed project content such as `.env` and
+`.agents/` is included. Tau still skips known metadata and generated directories
+such as `.git`, `.venv`, `node_modules`, `__pycache__`, `build`, and `dist`.
 
 ## Dropping files into the prompt
 


### PR DESCRIPTION
## Description

- allow `@` file-reference autocomplete to include dot-prefixed files and directories
- allow `!` and `!!` shell path autocomplete to include dot-prefixed paths
- continue excluding known metadata and generated directories such as `.git` and `.venv`
- document the behavior and add regression coverage

## User experience

Users can now discover and complete project files such as `.env` and `.agents/rules.md` instead of typing those paths manually. This makes autocomplete consistent for important dot-prefixed project configuration.

## Issue

Addresses no existing issue.

## Manual validation

1. Open Tau in a project containing `.env` and `.agents/rules.md`.
2. Type `@.` and verify both dot-prefixed paths appear.
3. Type `!cat .` or `!!cat .agents/ru` and verify shell path suggestions appear.
4. Verify generated directories such as `.git` and `.venv` remain absent.
