### PR TITLE
Show export destination in transcript

### DIFF
--- a/dev-notes/export-transcript-notice.md
+++ b/dev-notes/export-transcript-notice.md
@@ -1,0 +1,25 @@
+# Export destination transcript notice
+
+## What changed
+
+A successful TUI `/export` now adds the exported file location as a status row in
+the visible transcript instead of using Textual's temporary lower-right toast.
+Export failures remain error notifications.
+
+## Why
+
+The destination is useful after a toast disappears. Keeping it in display state
+makes it easy to find and copy while preserving the boundary between TUI output
+and model context.
+
+## Context and persistence
+
+The status row uses the same non-persistent command-output path as `/reload`.
+It is not added to `CodingSession.messages`, written to session JSONL, or sent to
+the model.
+
+## Test
+
+```bash
+uv run pytest tests/test_tui_app.py -k export_command
+```

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3888,7 +3888,10 @@ class TauTuiApp(App[None]):
                         command.export_destination,
                         format=command.export_format,
                     )
-                    self._notify(f"Exported session to {exported_path}")
+                    self._append_command_message(
+                        text,
+                        f"Exported session to {exported_path}",
+                    )
                 except Exception as exc:  # noqa: BLE001 - surface command failures in the TUI
                     self._notify(f"Could not export session: {exc}", severity="error")
             if command.resume_session_id is not None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4313,7 +4313,11 @@ async def test_tui_app_export_command_runs_session_export() -> None:
         await pilot.press("enter")
 
         assert session.export_calls == [(Path("out.jsonl"), "jsonl")]
-        assert notifications == ["Exported session to /workspace/project/session.html"]
+        assert notifications == []
+        assert app.state.items[-1] == ChatItem(
+            role="status",
+            text="/export\nExported session to /workspace/project/session.html",
+        )
         assert session.prompt_texts == []
 
 

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -98,6 +98,10 @@ tau export <session-id> --format jsonl
 ```
 
 The source can be an indexed session id **or** a path to a JSONL session file.
+After a successful `/export`, Tau shows the destination in the TUI transcript.
+This status is display-only: it is not saved to session history or sent to the
+model as context.
+
 HTML exports are self-contained and include two tabs: **Transcript** preserves
 the session tree and entries in storage order, while **Cache** summarizes the
 active branch's model requests, prompt caching, output and reasoning tokens,


### PR DESCRIPTION
## Description

- show the successful `/export` destination as a non-persistent transcript status row
- keep export failures as Textual error notifications
- document the display and context behavior

## User experience

The exported file location remains visible and copyable in the transcript instead of disappearing with the lower-right toast. It remains UI-only and does not affect model context or durable session history.

## Issue

No linked issue.

## Manual validation

1. Start Tau's interactive TUI.
2. Run `/export` or `/export --format jsonl out.jsonl`.
3. Confirm `/export` and the exported path appear in the transcript.
4. Continue the conversation or inspect the JSONL session and confirm the status was not added to model context or durable history.
