### PR TITLE
feat: inject dynamic model identity into system prompt

### DIFF
--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -134,6 +134,7 @@ from tau_coding.thinking import (
     ThinkingLevel,
     next_thinking_level,
     normalize_thinking_level,
+    reasoning_effort_for_level,
 )
 from tau_coding.tools import ImageSupportState, create_bash_tool, create_coding_tools
 
@@ -464,6 +465,9 @@ class CodingSession:
                     ),
                     context_files=resources.context_files,
                     extra_guidelines=extension_runtime.prompt_guidelines,
+                    provider_name=config.provider_name,
+                    model=config.model,
+                    reasoning=reasoning_effort_for_level(config.thinking_level),
                 )
             )
         )
@@ -1509,6 +1513,9 @@ class CodingSession:
                     ),
                     context_files=resources.context_files,
                     extra_guidelines=after_guidelines,
+                    provider_name=self._provider_name,
+                    model=self.model,
+                    reasoning=reasoning_effort_for_level(self._thinking_level),
                 )
             )
 

--- a/src/tau_coding/system_prompt.py
+++ b/src/tau_coding/system_prompt.py
@@ -33,6 +33,9 @@ class BuildSystemPromptOptions:
     context_files: Sequence[ProjectContextFile] = ()
     current_date: date | None = None
     extra_guidelines: Sequence[str] = field(default_factory=tuple)
+    provider_name: str | None = None
+    model: str | None = None
+    reasoning: str | None = None
 
 
 def build_system_prompt(options: BuildSystemPromptOptions) -> str:
@@ -54,6 +57,21 @@ def build_system_prompt(options: BuildSystemPromptOptions) -> str:
     prompt = (
         "You are an expert coding assistant operating inside Tau, a coding agent harness. "
         "You help users by reading files, executing commands, editing code, and writing new files."
+    )
+
+    # Inject dynamic model identity so the agent knows what it's running as.
+    if options.provider_name or options.model or options.reasoning:
+        identity_parts: list[str] = []
+        if options.provider_name:
+            identity_parts.append(f"provider: {options.provider_name}")
+        if options.model:
+            identity_parts.append(f"model: {options.model}")
+        if options.reasoning:
+            identity_parts.append(f"reasoning: {options.reasoning}")
+        identity_line = ", ".join(identity_parts)
+        prompt += f"\n\nYou are running as: {identity_line}."
+
+    prompt += (
         f"\n\nAvailable tools:\n{format_available_tools(options.tools)}"
         "\n\nIn addition to the tools above, you may have access to other custom tools "
         "depending on the project."

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -144,3 +144,40 @@ def test_skills_are_included_only_when_read_tool_is_available(tmp_path: Path) ->
 
     assert "<available_skills>" not in without_read
     assert "<available_skills>" in with_read
+
+
+def test_model_identity_injected_when_all_fields_present(tmp_path: Path) -> None:
+    prompt = build_system_prompt(
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            tools=create_coding_tools(cwd=tmp_path),
+            provider_name="openai",
+            model="gpt-5.5",
+            reasoning="high",
+            current_date=date(2026, 6, 17),
+        )
+    )
+    assert "You are running as: provider: openai, model: gpt-5.5, reasoning: high." in prompt
+
+
+def test_model_identity_injected_with_partial_fields(tmp_path: Path) -> None:
+    prompt = build_system_prompt(
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            tools=create_coding_tools(cwd=tmp_path),
+            model="gpt-4o",
+            current_date=date(2026, 6, 17),
+        )
+    )
+    assert "You are running as: model: gpt-4o." in prompt
+
+
+def test_model_identity_not_injected_when_all_none(tmp_path: Path) -> None:
+    prompt = build_system_prompt(
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            tools=create_coding_tools(cwd=tmp_path),
+            current_date=date(2026, 6, 17),
+        )
+    )
+    assert "You are running as:" not in prompt


### PR DESCRIPTION
## Summary

Add provider_name, model, and reasoning fields to BuildSystemPromptOptions so Tau's system prompt includes the agent's actual runtime identity.

## Changes

- **system_prompt.py**: Added three new optional fields to BuildSystemPromptOptions (provider_name, model, reasoning). When any is set, build_system_prompt() injects a 'You are running as: provider: X, model: Y, reasoning: Z.' line into the prompt.
- **session.py**: Both BuildSystemPromptOptions call sites (initial load and reload path) now pass identity fields. reasoning_effort_for_level maps Tau's thinking level to standard reasoning effort vocabulary.
- **tests**: Added 3 tests for full, partial, and no identity injection.

## Why

Previously, agents couldn't reliably know their own provider/model/reasoning without parsing session metadata. The old approach of ~/.tau/APPEND_SYSTEM.md with static text couldn't use template variables. This code-level fix injects the identity at build time so every agent session starts with this information baked into the system prompt.

Fixes: #569