### PR TITLE
Add Kimi K3 to Hugging Face model catalog

### DIFF
--- a/dev-notes/kimi-k3-model-catalog.md
+++ b/dev-notes/kimi-k3-model-catalog.md
@@ -1,7 +1,8 @@
 # Kimi K3 model catalog support
 
-Tau's built-in `kimi-code` provider now exposes Kimi K3 through the model ID
-`k3`. It uses the existing Kimi Code subscription endpoint and credential:
+Tau exposes Kimi K3 through both the built-in `kimi-code` provider and Hugging
+Face Inference Providers. Kimi Code uses the model ID `k3` and its existing
+subscription endpoint and credential:
 
 - endpoint: `https://api.kimi.com/coding/v1`
 - environment variable: `KIMI_CODE_API_KEY`
@@ -12,10 +13,16 @@ Kimi documents native visual understanding and a context window of up to
 text and image input and records that maximum so Tau's context budgeting can use
 it; the API may reject requests beyond the user's plan entitlement.
 
-K3 currently accepts only `max` reasoning effort. Tau maps its `xhigh` thinking
-level to the API value `max` and excludes all other thinking levels for this
-model. `kimi-for-coding` remains the default to avoid silently changing existing
-users' selected rolling model.
+K3 accepts `low`, `high`, and `max` reasoning effort. Tau maps these to `low`,
+`high`, and `xhigh` respectively for both catalog entries. `kimi-for-coding`
+remains the Kimi Code default, and `moonshotai/Kimi-K2.6` remains the Hugging
+Face default, to avoid silently changing existing users' selections.
+
+The Hugging Face catalog uses the official `moonshotai/Kimi-K3` repository ID.
+Hugging Face currently advertises live routes through Together AI, Fireworks
+AI, Featherless AI, Baseten, and DeepInfra. The catalog records the official
+1,048,576-token context and the highest advertised route price of $3 input and
+$15 output per million tokens; actual routing and price can vary.
 
 ## Verify
 
@@ -27,5 +34,7 @@ uv run mypy
 ```
 
 After `/login kimi-code`, choose `kimi-code:k3` from `/model` or start Tau with
-`--provider kimi-code --model k3`. Kimi recommends beginning a new session when
-switching models because the old model's context cache cannot be reused.
+`--provider kimi-code --model k3`. For Hugging Face, use `/login huggingface`
+and choose `huggingface:moonshotai/Kimi-K3`. Kimi recommends beginning a new
+session when switching models because the old model's context cache cannot be
+reused.

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -4024,11 +4024,11 @@ kind = "openai-compatible"
 base_url = "https://router.huggingface.co/v1"
 api_key_env = "HF_TOKEN"
 credential_name = "huggingface"
-models = ["MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "MiniMaxAI/MiniMax-M3", "Qwen/Qwen3-235B-A22B", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-30B-A3B-Instruct", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3.5-122B-A10B", "Qwen/Qwen3.5-27B", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.5-9B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "XiaomiMiMo/MiMo-V2.5-Pro", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro", "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "moonshotai/Kimi-K2.7-Code", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "stepfun-ai/Step-3.5-Flash", "stepfun-ai/Step-3.7-Flash", "zai-org/GLM-4.5", "zai-org/GLM-4.5-Air", "zai-org/GLM-4.5V", "zai-org/GLM-4.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1", "zai-org/GLM-5.2"]
+models = ["MiniMaxAI/MiniMax-M2", "MiniMaxAI/MiniMax-M2.1", "MiniMaxAI/MiniMax-M2.5", "MiniMaxAI/MiniMax-M2.7", "MiniMaxAI/MiniMax-M3", "Qwen/Qwen3-235B-A22B", "Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-30B-A3B-Instruct", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen3-Coder-Next", "Qwen/Qwen3-Next-80B-A3B-Instruct", "Qwen/Qwen3.5-122B-A10B", "Qwen/Qwen3.5-27B", "Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3.5-9B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "XiaomiMiMo/MiMo-V2.5-Pro", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-0528", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Pro", "google/gemma-4-26B-A4B-it", "google/gemma-4-31B-it", "meta-llama/Llama-3.3-70B-Instruct", "moonshotai/Kimi-K2-Instruct", "moonshotai/Kimi-K2-Instruct-0905", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6", "moonshotai/Kimi-K2.7-Code", "moonshotai/Kimi-K3", "openai/gpt-oss-120b", "openai/gpt-oss-20b", "stepfun-ai/Step-3.5-Flash", "stepfun-ai/Step-3.7-Flash", "zai-org/GLM-4.5", "zai-org/GLM-4.5-Air", "zai-org/GLM-4.5V", "zai-org/GLM-4.6", "zai-org/GLM-4.7", "zai-org/GLM-4.7-Flash", "zai-org/GLM-5", "zai-org/GLM-5.1", "zai-org/GLM-5.2"]
 default_model = "moonshotai/Kimi-K2.6"
 docs_url = "https://huggingface.co/docs/inference-providers"
 api = "openai-completions"
-thinking_levels = ["off", "minimal", "low", "medium", "high"]
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
@@ -4066,6 +4066,7 @@ thinking_parameter = "reasoning_effort"
 "moonshotai/Kimi-K2.5" = 262144
 "moonshotai/Kimi-K2.6" = 262144
 "moonshotai/Kimi-K2.7-Code" = 262144
+"moonshotai/Kimi-K3" = 1048576
 "openai/gpt-oss-120b" = 131072
 "openai/gpt-oss-20b" = 131072
 "stepfun-ai/Step-3.5-Flash" = 262144
@@ -4412,6 +4413,16 @@ context_window = 262144
 max_tokens = 262144
 compat = { supportsDeveloperRole = false }
 cost = { input = 0.95, output = 4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."moonshotai/Kimi-K3"]
+name = "Kimi K3"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+compat = { supportsDeveloperRole = false }
+cost = { input = 3, output = 15, cacheRead = 0, cacheWrite = 0 }
+thinking_level_map = { low = "low", high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["off", "minimal", "medium"]
 
 [providers.model_metadata."openai/gpt-oss-120b"]
 name = "GPT OSS 120B"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -345,6 +345,7 @@ def test_builtin_catalog_huggingface_model_expansion() -> None:
         "google/gemma-4-31B-it",
         "meta-llama/Llama-3.3-70B-Instruct",
         "moonshotai/Kimi-K2.7-Code",
+        "moonshotai/Kimi-K3",
         "openai/gpt-oss-120b",
         "openai/gpt-oss-20b",
         "stepfun-ai/Step-3.5-Flash",
@@ -356,7 +357,7 @@ def test_builtin_catalog_huggingface_model_expansion() -> None:
         "zai-org/GLM-5.2",
     }
 
-    assert len(entry.models) == 46
+    assert len(entry.models) == 47
     assert added_models <= set(entry.models)
     assert set(entry.context_windows or {}) == set(entry.models)
     assert set(entry.model_metadata) == set(entry.models)
@@ -370,6 +371,21 @@ def test_builtin_catalog_huggingface_model_expansion() -> None:
     llama = entry.model_metadata["meta-llama/Llama-3.3-70B-Instruct"]
     assert llama.reasoning is False
     assert llama.context_window == 131_072
+
+    kimi_k3 = entry.model_metadata["moonshotai/Kimi-K3"]
+    assert kimi_k3.name == "Kimi K3"
+    assert kimi_k3.reasoning is True
+    assert kimi_k3.input == ("text", "image")
+    assert kimi_k3.context_window == 1_048_576
+    assert kimi_k3.cost == {"input": 3, "output": 15, "cacheRead": 0, "cacheWrite": 0}
+    assert kimi_k3.thinking_level_map == {
+        "off": None,
+        "minimal": None,
+        "low": "low",
+        "medium": None,
+        "high": "high",
+        "xhigh": "max",
+    }
 
 
 def test_builtin_catalog_golden_kimi_entries() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -990,6 +990,33 @@ def test_kimi_k3_maps_thinking_levels_to_reasoning_effort(
     assert config.reasoning_effort == expected_effort
 
 
+@pytest.mark.parametrize(
+    ("level", "expected_effort"),
+    [("low", "low"), ("high", "high"), ("xhigh", "max")],
+)
+def test_huggingface_kimi_k3_maps_thinking_levels_to_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    level: ThinkingLevel,
+    expected_effort: str,
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "test-key")
+    settings = load_provider_settings(TauPaths(home=Path("/missing")))
+    provider = settings.get_provider("huggingface")
+
+    config = openai_compatible_config_from_provider(
+        provider,
+        model="moonshotai/Kimi-K3",
+        thinking_level=level,
+    )
+
+    assert provider_thinking_levels(provider, model="moonshotai/Kimi-K3") == (
+        "low",
+        "high",
+        "xhigh",
+    )
+    assert config.reasoning_effort == expected_effort
+
+
 def test_openai_compatible_config_from_provider_rejects_unsupported_thinking_level(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -141,11 +141,14 @@ needed. Available models and plan limits change over time; consult the
 ### Hugging Face Inference Providers
 
 Log in with `/login huggingface` or set `HF_TOKEN`. Tau's built-in Hugging Face
-catalog includes 46 coding-capable models routed through
+catalog includes 47 coding-capable models routed through
 `https://router.huggingface.co/v1`, including DeepSeek, Gemma, GLM, GPT OSS,
-Kimi, Llama, MiniMax, MiMo, Qwen, and Step families. Use `/model` to search the
-full list; model availability and the inference provider selected by Hugging
-Face can vary over time and by account.
+Kimi, Llama, MiniMax, MiMo, Qwen, and Step families. This includes
+`moonshotai/Kimi-K3`, with text and image input, a 1,048,576-token context
+window, and `low`, `high`, and `max` reasoning effort. Tau exposes `max` as its
+`xhigh` thinking level. Use `/model` to search the full list; model availability
+and the inference provider selected by Hugging Face can vary over time and by
+account.
 
 For a new session without an explicit preference, Hugging Face initially routes
 the model automatically. After the first successful response, Tau reads Hugging


### PR DESCRIPTION
## Summary

- add `moonshotai/Kimi-K3` to the built-in Hugging Face Inference Providers catalog
- expose its text/image input, 1,048,576-token context, pricing, and `low`/`high`/`max` reasoning effort mapping
- preserve `moonshotai/Kimi-K2.6` as the Hugging Face default
- update provider tests, published docs, and the Kimi K3 development note

## Verification

- `uv run pytest` (1443 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --source website --destination /tmp/tau-website-public --cleanDestinationDir`
