### PR TITLE
Repair malformed tool history on replay

### DIFF
--- a/dev-notes/push-based-persistence.md
+++ b/dev-notes/push-based-persistence.md
@@ -65,12 +65,11 @@ change moves persistence to the same side of the event stream.
   and flushed before the next prompt, continuation, compaction, or contextual
   terminal command.
 
-A deliberate non-goal: repairing files that older builds already damaged. A
-branch-time heal was prototyped (PR #525) and closed — re-parenting the branch
-suffix changes the request prefix, which breaks prompt caching, and silent
-healing would hide future faults of this class. Old files still 400 on `/tree`;
-branch to the entry after the dangling call, or reload so the load-time repair
-heals the active path.
+Older files are repaired by the compatibility layer described in
+`dev-notes/tool-history-recovery.md`. It validates active history on load and
+`/tree`, writes a provider-safe append-only branch with a durable diagnostic,
+and leaves the original entries intact. The agent loop applies the same repair
+in memory as a final provider-request backstop.
 
 ## How to test
 

--- a/dev-notes/tool-history-recovery.md
+++ b/dev-notes/tool-history-recovery.md
@@ -1,0 +1,78 @@
+# Recover malformed tool history
+
+## What was added
+
+Tau now validates tool-call history before replaying it to a provider. The
+provider-neutral repair lives in `tau_agent.tool_history` and enforces one
+simple invariant: every assistant tool call is immediately followed by exactly
+one matching tool result.
+
+`CodingSession` applies that repair when loading or resuming an active branch
+and after `/tree` selects a branch. If history changes, Tau appends a new valid
+branch and a `tau.session-history-repair` custom entry containing repair counts.
+The original JSONL entries remain untouched. The agent loop repairs its
+provider input in memory as a final safety backstop for callers that construct a
+harness without `CodingSession`.
+
+## Why it exists
+
+Older cancellation and persistence paths could save either side of a tool
+exchange without the other. Providers reject those transcripts with errors such
+as:
+
+```text
+No tool call found for function call output with call_id call_...
+```
+
+Prevention stops new corruption, but it does not make existing user sessions
+usable. Recovery must therefore tolerate several shapes:
+
+- a call without a result;
+- a result without a call;
+- a result separated from its call by another message;
+- duplicate results for one call;
+- parallel results saved in the wrong order.
+
+## Repair policy
+
+The policy is deterministic and deliberately conservative:
+
+1. Existing results move directly after their calls and follow call order.
+2. A call without a result receives `Tool call interrupted by user`.
+3. A result without any call is omitted. Tau cannot safely invent the missing
+   call because its arguments are unavailable.
+4. Duplicate results collapse to one; a real result wins over Tau's synthetic
+   interruption result.
+5. The raw append-only history is retained. A repaired branch and diagnostic are
+   appended instead of rewriting the JSONL file. Active model, thinking-level,
+   and label state are snapshotted onto the repaired branch, and application
+   custom entries from the rewritten suffix are copied forward.
+
+Applying the policy again is a no-op, so repeated resumes do not add more repair
+branches or diagnostics.
+
+## Architecture
+
+- `tau_agent.tool_history` owns the pure, provider-neutral transformation.
+- `tau_agent.loop` applies it only to provider input; durable harness history is
+  not silently mutated at this safety boundary.
+- `tau_coding.session` owns append-only branch repair and durable diagnostics.
+- Provider adapters remain unchanged and receive valid canonical history.
+
+This preserves Tau's package boundary: portable transcript correctness belongs
+in `tau_agent`, while disk-session workflow belongs in `tau_coding`.
+
+## How to test
+
+```bash
+uv run pytest tests/test_tool_history.py tests/test_agent_loop.py tests/test_coding_session.py
+```
+
+Manual validation:
+
+1. Resume a session containing an orphan `ToolResultMessage`.
+2. Send a prompt that previously returned provider status 400.
+3. Confirm the prompt succeeds.
+4. Inspect JSONL and find one `tau.session-history-repair` custom entry followed
+   by the repaired branch.
+5. Resume again and confirm no second repair diagnostic is appended.

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -32,6 +32,7 @@ from tau_agent.provider_events import (
     AssistantMessageEvent,
     AssistantStartEvent,
 )
+from tau_agent.tool_history import repair_tool_history
 from tau_agent.tools import AgentTool, AgentToolResult
 
 BeforeToolCall = Callable[[ToolCall], Awaitable[tuple[bool, str | None]]]
@@ -181,7 +182,7 @@ def _provider_context(messages: list[AgentMessage]) -> list[AgentMessage]:
     persists terminal failures for diagnostics, but an empty failed or aborted
     turn is not model context and must not poison the next request.
     """
-    return [
+    replayable = tuple(
         message
         for message in messages
         if not (
@@ -189,7 +190,8 @@ def _provider_context(messages: list[AgentMessage]) -> list[AgentMessage]:
             and message.stop_reason in {"error", "aborted"}
             and not message.content
         )
-    ]
+    )
+    return list(repair_tool_history(replayable).messages)
 
 
 async def _assistant_events(

--- a/src/tau_agent/tool_history.py
+++ b/src/tau_agent/tool_history.py
@@ -45,65 +45,115 @@ def repair_tool_history(messages: tuple[AgentMessage, ...]) -> ToolHistoryRepair
     a missing call's arguments cannot be reconstructed safely. When duplicate
     results exist, a real result is preferred over Tau's synthetic interruption.
     """
-    calls: dict[str, ToolCall] = {}
-    expected_result_positions: dict[str, int] = {}
+    call_occurrences: list[tuple[tuple[int, int], ToolCall, int]] = []
     for message_index, message in enumerate(messages):
         if not isinstance(message, AssistantMessage):
             continue
         for call_offset, call in enumerate(message.tool_calls, start=1):
-            calls.setdefault(call.id, call)
-            expected_result_positions.setdefault(call.id, message_index + call_offset)
-
-    results_by_id: dict[str, list[ToolResultMessage]] = defaultdict(list)
-    for message in messages:
-        if isinstance(message, ToolResultMessage):
-            results_by_id[message.tool_call_id].append(message)
-
-    selected_results: dict[str, ToolResultMessage] = {}
-    synthesized_results = 0
-    dropped_duplicate_results = 0
-    for call_id, call in calls.items():
-        candidates = results_by_id.get(call_id, [])
-        if candidates:
-            selected_results[call_id] = next(
-                (result for result in candidates if not _is_interruption_result(result)),
-                candidates[0],
+            call_occurrences.append(
+                ((message_index, call_offset), call, message_index + call_offset)
             )
-            dropped_duplicate_results += len(candidates) - 1
+
+    results_by_id: dict[str, list[tuple[int, ToolResultMessage]]] = defaultdict(list)
+    for message_index, message in enumerate(messages):
+        if isinstance(message, ToolResultMessage):
+            results_by_id[message.tool_call_id].append((message_index, message))
+
+    selected_results: dict[tuple[int, int], tuple[int | None, ToolResultMessage]] = {}
+    used_result_positions: set[int] = set()
+
+    # Reserve already-adjacent pairs first. This keeps valid repeated IDs paired
+    # with their own turn rather than letting an earlier occurrence consume them.
+    for occurrence, call, expected_position in call_occurrences:
+        if expected_position >= len(messages):
             continue
-        selected_results[call_id] = ToolResultMessage(
-            tool_call_id=call.id,
-            tool_name=call.name,
-            content=[TextContent(text=_INTERRUPTED_TOOL_RESULT)],
-            is_error=True,
+        candidate = messages[expected_position]
+        if (
+            isinstance(candidate, ToolResultMessage)
+            and candidate.tool_call_id == call.id
+            and expected_position not in used_result_positions
+        ):
+            selected_results[occurrence] = (expected_position, candidate)
+            used_result_positions.add(expected_position)
+
+    synthesized_results = 0
+    for occurrence, call, _expected_position in call_occurrences:
+        if occurrence in selected_results:
+            continue
+        candidates = [
+            candidate
+            for candidate in results_by_id.get(call.id, [])
+            if candidate[0] not in used_result_positions
+        ]
+        if candidates:
+            after_call = [candidate for candidate in candidates if candidate[0] > occurrence[0]]
+            candidate_pool = after_call or candidates
+            selected = next(
+                (
+                    candidate
+                    for candidate in candidate_pool
+                    if not _is_interruption_result(candidate[1])
+                ),
+                candidate_pool[0],
+            )
+            selected_results[occurrence] = selected
+            used_result_positions.add(selected[0])
+            continue
+        selected_results[occurrence] = (
+            None,
+            ToolResultMessage(
+                tool_call_id=call.id,
+                tool_name=call.name,
+                content=[TextContent(text=_INTERRUPTED_TOOL_RESULT)],
+                is_error=True,
+            ),
         )
         synthesized_results += 1
 
-    original_positions = {id(message): index for index, message in enumerate(messages)}
+    # If every call occurrence is already paired and a real extra result remains,
+    # prefer it over a selected synthetic interruption for the same ID.
+    for occurrence, call, _expected_position in call_occurrences:
+        selected_position, selected_result = selected_results[occurrence]
+        if selected_position is None or not _is_interruption_result(selected_result):
+            continue
+        replacement = next(
+            (
+                candidate
+                for candidate in results_by_id.get(call.id, [])
+                if candidate[0] not in used_result_positions
+                and not _is_interruption_result(candidate[1])
+            ),
+            None,
+        )
+        if replacement is None:
+            continue
+        used_result_positions.remove(selected_position)
+        used_result_positions.add(replacement[0])
+        selected_results[occurrence] = replacement
+
     repaired: list[AgentMessage] = []
-    emitted_call_ids: set[str] = set()
     reordered_results = 0
-    for message in messages:
+    for message_index, message in enumerate(messages):
         if isinstance(message, ToolResultMessage):
             continue
         repaired.append(message)
         if not isinstance(message, AssistantMessage):
             continue
-        for call in message.tool_calls:
-            if call.id in emitted_call_ids:
-                continue
-            emitted_call_ids.add(call.id)
-            result = selected_results[call.id]
+        for call_offset, _call in enumerate(message.tool_calls, start=1):
+            result_position, result = selected_results[(message_index, call_offset)]
             repaired.append(result)
-            original_position = original_positions.get(id(result))
-            if original_position is not None and original_position != expected_result_positions.get(
-                call.id
-            ):
+            if result_position is not None and result_position != message_index + call_offset:
                 reordered_results += 1
 
-    orphan_results = sum(
-        len(results) for call_id, results in results_by_id.items() if call_id not in calls
-    )
+    call_ids = {call.id for _occurrence, call, _expected in call_occurrences}
+    unused_results = [
+        result
+        for results in results_by_id.values()
+        for position, result in results
+        if position not in used_result_positions
+    ]
+    orphan_results = sum(result.tool_call_id not in call_ids for result in unused_results)
+    dropped_duplicate_results = sum(result.tool_call_id in call_ids for result in unused_results)
     repaired_messages = tuple(repaired)
     return ToolHistoryRepair(
         messages=repaired_messages,

--- a/src/tau_agent/tool_history.py
+++ b/src/tau_agent/tool_history.py
@@ -1,0 +1,119 @@
+"""Provider-safe repair of malformed tool-call message history."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from tau_agent.messages import (
+    AgentMessage,
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+)
+
+_INTERRUPTED_TOOL_RESULT = "Tool call interrupted by user"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolHistoryRepair:
+    """A provider-safe transcript plus a summary of deterministic repairs."""
+
+    messages: tuple[AgentMessage, ...]
+    changed: bool = False
+    synthesized_results: int = 0
+    dropped_orphan_results: int = 0
+    dropped_duplicate_results: int = 0
+    reordered_results: int = 0
+
+    def diagnostic_data(self) -> dict[str, int]:
+        """Return JSON-safe counters for durable session diagnostics."""
+        return {
+            "synthesizedResults": self.synthesized_results,
+            "droppedOrphanResults": self.dropped_orphan_results,
+            "droppedDuplicateResults": self.dropped_duplicate_results,
+            "reorderedResults": self.reordered_results,
+        }
+
+
+def repair_tool_history(messages: tuple[AgentMessage, ...]) -> ToolHistoryRepair:
+    """Return history where every tool call has exactly one adjacent result.
+
+    Existing result messages are moved beside their calls. Missing results get a
+    deterministic interruption error. Results with no call are omitted because
+    a missing call's arguments cannot be reconstructed safely. When duplicate
+    results exist, a real result is preferred over Tau's synthetic interruption.
+    """
+    calls: dict[str, ToolCall] = {}
+    expected_result_positions: dict[str, int] = {}
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, AssistantMessage):
+            continue
+        for call_offset, call in enumerate(message.tool_calls, start=1):
+            calls.setdefault(call.id, call)
+            expected_result_positions.setdefault(call.id, message_index + call_offset)
+
+    results_by_id: dict[str, list[ToolResultMessage]] = defaultdict(list)
+    for message in messages:
+        if isinstance(message, ToolResultMessage):
+            results_by_id[message.tool_call_id].append(message)
+
+    selected_results: dict[str, ToolResultMessage] = {}
+    synthesized_results = 0
+    dropped_duplicate_results = 0
+    for call_id, call in calls.items():
+        candidates = results_by_id.get(call_id, [])
+        if candidates:
+            selected_results[call_id] = next(
+                (result for result in candidates if not _is_interruption_result(result)),
+                candidates[0],
+            )
+            dropped_duplicate_results += len(candidates) - 1
+            continue
+        selected_results[call_id] = ToolResultMessage(
+            tool_call_id=call.id,
+            tool_name=call.name,
+            content=[TextContent(text=_INTERRUPTED_TOOL_RESULT)],
+            is_error=True,
+        )
+        synthesized_results += 1
+
+    original_positions = {id(message): index for index, message in enumerate(messages)}
+    repaired: list[AgentMessage] = []
+    emitted_call_ids: set[str] = set()
+    reordered_results = 0
+    for message in messages:
+        if isinstance(message, ToolResultMessage):
+            continue
+        repaired.append(message)
+        if not isinstance(message, AssistantMessage):
+            continue
+        for call in message.tool_calls:
+            if call.id in emitted_call_ids:
+                continue
+            emitted_call_ids.add(call.id)
+            result = selected_results[call.id]
+            repaired.append(result)
+            original_position = original_positions.get(id(result))
+            if original_position is not None and original_position != expected_result_positions.get(
+                call.id
+            ):
+                reordered_results += 1
+
+    orphan_results = sum(
+        len(results) for call_id, results in results_by_id.items() if call_id not in calls
+    )
+    repaired_messages = tuple(repaired)
+    return ToolHistoryRepair(
+        messages=repaired_messages,
+        changed=repaired_messages != messages,
+        synthesized_results=synthesized_results,
+        dropped_orphan_results=orphan_results,
+        dropped_duplicate_results=dropped_duplicate_results,
+        reordered_results=reordered_results,
+    )
+
+
+def _is_interruption_result(message: ToolResultMessage) -> bool:
+    return message.is_error and message.text == _INTERRUPTED_TOOL_RESULT

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -15,8 +15,6 @@ from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
     CustomMessage,
-    TextContent,
-    ToolResultMessage,
     UserMessage,
     message_text,
 )
@@ -27,6 +25,7 @@ from tau_agent.session import (
     CompactionEntry,
     CustomEntry,
     JsonlSessionStorage,
+    LabelEntry,
     LeafEntry,
     MessageEntry,
     ModelChangeEntry,
@@ -38,6 +37,7 @@ from tau_agent.session import (
 from tau_agent.session.entries import SessionEntry
 from tau_agent.session.jsonl import entry_to_json_line
 from tau_agent.session.tree import SessionTreeError, path_to_entry
+from tau_agent.tool_history import ToolHistoryRepair, repair_tool_history
 from tau_agent.tools import AgentTool
 from tau_agent.types import JSONValue
 from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
@@ -513,14 +513,14 @@ class CodingSession:
             image_support=image_support,
             project_trust_resolution=trust_resolution,
         )
-        await session._persist_loaded_interrupted_tool_repairs()
+        await session._persist_active_tool_history_repairs()
         session._sync_thinking_level_to_active_model()
         session._refresh_runtime_provider()
         await session._refresh_runtime_model_limits()
         extension_runtime.bind(session)
         # Attach to session._harness, not the local `harness`:
-        # _persist_loaded_interrupted_tool_repairs() above may have replaced the
-        # harness, and listeners on the discarded one would never see an event.
+        # Tool-history repair above updates the active harness before extension
+        # listeners attach.
         extension_runtime.attach_harness_listener(session._harness.subscribe)
         # session_start is deferred: hosts emit it via emit_pending_session_start()
         # after installing their UI bridge.
@@ -680,7 +680,9 @@ class CodingSession:
         self._last_parent_id = target_id
 
         await self._refresh_persisted_state(leaf_id=target_id)
-        self._harness.replace_messages(self._state.messages)
+        history_repair = await self._persist_active_tool_history_repairs()
+        if history_repair is None:
+            self._harness.replace_messages(self._state.messages)
         self._invalidate_context_usage_cache()
         self._thinking_level = _state_thinking_level(
             self._state,
@@ -689,9 +691,11 @@ class CodingSession:
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         suffix = " with branch summary" if summary_entry is not None else ""
+        if history_repair is not None:
+            suffix += " and repaired malformed tool history"
         if input_prefill is not None:
             return SessionTreeBranchResult(
-                message=f"Branched session before {entry_id}.",
+                message=f"Branched session before {entry_id}{suffix}.",
                 input_prefill=input_prefill,
             )
         return SessionTreeBranchResult(message=f"Branched session at {target_id}{suffix}.")
@@ -2124,44 +2128,70 @@ class CodingSession:
             run_id=new_agent_call_run_id(),
         )
 
-    async def _persist_loaded_interrupted_tool_repairs(self) -> None:
-        """Persist repairs for loaded sessions with dangling tool calls.
-
-        Older Tau builds repaired interrupted tool-call transcripts only in the
-        in-memory harness. If the app was later resumed from JSONL, the synthetic
-        tool result was absent and providers rejected the whole transcript. Repair
-        the active branch on load so resume/tree branches are durable and
-        provider-safe.
-        """
-        repair = _interrupted_tool_repair_plan(
+    async def _persist_active_tool_history_repairs(self) -> ToolHistoryRepair | None:
+        """Rewrite malformed active tool history as a valid append-only branch."""
+        plan = _tool_history_repair_plan(
             self._state.messages,
             context_entry_ids=self._state.context_entry_ids,
+            entries=self._state.entries,
         )
-        if repair is None:
-            return
+        if plan is None:
+            return None
 
-        parent_id, suffix = repair
+        parent_id, suffix, repair = plan
+        active_model = self._state.model
+        active_thinking_level = self._state.thinking_level
+        active_label = self._state.label
+        active_entries = self._state.entries
+        parent_index = next(
+            (index for index, entry in enumerate(active_entries) if entry.id == parent_id),
+            -1,
+        )
+        custom_entries = [
+            entry
+            for entry in active_entries[parent_index + 1 :]
+            if isinstance(entry, CustomEntry) and entry.namespace != "tau.session-history-repair"
+        ]
+        diagnostic = CustomEntry(
+            parent_id=parent_id,
+            namespace="tau.session-history-repair",
+            data={"version": 1, **repair.diagnostic_data()},
+        )
+        await self._append_session_entry(diagnostic)
+        parent_id = diagnostic.id
         for message in suffix:
             entry = MessageEntry(parent_id=parent_id, message=message)
             await self._append_session_entry(entry)
             parent_id = entry.id
+        if active_model is not None:
+            model_entry = ModelChangeEntry(parent_id=parent_id, model=active_model)
+            await self._append_session_entry(model_entry)
+            parent_id = model_entry.id
+        thinking_entry = ThinkingLevelChangeEntry(
+            parent_id=parent_id,
+            thinking_level=active_thinking_level,
+        )
+        await self._append_session_entry(thinking_entry)
+        parent_id = thinking_entry.id
+        if active_label is not None:
+            label_entry = LabelEntry(parent_id=parent_id, label=active_label)
+            await self._append_session_entry(label_entry)
+            parent_id = label_entry.id
+        for custom_entry in custom_entries:
+            copied_entry = CustomEntry(
+                parent_id=parent_id,
+                namespace=custom_entry.namespace,
+                data=custom_entry.data,
+            )
+            await self._append_session_entry(copied_entry)
+            parent_id = copied_entry.id
         leaf = LeafEntry(parent_id=parent_id, entry_id=parent_id)
         await self._append_session_entry(leaf)
         self._last_parent_id = parent_id
         await self._refresh_persisted_state(leaf_id=parent_id)
-        self._harness = AgentHarness(
-            AgentHarnessConfig(
-                provider=self._harness.config.provider,
-                model=self._harness.config.model,
-                system=self._harness.config.system,
-                tools=self._harness.config.tools,
-                max_turns=self._harness.config.max_turns,
-                queue_mode=self._harness.config.queue_mode,
-                session_id=self._config.session_id,
-            ),
-            messages=self._state.messages,
-        )
-        self._attach_persistence_listener()
+        self._harness.replace_messages(self._state.messages)
+        self._invalidate_context_usage_cache()
+        return repair
 
     def _attach_persistence_listener(self) -> None:
         """(Re-)attach push persistence to the current harness.
@@ -3192,44 +3222,32 @@ def _merge_context_files(
     return tuple(merged)
 
 
-def _interrupted_tool_repair_plan(
+def _tool_history_repair_plan(
     messages: tuple[AgentMessage, ...],
     *,
     context_entry_ids: tuple[str, ...],
-) -> tuple[str, tuple[AgentMessage, ...]] | None:
-    repaired: list[AgentMessage] = []
-    returned_ids = {
-        message.tool_call_id for message in messages if isinstance(message, ToolResultMessage)
-    }
-    for message in messages:
-        repaired.append(message)
-        if not isinstance(message, AssistantMessage):
-            continue
-        for tool_call in message.tool_calls:
-            if tool_call.id in returned_ids:
-                continue
-            returned_ids.add(tool_call.id)
-            content = "Tool call interrupted by user"
-            repaired.append(
-                ToolResultMessage(
-                    tool_call_id=tool_call.id,
-                    tool_name=tool_call.name,
-                    content=[TextContent(text=content)],
-                    is_error=True,
-                )
-            )
-
-    if tuple(repaired) == messages:
+    entries: tuple[SessionEntry, ...],
+) -> tuple[str | None, tuple[AgentMessage, ...], ToolHistoryRepair] | None:
+    repair = repair_tool_history(messages)
+    if not repair.changed:
         return None
 
     common_prefix_length = 0
-    for old_message, repaired_message in zip(messages, repaired, strict=False):
+    for old_message, repaired_message in zip(messages, repair.messages, strict=False):
         if old_message != repaired_message:
             break
         common_prefix_length += 1
-    if common_prefix_length == 0:
-        return None
-    return context_entry_ids[common_prefix_length - 1], tuple(repaired[common_prefix_length:])
+
+    if common_prefix_length > 0:
+        parent_id: str | None = context_entry_ids[common_prefix_length - 1]
+    elif context_entry_ids:
+        entries_by_id = {entry.id: entry for entry in entries}
+        first_entry = entries_by_id.get(context_entry_ids[0])
+        parent_id = first_entry.parent_id if first_entry is not None else None
+    else:
+        parent_id = None
+
+    return parent_id, repair.messages[common_prefix_length:], repair
 
 
 def default_session_path(cwd: Path) -> Path:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -316,6 +316,37 @@ async def test_agent_loop_excludes_empty_failed_assistant_from_next_provider_cal
 
 
 @pytest.mark.anyio
+async def test_agent_loop_repairs_malformed_tool_history_before_provider_call() -> None:
+    call = ToolCall(id="call-1", name="read", arguments={"path": "README.md"})
+    assistant = AssistantMessage(content=[call])
+    late_user = UserMessage(content="continue")
+    orphan = ToolResultMessage(tool_call_id="call-missing", tool_name="bash", content="orphan")
+    recovered = AssistantMessage(content="recovered", model="fake")
+    provider = FakeProvider([[assistant_start(), assistant_done(recovered)]])
+    messages: list[AgentMessage] = [assistant, late_user, orphan]
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[],
+        )
+    )
+
+    replayed = provider.calls[0][2]
+    assert replayed[0] is assistant
+    repair = replayed[1]
+    assert isinstance(repair, ToolResultMessage)
+    assert repair.tool_call_id == "call-1"
+    assert repair.is_error is True
+    assert replayed[2] is late_user
+    assert orphan not in replayed
+    assert orphan in messages
+
+
+@pytest.mark.anyio
 async def test_agent_loop_injects_steering_and_follow_up_messages() -> None:
     call = ToolCall(id="call-1", name="work", arguments={})
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -28,6 +28,7 @@ from tau_agent.messages import AssistantMessageDiagnostic, assistant_content
 from tau_agent.provider_events import AssistantErrorEvent
 from tau_agent.session import (
     CompactionEntry,
+    CustomEntry,
     JsonlSessionStorage,
     LeafEntry,
     MessageEntry,
@@ -727,6 +728,90 @@ async def test_load_persists_repair_for_session_with_interrupted_tail_tool_call(
 
 
 @pytest.mark.anyio
+async def test_load_persists_branch_without_orphaned_tool_result(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user_entry = MessageEntry(message=UserMessage(content="what remains?"))
+    await storage.append(user_entry)
+    orphan_entry = MessageEntry(
+        parent_id=user_entry.id,
+        message=ToolResultMessage(
+            tool_call_id="call-missing",
+            tool_name="bash",
+            content="Tool call interrupted by user",
+            is_error=True,
+        ),
+    )
+    await storage.append(orphan_entry)
+    custom_entry = CustomEntry(
+        parent_id=orphan_entry.id,
+        namespace="example.state",
+        data={"kept": True},
+    )
+    await storage.append(custom_entry)
+    model_entry = ModelChangeEntry(
+        parent_id=custom_entry.id,
+        model="recovered-model",
+    )
+    await storage.append(model_entry)
+    continued_entry = MessageEntry(
+        parent_id=model_entry.id,
+        message=UserMessage(content="continue"),
+    )
+    await storage.append(continued_entry)
+    await storage.append(LeafEntry(parent_id=continued_entry.id, entry_id=continued_entry.id))
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    _assert_messages(
+        session.messages,
+        [UserMessage(content="what remains?"), UserMessage(content="continue")],
+    )
+    assert session.state.model == "recovered-model"
+    assert any(
+        entry.namespace == "example.state" and entry.data == {"kept": True}
+        for entry in session.state.custom_entries
+    )
+    diagnostics = [
+        entry
+        for entry in (await storage.read_all())
+        if isinstance(entry, CustomEntry) and entry.namespace == "tau.session-history-repair"
+    ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].data == {
+        "version": 1,
+        "synthesizedResults": 0,
+        "droppedOrphanResults": 1,
+        "droppedDuplicateResults": 0,
+        "reorderedResults": 0,
+    }
+
+    restored = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+    _assert_messages(restored.messages, session.messages)
+    diagnostics = [
+        entry
+        for entry in (await storage.read_all())
+        if isinstance(entry, CustomEntry) and entry.namespace == "tau.session-history-repair"
+    ]
+    assert len(diagnostics) == 1
+
+
+@pytest.mark.anyio
 async def test_load_persists_repair_for_historical_interrupted_tool_call(
     tmp_path: Path,
 ) -> None:
@@ -1109,6 +1194,47 @@ def test_ordered_tree_entries_terminates_on_parent_cycle() -> None:
 
     assert sorted(entry.id for entry in ordered) == ["a", "b"]
     assert len(ordered) == 2
+
+
+@pytest.mark.anyio
+async def test_branch_to_entry_repairs_orphaned_tool_result(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    root = MessageEntry(id="root", message=UserMessage(content="start"))
+    orphan = MessageEntry(
+        id="orphan",
+        parent_id=root.id,
+        message=ToolResultMessage(tool_call_id="call-missing", tool_name="bash", content="orphan"),
+    )
+    answer = MessageEntry(
+        id="answer",
+        parent_id=orphan.id,
+        message=AssistantMessage(content="answer"),
+    )
+    for entry in (root, orphan, answer, LeafEntry(parent_id=root.id, entry_id=root.id)):
+        await storage.append(entry)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+
+    result = await session.branch_to_entry(answer.id)
+
+    assert result.message.endswith("and repaired malformed tool history.")
+    _assert_messages(
+        session.messages,
+        [UserMessage(content="start"), AssistantMessage(content="answer")],
+    )
+    diagnostics = [
+        entry
+        for entry in (await storage.read_all())
+        if isinstance(entry, CustomEntry) and entry.namespace == "tau.session-history-repair"
+    ]
+    assert len(diagnostics) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_tool_history.py
+++ b/tests/test_tool_history.py
@@ -94,6 +94,37 @@ def test_duplicate_results_prefer_real_output_over_interruption() -> None:
     assert repair.dropped_duplicate_results == 1
 
 
+def test_repeated_call_ids_keep_one_result_per_turn() -> None:
+    first_call = _call("same")
+    first_assistant = AssistantMessage(content=[first_call])
+    first_result = _result("same", text="first")
+    second_call = _call("same")
+    second_assistant = AssistantMessage(content=[second_call])
+    second_result = _result("same", text="second")
+    messages = (first_assistant, first_result, second_assistant, second_result)
+
+    repair = repair_tool_history(messages)
+
+    assert repair.changed is False
+    assert repair.messages == messages
+    assert repair.dropped_duplicate_results == 0
+
+
+def test_repeated_call_id_reserves_later_adjacent_result() -> None:
+    first_assistant = AssistantMessage(content=[_call("same")])
+    user = UserMessage(content="continue")
+    second_assistant = AssistantMessage(content=[_call("same")])
+    second_result = _result("same", text="second")
+
+    repair = repair_tool_history((first_assistant, user, second_assistant, second_result))
+
+    first_result = repair.messages[1]
+    assert isinstance(first_result, ToolResultMessage)
+    assert first_result.text == "Tool call interrupted by user"
+    assert repair.messages == (first_assistant, first_result, user, second_assistant, second_result)
+    assert repair.synthesized_results == 1
+
+
 def test_parallel_results_follow_tool_call_order() -> None:
     first = _call("call-1", "read")
     second = _call("call-2", "bash")

--- a/tests/test_tool_history.py
+++ b/tests/test_tool_history.py
@@ -1,0 +1,106 @@
+from tau_agent import AssistantMessage, TextContent, ToolCall, ToolResultMessage, UserMessage
+from tau_agent.tool_history import repair_tool_history
+
+
+def _call(call_id: str = "call-1", name: str = "read") -> ToolCall:
+    return ToolCall(id=call_id, name=name, arguments={"path": "README.md"})
+
+
+def _result(
+    call_id: str = "call-1",
+    *,
+    text: str = "contents",
+    is_error: bool = False,
+) -> ToolResultMessage:
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name="read",
+        content=[TextContent(text=text)],
+        is_error=is_error,
+    )
+
+
+def test_valid_tool_history_is_unchanged() -> None:
+    call = _call()
+    result = _result()
+    messages = (
+        UserMessage(content="read"),
+        AssistantMessage(content=[call]),
+        result,
+        AssistantMessage(content="done"),
+    )
+
+    repair = repair_tool_history(messages)
+
+    assert repair.changed is False
+    assert repair.messages == messages
+    assert repair.diagnostic_data() == {
+        "synthesizedResults": 0,
+        "droppedOrphanResults": 0,
+        "droppedDuplicateResults": 0,
+        "reorderedResults": 0,
+    }
+
+
+def test_missing_result_gets_synthetic_interruption() -> None:
+    call = _call()
+
+    repair = repair_tool_history((UserMessage(content="read"), AssistantMessage(content=[call])))
+
+    assert repair.changed is True
+    result = repair.messages[-1]
+    assert isinstance(result, ToolResultMessage)
+    assert result.tool_call_id == call.id
+    assert result.tool_name == call.name
+    assert result.text == "Tool call interrupted by user"
+    assert result.is_error is True
+    assert repair.synthesized_results == 1
+
+
+def test_orphan_result_is_dropped_without_inventing_a_call() -> None:
+    user = UserMessage(content="continue")
+    orphan = _result("call-missing")
+
+    repair = repair_tool_history((orphan, user))
+
+    assert repair.changed is True
+    assert repair.messages == (user,)
+    assert repair.dropped_orphan_results == 1
+    assert repair.synthesized_results == 0
+
+
+def test_late_result_moves_next_to_its_call() -> None:
+    call = _call()
+    assistant = AssistantMessage(content=[call])
+    user = UserMessage(content="continue")
+    result = _result()
+
+    repair = repair_tool_history((assistant, user, result))
+
+    assert repair.messages == (assistant, result, user)
+    assert repair.changed is True
+    assert repair.reordered_results == 1
+
+
+def test_duplicate_results_prefer_real_output_over_interruption() -> None:
+    call = _call()
+    assistant = AssistantMessage(content=[call])
+    interrupted = _result(text="Tool call interrupted by user", is_error=True)
+    actual = _result(text="contents")
+
+    repair = repair_tool_history((assistant, interrupted, actual))
+
+    assert repair.messages == (assistant, actual)
+    assert repair.dropped_duplicate_results == 1
+
+
+def test_parallel_results_follow_tool_call_order() -> None:
+    first = _call("call-1", "read")
+    second = _call("call-2", "bash")
+    assistant = AssistantMessage(content=[first, second])
+    second_result = ToolResultMessage(tool_call_id="call-2", tool_name="bash", content="second")
+    first_result = _result("call-1", text="first")
+
+    repair = repair_tool_history((assistant, second_result, first_result))
+
+    assert repair.messages == (assistant, first_result, second_result)

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -58,6 +58,18 @@ Run `/tree` to open the session tree, then select an earlier entry:
 
 If a summary request fails, Tau falls back to a deterministic summary.
 
+## Recovering older sessions
+
+Older Tau versions could leave malformed tool-call history when a run was
+interrupted. Providers reject that history, so every prompt in the resumed
+session could fail with a 400 error about a missing tool call or tool output.
+
+Tau validates the active branch during resume and after `/tree` navigation. It
+repairs missing, misplaced, duplicate, or orphaned tool results by appending a
+provider-safe branch while preserving the original JSONL entries. A durable
+session diagnostic records what changed. Repeating resume is idempotent and does
+not append another repair when history is already valid.
+
 ## Renaming
 
 New sessions are automatically given a short name from the first message when


### PR DESCRIPTION
## Summary

Repair malformed tool-call history from older Tau sessions before it reaches providers.

This adds a provider-neutral history repair that:

- synthesizes interruption results for tool calls with no result
- drops orphaned results whose calls are absent instead of inventing unknown arguments
- moves late results next to their calls
- collapses duplicate results, preferring real output over synthetic interruption errors
- restores parallel results in tool-call order

`CodingSession` applies the repair during load/resume and `/tree` navigation. It appends a valid branch plus a durable `tau.session-history-repair` diagnostic while preserving the original JSONL entries. The agent loop applies the same transformation to provider input as a final safety backstop.

## User experience

Sessions created by older builds no longer remain permanently stuck on provider 400 errors such as:

```text
No tool call found for function call output with call_id call_...
```

Users can resume or branch into affected sessions and continue normally. Repeated resumes are idempotent and do not append repeated repair branches.

## Related issue

Addresses #301. PR #526 prevents new interrupted-tool persistence corruption; this PR adds compatibility recovery for session files that were already malformed.

## Manual validation

1. Copy or resume a session JSONL containing a `ToolResultMessage` whose call ID has no matching assistant tool call.
2. Start Tau with that session.
3. Send a prompt that previously failed with provider status 400.
4. Confirm the provider responds normally.
5. Inspect the JSONL and confirm it retains the original entries and contains one `tau.session-history-repair` custom entry followed by a valid active branch.
6. Resume the session again and confirm no second repair diagnostic is appended.
7. Repeat through `/tree` by selecting a malformed historical branch; confirm Tau reports that it repaired malformed tool history and the next prompt succeeds.

## Validation

```text
uv run pytest
1465 passed, 2 skipped (Windows/PowerShell-only)

uv run ruff check .
All checks passed

uv run ruff format --check .
152 files already formatted

uv run mypy
Success: no issues found in 101 source files

uv build
Built source distribution and wheel successfully
```
