### PR TITLE
Release Tau 0.3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.8"
+version = "0.3.9"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.3.9",
+    "date": "2026-08-11",
+    "sections": {
+      "New": [
+        "Autocomplete dot-prefixed project files and directories in file references and shell commands while continuing to hide generated metadata paths.",
+        "Keep successful /export destinations visible and copyable in the TUI transcript without adding them to model context or session history.",
+        "Add Kimi K3 to the Hugging Face Inference Providers catalog with image input, a 1M-token context window, pricing, and reasoning effort controls."
+      ],
+      "Changed": [
+        "Improve Markdown heading and accent contrast in the built-in light theme.",
+        "Use model-specific output token limits for Anthropic-protocol requests, including explicit GitHub Copilot Claude limits."
+      ],
+      "Fixed": [
+        "Persist interrupted tool results during cancellation so newly interrupted sessions retain valid provider history.",
+        "Repair malformed tool-call history from older sessions before provider replay so affected sessions can resume normally."
+      ]
+    }
+  },
+  {
     "version": "0.3.8",
     "date": "2026-08-06",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -673,7 +673,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.8" in console.export_text()
+    assert "τ = 2π  0.3.9" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release Tau 0.3.9

Prepares the v0.3.9 patch release.

### Changes

- Bump `tau-ai` version to 0.3.9 in `pyproject.toml` and `uv.lock`
- Update the TUI sidebar brand test expectation
- Add structured 0.3.9 release notes

### Highlights since v0.3.8

- Autocomplete dot-prefixed project paths and keep successful export destinations visible
- Add Kimi K3 to the Hugging Face catalog
- Honor model-specific output limits for Anthropic-protocol models
- Persist interrupted tool results and repair malformed history from older sessions
- Improve light-theme Markdown accents

### Checks

- `uv run mypy` ✅
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest` ✅ (1467 passed, 2 skipped)
- Hugo documentation build and Pagefind indexing ✅
