### PR TITLE
Add parent-relative file autocomplete

### DIFF
--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -160,12 +160,77 @@ def _file_reference_completions(*, text: str, cwd: Path) -> tuple[CompletionItem
         return ()
     start, end = token
     prefix = text[start + 1 : end]
+    external_completions = _external_file_reference_completions(
+        prefix=prefix,
+        start=start,
+        end=end,
+        cwd=cwd,
+    )
+    if external_completions is not None:
+        return external_completions
+
     suggestions: list[CompletionItem] = []
     for path in _iter_file_reference_paths(cwd):
         relative = path.relative_to(cwd).as_posix()
         if prefix.lower() not in relative.lower():
             continue
         display = f"@{relative}{'/' if path.is_dir() else ''}"
+        suggestions.append(
+            CompletionItem(
+                display=display,
+                replacement=display,
+                start=start,
+                end=end,
+                description="File reference",
+            )
+        )
+        if len(suggestions) >= MAX_FILE_COMPLETIONS:
+            break
+    return tuple(suggestions)
+
+
+def _external_file_reference_completions(
+    *, prefix: str, start: int, end: int, cwd: Path
+) -> tuple[CompletionItem, ...] | None:
+    if prefix == ".." or prefix.endswith("/.."):
+        target = cwd / prefix
+        if not target.is_dir():
+            return ()
+        display = f"@{prefix}/"
+        return (
+            CompletionItem(
+                display=display,
+                replacement=display,
+                start=start,
+                end=end,
+                description="File reference",
+            ),
+        )
+
+    if not prefix.startswith("../"):
+        return None
+
+    parent_text, name_prefix = prefix.rsplit("/", 1)
+    if any(part in IGNORED_FILE_COMPLETION_DIRS for part in Path(parent_text).parts):
+        return ()
+    parent_dir = cwd / parent_text
+    if not parent_dir.is_dir():
+        return ()
+
+    try:
+        children = sorted(parent_dir.iterdir(), key=lambda path: path.name.lower())
+    except OSError:
+        return ()
+
+    suggestions: list[CompletionItem] = []
+    for child in children:
+        if child.name in IGNORED_FILE_COMPLETION_DIRS:
+            continue
+        if not child.name.lower().startswith(name_prefix.lower()):
+            continue
+        display = f"@{parent_text}/{child.name}{'/' if child.is_dir() else ''}"
+        if display == f"@{prefix}":
+            continue
         suggestions.append(
             CompletionItem(
                 display=display,

--- a/tests/test_tui_autocomplete.py
+++ b/tests/test_tui_autocomplete.py
@@ -493,6 +493,63 @@ def test_file_reference_completion_includes_dotfiles_and_dot_directories(
     }
 
 
+def test_file_reference_completion_reaches_outside_workspace_with_parent_path(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    sibling = tmp_path / "shared"
+    sibling.mkdir()
+    (sibling / "notes.md").write_text("shared notes\n", encoding="utf-8")
+
+    parent_state = build_completion_state(
+        "read @..",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=project,
+    )
+    sibling_state = build_completion_state(
+        "read @../sha",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=project,
+    )
+    file_state = build_completion_state(
+        "read @../shared/no",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=project,
+    )
+
+    assert [item.display for item in parent_state.items] == ["@../"]
+    assert [item.display for item in sibling_state.items] == ["@../shared/"]
+    assert [item.display for item in file_state.items] == ["@../shared/notes.md"]
+    assert file_state.selected is not None
+    assert file_state.selected.apply("read @../shared/no") == "read @../shared/notes.md"
+
+
+def test_external_file_reference_completion_skips_generated_directories(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "notes.md").write_text("notes\n", encoding="utf-8")
+
+    state = build_completion_state(
+        "read @../no",
+        command_registry=create_default_command_registry(),
+        skills=(),
+        prompt_templates=(),
+        cwd=project,
+    )
+
+    assert [item.display for item in state.items] == ["@../notes.md"]
+
+
 def test_file_reference_completion_works_in_custom_prompt_arguments(tmp_path: Path) -> None:
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -90,9 +90,12 @@ aliases, set a `shellCommandPrefix` — see
 ## Referencing files with `@`
 
 Type `@` in the prompt to open file suggestions from the project tree, and insert
-a path like `@src/app.py`. Dot-prefixed project content such as `.env` and
-`.agents/` is included. Tau still skips known metadata and generated directories
-such as `.git`, `.venv`, `node_modules`, `__pycache__`, `build`, and `dist`.
+a path like `@src/app.py`. Use an explicit parent-relative path such as `@../` to
+complete files and directories outside the project root. External completion
+follows only the path you type instead of scanning the surrounding filesystem.
+Dot-prefixed content such as `.env` and `.agents/` is included. Tau still skips
+known metadata and generated directories such as `.git`, `.venv`, `node_modules`,
+`__pycache__`, `build`, and `dist`.
 
 ## Dropping files into the prompt
 


### PR DESCRIPTION
## Description

Allow `@` file-reference autocomplete to follow explicit parent-relative paths such as `@../` and `@../../shared/`. External completion lists only the directory named by the prompt instead of recursively scanning outside the project.

Includes tests for parent-directory navigation and generated-directory filtering, plus updated TUI documentation.

## User experience

Users working across sibling repositories or shared parent directories can discover and insert those paths without typing them manually. Existing project-tree fuzzy completion remains unchanged.

## Issue

No linked issue.

## Manual validation

1. Start Tau from a project nested inside a directory that has sibling files or directories.
2. Type `@..` and accept the `@../` completion.
3. Continue typing a sibling path, such as `@../shared/`, and confirm its children are suggested.
4. Accept a file suggestion and confirm the parent-relative path is inserted into the prompt.
