### PR TITLE
docs: add Your Model provider catalog entry

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -18,6 +18,18 @@ thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
 thinking_default = "medium"
 thinking_parameter = "reasoning_effort"
 
+[[providers]]
+name = "yourmodel"
+display_name = "Your Model"
+kind = "openai-compatible"
+base_url = "https://y-models.com/v1"
+api_key_env = "YOURMODEL_API_KEY"
+credential_name = "yourmodel"
+models = ["gpt-5.4-mini"]
+default_model = "gpt-5.4-mini"
+docs_url = "https://docs.y-models.com/quick-start"
+api = "openai-responses"
+
 [providers.context_windows]
 gpt-4 = 8192
 gpt-4-turbo = 128000

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -54,6 +54,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
     names = [entry.name for entry in BUILTIN_PROVIDER_CATALOG]
     assert names == [
         "openai",
+        "yourmodel",
         "openai-codex",
         "anthropic",
         "google",


### PR DESCRIPTION
## Summary
- add a minimal OpenAI-compatible Your Model provider entry to Tau
- point users to the public quick-start docs and `https://y-models.com/v1`
- expose the currently validated `gpt-5.4-mini` model only

## Validation
- TOML parsed with Python `tomllib`
- `git diff --check`
- Full pytest was not run because this checkout has no pytest/uv environment available

This change was AI-assisted and reviewed against the repository contribution guide and the public Your Model quick-start documentation.