### PR TITLE
fix(catalog): add GLM-5.2 to ZAI provider

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3361,7 +3361,7 @@ kind = "openai-compatible"
 base_url = "https://api.z.ai/api/coding/paas/v4"
 api_key_env = "ZAI_API_KEY"
 credential_name = "zai"
-models = ["glm-4.5-air", "glm-4.7", "glm-5-turbo", "glm-5.1", "glm-5v-turbo"]
+models = ["glm-4.5-air", "glm-4.7", "glm-5-turbo", "glm-5.1", "glm-5.2", "glm-5v-turbo"]
 default_model = "glm-5.1"
 docs_url = "https://docs.z.ai"
 api = "openai-completions"
@@ -3374,6 +3374,7 @@ thinking_parameter = "reasoning_effort"
 "glm-4.7" = 204800
 glm-5-turbo = 200000
 "glm-5.1" = 200000
+"glm-5.2" = 1000000
 glm-5v-turbo = 200000
 
 [providers.model_metadata."glm-4.5-air"]
@@ -3408,6 +3409,15 @@ name = "GLM-5.1"
 reasoning = true
 input = ["text"]
 context_window = 200000
+max_tokens = 131072
+compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."glm-5.2"]
+name = "GLM-5.2"
+reasoning = true
+input = ["text"]
+context_window = 1000000
 max_tokens = 131072
 compat = { supportsDeveloperRole = false, thinkingFormat = "zai", zaiToolStream = true }
 cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }


### PR DESCRIPTION
## What

GLM-5.2 was missing from the ZAI provider model list, so users authenticated with a ZAI API key could not see or select it.

Closes #542.

## Root cause

The ZAI provider in `src/tau_coding/data/catalog.toml` had a hand-maintained `models` list that stopped at `glm-5.1`. GLM-5.2 (Z.ai coding plan) was never added, so it did not appear after `/login`.

Note: the catalog is static — there is no remote `/models` discovery — so new models must be added here explicitly.

## Verified model specs (from Z.ai docs)

Cross-checked against Z.ai documentation, not copied from sibling entries:

- **model id:** `glm-5.2` — confirmed to exist
- **context window:** `1,000,000` — Z.ai advertises GLM-5.2 as "supporting up to 1M context". This is a GLM-5.2-specific claim; the other GLM-5 models (e.g. `glm-5.1`) are **not** advertised as 1M, which is why they remain at `200000`.
- **max output tokens:** `131072` (128K) — matches GLM-5.1
- reasoning: `true` (supports `reasoning_effort`)
- input: `text` only (the `*-turbo` vision variant is separate)
- cost: all zero — ZAI uses a coding-plan credit model, consistent with the existing GLM-5 entries
- compat: `supportsDeveloperRole = false`, `thinkingFormat = "zai"`, `zaiToolStream = true` — same as `glm-5.1` / `glm-5-turbo` (same protocol)

## Changes

Three additions to the `zai` provider block in `src/tau_coding/data/catalog.toml`:

1. `models` list: add `"glm-5.2"` (between `glm-5.1` and `glm-5v-turbo`)
2. `context_windows`: add `"glm-5.2" = 1000000`
3. new `[providers.model_metadata."glm-5.2"]` block

`default_model` is intentionally left as `glm-5.1` — this PR only makes GLM-5.2 selectable; changing the default is a separate behavioral decision for maintainers.

## Verification

- `uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py` → **107 passed**
- Runtime smoke test: catalog loads, `glm-5.2` appears in `zai.models`, `context_windows`, and `model_metadata` with consistent values; `default_model` validation passes
- `uv run ruff check` → clean
