### PR TITLE
Improve HTML export usage charts

### DIFF
--- a/dev-notes/export-usage-event-markers.md
+++ b/dev-notes/export-usage-event-markers.md
@@ -1,0 +1,26 @@
+# Usage events in HTML session exports
+
+The HTML session export's former **Cache** tab is now **Usage**, matching its broader
+request, token, cost, tool, and compaction data.
+
+The prompt-input chart now places notable persisted session events at the next model
+request:
+
+- context compaction
+- model change
+- thinking-level change
+- branch summary
+
+Events after the final response are attached to that last request. Markers use the Tau
+theme palette, include accessible SVG labels/tooltips, switch with the page theme, and
+remain in downloaded PNG charts.
+
+## Verification
+
+```bash
+uv run pytest tests/test_session_usage.py tests/test_session_export.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -803,13 +803,13 @@ def render_session_html(
       <button
         type="button"
         class="tab"
-        id="tab-cache"
+        id="tab-usage"
         role="tab"
-        aria-controls="panel-cache"
+        aria-controls="panel-usage"
         aria-selected="false"
         tabindex="-1"
       >
-        Cache
+        Usage
       </button>
     </nav>
     <div class="filter-bar" id="filterBar" aria-label="Transcript filters">
@@ -858,9 +858,9 @@ def render_session_html(
   </main>
   <section
     class="usage-shell"
-    id="panel-cache"
+    id="panel-usage"
     role="tabpanel"
-    aria-labelledby="tab-cache"
+    aria-labelledby="tab-usage"
     hidden
   >
     {usage_html}
@@ -1012,11 +1012,11 @@ def render_session_html(
 
       var tabs = [
         document.getElementById("tab-transcript"),
-        document.getElementById("tab-cache")
+        document.getElementById("tab-usage")
       ];
       var panels = [
         document.getElementById("panel-transcript"),
-        document.getElementById("panel-cache")
+        document.getElementById("panel-usage")
       ];
       function selectTab(index, updateHash) {{
         tabs.forEach(function (tab, tabIndex) {{
@@ -1027,10 +1027,11 @@ def render_session_html(
         }});
         document.getElementById("filterBar").hidden = index !== 0;
         var currentHash = window.location.hash;
-        var tabHash = !currentHash || currentHash === "#transcript" || currentHash === "#cache";
+        var tabHash = !currentHash || currentHash === "#transcript"
+          || currentHash === "#usage" || currentHash === "#cache";
         if (updateHash && tabHash) {{
           try {{
-            window.history.replaceState(null, "", index === 1 ? "#cache" : "#transcript");
+            window.history.replaceState(null, "", index === 1 ? "#usage" : "#transcript");
           }} catch (err) {{ /* file:// pages may restrict history APIs. */ }}
         }}
       }}
@@ -1048,7 +1049,10 @@ def render_session_html(
         }});
       }});
       // Preserve transcript entry deep links. Only tab hashes select a panel.
-      selectTab(window.location.hash === "#cache" ? 1 : 0, false);
+      selectTab(
+        window.location.hash === "#usage" || window.location.hash === "#cache" ? 1 : 0,
+        false
+      );
     }})();
   </script>
   <script>{USAGE_SCRIPT}</script>

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -340,6 +340,8 @@ def _line_chart(
         description = f"{event.label} before request {event.request_number} at {event.timestamp}"
         parts.append(
             f'<g class="usage-event usage-event-{html.escape(event.kind, quote=True)}" '
+            f'data-request="{event.request_number}" '
+            f'data-event-info="{html.escape(description, quote=True)}" '
             f'role="img" aria-label="{html.escape(description, quote=True)}">'
             f"<title>{html.escape(description)}</title>"
             f'<line class="event-line" data-dark="{event_dark}" data-light="{event_light}" '
@@ -767,6 +769,10 @@ USAGE_SCRIPT = """
             var labels = (series.dataset.labels || "").split("|");
             tooltipLines.push(series.dataset.name + "  " + labels[index]);
           });
+          chart.querySelectorAll('.usage-event[data-request="' + (index + 1) + '"]')
+            .forEach(function (sessionEvent) {
+              tooltipLines.push("Event  " + sessionEvent.dataset.eventInfo);
+            });
           var x = activeSeries[0].querySelector(".hover-point").getAttribute("cx");
           var line = chart.querySelector(".hover-line");
           line.setAttribute("x1", x);

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -8,7 +8,14 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from tau_agent.messages import AssistantMessage
-from tau_agent.session import CompactionEntry, MessageEntry, SessionEntry
+from tau_agent.session import (
+    BranchSummaryEntry,
+    CompactionEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    SessionEntry,
+    ThinkingLevelChangeEntry,
+)
 from tau_coding.provider_catalog import builtin_provider_entry, model_cost_for_input_tokens
 from tau_coding.session_stats import _response_cost
 from tau_coding.tui.themes import TAU_DARK_THEME, TAU_LIGHT_THEME
@@ -16,6 +23,7 @@ from tau_coding.tui.themes import TAU_DARK_THEME, TAU_LIGHT_THEME
 __all__ = [
     "RequestUsage",
     "SessionUsage",
+    "UsageEvent",
     "USAGE_SCRIPT",
     "USAGE_STYLES",
     "collect_session_usage",
@@ -51,12 +59,23 @@ class RequestUsage:
 
 
 @dataclass(frozen=True, slots=True)
+class UsageEvent:
+    """A notable session event positioned against the next model request."""
+
+    request_number: int
+    timestamp: str
+    kind: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
 class SessionUsage:
     """Aggregated usage for the entries shown in an export."""
 
     requests: tuple[RequestUsage, ...]
     tool_calls: tuple[tuple[str, int], ...]
     compactions: int
+    events: tuple[UsageEvent, ...] = ()
 
     @property
     def total_fresh(self) -> int:
@@ -124,13 +143,19 @@ def estimated_request_cost(
 
 
 def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
-    """Collect per-request token usage, tool-call counts, and compactions."""
+    """Collect per-request token usage, tool-call counts, and notable events."""
     requests: list[RequestUsage] = []
     tools: dict[str, int] = {}
     compactions = 0
+    pending_events: list[tuple[str, str, str]] = []
+    events: list[UsageEvent] = []
     for entry in entries:
-        if isinstance(entry, CompactionEntry):
-            compactions += 1
+        event = _usage_event(entry)
+        if event is not None:
+            kind, label = event
+            pending_events.append((_entry_time(entry.timestamp), kind, label))
+            if isinstance(entry, CompactionEntry):
+                compactions += 1
             continue
         if not isinstance(entry, MessageEntry):
             continue
@@ -152,9 +177,10 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
         )
         if estimated is None and usage.cost.total > 0:
             estimated = usage.cost.total
+        request_number = len(requests) + 1
         requests.append(
             RequestUsage(
-                number=len(requests) + 1,
+                number=request_number,
                 timestamp=datetime.fromtimestamp(entry.timestamp, tz=UTC).strftime("%H:%M:%S"),
                 provider=message.provider,
                 model=message.model,
@@ -169,8 +195,50 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                 estimated_cost=estimated,
             )
         )
+        events.extend(
+            UsageEvent(
+                request_number=request_number,
+                timestamp=timestamp,
+                kind=kind,
+                label=label,
+            )
+            for timestamp, kind, label in pending_events
+        )
+        pending_events.clear()
+    if requests:
+        events.extend(
+            UsageEvent(
+                request_number=len(requests),
+                timestamp=timestamp,
+                kind=kind,
+                label=label,
+            )
+            for timestamp, kind, label in pending_events
+        )
     ordered_tools = tuple(sorted(tools.items(), key=lambda item: (-item[1], item[0])))
-    return SessionUsage(requests=tuple(requests), tool_calls=ordered_tools, compactions=compactions)
+    return SessionUsage(
+        requests=tuple(requests),
+        tool_calls=ordered_tools,
+        compactions=compactions,
+        events=tuple(events),
+    )
+
+
+def _entry_time(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=UTC).strftime("%H:%M:%S")
+
+
+def _usage_event(entry: SessionEntry) -> tuple[str, str] | None:
+    """Return chart metadata for session events that can affect prompt usage."""
+    if isinstance(entry, CompactionEntry):
+        return "compaction", "Compaction"
+    if isinstance(entry, ModelChangeEntry):
+        return "model", f"Model changed to {entry.model}"
+    if isinstance(entry, ThinkingLevelChangeEntry):
+        return "thinking", f"Thinking changed to {entry.thinking_level or 'off'}"
+    if isinstance(entry, BranchSummaryEntry):
+        return "branch", "Branch summary"
+    return None
 
 
 _SERIES_COLORS = {
@@ -185,6 +253,7 @@ _SERIES_COLORS = {
         TAU_LIGHT_THEME.role_styles["branch_summary"].border,
     ),
     "reasoning": (TAU_DARK_THEME.success, TAU_LIGHT_THEME.success),
+    "event": (TAU_DARK_THEME.markdown_bullet, TAU_LIGHT_THEME.markdown_bullet),
 }
 
 
@@ -218,6 +287,7 @@ def _line_chart(
     y_max: float | None = None,
     percent: bool = False,
     timestamps: Sequence[str] | None = None,
+    events: Sequence[UsageEvent] = (),
 ) -> str:
     """Render one interactive line chart as inline SVG."""
     width, height = 900, 330
@@ -263,6 +333,21 @@ def _line_chart(
         f'<line class="hover-line" x1="{left}" y1="{top}" x2="{left}" '
         f'y2="{top + plot_height}" visibility="hidden"/>'
     )
+    event_dark, event_light = _series_color_pair("event")
+    for event_index, event in enumerate(events):
+        x, _ = point(max(0, min(count - 1, event.request_number - 1)), 0)
+        marker_y = top + 7 + (event_index % 3) * 9
+        description = f"{event.label} before request {event.request_number} at {event.timestamp}"
+        parts.append(
+            f'<g class="usage-event usage-event-{html.escape(event.kind, quote=True)}" '
+            f'role="img" aria-label="{html.escape(description, quote=True)}">'
+            f"<title>{html.escape(description)}</title>"
+            f'<line class="event-line" data-dark="{event_dark}" data-light="{event_light}" '
+            f'x1="{x:.1f}" y1="{top}" x2="{x:.1f}" y2="{top + plot_height}" '
+            f'stroke="{event_dark}"/>'
+            f'<circle class="event-marker" data-dark="{event_dark}" data-light="{event_light}" '
+            f'cx="{x:.1f}" cy="{marker_y:.1f}" r="4" fill="{event_dark}"/></g>'
+        )
     for series_index, (name, values) in enumerate(series):
         dark, light = _series_color_pair(name)
         points = " ".join(
@@ -352,6 +437,7 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
             "Prompt input by request",
             [("cached", cached), ("cache writes", cache_writes), ("fresh", fresh)],
             timestamps=timestamps,
+            events=usage.events,
         )
     ]
     if cache_hit_rate is not None:
@@ -399,7 +485,8 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
         '<p class="usage-note">Costs use Tau\'s provider catalog rates. OAuth subscription '
         "estimates are API-rate equivalents, not actual subscription charges. Hover a request "
         "for exact values, select a legend item to hide a series, and use PNG to save a "
-        "chart.</p>"
+        "chart. Event markers show compactions, model or thinking changes, and branch summaries."
+        "</p>"
         f'<div class="usage-charts">{charts_html}</div>'
         '<div class="usage-details">'
         '<div class="usage-panel"><h2>Requests</h2><div class="usage-table-wrap"><table>'
@@ -514,6 +601,9 @@ USAGE_STYLES = """
       stroke-dasharray: 3 4;
       pointer-events: none;
     }
+    .event-line { stroke-width: 1.5; stroke-dasharray: 5 4; opacity: .8; }
+    .event-marker { stroke: var(--surface); stroke-width: 2; }
+    .usage-event:hover .event-line, .usage-event:hover .event-marker { opacity: 1; }
     .hover-point { stroke: var(--surface); stroke-width: 2; pointer-events: none; }
     .series { transition: opacity .15s ease; }
     .series.is-hidden { opacity: .07; pointer-events: none; }
@@ -616,7 +706,8 @@ USAGE_SCRIPT = """
           var colored = chart.querySelectorAll("[data-dark][data-light]");
           Array.prototype.forEach.call(colored, function (node) {
             var color = dark ? node.dataset.dark : node.dataset.light;
-            if (node.tagName.toLowerCase() === "polyline") {
+            var tagName = node.tagName.toLowerCase();
+            if (tagName === "polyline" || tagName === "line") {
               node.setAttribute("stroke", color);
             } else {
               node.setAttribute("fill", color);
@@ -751,7 +842,8 @@ USAGE_SCRIPT = """
           node.remove();
         });
         clone.querySelectorAll("[data-light]").forEach(function (node) {
-          if (node.tagName.toLowerCase() === "polyline") {
+          var tagName = node.tagName.toLowerCase();
+          if (tagName === "polyline" || tagName === "line") {
             node.setAttribute("stroke", node.dataset.light);
           } else {
             node.setAttribute("fill", node.dataset.light);

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -296,17 +296,17 @@ def test_render_session_html_includes_usage_tab() -> None:
 
     html = render_session_html(entries, title="Usage Export")
 
-    assert 'id="panel-cache"' in html
+    assert 'id="panel-usage"' in html
     assert 'class="usage-chart"' in html
     assert 'class="png-button"' in html
     assert "Cache hit rate" in html
     assert "Estimated cost" in html
     # Tabs use focusable buttons and implement the ARIA keyboard interaction.
-    assert '<button\n        type="button"\n        class="tab"\n        id="tab-cache"' in html
+    assert '<button\n        type="button"\n        class="tab"\n        id="tab-usage"' in html
     assert 'event.key !== "ArrowLeft" && event.key !== "ArrowRight"' in html
     assert "tabs[next].focus()" in html
-    assert 'currentHash === "#transcript" || currentHash === "#cache"' in html
-    assert 'selectTab(window.location.hash === "#cache" ? 1 : 0, false)' in html
+    assert 'currentHash === "#usage" || currentHash === "#cache"' in html
+    assert 'window.location.hash === "#usage" || window.location.hash === "#cache"' in html
 
 
 def test_render_session_html_uses_tau_theme_palette() -> None:
@@ -326,7 +326,7 @@ def test_render_session_html_uses_tau_theme_palette() -> None:
     assert f"--bg: {TAU_LIGHT_THEME.screen_background}" in html
     assert f"--bg: {TAU_DARK_THEME.screen_background}" in html
     assert ":root.theme-dark" in html
-    assert 'id="tab-cache"' in html
+    assert 'id="tab-usage"' in html
     assert "tau-themechange" in html
     assert f'data-dark="{TAU_DARK_THEME.error}"' in html
     assert f'data-light="{TAU_LIGHT_THEME.error}"' in html

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -9,7 +9,7 @@ from tau_agent import (
     UserMessage,
 )
 from tau_agent.messages import Usage, UsageCost, assistant_content
-from tau_coding.session_usage import collect_session_usage, render_usage_dashboard
+from tau_coding.session_usage import USAGE_SCRIPT, collect_session_usage, render_usage_dashboard
 
 
 def _assistant(
@@ -149,6 +149,9 @@ def test_render_usage_dashboard_marks_events_on_prompt_input_chart() -> None:
     assert 'class="usage-event usage-event-compaction"' in markup
     assert "Model changed to claude-sonnet-4-5 before request 1" in markup
     assert "Compaction before request 2" in markup
+    assert 'data-request="1"' in markup
+    assert 'data-event-info="Model changed to claude-sonnet-4-5 before request 1' in markup
+    assert 'tooltipLines.push("Event  " + sessionEvent.dataset.eventInfo)' in USAGE_SCRIPT
     assert markup.count('class="event-line"') == 2
 
 

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -1,4 +1,13 @@
-from tau_agent import AssistantMessage, CompactionEntry, MessageEntry, ToolCall, UserMessage
+from tau_agent import (
+    AssistantMessage,
+    BranchSummaryEntry,
+    CompactionEntry,
+    MessageEntry,
+    ModelChangeEntry,
+    ThinkingLevelChangeEntry,
+    ToolCall,
+    UserMessage,
+)
 from tau_agent.messages import Usage, UsageCost, assistant_content
 from tau_coding.session_usage import collect_session_usage, render_usage_dashboard
 
@@ -50,6 +59,31 @@ def test_collect_session_usage_aggregates_requests_tools_and_compactions() -> No
     assert usage.hit_rate == 2850 / 3050
 
 
+def test_collect_session_usage_positions_notable_events_at_next_request() -> None:
+    entries = [
+        ModelChangeEntry(id="model", timestamp=1, model="claude-sonnet-4-5"),
+        _assistant("a1", usage=Usage(input=10)),
+        CompactionEntry(
+            id="compact",
+            timestamp=2,
+            summary="summary",
+            replaces_entry_ids=["a1"],
+        ),
+        ThinkingLevelChangeEntry(id="thinking", timestamp=3, thinking_level="high"),
+        _assistant("a2", usage=Usage(input=20)),
+        BranchSummaryEntry(id="branch", timestamp=4, summary="abandoned path"),
+    ]
+
+    usage = collect_session_usage(entries)
+
+    assert [(event.request_number, event.kind, event.label) for event in usage.events] == [
+        (1, "model", "Model changed to claude-sonnet-4-5"),
+        (2, "compaction", "Compaction"),
+        (2, "thinking", "Thinking changed to high"),
+        (2, "branch", "Branch summary"),
+    ]
+
+
 def test_collect_session_usage_estimates_cost_from_catalog() -> None:
     known = collect_session_usage([_assistant("a1", usage=Usage(input=1_000_000, output=0))])
     unknown = collect_session_usage(
@@ -91,6 +125,31 @@ def test_render_usage_dashboard_renders_charts_and_table() -> None:
     assert "Prompt input by request" in markup
     assert "Cache hit rate" in markup
     assert "claude-sonnet-4-5" in markup
+
+
+def test_render_usage_dashboard_marks_events_on_prompt_input_chart() -> None:
+    usage = collect_session_usage(
+        [
+            ModelChangeEntry(id="model", timestamp=1, model="claude-sonnet-4-5"),
+            _assistant("a1", usage=Usage(input=10, cache_read=90)),
+            CompactionEntry(
+                id="compact",
+                timestamp=2,
+                summary="summary",
+                replaces_entry_ids=["a1"],
+            ),
+            _assistant("a2", usage=Usage(input=20, cache_read=80)),
+        ]
+    )
+
+    markup = render_usage_dashboard(usage)
+
+    assert markup.count('class="usage-event ') == 2
+    assert 'class="usage-event usage-event-model"' in markup
+    assert 'class="usage-event usage-event-compaction"' in markup
+    assert "Model changed to claude-sonnet-4-5 before request 1" in markup
+    assert "Compaction before request 2" in markup
+    assert markup.count('class="event-line"') == 2
 
 
 def test_render_usage_dashboard_without_cache_activity_shows_na() -> None:

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -34,6 +34,9 @@ command palette with **Ctrl+K**.
 creates HTML. Review it before sharing because it may expose project
 instructions or other local context. JSONL exports do not include the prompt.
 Offline `tau export` from stored JSONL cannot recover it and omits the section.
+The HTML export's **Usage** view charts token and cache activity. Its prompt-input
+chart marks compactions, model and thinking-level changes, and branch summaries
+against the next model request so cache changes have session context.
 {{% /note %}}
 
 {{% note title="`/skill:` is special" %}}


### PR DESCRIPTION
## Summary

- rename the HTML session export's Cache tab to Usage
- annotate prompt-input charts with compaction, model, thinking-level, and branch-summary events
- include event details in the chart hover tooltip and preserve legacy `#cache` links
- document and test the updated export behavior

## User experience

Usage changes and cache misses can now be correlated with important session events directly in exported charts. Hovering a request shows event details alongside token-series values.

## Validation

- `uv run pytest` (1471 passed, 2 Windows-only skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
