### PR TITLE
Edit custom prompts from the prompts picker

### DIFF
--- a/dev-notes/design/edit-prompts-modal.md
+++ b/dev-notes/design/edit-prompts-modal.md
@@ -1,0 +1,24 @@
+# Edit prompt templates from `/prompts`
+
+## What changed
+
+The `/prompts` picker now offers **Ctrl+E** for the highlighted template. Tau opens the complete Markdown source in a Textual `TextArea`; **Ctrl+S** writes it back to the template's existing path and reloads session resources. **Escape** returns without saving.
+
+## Why
+
+Previously the picker could only insert `/name` into the composer. Updating a template required leaving Tau, locating its winning user- or project-level file, editing it externally, then running `/reload`. In-modal editing keeps this maintenance flow inside the active session and makes the new content available immediately.
+
+## Architecture
+
+The feature stays in `tau_coding.tui`, Textual's adapter layer. `PromptTemplate` continues to represent discovered resources, and `CodingSession.reload()` remains the single path that republishes resource state after a file change. No Textual dependency enters `tau_agent`.
+
+The editor loads and saves the full Markdown source rather than only parsed prompt content, preserving editable frontmatter such as `description`. Read, write, and reload failures are shown as TUI notifications.
+
+## Validation
+
+Automated pilot coverage opens `/prompts`, invokes **Ctrl+E**, edits and saves a temporary template, and verifies both the file content and resource reload. Manual validation:
+
+1. Create `~/.agents/prompts/example.md`.
+2. Start Tau and run `/prompts`.
+3. Highlight `/example`, press **Ctrl+E**, change the Markdown, and press **Ctrl+S**.
+4. Confirm the picker returns and `/example` uses the updated template without a manual `/reload`.

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5039,6 +5039,9 @@ class TauTuiApp(App[None]):
 
     def action_completion_next(self) -> None:
         """Select the next prompt completion or move down in the prompt."""
+        if isinstance(self.screen, PromptTemplateEditorScreen):
+            self.screen.query_one("#prompt-template-editor-input", TextArea).action_cursor_down()
+            return
         if isinstance(self.screen, CommandOutputScreen):
             self.screen.action_scroll_down()
             return
@@ -5067,6 +5070,9 @@ class TauTuiApp(App[None]):
 
     def action_completion_previous(self) -> None:
         """Select the previous prompt completion or move up in the prompt."""
+        if isinstance(self.screen, PromptTemplateEditorScreen):
+            self.screen.query_one("#prompt-template-editor-input", TextArea).action_cursor_up()
+            return
         if isinstance(self.screen, CommandOutputScreen):
             self.screen.action_scroll_up()
             return

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -1197,7 +1197,15 @@ class SessionPickerSearchInput(Input):
         self._picker().action_cancel()
 
 
-class PromptTemplatePickerScreen(ModalScreen[str | None]):
+@dataclass(frozen=True, slots=True)
+class PromptTemplatePickerResult:
+    """Action selected from the prompt-template picker."""
+
+    action: Literal["insert", "edit"]
+    template: PromptTemplate
+
+
+class PromptTemplatePickerScreen(ModalScreen[PromptTemplatePickerResult | None]):
     """Searchable picker for loaded prompt templates."""
 
     BINDINGS: ClassVar[list[BindingEntry]] = [
@@ -1205,6 +1213,7 @@ class PromptTemplatePickerScreen(ModalScreen[str | None]):
         Binding("up", "cursor_up", "Up", show=False),
         Binding("down", "cursor_down", "Down", show=False),
         Binding("enter", "select_cursor", "Select", show=False),
+        Binding("ctrl+e", "edit_cursor", "Edit", show=False, priority=True),
     ]
 
     def __init__(self, templates: Sequence[PromptTemplate]) -> None:
@@ -1253,12 +1262,25 @@ class PromptTemplatePickerScreen(ModalScreen[str | None]):
         self.query_one("#prompt-template-picker-list", ListView).action_cursor_down()
 
     def action_select_cursor(self) -> None:
-        picker_list = self.query_one("#prompt-template-picker-list", ListView)
-        if self.visible_templates and picker_list.index is not None:
-            self.dismiss(self.visible_templates[picker_list.index].name)
+        template = self._selected_template()
+        if template is not None:
+            self.dismiss(PromptTemplatePickerResult(action="insert", template=template))
+
+    def action_edit_cursor(self) -> None:
+        """Open the selected template in Tau's prompt editor."""
+        template = self._selected_template()
+        if template is not None:
+            self.dismiss(PromptTemplatePickerResult(action="edit", template=template))
 
     def action_cancel(self) -> None:
         self.dismiss(None)
+
+    def _selected_template(self) -> PromptTemplate | None:
+        picker_list = self.query_one("#prompt-template-picker-list", ListView)
+        index = picker_list.index
+        if index is None or index >= len(self.visible_templates):
+            return None
+        return self.visible_templates[index]
 
     def _refresh_list(self) -> None:
         picker_list = self.query_one("#prompt-template-picker-list", ListView)
@@ -1274,12 +1296,46 @@ class PromptTemplatePickerScreen(ModalScreen[str | None]):
         )
         picker_list.index = 0 if self.visible_templates else None
         if self.visible_templates:
-            help_text = "Enter selects - Escape closes"
+            help_text = "Enter inserts - Ctrl+E edits - Escape closes"
         elif self.templates:
             help_text = "No matching prompt templates - Escape closes"
         else:
             help_text = "No prompt templates loaded - Escape closes"
         self.query_one("#prompt-template-picker-help", Static).update(help_text)
+
+
+class PromptTemplateEditorScreen(ModalScreen[str | None]):
+    """Edit one prompt-template Markdown file inside the TUI."""
+
+    BINDINGS: ClassVar[list[BindingEntry]] = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+s", "save", "Save", show=False, priority=True),
+    ]
+
+    def __init__(self, template: PromptTemplate, source: str) -> None:
+        super().__init__()
+        self.template = template
+        self.source = source
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="prompt-template-editor"):
+            yield Static(f"Edit /{self.template.name}", id="prompt-template-editor-title")
+            yield Static(str(self.template.path), id="prompt-template-editor-path")
+            yield TextArea(self.source, id="prompt-template-editor-input")
+            yield Static(
+                "Ctrl+S saves - Escape returns without saving",
+                id="prompt-template-editor-help",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#prompt-template-editor-input", TextArea).focus()
+
+    def action_save(self) -> None:
+        source = self.query_one("#prompt-template-editor-input", TextArea).text
+        self.dismiss(source)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
 
 class SessionPickerScreen(ModalScreen[str | None]):
@@ -3047,6 +3103,7 @@ class TauTuiApp(App[None]):
 
     SessionPickerScreen,
     PromptTemplatePickerScreen,
+    PromptTemplateEditorScreen,
     SkillPickerScreen,
     TreePickerScreen,
     ToolsReferenceScreen,
@@ -3056,6 +3113,7 @@ class TauTuiApp(App[None]):
 
     #session-picker,
     #prompt-template-picker,
+    #prompt-template-editor,
     #skill-picker,
     #tree-picker,
     #tools-reference {
@@ -3070,6 +3128,7 @@ class TauTuiApp(App[None]):
 
     #session-picker-title,
     #prompt-template-picker-title,
+    #prompt-template-editor-title,
     #skill-picker-title,
     #tree-picker-title,
     #tools-reference-title {
@@ -3094,6 +3153,23 @@ class TauTuiApp(App[None]):
         height: 1;
         color: $tau-muted-text;
         text-style: bold;
+    }
+
+    #prompt-template-editor {
+        height: 80%;
+    }
+
+    #prompt-template-editor-path {
+        height: 1;
+        margin-bottom: 1;
+        color: $tau-muted-text;
+    }
+
+    #prompt-template-editor-input {
+        height: 1fr;
+        background: $tau-prompt-background;
+        color: $tau-prompt-text;
+        border: tall $tau-prompt-border;
     }
 
     #session-picker-list,
@@ -3137,6 +3213,7 @@ class TauTuiApp(App[None]):
 
     #session-picker-help,
     #prompt-template-picker-help,
+    #prompt-template-editor-help,
     #skill-picker-help,
     #tree-picker-help,
     #tools-reference-help {
@@ -5101,16 +5178,60 @@ class TauTuiApp(App[None]):
             callback=self._handle_prompt_template_picker_result,
         )
 
-    def _handle_prompt_template_picker_result(self, name: str | None) -> None:
+    def _handle_prompt_template_picker_result(
+        self, result: PromptTemplatePickerResult | None
+    ) -> None:
         prompt = self.query_one("#prompt", PromptInput)
         prompt.focus()
-        if name is None:
+        if result is None:
             return
-        invocation = f"/{name}"
+        if result.action == "edit":
+            try:
+                source = result.template.path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                self._notify(f"Could not read /{result.template.name}: {exc}", severity="error")
+                self._open_prompt_template_picker()
+                return
+            self.push_screen(
+                PromptTemplateEditorScreen(result.template, source),
+                callback=lambda edited: self._handle_prompt_template_edit(result.template, edited),
+            )
+            return
+        invocation = f"/{result.template.name}"
         prompt.text = invocation
         prompt.move_cursor(_text_end_location(invocation))
         self._completion_state = self._build_completion_state(invocation)
         self._refresh_completions()
+
+    def _handle_prompt_template_edit(self, template: PromptTemplate, source: str | None) -> None:
+        if source is None:
+            self._open_prompt_template_picker()
+            return
+        self.run_worker(self._save_prompt_template_edit(template, source), exclusive=False)
+
+    async def _save_prompt_template_edit(self, template: PromptTemplate, source: str) -> None:
+        try:
+            template.path.write_text(source, encoding="utf-8")
+        except OSError as exc:
+            self._notify(f"Could not save /{template.name}: {exc}", severity="error")
+            self._open_prompt_template_picker()
+            return
+
+        try:
+            reload_result = self.session.reload()
+            if isawaitable(reload_result):
+                await reload_result
+        except Exception as exc:  # noqa: BLE001 - saved file remains valid; surface reload errors
+            self._notify(
+                f"Saved /{template.name}, but could not reload resources: {exc}",
+                severity="error",
+            )
+        else:
+            self.state.set_skills(self.session.skills)
+            self._completion_state = self._build_completion_state("")
+            self._refresh()
+            self._notify(f"Saved /{template.name} and reloaded resources.")
+        self._open_prompt_template_picker()
 
     def _open_skills_picker(self) -> None:
         """Open loaded-skill discovery."""

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -90,6 +90,7 @@ from tau_coding.tui.app import (
     ModelPickerScreen,
     OAuthLoginScreen,
     PromptInput,
+    PromptTemplateEditorScreen,
     PromptTemplatePickerScreen,
     SessionPickerScreen,
     SkillPickerScreen,
@@ -4704,6 +4705,50 @@ async def test_tui_app_prompts_picker_filters_and_inserts_without_submitting() -
         assert prompt.value == "/test"
         assert prompt.has_focus
         assert app.state.items == []
+
+
+@pytest.mark.anyio
+async def test_tui_app_prompts_picker_edits_template_and_reloads(tmp_path: Path) -> None:
+    template_path = tmp_path / "review.md"
+    template_path.write_text("Original prompt.\n", encoding="utf-8")
+    session = FakeSession()
+    session.prompt_templates = (
+        PromptTemplate(
+            name="review",
+            path=template_path,
+            content="Original prompt.",
+            description="Inspect changes",
+        ),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/prompts"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        picker = app.screen
+        assert isinstance(picker, PromptTemplatePickerScreen)
+        assert "Ctrl+E edits" in str(
+            picker.query_one("#prompt-template-picker-help", Static).content
+        )
+        await pilot.press("ctrl+e")
+        await pilot.pause()
+
+        editor = app.screen
+        assert isinstance(editor, PromptTemplateEditorScreen)
+        assert editor.query_one("#prompt-template-editor-input", TextArea).text == (
+            "Original prompt.\n"
+        )
+        editor.query_one("#prompt-template-editor-input", TextArea).text = "Updated prompt.\n"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+        assert template_path.read_text(encoding="utf-8") == "Updated prompt.\n"
+        assert session.reload_count == 1
+        assert isinstance(app.screen, PromptTemplatePickerScreen)
+        assert prompt.value == ""
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4738,10 +4738,20 @@ async def test_tui_app_prompts_picker_edits_template_and_reloads(tmp_path: Path)
 
         editor = app.screen
         assert isinstance(editor, PromptTemplateEditorScreen)
-        assert editor.query_one("#prompt-template-editor-input", TextArea).text == (
-            "Original prompt.\n"
-        )
-        editor.query_one("#prompt-template-editor-input", TextArea).text = "Updated prompt.\n"
+        editor_input = editor.query_one("#prompt-template-editor-input", TextArea)
+        assert editor_input.text == "Original prompt.\n"
+        editor_input.text = "first\nsecond"
+        editor_input.move_cursor((0, 0))
+        await pilot.press("right")
+        assert editor_input.cursor_location == (0, 1)
+        await pilot.press("down")
+        assert editor_input.cursor_location == (1, 1)
+        await pilot.press("left")
+        assert editor_input.cursor_location == (1, 0)
+        await pilot.press("up")
+        assert editor_input.cursor_location == (0, 0)
+
+        editor_input.text = "Updated prompt.\n"
         await pilot.press("ctrl+s")
         await pilot.pause()
 

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -100,8 +100,9 @@ inline or multiline request into your prompt, then runs it as a normal turn.
 
 A prompt template is a saved prompt you trigger by its filename. For example,
 `~/.agents/prompts/wt.md` is invoked with `/wt`. Run `/prompts` in the TUI to
-search every loaded template and insert its invocation for editing; selection
-does not submit the prompt. The filenames `prompts.md` and `tools.md` are
+search every loaded template. Press **Enter** to insert its invocation without
+submitting it, or **Ctrl+E** to edit its Markdown directly. Save with **Ctrl+S**;
+Tau reloads resources automatically. The filenames `prompts.md` and `tools.md` are
 reserved for built-in commands; Tau ignores templates with those names and
 reports a resource diagnostic. Templates can include variables with `{{ name }}`:
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -59,7 +59,7 @@ to search and run them. Common ones:
 - `/tools` — search active tools by origin and open their full descriptions
 - `/compact` — summarize and shrink the context
 - `/resume`, `/tree` — open previous sessions or branch from history
-- `/prompts` — search prompt templates and insert one for editing
+- `/prompts` — search prompt templates, insert an invocation, or edit the template file with **Ctrl+E**
 - `/hotkeys` — show the keyboard shortcuts
 
 The full list is in the [Slash commands reference]({{< relref "../reference/slash-commands.md" >}}).

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -26,6 +26,8 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 | `Ctrl+R` | Open the session picker |
 | `Tab` | Accept the highlighted completion |
 | `Down` / `Up` | Move through completions |
+| `Ctrl+E` (in `/prompts`) | Edit the selected prompt template |
+| `Ctrl+S` (while editing a prompt template) | Save and reload resources |
 
 ## Models & thinking
 

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -24,7 +24,7 @@ command palette with **Ctrl+K**.
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
-| `/prompts` | Search loaded prompt templates and insert an invocation for editing |
+| `/prompts` | Search loaded prompt templates; press Enter to insert an invocation or Ctrl+E to edit the file |
 | `/hotkeys` | Show the keyboard shortcuts |
 | `/skills` | Open a searchable picker of loaded skills and insert a selection into the prompt |
 | `/skill:<name> [request]` | Expand a loaded skill into your prompt |
@@ -54,4 +54,4 @@ Related:
 
 - **Thinking mode** is keyboard-driven, not a slash command — see
   [Keyboard shortcuts]({{< relref "./keybindings.md" >}}) and [Managing context]({{< relref "../guides/context.md#thinking-modes" >}}).
-- **Prompt templates** use slash invocations (for example, `/wt …`). Use `/prompts` to search loaded templates and insert an invocation without submitting it.
+- **Prompt templates** use slash invocations (for example, `/wt …`). Use `/prompts` to search loaded templates, insert an invocation without submitting it, or edit a selected template with **Ctrl+E**.


### PR DESCRIPTION
## Description

Add an in-TUI Markdown editor for loaded custom prompt templates. From `/prompts`, `Ctrl+E` opens the selected template; `Ctrl+S` saves it and reloads session resources automatically.

Includes Textual pilot coverage plus user and contributor documentation.

## User experience

Users no longer need to leave Tau, locate the winning prompt file, edit it externally, and run `/reload`. Prompt maintenance now stays in the active session while preserving the full Markdown source and frontmatter.

## Issue

No linked issue.

## Manual validation

1. Create `~/.agents/prompts/example.md`.
2. Start Tau and run `/prompts`.
3. Highlight `/example` and press `Ctrl+E`.
4. Edit the Markdown and press `Ctrl+S`.
5. Confirm the picker reopens and `/example` uses the updated content without manually running `/reload`.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` (from `website/`)
