### PR TITLE
Prepare Tau 0.3.10 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.9"
+version = "0.3.10"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.3.10",
+    "date": "2026-08-15",
+    "sections": {
+      "New": [
+        "Edit custom prompt templates directly from the prompts picker with Ctrl+E, then save and reload them with Ctrl+S."
+      ],
+      "Changed": [
+        "Autocomplete explicit parent-relative file references while limiting external completion to the requested directory.",
+        "Rename the HTML session export Cache tab to Usage and annotate prompt-input charts with session events and tooltip details.",
+        "Move Hugging Face route controls out of Tau core and expose route inspection and selection through the public extension API."
+      ]
+    }
+  },
+  {
     "version": "0.3.9",
     "date": "2026-08-11",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -674,7 +674,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.9" in console.export_text()
+    assert "τ = 2π  0.3.10" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

Prepare the Tau 0.3.10 patch release.

- bump package and lockfile versions to `0.3.10`
- add bundled startup and website release notes
- update the version-sensitive TUI test

## Release highlights

- edit custom prompt templates directly from the prompts picker
- autocomplete explicit parent-relative file references
- annotate HTML export usage charts with session events
- move Hugging Face route controls from core to the public extension API

## Checks

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` (1473 passed, 2 Windows-only skipped)
- `uv build`
- `cd website && hugo --minify`
