### PR TITLE
Support session resume in print mode

### DIFF
--- a/dev-notes/print-mode-session-resume.md
+++ b/dev-notes/print-mode-session-resume.md
@@ -1,0 +1,32 @@
+# Non-interactive session resume
+
+Tau print mode can now continue an indexed conversation:
+
+```bash
+tau --print --session <session-id> "Follow-up message"
+```
+
+## Design
+
+The CLI keeps orchestration in `tau_coding`. `SessionManager` resolves the
+indexed record, then print mode opens its append-only JSONL transcript and loads
+it through `CodingSession`. The reusable `tau_agent` layer remains unaware of CLI
+flags and Tau's home-directory layout.
+
+A resumed run uses the record's cwd, model, provider, inference-provider routing,
+and active conversation branch. Explicit `--provider` or `--model` options still
+override saved selection for that run. New print sessions retain exclusive file
+creation; resume never creates a missing id.
+
+`--session` is mutually exclusive with `--new-session` and `--session-id` because
+those options request new transcripts. Output remains unchanged across text,
+JSON, and transcript modes.
+
+## Testing
+
+```bash
+uv run pytest tests/test_cli.py
+```
+
+Tests cover CLI forwarding and conflicts, existing/unknown record lookup, and
+provider history for a resumed follow-up.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -217,7 +217,7 @@ def main(
     ] = None,
     session: Annotated[
         str | None,
-        typer.Option("--session", help="Resume a session id in TUI mode."),
+        typer.Option("--session", help="Resume a session id in TUI or print mode."),
     ] = None,
     resume: Annotated[
         str | None,
@@ -333,6 +333,8 @@ def main(
 
     if session is not None and new_session:
         raise typer.BadParameter("--session and --new-session cannot be used together")
+    if session is not None and session_id is not None:
+        raise typer.BadParameter("--session and --session-id cannot be used together")
 
     if prompt_option is not None:
         raise typer.BadParameter(
@@ -461,11 +463,14 @@ def main(
             custom_system_prompt,
             resolved_append_system_prompt,
         )
-        ok = (
-            anyio.run(run_openai_print_mode, *print_args)
-            if trust_override is None
-            else anyio.run(run_openai_print_mode, *print_args, trust_override)
-        )
+        if session is not None:
+            ok = anyio.run(run_openai_print_mode, *print_args, trust_override, session)
+        else:
+            ok = (
+                anyio.run(run_openai_print_mode, *print_args)
+                if trust_override is None
+                else anyio.run(run_openai_print_mode, *print_args, trust_override)
+            )
     except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
     if not ok:
@@ -766,13 +771,31 @@ async def run_openai_print_mode(
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
+    resume_session_id: str | None = None,
 ) -> bool:
-    """Run print mode with the OpenAI-compatible provider configured from the environment."""
+    """Run a new or resumed print-mode turn using the configured provider."""
     settings = load_provider_settings()
     shell_settings = load_shell_settings()
-    selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
+    manager = session_manager or SessionManager()
+    record = _print_session_record(
+        manager,
+        resume_session_id=resume_session_id,
+        cwd=cwd,
+        settings=settings,
+        provider_name=provider_name,
+        model=model,
+        session_id=session_id,
+    )
+    explicit_selection = provider_name is not None or model is not None
+    selection = resolve_provider_selection(
+        settings,
+        provider_name=provider_name if explicit_selection else record.provider_name,
+        model=model if explicit_selection else record.model,
+    )
     inference_provider = (
-        selection.provider.inference_providers.get(selection.model)
+        record.inference_provider
+        if resume_session_id is not None and record.model == selection.model
+        else selection.provider.inference_providers.get(selection.model)
         if isinstance(selection.provider, OpenAICompatibleProviderConfig)
         and selection.provider.name == "huggingface"
         else None
@@ -784,15 +807,6 @@ async def run_openai_print_mode(
         thinking_level=resolve_startup_thinking_level(selection.provider, selection.model),
     )
     try:
-        manager = session_manager or SessionManager()
-        record = _create_print_session(
-            manager,
-            cwd=cwd,
-            model=selection.model,
-            provider_name=selection.provider.name,
-            inference_provider=inference_provider,
-            session_id=session_id,
-        )
         return await run_print_mode(
             prompt=prompt,
             model=selection.model,
@@ -817,6 +831,40 @@ async def run_openai_print_mode(
         )
     finally:
         await provider.aclose()
+
+
+def _print_session_record(
+    manager: SessionManager,
+    *,
+    resume_session_id: str | None,
+    cwd: Path,
+    settings: ProviderSettings,
+    provider_name: str | None,
+    model: str | None,
+    session_id: str | None,
+) -> CodingSessionRecord:
+    """Resolve a resumed transcript or exclusively create a new one."""
+    if resume_session_id is not None:
+        record = manager.get_session(resume_session_id)
+        if record is None:
+            raise ValueError(f"Unknown session: {resume_session_id}")
+        return record
+
+    selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
+    inference_provider = (
+        selection.provider.inference_providers.get(selection.model)
+        if isinstance(selection.provider, OpenAICompatibleProviderConfig)
+        and selection.provider.name == "huggingface"
+        else None
+    )
+    return _create_print_session(
+        manager,
+        cwd=cwd,
+        model=selection.model,
+        provider_name=selection.provider.name,
+        inference_provider=inference_provider,
+        session_id=session_id,
+    )
 
 
 def _create_print_session(

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -794,7 +794,10 @@ async def run_openai_print_mode(
     )
     inference_provider = (
         record.inference_provider
-        if resume_session_id is not None and record.model == selection.model
+        if resume_session_id is not None
+        and record.provider_name == "huggingface"
+        and selection.provider.name == "huggingface"
+        and record.model == selection.model
         else selection.provider.inference_providers.get(selection.model)
         if isinstance(selection.provider, OpenAICompatibleProviderConfig)
         and selection.provider.name == "huggingface"

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -828,6 +828,7 @@ async def run_openai_print_mode(
             append_system_prompt=append_system_prompt,
             trust_override=trust_override,
             trust_default=shell_settings.default_project_trust,
+            startup_model_override=provider_name is not None or model is not None,
         )
     finally:
         await provider.aclose()
@@ -909,6 +910,7 @@ async def run_print_mode(
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
     trust_default: TrustDefault = "ask",
+    startup_model_override: bool = False,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -938,6 +940,8 @@ async def run_print_mode(
             trust_default=trust_default,
         )
     )
+    if startup_model_override:
+        await session.apply_startup_model_override(model)
     session.extension_runtime.set_ui_bridge(StderrUiBridge())
     for diagnostic in session.resource_diagnostics:
         if diagnostic.kind == "project-trust":

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1080,6 +1080,7 @@ class CodingSession:
         self._harness.config.model = model
         self._inference_provider = _configured_inference_provider(provider, model)
         self._sync_thinking_level_to_active_model()
+        self._refresh_runtime_provider()
         self._sync_image_support()
         entry = ModelChangeEntry(parent_id=self._last_parent_id, model=model)
         await self._append_session_entry(entry)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1069,6 +1069,25 @@ class CodingSession:
                 preserve_inference_provider=False,
             )
 
+    async def apply_startup_model_override(self, model: str) -> None:
+        """Activate and persist an explicit startup model before the next turn."""
+        provider = self._active_provider_config()
+        if provider is not None:
+            validate_provider_model(provider, model)
+        if self.model == model:
+            return
+
+        self._harness.config.model = model
+        self._inference_provider = _configured_inference_provider(provider, model)
+        self._sync_thinking_level_to_active_model()
+        self._sync_image_support()
+        entry = ModelChangeEntry(parent_id=self._last_parent_id, model=model)
+        await self._append_session_entry(entry)
+        leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
+        await self._append_session_entry(leaf)
+        self._last_parent_id = entry.id
+        await self._refresh_persisted_state(leaf_id=entry.id)
+
     def set_inference_provider(self, route: str | None) -> str:
         """Select or reset the active Hugging Face session route."""
         if self.provider_name != "huggingface":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 from conftest import isolate_home
 from pi_event_helpers import assistant_done, assistant_error, assistant_start, text_delta
 from tau_agent import AssistantMessage, UserMessage
-from tau_agent.session import JsonlSessionStorage, MessageEntry
+from tau_agent.session import JsonlSessionStorage, MessageEntry, ModelChangeEntry
 from tau_ai import (
     FakeProvider,
 )
@@ -797,21 +797,29 @@ async def test_run_print_mode_resumes_persisted_conversation(
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     await storage.append(MessageEntry(message=UserMessage(content="First question")))
     await storage.append(MessageEntry(message=AssistantMessage(content="First answer")))
+    await storage.append(ModelChangeEntry(model="model-a"))
     provider = FakeProvider(
-        [[assistant_start(model="fake"), assistant_done(message=AssistantMessage(content="Done"))]]
+        [
+            [
+                assistant_start(model="model-b"),
+                assistant_done(message=AssistantMessage(content="Done")),
+            ]
+        ]
     )
 
     ok = await run_print_mode(
         prompt="Follow-up message",
-        model="fake",
+        model="model-b",
         cwd=tmp_path,
         provider=provider,
         storage=storage,
         session_id="session-123",
+        startup_model_override=True,
     )
 
     assert ok is True
     assert capsys.readouterr().out == "Done\n"
+    assert provider.calls[0][0] == "model-b"
     messages = provider.calls[0][2]
     assert [(message.role, message.text) for message in messages] == [
         ("user", "First question"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1149,6 +1149,76 @@ def test_print_session_record_rejects_unknown_session(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.anyio
+async def test_print_resume_does_not_apply_hf_route_to_explicit_non_hf_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model = "shared-model"
+    settings = ProviderSettings(
+        default_provider="huggingface",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="huggingface",
+                models=(model,),
+                default_model=model,
+                inference_providers={model: "together"},
+            ),
+            OpenAICompatibleProviderConfig(
+                name="local",
+                base_url="http://localhost:11434/v1",
+                api_key_env="LOCAL_API_KEY",
+                models=(model,),
+                default_model=model,
+            ),
+        ),
+    )
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    manager.create_session(
+        cwd=tmp_path,
+        model=model,
+        provider_name="huggingface",
+        inference_provider="together",
+        session_id="session-123",
+    )
+
+    class ClosableFakeProvider(FakeProvider):
+        async def aclose(self) -> None:
+            return None
+
+    provider = ClosableFakeProvider([])
+    create_calls: list[tuple[str, str | None]] = []
+
+    def fake_create_model_provider(
+        provider_config: OpenAICompatibleProviderConfig,
+        *,
+        model: str,
+        inference_provider: str | None,
+        **kwargs: object,
+    ) -> ClosableFakeProvider:
+        del model, kwargs
+        create_calls.append((provider_config.name, inference_provider))
+        return provider
+
+    async def fake_run_print_mode(**kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(cli, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(cli, "create_model_provider", fake_create_model_provider)
+    monkeypatch.setattr(cli, "run_print_mode", fake_run_print_mode)
+
+    ok = await cli.run_openai_print_mode(
+        "Follow up",
+        model,
+        tmp_path,
+        provider_name="local",
+        session_manager=manager,
+        resume_session_id="session-123",
+    )
+
+    assert ok is True
+    assert create_calls == [("local", None)]
+
+
 def test_create_print_session_uses_requested_id_and_rejects_collision(tmp_path: Path) -> None:
     manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -791,6 +791,36 @@ async def test_run_print_mode_persists_session_entries(
 
 
 @pytest.mark.anyio
+async def test_run_print_mode_resumes_persisted_conversation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(MessageEntry(message=UserMessage(content="First question")))
+    await storage.append(MessageEntry(message=AssistantMessage(content="First answer")))
+    provider = FakeProvider(
+        [[assistant_start(model="fake"), assistant_done(message=AssistantMessage(content="Done"))]]
+    )
+
+    ok = await run_print_mode(
+        prompt="Follow-up message",
+        model="fake",
+        cwd=tmp_path,
+        provider=provider,
+        storage=storage,
+        session_id="session-123",
+    )
+
+    assert ok is True
+    assert capsys.readouterr().out == "Done\n"
+    messages = provider.calls[0][2]
+    assert [(message.role, message.text) for message in messages] == [
+        ("user", "First question"),
+        ("assistant", "First answer"),
+        ("user", "Follow-up message"),
+    ]
+
+
+@pytest.mark.anyio
 async def test_run_print_mode_terminal_command_adds_context(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
@@ -986,6 +1016,70 @@ def test_print_mode_passes_exact_session_id_without_changing_output(
     assert calls == ["worker-499"]
 
 
+def test_print_mode_passes_session_id_for_resume(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    async def fake_run_openai_print_mode(
+        prompt: str,
+        model: str | None,
+        cwd: Path,
+        output: PrintOutputMode,
+        provider_name: str | None,
+        session_manager: SessionManager | None,
+        extension_paths: tuple[Path, ...],
+        extensions_enabled: bool,
+        project_extensions_enabled: bool,
+        session_id: str | None,
+        custom_system_prompt: str | None,
+        append_system_prompt: str | None,
+        trust_override: object | None,
+        resume_session_id: str | None,
+    ) -> bool:
+        del (
+            model,
+            cwd,
+            output,
+            provider_name,
+            session_manager,
+            extension_paths,
+            extensions_enabled,
+            project_extensions_enabled,
+            session_id,
+            custom_system_prompt,
+            append_system_prompt,
+            trust_override,
+        )
+        calls.append((prompt, resume_session_id))
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["--print", "--session", "session-123", "follow up"])
+
+    assert result.exit_code == 0
+    assert calls == [("follow up", "session-123")]
+
+
+def test_print_mode_rejects_session_and_new_session() -> None:
+    result = CliRunner().invoke(
+        app, ["--print", "--session", "session-123", "--new-session", "follow up"]
+    )
+
+    assert result.exit_code == 2
+    assert "--session and --new-session cannot be used together" in _strip_ansi(result.output)
+
+
+def test_print_mode_rejects_session_and_session_id() -> None:
+    result = CliRunner().invoke(
+        app,
+        ["--print", "--session", "session-123", "--session-id", "new-id", "follow up"],
+    )
+
+    assert result.exit_code == 2
+    assert "--session and --session-id cannot be used together" in _strip_ansi(result.output)
+
+
 @pytest.mark.parametrize(
     ("session_id", "error"),
     [
@@ -1009,6 +1103,42 @@ def test_session_id_is_print_mode_only() -> None:
 
     assert result.exit_code == 2
     assert "--session-id is only supported in print mode" in _strip_ansi(result.output)
+
+
+def test_print_session_record_resumes_existing_session(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(
+        cwd=tmp_path,
+        model="fake",
+        session_id="session-123",
+    )
+
+    resumed = cli._print_session_record(
+        manager,
+        resume_session_id="session-123",
+        cwd=tmp_path / "other",
+        settings=_constrained_provider_settings(),
+        provider_name=None,
+        model=None,
+        session_id=None,
+    )
+
+    assert resumed == record
+
+
+def test_print_session_record_rejects_unknown_session(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+
+    with pytest.raises(ValueError, match="Unknown session: missing"):
+        cli._print_session_record(
+            manager,
+            resume_session_id="missing",
+            cwd=tmp_path,
+            settings=_constrained_provider_settings(),
+            provider_name=None,
+            model=None,
+            session_id=None,
+        )
 
 
 def test_create_print_session_uses_requested_id_and_rejects_collision(tmp_path: Path) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3678,6 +3678,65 @@ async def test_huggingface_session_re_resolves_pin_on_model_switch(
 
 
 @pytest.mark.anyio
+async def test_startup_model_override_rebuilds_model_dependent_runtime_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    created: list[tuple[str | None, str | None]] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+        inference_provider: str | None = None,
+        response_headers_observer: object | None = None,
+    ) -> SwitchableFakeProvider:
+        del credential_store, thinking_level, response_headers_observer
+        created.append((model, inference_provider))
+        return SwitchableFakeProvider(provider_config)
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    old_model = "zai-org/GLM-5.2"
+    override_model = "deepseek-ai/DeepSeek-V4-Flash"
+    provider_config = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        models=(old_model, override_model),
+        default_model=old_model,
+        inference_providers={old_model: "deepinfra", override_model: "fireworks-ai"},
+    )
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(ModelChangeEntry(model=old_model))
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=override_model,
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="huggingface",
+            inference_provider="fireworks-ai",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            runtime_provider_config=provider_config,
+            resource_paths=TauResourcePaths(
+                root=tmp_path / ".tau",
+                paths=TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"),
+            ),
+        )
+    )
+
+    await session.apply_startup_model_override(override_model)
+
+    assert session.model == override_model
+    assert session.inference_provider == "fireworks-ai"
+    assert created == [
+        (old_model, "fireworks-ai"),
+        (override_model, "fireworks-ai"),
+    ]
+    assert session._harness.config.provider is session._owned_providers[-1]
+
+
+@pytest.mark.anyio
 async def test_session_switches_configured_provider(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/content/guides/print-mode.md
+++ b/website/content/guides/print-mode.md
@@ -65,6 +65,23 @@ tau --provider local -p "explain this module"
 tau --cwd ./services/api -p "audit for secrets"
 ```
 
+## Resume a conversation
+
+Pass an existing session id to run a follow-up turn non-interactively:
+
+```bash
+tau --print --session <session-id> "Follow-up message"
+```
+
+Tau appends the turn to the existing transcript and sends its active conversation
+history to the model. It also uses the session's saved working directory,
+provider, and model unless explicit selection flags override them. This works
+with every output mode and keeps stdout dedicated to that mode. Unknown ids fail
+without creating a session. `--session` cannot be combined with `--new-session`
+or `--session-id`.
+
+Use `tau sessions` to find session ids.
+
 ## Recording the session id
 
 Automation can choose the exact id of a new print-mode session with

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -45,7 +45,7 @@ features and fixes.
 | `--provider TEXT` | Configured provider name to use |
 | `--cwd PATH` | Working directory for the built-in tools |
 | `--mode [text\|json\|transcript]` | Output mode for print mode (default `text`); also triggers print mode on its own |
-| `--session TEXT` | Resume a session id in the TUI |
+| `--session TEXT` | Resume a session id in the TUI or print mode |
 | `--new-session` | Start a new session instead of resuming the default |
 | `--session-id TEXT` | Set the exact id for a newly created print-mode session; errors if it already exists |
 | `--system-prompt TEXT_OR_PATH` | Replace Tau's default system-prompt base with literal text or an existing UTF-8 file |
@@ -96,6 +96,20 @@ project files win over user files. Use `/reload` after changing a file. These ar
 Tau-specific configuration files, not `.agents` resources. See
 [Configuration & files]({{< relref "./configuration.md#system-prompt-files" >}})
 for paths, precedence, diagnostics, and the project-resource security warning.
+
+### Resume in print mode
+
+Use `--print` and `--session` together to append a non-interactive follow-up to
+an existing conversation. Tau loads the session's saved working directory,
+provider, model, and conversation history:
+
+```bash
+tau --print --session <session-id> "Follow-up message"
+```
+
+Explicit `--provider`, `--model`, and system-prompt options override the saved
+startup choices for this invocation. `--session` cannot be combined with
+`--new-session` or `--session-id`. An unknown session id exits with an error.
 
 `--resume`, `--prompt`, `-o/--output`, and `-x` are removed; each now exits
 with an error naming its replacement (`--session`, `--print`, `--mode`, and


### PR DESCRIPTION
## Summary

Tau can now continue an existing conversation without opening the interactive TUI:

```bash
tau --print --session <session-id> "Follow-up message"
```

This brings print mode closer to Pi's non-interactive session workflow and makes multi-turn automation possible while preserving Tau's existing output formats.

## User experience

A resumed print-mode run:

- loads the indexed session and its append-only conversation history
- appends the follow-up turn to the same transcript
- uses the session's saved working directory, provider, model, and Hugging Face inference-provider route by default
- supports `text`, `json`, and `transcript` output without adding session metadata to stdout
- exits with a clear error when the session id is unknown

Users can find resumable ids with:

```bash
tau sessions
```

Then continue one from a script or terminal:

```bash
tau --print --session 8a4f... "Now update the implementation based on that review"
```

## Explicit overrides

Provider and model flags override the saved session choice for the resumed turn:

```bash
tau --print \
  --session 8a4f... \
  --provider local \
  --model qwen \
  "Try the same task with this model"
```

The override is activated before the follow-up request, persisted as a model-change entry, and rebuilds the runtime provider so model-specific settings remain correct. This includes Hugging Face model aliases, inference-provider routes, thinking configuration, and image support.

Saved Hugging Face inference-provider routing is restored only when both the saved and selected providers are Hugging Face and the model still matches. It is never passed accidentally to a non-Hugging Face provider that happens to expose a model with the same name.

## Option compatibility

`--session` now works in both TUI and print mode. Because it resumes an existing transcript, it cannot be combined with options that request a new transcript:

- `--new-session`
- `--session-id`

New print-mode sessions keep their existing exclusive transcript creation and collision protection.

## Architecture

The change stays within Tau's existing package boundaries:

- `tau_coding.cli` resolves the indexed session and CLI overrides
- `SessionManager` remains responsible for session metadata and transcript paths
- `CodingSession` loads and persists the active conversation branch
- `tau_agent` remains independent of CLI flags and Tau's filesystem layout

## Documentation

Updated:

- print-mode scripting guide
- CLI option reference
- developer notes describing the resume flow and design decisions

## Validation

- `uv run pytest` — **1481 passed, 2 Windows-only skipped**
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
