### PR TITLE
Compact bash tool calls in the TUI

### DIFF
--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -32,8 +32,11 @@ metadata carried inside the existing `ToolCall.arguments` mapping.
 Formatting lives in `src/tau_coding/tui/state.py`. The state prefers a supplied
 description, otherwise creates the deterministic compact row, then resolves the
 exact invocation lazily when tool results are expanded. Existing custom tool
-`render_call` output still takes precedence. No TUI concerns enter `tau_agent`,
-and command execution is unchanged.
+`render_call` output still takes precedence. The print-mode transcript renderer
+explicitly requests the unabridged invocation because it has no interactive
+expansion control. Session JSONL serialization remains independent of these
+display formatters and retains the complete `command`. No TUI concerns enter
+`tau_agent`, and command execution is unchanged.
 
 ## Tests
 
@@ -44,6 +47,8 @@ and command execution is unchanged.
   and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
+- `tests/test_rendering.py` confirms print-mode transcripts always show the exact
+  command instead of the optional description.
 
 Run:
 

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -7,8 +7,10 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 ## What changed
 
 The bash tool now asks the model for an optional, brief present-participle
-`description` in the same tool call. The TUI uses that semantic summary when it
-is present, normalizing whitespace and limiting it to 80 characters. This adds
+`description` in the same tool call. For long or multiline commands, the TUI
+normalizes that summary, limits it to 56 characters, and pairs it with a
+32-character prefix derived from the real command. Short commands always render
+verbatim, and summaries always retain deterministic command text. This adds
 no second provider request. Calls from models that omit the optional field keep
 a deterministic fallback:
 
@@ -29,10 +31,11 @@ The provider-visible bash schema and tool prompt guideline live in
 cannot prevent command execution. The executor ignores it; the value is display
 metadata carried inside the existing `ToolCall.arguments` mapping.
 
-Formatting lives in `src/tau_coding/tui/state.py`. The state prefers a supplied
-description, otherwise creates the deterministic compact row, then resolves the
-exact invocation lazily when tool results are expanded. Existing custom tool
-`render_call` output still takes precedence. The print-mode transcript renderer
+Formatting lives in `src/tau_coding/tui/state.py`. The state keeps short commands
+verbatim, combines supplied descriptions with deterministic command hints for
+long calls, or creates the argument-only compact row when no description exists.
+It resolves the exact invocation lazily when tool results are expanded. Existing
+custom tool `render_call` output still takes precedence. The print-mode transcript renderer
 explicitly requests the unabridged invocation because it has no interactive
 expansion control. Session JSONL serialization remains independent of these
 display formatters and retains the complete `command`. No TUI concerns enter
@@ -43,8 +46,9 @@ display formatters and retains the complete `command`. No TUI concerns enter
 - `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the optional
   schema field and model instruction.
 - `tests/test_tui_adapter.py` covers semantic descriptions, short commands,
-  heredocs, generic multiline commands, long inline code, long ordinary commands,
-  and exact expansion.
+  command hints, short-command safety, heredocs, generic multiline commands,
+  whitespace-only input, interpreter flags, long inline code, long ordinary
+  commands, and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
 - `tests/test_rendering.py` confirms print-mode transcripts always show the exact

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -6,8 +6,11 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 
 ## What changed
 
-The TUI now keeps short bash commands intact and compacts only commands that are
-likely to clutter the transcript:
+The bash tool now asks the model for an optional, brief present-participle
+`description` in the same tool call. The TUI uses that semantic summary when it
+is present, normalizing whitespace and limiting it to 80 characters. This adds
+no second provider request. Calls from models that omit the optional field keep
+a deterministic fallback:
 
 - multiline heredocs show the opening line and inline-script line count;
 - other multiline commands show the first line and total line count;
@@ -21,19 +24,24 @@ the full result. Collapsing restores the compact command preview.
 
 ## Architecture
 
-This is presentation-only behavior in `tau_coding.tui`. The canonical `ToolCall`
-and persisted session message are unchanged. `ChatItem` already retains raw tool
-arguments, so expanded rendering can recover the original command without adding
-TUI concerns to `tau_agent` or changing command execution.
+The provider-visible bash schema and tool prompt guideline live in
+`src/tau_coding/tools.py`. `description` remains optional so a model omission
+cannot prevent command execution. The executor ignores it; the value is display
+metadata carried inside the existing `ToolCall.arguments` mapping.
 
-Formatting lives in `src/tau_coding/tui/state.py`. The state creates the compact
-row once, then resolves the exact invocation lazily when tool results are
-expanded. Existing custom tool `render_call` output still takes precedence.
+Formatting lives in `src/tau_coding/tui/state.py`. The state prefers a supplied
+description, otherwise creates the deterministic compact row, then resolves the
+exact invocation lazily when tool results are expanded. Existing custom tool
+`render_call` output still takes precedence. No TUI concerns enter `tau_agent`,
+and command execution is unchanged.
 
 ## Tests
 
-- `tests/test_tui_adapter.py` covers short commands, heredocs, generic multiline
-  commands, long inline code, long ordinary commands, and exact expansion.
+- `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the optional
+  schema field and model instruction.
+- `tests/test_tui_adapter.py` covers semantic descriptions, short commands,
+  heredocs, generic multiline commands, long inline code, long ordinary commands,
+  and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
 

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -1,0 +1,48 @@
+# Compact bash invocations in the TUI
+
+Long shell commands used to wrap across many transcript lines before their output
+was even shown. This was especially noisy for heredocs and interpreter commands
+that embed source code directly in `python -c`, `node -e`, or similar arguments.
+
+## What changed
+
+The TUI now keeps short bash commands intact and compacts only commands that are
+likely to clutter the transcript:
+
+- multiline heredocs show the opening line and inline-script line count;
+- other multiline commands show the first line and total line count;
+- long inline-code commands show the prefix through `-c` or `-e` and a character
+  count;
+- other commands over 120 characters show their first 120 characters and total
+  character count.
+
+`Ctrl+O` now expands both sides of a tool interaction: the exact bash command and
+the full result. Collapsing restores the compact command preview.
+
+## Architecture
+
+This is presentation-only behavior in `tau_coding.tui`. The canonical `ToolCall`
+and persisted session message are unchanged. `ChatItem` already retains raw tool
+arguments, so expanded rendering can recover the original command without adding
+TUI concerns to `tau_agent` or changing command execution.
+
+Formatting lives in `src/tau_coding/tui/state.py`. The state creates the compact
+row once, then resolves the exact invocation lazily when tool results are
+expanded. Existing custom tool `render_call` output still takes precedence.
+
+## Tests
+
+- `tests/test_tui_adapter.py` covers short commands, heredocs, generic multiline
+  commands, long inline code, long ordinary commands, and exact expansion.
+- `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
+  compact heredoc row with the exact command and full result.
+
+Run:
+
+```bash
+uv run pytest tests/test_tui_adapter.py tests/test_tui_app.py
+```
+
+For manual validation, ask Tau to run a multiline heredoc. Confirm the collapsed
+row occupies one line, press `Ctrl+O` to see the complete command, then press it
+again to restore the preview.

--- a/src/tau_coding/rendering/transcript.py
+++ b/src/tau_coding/rendering/transcript.py
@@ -41,9 +41,8 @@ class TranscriptRenderer:
             return
         if isinstance(event, ToolExecutionStartEvent):
             self._newline()
-            # Keep the established compact line while tool definitions migrate.
             call = ToolCall(id=event.tool_call_id, name=event.tool_name, arguments=event.args)
-            self._console.print(Text(format_tool_call_block(call), style="cyan"))
+            self._console.print(Text(format_tool_call_block(call, compact=False), style="cyan"))
             return
         if isinstance(event, ToolExecutionUpdateEvent):
             self._newline()

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -705,11 +705,21 @@ def create_bash_tool_definition(
             "full output is saved to a temp file. Optionally provide a timeout in seconds."
         ),
         prompt_snippet="Execute bash commands (ls, grep, find, etc.)",
-        prompt_guidelines=(),
+        prompt_guidelines=(
+            "When using bash, include a brief present-participle description of the "
+            "command's purpose (for example, 'Running tests').",
+        ),
         input_schema={
             "type": "object",
             "properties": {
                 "command": {"type": "string", "description": "Bash command to execute"},
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Brief present-participle summary of the command's purpose, such as "
+                        "'Running tests' or 'Validating and committing changes'"
+                    ),
+                },
                 "timeout": {
                     "type": "number",
                     "description": "Timeout in seconds (optional, no default timeout)",

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4904,7 +4904,9 @@ class TauTuiApp(App[None]):
                 item,
                 theme=theme,
                 show_tool_results=self.state.show_tool_results,
-                invocation=self.state.resolve_tool_invocation(item),
+                invocation=self.state.resolve_tool_invocation(
+                    item, expanded=self.state.show_tool_results
+                ),
             )
             self._refresh_chrome()
             return
@@ -4917,7 +4919,7 @@ class TauTuiApp(App[None]):
                     updated_item,
                     theme=theme,
                     show_tool_results=expanded,
-                    invocation=self.state.resolve_tool_invocation(updated_item),
+                    invocation=self.state.resolve_tool_invocation(updated_item, expanded=expanded),
                     result_markup=self.state.resolve_tool_result(updated_item, expanded=expanded),
                 )
             self._refresh_chrome()
@@ -4948,7 +4950,7 @@ class TauTuiApp(App[None]):
                     updated_item,
                     theme=theme,
                     show_tool_results=expanded,
-                    invocation=self.state.resolve_tool_invocation(updated_item),
+                    invocation=self.state.resolve_tool_invocation(updated_item, expanded=expanded),
                     result_markup=self.state.resolve_tool_result(updated_item, expanded=expanded),
                 )
             self._refresh_chrome()
@@ -5941,7 +5943,7 @@ class TauTuiApp(App[None]):
             item,
             theme=self.tui_settings.resolved_theme,
             show_tool_results=expanded,
-            invocation=self.state.resolve_tool_invocation(item),
+            invocation=self.state.resolve_tool_invocation(item, expanded=expanded),
             result_markup=self.state.resolve_tool_result(item, expanded=expanded),
         )
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -35,9 +35,10 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_COMMAND_PREVIEW_CHARS = 120
-BASH_DESCRIPTION_PREVIEW_CHARS = 80
+BASH_DESCRIPTION_PREVIEW_CHARS = 56
+BASH_COMMAND_HINT_CHARS = 32
 _INLINE_CODE_PATTERN = re.compile(
-    r"(?:^|[;&|]\s*|\s)(?:python(?:\d+(?:\.\d+)*)?|node|bash|sh|zsh)\s+-(?:c|e)\s+"
+    r"(?:^|[;&|]\s*|\s)(?:(?:python(?:\d+(?:\.\d+)*)?|bash|sh|zsh)\s+-c|node\s+-e)\s+"
 )
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
@@ -139,7 +140,14 @@ class TuiState:
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
         if line is None and expanded and item.tool_name == "bash":
-            line = _format_bash_tool_call_invocation(item.tool_arguments or {}, compact=False)
+            line = format_tool_call_invocation(
+                ToolCall(
+                    id=item.tool_call_id or "display-call",
+                    name=item.tool_name,
+                    arguments=item.tool_arguments or {},
+                ),
+                expanded=True,
+            )
         if item.tool_result_text is None and item.started_at is not None:
             elapsed = time.monotonic() - item.started_at
             if elapsed >= TOOL_TIMER_MIN_SECONDS:
@@ -446,14 +454,31 @@ def _format_bash_tool_call_invocation(
         return None
     timeout = _number_argument(arguments, "timeout")
     suffix = f" (timeout {timeout:g}s)" if timeout is not None else ""
+    if compact and _is_short_single_line_bash_command(command):
+        return f"$ {command}{suffix}"
     if compact:
         description = _string_argument(arguments, "description")
         if description is not None:
             displayed_description = _compact_bash_description(description)
             if displayed_description:
-                return f"→ {displayed_description}{suffix}"
+                hint = _bash_command_hint(command)
+                return f"→ {displayed_description} · $ {hint}{suffix}"
     displayed_command = _compact_bash_command(command) if compact else command
     return f"$ {displayed_command}{suffix}"
+
+
+def _is_short_single_line_bash_command(command: str) -> bool:
+    return (
+        "\n" not in command and "\r" not in command and len(command) <= BASH_COMMAND_PREVIEW_CHARS
+    )
+
+
+def _bash_command_hint(command: str) -> str:
+    first_line = next((line.strip() for line in command.splitlines() if line.strip()), "")
+    normalized = " ".join(first_line.split()) or "[empty command]"
+    if len(normalized) <= BASH_COMMAND_HINT_CHARS:
+        return normalized
+    return normalized[: BASH_COMMAND_HINT_CHARS - 1].rstrip() + "…"
 
 
 def _compact_bash_description(description: str) -> str:
@@ -471,7 +496,7 @@ def _compact_bash_command(command: str) -> str:
             None,
         )
         if meaningful_line is None:
-            return command
+            return f"[empty command: {len(lines)} lines]"
         first_index, first_line = meaningful_line
         preview = _truncate_bash_preview(first_line)
         heredoc = _HEREDOC_PATTERN.search(first_line)
@@ -488,8 +513,7 @@ def _compact_bash_command(command: str) -> str:
             script_lines = max(0, closing_index - first_index - 1)
             noun = "line" if script_lines == 1 else "lines"
             return f"{preview} … [inline script: {script_lines} {noun}]"
-        noun = "line" if len(lines) == 1 else "lines"
-        return f"{preview} … [command: {len(lines)} {noun}]"
+        return f"{preview} … [command: {len(lines)} lines]"
 
     if len(command) <= BASH_COMMAND_PREVIEW_CHARS:
         return command

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -406,9 +406,9 @@ def format_elapsed(seconds: float) -> str:
     return f"{hours}h {minutes}m"
 
 
-def format_tool_call_block(tool_call: ToolCall) -> str:
-    """Format a collapsed tool call for live and restored transcript blocks."""
-    invocation = format_tool_call_invocation(tool_call)
+def format_tool_call_block(tool_call: ToolCall, *, compact: bool = True) -> str:
+    """Format a tool call, optionally compacting long bash invocations."""
+    invocation = format_tool_call_invocation(tool_call, expanded=not compact)
     if tool_call.name == "bash":
         return invocation
     return f"→ {invocation}"

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -33,6 +34,11 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # Show live elapsed time on an executing tool row once it stops being instant;
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
+BASH_COMMAND_PREVIEW_CHARS = 120
+_INLINE_CODE_PATTERN = re.compile(
+    r"(?:^|[;&|]\s*|\s)(?:python(?:\d+(?:\.\d+)*)?|node|bash|sh|zsh)\s+-(?:c|e)\s+"
+)
+_HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
 
 @dataclass(slots=True)
@@ -117,19 +123,22 @@ class TuiState:
             return None
         return self.custom_renderer(item.custom_type, item.text, item.details, expanded)
 
-    def resolve_tool_invocation(self, item: ChatItem) -> str | None:
+    def resolve_tool_invocation(self, item: ChatItem, *, expanded: bool = False) -> str | None:
         """Render a tool item's invocation via the installed resolver, or ``None``.
 
         Resolved lazily at render time (like custom markup) so tool calls
         restored before the extension runtime connects still pick up their
-        tool's `render_call` on the next redraw. ``None`` means "no renderer"
-        and the caller falls back to the generic ``item.text``.
+        tool's `render_call` on the next redraw. Expanded built-in bash calls
+        recover the exact command from their retained arguments. ``None`` means
+        "no renderer" and the caller falls back to the generic ``item.text``.
         """
         if item.role != "tool":
             return None
         line: str | None = None
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
+        if line is None and expanded and item.tool_name == "bash":
+            line = _format_bash_tool_call_invocation(item.tool_arguments or {}, compact=False)
         if item.tool_result_text is None and item.started_at is not None:
             elapsed = time.monotonic() - item.started_at
             if elapsed >= TOOL_TIMER_MIN_SECONDS:
@@ -404,7 +413,7 @@ def format_tool_call_block(tool_call: ToolCall) -> str:
     return f"→ {invocation}"
 
 
-def format_tool_call_invocation(tool_call: ToolCall) -> str:
+def format_tool_call_invocation(tool_call: ToolCall, *, expanded: bool = False) -> str:
     """Format a tool call as a terse human-readable invocation."""
     arguments = tool_call.arguments
     if tool_call.name == "read":
@@ -423,13 +432,69 @@ def format_tool_call_invocation(tool_call: ToolCall) -> str:
             return _fallback_tool_call_invocation(tool_call)
         return f"write {path}"
     if tool_call.name == "bash":
-        command = _string_argument(arguments, "command")
-        if command is None:
-            return _fallback_tool_call_invocation(tool_call)
-        timeout = _number_argument(arguments, "timeout")
-        suffix = f" (timeout {timeout:g}s)" if timeout is not None else ""
-        return f"$ {command}{suffix}"
+        invocation = _format_bash_tool_call_invocation(arguments, compact=not expanded)
+        return invocation if invocation is not None else _fallback_tool_call_invocation(tool_call)
     return _fallback_tool_call_invocation(tool_call)
+
+
+def _format_bash_tool_call_invocation(
+    arguments: dict[str, JSONValue], *, compact: bool
+) -> str | None:
+    command = _string_argument(arguments, "command")
+    if command is None:
+        return None
+    timeout = _number_argument(arguments, "timeout")
+    suffix = f" (timeout {timeout:g}s)" if timeout is not None else ""
+    displayed_command = _compact_bash_command(command) if compact else command
+    return f"$ {displayed_command}{suffix}"
+
+
+def _compact_bash_command(command: str) -> str:
+    lines = command.splitlines()
+    if len(lines) > 1:
+        meaningful_line = next(
+            ((index, line.strip()) for index, line in enumerate(lines) if line.strip()),
+            None,
+        )
+        if meaningful_line is None:
+            return command
+        first_index, first_line = meaningful_line
+        preview = _truncate_bash_preview(first_line)
+        heredoc = _HEREDOC_PATTERN.search(first_line)
+        if heredoc is not None:
+            delimiter = heredoc.group(2)
+            closing_index = next(
+                (
+                    index
+                    for index in range(len(lines) - 1, first_index, -1)
+                    if lines[index].strip() == delimiter
+                ),
+                len(lines),
+            )
+            script_lines = max(0, closing_index - first_index - 1)
+            noun = "line" if script_lines == 1 else "lines"
+            return f"{preview} … [inline script: {script_lines} {noun}]"
+        noun = "line" if len(lines) == 1 else "lines"
+        return f"{preview} … [command: {len(lines)} {noun}]"
+
+    if len(command) <= BASH_COMMAND_PREVIEW_CHARS:
+        return command
+
+    inline_code = _INLINE_CODE_PATTERN.search(command)
+    if inline_code is not None:
+        prefix = command[: inline_code.end()].rstrip()
+        code_chars = len(command[inline_code.end() :].strip())
+        noun = "char" if code_chars == 1 else "chars"
+        return f"{prefix} … [inline code: {code_chars} {noun}]"
+
+    preview = _truncate_bash_preview(command)
+    return f"{preview}… [command: {len(command)} chars]"
+
+
+def _truncate_bash_preview(command: str) -> str:
+    if len(command) <= BASH_COMMAND_PREVIEW_CHARS:
+        return command
+    return command[:BASH_COMMAND_PREVIEW_CHARS].rstrip()
 
 
 def _read_line_suffix(arguments: dict[str, JSONValue]) -> str:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -35,6 +35,7 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_COMMAND_PREVIEW_CHARS = 120
+BASH_DESCRIPTION_PREVIEW_CHARS = 80
 _INLINE_CODE_PATTERN = re.compile(
     r"(?:^|[;&|]\s*|\s)(?:python(?:\d+(?:\.\d+)*)?|node|bash|sh|zsh)\s+-(?:c|e)\s+"
 )
@@ -445,8 +446,21 @@ def _format_bash_tool_call_invocation(
         return None
     timeout = _number_argument(arguments, "timeout")
     suffix = f" (timeout {timeout:g}s)" if timeout is not None else ""
+    if compact:
+        description = _string_argument(arguments, "description")
+        if description is not None:
+            displayed_description = _compact_bash_description(description)
+            if displayed_description:
+                return f"→ {displayed_description}{suffix}"
     displayed_command = _compact_bash_command(command) if compact else command
     return f"$ {displayed_command}{suffix}"
+
+
+def _compact_bash_description(description: str) -> str:
+    normalized = " ".join(description.split())
+    if len(normalized) <= BASH_DESCRIPTION_PREVIEW_CHARS:
+        return normalized
+    return normalized[: BASH_DESCRIPTION_PREVIEW_CHARS - 1].rstrip() + "…"
 
 
 def _compact_bash_command(command: str) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -911,7 +911,7 @@ class TranscriptView(VerticalScroll):
                     if item.role == "custom"
                     else None
                 ),
-                invocation=state.resolve_tool_invocation(item),
+                invocation=state.resolve_tool_invocation(item, expanded=expanded),
                 result_markup=state.resolve_tool_result(item, expanded=expanded),
             )
             self._item_widgets[id(item)] = widget
@@ -1026,7 +1026,7 @@ class TranscriptView(VerticalScroll):
                 item,
                 theme=theme,
                 show_tool_results=expanded,
-                invocation=state.resolve_tool_invocation(item),
+                invocation=state.resolve_tool_invocation(item, expanded=expanded),
                 result_markup=state.resolve_tool_result(item, expanded=expanded),
             )
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -343,6 +343,7 @@ class TranscriptMessageWidget(Horizontal):
     ) -> None:
         self.item = item
         self._custom_markup = custom_markup if item.role == "custom" else None
+        self._show_tool_results = show_tool_results
         self._invocation = invocation if item.role == "tool" else None
         self._result_markup = result_markup if item.role == "tool" else None
         self.selection_text = transcript_item_selection_text(
@@ -402,6 +403,7 @@ class TranscriptMessageWidget(Horizontal):
                     text=self.selection_text,
                     body_style=self._role_style.body,
                     theme=self._theme,
+                    show_tool_results=self._show_tool_results,
                     invocation=self._invocation,
                     result_markup=self._result_markup,
                 ),
@@ -443,6 +445,7 @@ class TranscriptMessageWidget(Horizontal):
         """
         if self.item.role == "custom" or not _use_plain_transcript_body(self.item):
             return False
+        self._show_tool_results = show_tool_results
         self._invocation = invocation if self.item.role == "tool" else None
         self._result_markup = result_markup if self.item.role == "tool" else None
         next_role_style = _chat_item_role_style(self.item, self._theme)
@@ -484,6 +487,7 @@ class TranscriptMessageWidget(Horizontal):
                 text=self.selection_text,
                 body_style=self._role_style.body,
                 theme=self._theme,
+                show_tool_results=show_tool_results,
                 invocation=self._invocation,
                 result_markup=self._result_markup,
             )
@@ -1368,6 +1372,7 @@ def _transcript_plain_body_text(
     text: str,
     body_style: str,
     theme: TuiTheme,
+    show_tool_results: bool = False,
     invocation: str | None = None,
     result_markup: str | None = None,
 ) -> RenderableType:
@@ -1375,26 +1380,25 @@ def _transcript_plain_body_text(
     if item.role != "tool":
         return Text(text, style=body_style, overflow="fold", no_wrap=False)
 
+    invocation_text = _render_transcript_tool_invocation(
+        invocation if invocation else item.text,
+        body_style=body_style,
+        accent_style=_tool_accent_style(item, theme=theme),
+    )
     if result_markup is not None:
         # The tool's `render_result` markup replaces the generic result block;
         # the invocation line keeps its usual status-accented rendering.
-        invocation_text = _render_transcript_tool_invocation(
-            invocation if invocation else item.text,
-            body_style=body_style,
-            accent_style=_tool_accent_style(item, theme=theme),
-        )
         markup_text = _custom_markup_to_text(result_markup)
         markup_text.overflow = "fold"
         markup_text.no_wrap = False
         return Group(invocation_text, markup_text)
 
-    invocation_line, separator, result_text = text.partition("\n\n")
-    invocation_text = _render_transcript_tool_invocation(
-        invocation_line,
-        body_style=body_style,
-        accent_style=_tool_accent_style(item, theme=theme),
-    )
-    if not separator:
+    result_text: str | None = None
+    if show_tool_results and item.tool_result_text:
+        result_text = item.tool_result_text
+    elif item.update_text and not item.tool_result_text:
+        result_text = f"… {item.update_text}"
+    if result_text is None:
         return invocation_text
 
     patch_body = _render_patch_body(
@@ -1408,7 +1412,7 @@ def _transcript_plain_body_text(
 
     rendered = Text(style=body_style, overflow="fold", no_wrap=False)
     rendered.append(invocation_text)
-    rendered.append(separator)
+    rendered.append("\n\n")
     rendered.append(result_text, style=body_style)
     return rendered
 

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -13,6 +13,7 @@ from tau_coding import (
     ImageSupportState,
     ReadOperations,
     create_bash_tool,
+    create_bash_tool_definition,
     create_coding_tools,
     create_edit_tool,
     create_edit_tool_definition,
@@ -55,6 +56,17 @@ async def test_create_coding_tools_returns_initial_tool_set(tmp_path: Path) -> N
     edit_tool = tools[2]
     assert edit_tool.prompt_snippet is not None
     assert "Use edit for precise changes" in edit_tool.prompt_guidelines[0]
+    assert "present-participle description" in tools[3].prompt_guidelines[0]
+
+
+def test_bash_tool_schema_requests_optional_display_description(tmp_path: Path) -> None:
+    definition = create_bash_tool_definition(cwd=tmp_path)
+    properties = definition.input_schema["properties"]
+
+    assert isinstance(properties, dict)
+    assert properties["description"]["type"] == "string"
+    assert "present-participle summary" in properties["description"]["description"]
+    assert definition.input_schema["required"] == ["command"]
 
 
 def test_tool_definitions_expose_pi_style_prompt_metadata(tmp_path: Path) -> None:

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -83,6 +83,29 @@ def test_transcript_renderer_streams_text_and_tool_events(
     assert "done" in captured.err
 
 
+def test_transcript_renderer_keeps_full_bash_command(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    renderer = TranscriptRenderer()
+    command = "git diff --check && git commit -m 'Finish work'"
+
+    renderer.render(
+        ToolExecutionStartEvent(
+            tool_call_id="call-1",
+            tool_name="bash",
+            args={
+                "command": command,
+                "description": "Validating and committing changes",
+                "timeout": 120,
+            },
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert f"$ {command} (timeout 120s)" in captured.err
+    assert "Validating and committing changes" not in captured.err
+
+
 def test_transcript_renderer_uses_custom_message_renderer(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -38,6 +38,7 @@ def test_default_prompt_includes_tools_guidelines_date_and_cwd(tmp_path: Path) -
     assert "You are an expert coding assistant operating inside Tau" in prompt
     assert "Available tools:\n- read: Read file contents" in prompt
     assert "- Use bash for file operations like ls, rg, find" in prompt
+    assert "- When using bash, include a brief present-participle description" in prompt
     assert "- Use read to examine files instead of cat or sed." in prompt
     assert "- Inspect relevant files and project instructions before editing" in prompt
     assert "- Do not overwrite or discard unrelated user changes" in prompt

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -315,8 +315,19 @@ def test_bash_tool_formatter_keeps_short_commands_visible() -> None:
     )
 
 
-def test_bash_tool_formatter_prefers_description_until_expanded() -> None:
-    command = "git diff --check && git commit -m 'Finish work'"
+def test_bash_tool_formatter_keeps_short_command_instead_of_description() -> None:
+    command = "rm -rf /tmp/x"
+    call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": command, "description": "Listing files"},
+    )
+
+    assert format_tool_call_block(call) == f"$ {command}"
+
+
+def test_bash_tool_formatter_pairs_description_with_real_command_hint() -> None:
+    command = "git diff --check && git commit -m 'Finish work' && " + "echo done " * 12
     call = ToolCall(
         id="call-1",
         name="bash",
@@ -327,9 +338,26 @@ def test_bash_tool_formatter_prefers_description_until_expanded() -> None:
         },
     )
 
-    assert format_tool_call_block(call) == "→ Validating and committing changes (timeout 120s)"
+    collapsed = format_tool_call_block(call)
+    assert collapsed.startswith("→ Validating and committing changes · $ git diff --check")
+    assert collapsed.endswith("… (timeout 120s)")
+    assert "\n" not in collapsed
     assert format_tool_call_block(call, compact=False) == f"$ {command} (timeout 120s)"
     assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 120s)"
+
+
+def test_bash_tool_formatter_keeps_hint_after_long_description() -> None:
+    command = "python - <<'PY'\nprint('hello')\nPY"
+    description = "Describing a deliberately overlong inline script operation " * 2
+    call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": command, "description": description},
+    )
+
+    collapsed = format_tool_call_block(call)
+    assert collapsed.endswith("… · $ python - <<'PY'")
+    assert "\n" not in collapsed
 
 
 def test_bash_tool_formatter_collapses_heredoc_and_expands_exact_command() -> None:
@@ -363,6 +391,21 @@ def test_bash_tool_formatter_identifies_long_inline_code() -> None:
     assert format_tool_call_block(call) == (
         f"$ uv run python -c … [inline code: {len(code) + 2} chars]"
     )
+
+
+def test_bash_tool_formatter_does_not_treat_shell_errexit_as_inline_code() -> None:
+    command = "sh -e ./deploy.sh " + "production " * 15
+    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
+
+    collapsed = format_tool_call_block(call)
+    assert "inline code" not in collapsed
+    assert "sh -e ./deploy.sh" in collapsed
+
+
+def test_bash_tool_formatter_compacts_whitespace_only_multiline_command() -> None:
+    call = ToolCall(id="call-1", name="bash", arguments={"command": "\n\n"})
+
+    assert format_tool_call_block(call) == "$ [empty command: 2 lines]"
 
 
 def test_tui_state_recovers_full_bash_command_when_tool_output_expands() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -328,6 +328,7 @@ def test_bash_tool_formatter_prefers_description_until_expanded() -> None:
     )
 
     assert format_tool_call_block(call) == "→ Validating and committing changes (timeout 120s)"
+    assert format_tool_call_block(call, compact=False) == f"$ {command} (timeout 120s)"
     assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 120s)"
 
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -27,7 +27,12 @@ from tau_coding.events import (
 )
 from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.tui import TuiEventAdapter, TuiState
-from tau_coding.tui.state import format_tool_call_block, format_tool_result_block
+from tau_coding.tui.state import (
+    BASH_COMMAND_PREVIEW_CHARS,
+    format_tool_call_block,
+    format_tool_call_invocation,
+    format_tool_result_block,
+)
 
 
 def _update(event) -> MessageUpdateEvent:  # noqa: ANN001
@@ -295,6 +300,64 @@ def test_tool_formatters_keep_human_readable_output() -> None:
     assert "line 8" in block
     assert "line 9" not in block
     assert "3 more lines" in block
+
+
+def test_bash_tool_formatter_keeps_short_commands_visible() -> None:
+    call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": 'rg -n "ToolCall" src', "timeout": 10},
+    )
+
+    assert format_tool_call_block(call) == '$ rg -n "ToolCall" src (timeout 10s)'
+    assert format_tool_call_invocation(call, expanded=True) == (
+        '$ rg -n "ToolCall" src (timeout 10s)'
+    )
+
+
+def test_bash_tool_formatter_collapses_heredoc_and_expands_exact_command() -> None:
+    command = "python - <<'PY'\nprint('one')\nprint('two')\nPY"
+    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
+
+    assert format_tool_call_block(call) == ("$ python - <<'PY' … [inline script: 2 lines]")
+    assert format_tool_call_invocation(call, expanded=True) == f"$ {command}"
+
+
+def test_bash_tool_formatter_collapses_multiline_and_long_commands() -> None:
+    multiline = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={"command": "git status &&\ngit diff"},
+    )
+    long_command = "echo " + "x" * BASH_COMMAND_PREVIEW_CHARS
+    long_call = ToolCall(id="call-2", name="bash", arguments={"command": long_command})
+
+    assert format_tool_call_block(multiline) == "$ git status && … [command: 2 lines]"
+    assert format_tool_call_block(long_call) == (
+        f"$ {long_command[:BASH_COMMAND_PREVIEW_CHARS]}… [command: {len(long_command)} chars]"
+    )
+
+
+def test_bash_tool_formatter_identifies_long_inline_code() -> None:
+    code = "print('x');" * 20
+    command = f'uv run python -c "{code}"'
+    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
+
+    assert format_tool_call_block(call) == (
+        f"$ uv run python -c … [inline code: {len(code) + 2} chars]"
+    )
+
+
+def test_tui_state_recovers_full_bash_command_when_tool_output_expands() -> None:
+    command = "python - <<'PY'\nprint('hello')\nPY"
+    state = TuiState(tool_call_renderer=lambda _name, _arguments: None)
+    state.add_tool_call(ToolCall(id="call-1", name="bash", arguments={"command": command}))
+    item = state.items[0]
+    item.started_at = None
+
+    assert item.text == "$ python - <<'PY' … [inline script: 1 line]"
+    assert state.resolve_tool_invocation(item) is None
+    assert state.resolve_tool_invocation(item, expanded=True) == f"$ {command}"
 
 
 def test_tui_adapter_uses_canonical_result_details_for_patch() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -315,6 +315,22 @@ def test_bash_tool_formatter_keeps_short_commands_visible() -> None:
     )
 
 
+def test_bash_tool_formatter_prefers_description_until_expanded() -> None:
+    command = "git diff --check && git commit -m 'Finish work'"
+    call = ToolCall(
+        id="call-1",
+        name="bash",
+        arguments={
+            "command": command,
+            "description": "  Validating and\ncommitting changes  ",
+            "timeout": 120,
+        },
+    )
+
+    assert format_tool_call_block(call) == "→ Validating and committing changes (timeout 120s)"
+    assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 120s)"
+
+
 def test_bash_tool_formatter_collapses_heredoc_and_expands_exact_command() -> None:
     command = "python - <<'PY'\nprint('one')\nprint('two')\nPY"
     call = ToolCall(id="call-1", name="bash", arguments={"command": command})

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1068,6 +1068,7 @@ def test_transcript_plain_tool_body_renders_patch_as_colored_diff() -> None:
         text=transcript_item_selection_text(item, show_tool_results=True),
         body_style="#cbd5e1 on #000000",
         theme=TAU_DARK_THEME,
+        show_tool_results=True,
     )
 
     console = Console(record=True, width=100, color_system="truecolor")
@@ -1413,6 +1414,29 @@ def test_light_theme_markdown_code_uses_aqua_without_background() -> None:
 
     assert "38;2;15;118;110" in output
     assert "38;2;15;118;110;48;2" not in output
+
+
+def test_expanded_tool_invocation_blank_line_stays_separate_from_result() -> None:
+    invocation = "$ python <<'PY'\n\nPatch:\n-old\nPY"
+    item = ChatItem(
+        role="tool",
+        text="$ compact",
+        tool_result_text="✓ bash\nfinished",
+    )
+    body = _transcript_plain_body_text(
+        item,
+        text=f"{invocation}\n\n{item.tool_result_text}",
+        body_style=TAU_DARK_THEME.role_styles["tool"].body,
+        theme=TAU_DARK_THEME,
+        show_tool_results=True,
+        invocation=invocation,
+    )
+
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(body)
+
+    assert console.export_text(clear=False) == f"{invocation}\n\n✓ bash\nfinished\n"
+    assert "\x1b[91" not in console.export_text(styles=True)
 
 
 def test_pending_tool_invocation_uses_tool_accent_color() -> None:
@@ -7094,7 +7118,7 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
 
     async with app.run_test() as pilot:
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
-        assert widget.selection_text == "→ Running inline script"
+        assert widget.selection_text == "→ Running inline script · $ python - <<'PY'"
 
         await pilot.press("ctrl+o")
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7072,7 +7072,16 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
         FakeSession(
             messages=[
                 AssistantMessage(
-                    content=[ToolCall(id="call-1", name="bash", arguments={"command": command})]
+                    content=[
+                        ToolCall(
+                            id="call-1",
+                            name="bash",
+                            arguments={
+                                "command": command,
+                                "description": "Running inline script",
+                            },
+                        )
+                    ]
                 ),
                 ToolResultMessage(
                     tool_call_id="call-1",
@@ -7085,7 +7094,7 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
 
     async with app.run_test() as pilot:
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
-        assert widget.selection_text == "$ python - <<'PY' … [inline script: 2 lines]"
+        assert widget.selection_text == "→ Running inline script"
 
         await pilot.press("ctrl+o")
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7066,6 +7066,35 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
 
 
 @pytest.mark.anyio
+async def test_tool_result_toggle_expands_full_bash_command() -> None:
+    command = "python - <<'PY'\nprint('one')\nprint('two')\nPY"
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content=[ToolCall(id="call-1", name="bash", arguments={"command": command})]
+                ),
+                ToolResultMessage(
+                    tool_call_id="call-1",
+                    tool_name="bash",
+                    content="finished",
+                ),
+            ]
+        )
+    )
+
+    async with app.run_test() as pilot:
+        widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
+        assert widget.selection_text == "$ python - <<'PY' … [inline script: 2 lines]"
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+
+        widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
+        assert widget.selection_text == f"$ {command}\n\n✓ bash\nfinished"
+
+
+@pytest.mark.anyio
 async def test_tool_result_toggle_preserves_unrelated_message_widgets() -> None:
     app = TauTuiApp(
         FakeSession(

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -117,16 +117,20 @@ tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau asks the model to give each `bash` call a brief
-description such as `Running tests`; when provided, that description replaces the
-command in the collapsed row. Calls without a description use a deterministic
-fallback: multiline commands and heredocs show their first line plus a line count,
-inline code shows its interpreter plus a character count, and other commands over
-120 characters show a shortened preview. Short shell commands remain unchanged.
+description such as `Running tests`. Long or multiline calls pair that description
+with a short prefix taken from the real command, so model-generated text is always
+accompanied by deterministic command text. Short shell commands remain visible and ignore the
+description. Calls without a description use a deterministic fallback: multiline
+commands and heredocs show their first line plus a line count, inline code shows
+its interpreter plus a character count, and other commands over 120 characters
+show a shortened preview.
+
 Toggle the exact commands and full tool output with **Ctrl+O**. Command compaction
 affects only the TUI display; execution, session history, and print-mode
-transcripts retain the complete command. Markdown
-link hover styling underlines only the linked text, never the rest of its row. User
-message blocks use the same theme background as the prompt field and sidebar,
+transcripts retain the complete command.
+
+Markdown link hover styling underlines only the linked text, never the rest of its
+row. User message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.
 This visually ties submitted prompts to the composer.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -116,12 +116,15 @@ indicator provides the run-wide animation without adding a second spinner to eac
 tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
-the transcript stays readable. Long `bash` invocations are compact too: multiline
-commands and heredocs show their first line plus a line count, inline code shows
-its interpreter plus a character count, and other commands over 120 characters
-show a shortened preview. Short shell commands remain unchanged. Toggle the exact
-commands and full tool output with **Ctrl+O**. Command compaction affects only the
-TUI display; execution and session history retain the complete command. Markdown
+the transcript stays readable. Tau asks the model to give each `bash` call a brief
+description such as `Running tests`; when provided, that description replaces the
+command in the collapsed row. Calls without a description use a deterministic
+fallback: multiline commands and heredocs show their first line plus a line count,
+inline code shows its interpreter plus a character count, and other commands over
+120 characters show a shortened preview. Short shell commands remain unchanged.
+Toggle the exact commands and full tool output with **Ctrl+O**. Command compaction
+affects only the TUI display; execution and session history retain the complete
+command. Markdown
 link hover styling underlines only the linked text, never the rest of its row. User
 message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -116,7 +116,12 @@ indicator provides the run-wide animation without adding a second spinner to eac
 tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
-the transcript stays readable. Toggle full tool output with **Ctrl+O**. Markdown
+the transcript stays readable. Long `bash` invocations are compact too: multiline
+commands and heredocs show their first line plus a line count, inline code shows
+its interpreter plus a character count, and other commands over 120 characters
+show a shortened preview. Short shell commands remain unchanged. Toggle the exact
+commands and full tool output with **Ctrl+O**. Command compaction affects only the
+TUI display; execution and session history retain the complete command. Markdown
 link hover styling underlines only the linked text, never the rest of its row. User
 message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -123,8 +123,8 @@ fallback: multiline commands and heredocs show their first line plus a line coun
 inline code shows its interpreter plus a character count, and other commands over
 120 characters show a shortened preview. Short shell commands remain unchanged.
 Toggle the exact commands and full tool output with **Ctrl+O**. Command compaction
-affects only the TUI display; execution and session history retain the complete
-command. Markdown
+affects only the TUI display; execution, session history, and print-mode
+transcripts retain the complete command. Markdown
 link hover styling underlines only the linked text, never the rest of its row. User
 message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -41,7 +41,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 
 | Key | Action |
 | --- | --- |
-| `Ctrl+O` | Toggle full tool output (vs. compact preview) |
+| `Ctrl+O` | Toggle exact tool commands and full output (vs. compact previews) |
 | `Ctrl+C` | Clear the prompt input |
 | `Ctrl+D` | Quit |
 


### PR DESCRIPTION
## Summary

- compact long and multiline `bash` invocations in the TUI transcript
- ask models for an optional semantic bash description and show it when available
- use deterministic command previews when descriptions are absent
- reveal the exact command and full output with `Ctrl+O`
- document the behavior and implementation

## User experience

Bash tool calls no longer fill the transcript with inline scripts or long command chains. A call can appear as a short description such as `Validating and committing changes`, while the exact command remains available through the existing expansion shortcut.

## Validation

- `uv run pytest` — 1481 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
