### PR TITLE
Improve compact TUI activity presentation

### DIFF
--- a/dev-notes/openai-reasoning-summary-boundaries.md
+++ b/dev-notes/openai-reasoning-summary-boundaries.md
@@ -1,0 +1,29 @@
+# OpenAI reasoning summary boundaries
+
+OpenAI Responses models can stream several `reasoning_summary_text` parts during
+one assistant turn. Each part is followed by a
+`response.reasoning_summary_part.done` event. Tau previously forwarded only the
+text deltas, so Markdown summaries such as `**First step**` and `**Second step**`
+were concatenated into `**First step****Second step**` in live display, persisted
+messages, and replay.
+
+Both Responses parsers now translate each completed summary-part boundary into a
+blank-line thinking delta. The canonical stream therefore retains separate
+Markdown paragraphs without inventing or exposing private reasoning content.
+This applies to the OpenAI-compatible Responses transport and the ChatGPT Codex
+subscription transport.
+
+The fix belongs in `tau_ai` rather than the TUI: canonical `ThinkingContent` must
+already contain the correct boundaries so every frontend, session file, export,
+and replay observes the same text. Existing sessions remain unchanged because
+Tau does not rewrite durable history; newly streamed responses preserve the
+boundaries.
+
+Tests in `tests/test_tau_ai.py` cover both transports and assert the individual
+thinking deltas plus the final canonical message.
+
+Run:
+
+```bash
+uv run pytest tests/test_tau_ai.py -k reasoning_summary
+```

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -8,14 +8,16 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 
 The bash tool requires the model to provide a brief present-participle
 `description` in the same tool call. The TUI normalizes that summary, limits it
-to 56 characters, and shows no command text while collapsed. `Ctrl+O` reveals the
-exact command. The running/success/failure color applies to the description. This
+to 56 characters, and shows no command text while collapsed. `Ctrl+O` keeps the
+description as the first line and reveals the exact command and result beneath it.
+The running/success/failure color applies to the description. This
 adds no second provider request. Calls that still omit the field because of
 malformed provider output, custom integrations, or older session history show the
 generic `Running shell command` label without exposing command text.
 
-`Ctrl+O` now expands both sides of a tool interaction: the exact bash command and
-the full result. Collapsing restores the compact command preview.
+`Ctrl+O` expands both sides of a tool interaction beneath the retained
+description: the exact bash command and the full result. Collapsing restores the
+description-only row.
 
 ## Architecture
 

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -7,21 +7,12 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 ## What changed
 
 The bash tool requires the model to provide a brief present-participle
-`description` in the same tool call. The TUI normalizes that summary and limits
-it to 56 characters. Short commands pair it with the complete command. Long or
-multiline commands show only the semantic description while collapsed; `Ctrl+O`
-reveals the exact command. The running/success/failure color applies only to the
-description, while visible short commands keep the neutral tool-body color. This
+`description` in the same tool call. The TUI normalizes that summary, limits it
+to 56 characters, and shows no command text while collapsed. `Ctrl+O` reveals the
+exact command. The running/success/failure color applies to the description. This
 adds no second provider request. Calls that still omit the field because of
-malformed provider output, custom integrations, or older session history keep a
-deterministic fallback:
-
-- multiline heredocs show the opening line and inline-script line count;
-- other multiline commands show the first line and total line count;
-- long inline-code commands show the prefix through `-c` or `-e` and a character
-  count;
-- other commands over 120 characters show their first 120 characters and total
-  character count.
+malformed provider output, custom integrations, or older session history show the
+generic `Running shell command` label without exposing command text.
 
 `Ctrl+O` now expands both sides of a tool interaction: the exact bash command and
 the full result. Collapsing restores the compact command preview.
@@ -35,9 +26,9 @@ of omissions and ignores the value, so malformed provider output, custom
 integrations, and older history cannot prevent command execution. The value is
 display metadata carried inside the existing `ToolCall.arguments` mapping.
 
-Formatting lives in `src/tau_coding/tui/state.py`. The state combines supplied
-descriptions with complete short commands, hides long commands behind their
-description, and creates an argument-only compact row when no description exists.
+Formatting lives in `src/tau_coding/tui/state.py`. The state shows supplied
+descriptions without command text and uses a generic label when no description
+exists.
 It resolves the exact invocation lazily when tool results are expanded. Existing
 custom tool `render_call` output still takes precedence. The print-mode transcript renderer
 explicitly requests the unabridged invocation because it has no interactive
@@ -49,10 +40,8 @@ display formatters and retains the complete `command`. No TUI concerns enter
 
 - `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the required
   schema field, omission-tolerant execution, and model instruction.
-- `tests/test_tui_adapter.py` covers semantic descriptions, complete short
-  commands, description-only long calls, heredocs, generic multiline commands,
-  whitespace-only input, interpreter flags, long inline code, long ordinary
-  commands, and exact expansion.
+- `tests/test_tui_adapter.py` covers semantic descriptions, generic omission
+  fallback, command-shape privacy, description truncation, and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
 - `tests/test_rendering.py` confirms print-mode transcripts always show the exact

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -7,10 +7,10 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 ## What changed
 
 The bash tool requires the model to provide a brief present-participle
-`description` in the same tool call. For long or multiline commands, the TUI
-normalizes that summary, limits it to 56 characters, and pairs it with a
-32-character prefix derived from the real command. Short commands always render
-verbatim, and summaries always retain deterministic command text. This adds
+`description` in the same tool call. The TUI normalizes that summary and limits
+it to 56 characters. Short commands pair it with the complete command; long or
+multiline commands pair it with a 32-character prefix derived from the real
+command. Every summary therefore retains deterministic command text. This adds
 no second provider request. Calls that still omit the field because of malformed
 provider output, custom integrations, or older session history keep a
 deterministic fallback:
@@ -34,9 +34,9 @@ of omissions and ignores the value, so malformed provider output, custom
 integrations, and older history cannot prevent command execution. The value is
 display metadata carried inside the existing `ToolCall.arguments` mapping.
 
-Formatting lives in `src/tau_coding/tui/state.py`. The state keeps short commands
-verbatim, combines supplied descriptions with deterministic command hints for
-long calls, or creates the argument-only compact row when no description exists.
+Formatting lives in `src/tau_coding/tui/state.py`. The state combines supplied
+descriptions with complete short commands or deterministic command hints for long
+calls, and creates an argument-only compact row when no description exists.
 It resolves the exact invocation lazily when tool results are expanded. Existing
 custom tool `render_call` output still takes precedence. The print-mode transcript renderer
 explicitly requests the unabridged invocation because it has no interactive
@@ -48,8 +48,8 @@ display formatters and retains the complete `command`. No TUI concerns enter
 
 - `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the required
   schema field, omission-tolerant execution, and model instruction.
-- `tests/test_tui_adapter.py` covers semantic descriptions, short commands,
-  command hints, short-command safety, heredocs, generic multiline commands,
+- `tests/test_tui_adapter.py` covers semantic descriptions, complete short
+  commands, command hints, short-command safety, heredocs, generic multiline commands,
   whitespace-only input, interpreter flags, long inline code, long ordinary
   commands, and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -8,14 +8,12 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 
 The bash tool requires the model to provide a brief present-participle
 `description` in the same tool call. The TUI normalizes that summary and limits
-it to 56 characters. Short commands pair it with the complete command; long or
-multiline commands pair it with a 32-character prefix derived from the real
-command. Every summary therefore retains deterministic command text. The
-running/success/failure color applies only to the semantic description; command
-text keeps the neutral tool-body color so description and evidence remain
-visually distinct. This adds no second provider request. Calls that still omit
-the field because of malformed
-provider output, custom integrations, or older session history keep a
+it to 56 characters. Short commands pair it with the complete command. Long or
+multiline commands show only the semantic description while collapsed; `Ctrl+O`
+reveals the exact command. The running/success/failure color applies only to the
+description, while visible short commands keep the neutral tool-body color. This
+adds no second provider request. Calls that still omit the field because of
+malformed provider output, custom integrations, or older session history keep a
 deterministic fallback:
 
 - multiline heredocs show the opening line and inline-script line count;
@@ -38,8 +36,8 @@ integrations, and older history cannot prevent command execution. The value is
 display metadata carried inside the existing `ToolCall.arguments` mapping.
 
 Formatting lives in `src/tau_coding/tui/state.py`. The state combines supplied
-descriptions with complete short commands or deterministic command hints for long
-calls, and creates an argument-only compact row when no description exists.
+descriptions with complete short commands, hides long commands behind their
+description, and creates an argument-only compact row when no description exists.
 It resolves the exact invocation lazily when tool results are expanded. Existing
 custom tool `render_call` output still takes precedence. The print-mode transcript renderer
 explicitly requests the unabridged invocation because it has no interactive
@@ -52,7 +50,7 @@ display formatters and retains the complete `command`. No TUI concerns enter
 - `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the required
   schema field, omission-tolerant execution, and model instruction.
 - `tests/test_tui_adapter.py` covers semantic descriptions, complete short
-  commands, command hints, short-command safety, heredocs, generic multiline commands,
+  commands, description-only long calls, heredocs, generic multiline commands,
   whitespace-only input, interpreter flags, long inline code, long ordinary
   commands, and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -7,8 +7,8 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 ## What changed
 
 The bash tool requires the model to provide a brief present-participle
-`description` in the same tool call. The TUI normalizes that summary, limits it
-to 56 characters, and shows no command text while collapsed. `Ctrl+O` keeps the
+`description` in the same tool call. The TUI normalizes whitespace but shows the
+complete summary and no command text while collapsed. `Ctrl+O` keeps the
 description as the first line and reveals the exact command and result beneath it.
 The running/success/failure color applies to the description. This
 adds no second provider request. Calls that still omit the field because of
@@ -43,7 +43,7 @@ display formatters and retains the complete `command`. No TUI concerns enter
 - `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the required
   schema field, omission-tolerant execution, and model instruction.
 - `tests/test_tui_adapter.py` covers semantic descriptions, generic omission
-  fallback, command-shape privacy, description truncation, and exact expansion.
+  fallback, command-shape privacy, complete descriptions, and exact expansion.
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
 - `tests/test_rendering.py` confirms print-mode transcripts always show the exact

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -10,8 +10,11 @@ The bash tool requires the model to provide a brief present-participle
 `description` in the same tool call. The TUI normalizes that summary and limits
 it to 56 characters. Short commands pair it with the complete command; long or
 multiline commands pair it with a 32-character prefix derived from the real
-command. Every summary therefore retains deterministic command text. This adds
-no second provider request. Calls that still omit the field because of malformed
+command. Every summary therefore retains deterministic command text. The
+running/success/failure color applies only to the semantic description; command
+text keeps the neutral tool-body color so description and evidence remain
+visually distinct. This adds no second provider request. Calls that still omit
+the field because of malformed
 provider output, custom integrations, or older session history keep a
 deterministic fallback:
 

--- a/dev-notes/tui-compact-bash-invocations.md
+++ b/dev-notes/tui-compact-bash-invocations.md
@@ -6,13 +6,14 @@ that embed source code directly in `python -c`, `node -e`, or similar arguments.
 
 ## What changed
 
-The bash tool now asks the model for an optional, brief present-participle
+The bash tool requires the model to provide a brief present-participle
 `description` in the same tool call. For long or multiline commands, the TUI
 normalizes that summary, limits it to 56 characters, and pairs it with a
 32-character prefix derived from the real command. Short commands always render
 verbatim, and summaries always retain deterministic command text. This adds
-no second provider request. Calls from models that omit the optional field keep
-a deterministic fallback:
+no second provider request. Calls that still omit the field because of malformed
+provider output, custom integrations, or older session history keep a
+deterministic fallback:
 
 - multiline heredocs show the opening line and inline-script line count;
 - other multiline commands show the first line and total line count;
@@ -27,9 +28,11 @@ the full result. Collapsing restores the compact command preview.
 ## Architecture
 
 The provider-visible bash schema and tool prompt guideline live in
-`src/tau_coding/tools.py`. `description` remains optional so a model omission
-cannot prevent command execution. The executor ignores it; the value is display
-metadata carried inside the existing `ToolCall.arguments` mapping.
+`src/tau_coding/tools.py`. The schema requires `description` to make compliant
+models return the display metadata consistently. The executor remains tolerant
+of omissions and ignores the value, so malformed provider output, custom
+integrations, and older history cannot prevent command execution. The value is
+display metadata carried inside the existing `ToolCall.arguments` mapping.
 
 Formatting lives in `src/tau_coding/tui/state.py`. The state keeps short commands
 verbatim, combines supplied descriptions with deterministic command hints for
@@ -43,8 +46,8 @@ display formatters and retains the complete `command`. No TUI concerns enter
 
 ## Tests
 
-- `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the optional
-  schema field and model instruction.
+- `tests/test_coding_tools.py` and `tests/test_system_prompt.py` cover the required
+  schema field, omission-tolerant execution, and model instruction.
 - `tests/test_tui_adapter.py` covers semantic descriptions, short commands,
   command hints, short-command safety, heredocs, generic multiline commands,
   whitespace-only input, interpreter flags, long inline code, long ordinary
@@ -52,7 +55,7 @@ display formatters and retains the complete `command`. No TUI concerns enter
 - `tests/test_tui_app.py` uses a Textual pilot to confirm `Ctrl+O` replaces a
   compact heredoc row with the exact command and full result.
 - `tests/test_rendering.py` confirms print-mode transcripts always show the exact
-  command instead of the optional description.
+  command instead of the display description.
 
 Run:
 

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -32,9 +32,10 @@ skill presentation.
 Grouping is display-only in `src/tau_coding/tui/`. `TuiEventAdapter` assigns a
 presentation batch identifier to tool calls from one completed assistant message.
 `TuiState` keeps each grouped call's ID, arguments, progress, result, and timing,
-while exposing one aggregate `ChatItem`. Every call ID maps back to that item, so
-live updates continue to use O(1) lookup and refresh the existing Textual widget
-in place. Results still determine aggregate progress and error styling, but the
+while exposing one aggregate read row. That row can stand alone or live inside a
+larger mixed-tool batch. Every call ID maps back to its top-level item, so live
+updates continue to use O(1) lookup and refresh the existing Textual widget in
+place. Results still determine aggregate progress and error styling, but the
 widget suppresses their content when rendering a grouped row.
 
 Restored canonical messages use the same assistant-message boundary to rebuild

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -30,6 +30,11 @@ existing row and result behavior. Reads separated by another tool, text block,
 or assistant response are not grouped. Skill-file reads retain their special
 skill presentation.
 
+Adjacent built-in `edit` calls use the same presentation: `Editing N files`
+becomes `Edited N files`, with every edited path listed below. Expanding an edit
+group preserves each invocation and result, unlike read groups whose file-content
+results stay suppressed.
+
 ## Architecture
 
 Grouping is display-only in `src/tau_coding/tui/`. `TuiEventAdapter` assigns a
@@ -46,15 +51,13 @@ the group deterministically. Agent events, tool execution, provider payloads,
 and session JSONL remain unchanged. Existing custom call renderers are applied
 to each invocation when a group is expanded.
 
-The first version intentionally groups only built-in `read` calls. Mutating tools
-and shell commands remain separate so consequential actions are never hidden in
-an aggregate row. Other read-only tools can adopt the same presentation model
-later once their argument previews and extension behavior are defined.
+Only built-in `read` and `edit` calls use file grouping. Shell commands and
+extension tools retain their own presentation semantics.
 
 ## Tests
 
-- `tests/test_tui_adapter.py` covers restored groups, call-ID lookup, expanded
-  invocations/results, and assistant-message boundaries.
+- `tests/test_tui_adapter.py` covers restored read/edit groups, path lists,
+  call-ID lookup, expanded invocations/results, and assistant-message boundaries.
 - `tests/test_tui_app.py` covers live grouping, in-place progress updates,
   completion, and `Ctrl+O` expansion in Textual.
 

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -1,0 +1,56 @@
+# Grouped read calls in the TUI
+
+Models often request several files in one assistant response. Rendering every
+batched `read` as a separate collapsed row made exploration-heavy turns noisy,
+even though the calls formed one logical batch.
+
+## What changed
+
+The TUI now combines adjacent `read` calls from the same assistant message into
+one presentation row:
+
+```text
+→ Reading 4 files · tools.py, state.py, widgets.py, +1
+```
+
+As results arrive, the row reports aggregate progress such as `2/4 complete`.
+Once all calls finish it changes to `Read 4 files`; if any call failed, the row
+also reports the failure count and uses the existing error styling. At most three
+paths are previewed, and long paths retain their filename-bearing suffix.
+
+`Ctrl+O` expands the group into every exact read invocation and its individual
+result. A single read keeps its existing row. Reads separated by another tool,
+text block, or assistant response are not grouped. Skill-file reads retain their
+special skill presentation.
+
+## Architecture
+
+Grouping is display-only in `src/tau_coding/tui/`. `TuiEventAdapter` assigns a
+presentation batch identifier to tool calls from one completed assistant message.
+`TuiState` keeps each grouped call's ID, arguments, progress, result, and timing,
+while exposing one aggregate `ChatItem`. Every call ID maps back to that item, so
+live updates continue to use O(1) lookup and refresh the existing Textual widget
+in place.
+
+Restored canonical messages use the same assistant-message boundary to rebuild
+the group deterministically. Agent events, tool execution, provider payloads,
+and session JSONL remain unchanged. Existing custom call renderers are applied
+to each invocation when a group is expanded.
+
+The first version intentionally groups only built-in `read` calls. Mutating tools
+and shell commands remain separate so consequential actions are never hidden in
+an aggregate row. Other read-only tools can adopt the same presentation model
+later once their argument previews and extension behavior are defined.
+
+## Tests
+
+- `tests/test_tui_adapter.py` covers restored groups, call-ID lookup, expanded
+  invocations/results, and assistant-message boundaries.
+- `tests/test_tui_app.py` covers live grouping, in-place progress updates,
+  completion, and `Ctrl+O` expansion in Textual.
+
+Run:
+
+```bash
+uv run pytest tests/test_tui_adapter.py tests/test_tui_app.py
+```

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -15,8 +15,10 @@ one presentation row:
 
 As results arrive, the row reports aggregate progress such as `2/4 complete`.
 Once all calls finish it changes to `Read 4 files`; if any call failed, the row
-also reports the failure count and uses the existing error styling. At most three
-paths are previewed, and long paths retain their filename-bearing suffix.
+also reports the failure count and uses the existing error styling. The aggregate
+description and progress carry the running/success/failure color, while file paths
+stay in the neutral tool-body color. At most three paths are previewed, and long
+paths retain their filename-bearing suffix.
 
 `Ctrl+O` expands the group into every exact read invocation without repeating
 previews of the file contents. The model already receives each complete result;

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -7,18 +7,21 @@ even though the calls formed one logical batch.
 ## What changed
 
 The TUI now combines adjacent `read` calls from the same assistant message into
-one presentation row:
+one presentation group with every path listed below its headline:
 
 ```text
-→ Reading 4 files · tools.py, state.py, widgets.py, +1
+→ Reading 4 files
+  - tools.py
+  - state.py
+  - widgets.py
+  - adapter.py
 ```
 
 As results arrive, the row reports aggregate progress such as `2/4 complete`.
 Once all calls finish it changes to `Read 4 files`; if any call failed, the row
 also reports the failure count and uses the existing error styling. The aggregate
-description and progress carry the running/success/failure color, while file paths
-stay in the neutral tool-body color. At most three paths are previewed, and long
-paths retain their filename-bearing suffix.
+description and progress carry the running/success/failure color, while every
+file path stays in the neutral tool-body color.
 
 `Ctrl+O` expands the group into every exact read invocation without repeating
 previews of the file contents. The model already receives each complete result;

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -18,10 +18,12 @@ Once all calls finish it changes to `Read 4 files`; if any call failed, the row
 also reports the failure count and uses the existing error styling. At most three
 paths are previewed, and long paths retain their filename-bearing suffix.
 
-`Ctrl+O` expands the group into every exact read invocation and its individual
-result. A single read keeps its existing row. Reads separated by another tool,
-text block, or assistant response are not grouped. Skill-file reads retain their
-special skill presentation.
+`Ctrl+O` expands the group into every exact read invocation without repeating
+previews of the file contents. The model already receives each complete result;
+the expanded TUI stays focused on which files were read. A single read keeps its
+existing row and result behavior. Reads separated by another tool, text block,
+or assistant response are not grouped. Skill-file reads retain their special
+skill presentation.
 
 ## Architecture
 
@@ -30,7 +32,8 @@ presentation batch identifier to tool calls from one completed assistant message
 `TuiState` keeps each grouped call's ID, arguments, progress, result, and timing,
 while exposing one aggregate `ChatItem`. Every call ID maps back to that item, so
 live updates continue to use O(1) lookup and refresh the existing Textual widget
-in place.
+in place. Results still determine aggregate progress and error styling, but the
+widget suppresses their content when rendering a grouped row.
 
 Restored canonical messages use the same assistant-message boundary to rebuild
 the group deterministically. Agent events, tool execution, provider payloads,

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -1,0 +1,58 @@
+# Batched tool calls in the TUI
+
+Assistant responses frequently contain several adjacent tool calls. Even after
+read calls gained their own compact grouping, rendering each remaining call as a
+separate transcript message repeated the same border, padding, and vertical
+spacing for one logical burst of work.
+
+## What changed
+
+Adjacent built-in tool calls from one assistant response now share one transcript
+message. Each logical action remains one line:
+
+```text
+Doing thing one     · $ command one
+Doing thing two     · $ command two
+Read 5 files        · a.py, b.py, c.py, +2
+Doing something else · $ command three
+```
+
+Each line keeps its own running, success, or failure color on the semantic
+description. Commands, arguments, and paths remain neutral. Adjacent reads still
+collapse into one read row inside the larger batch.
+
+`Ctrl+O` expands every row using its tool-specific behavior. Bash rows recover
+the exact command and show their result. Grouped reads expand to individual read
+invocations without repeating file-content previews. Patch results retain their
+existing diff rendering.
+
+Batches never cross assistant text, thinking blocks, model continuations, skill
+loads, or separate assistant responses. Calls with custom call-card rendering
+remain separate so an extension's layout is not flattened into a text row.
+
+## Architecture
+
+This remains a TUI-only projection. `TuiEventAdapter` assigns one presentation
+batch identifier to each contiguous tool-call run in an assistant message.
+`TuiState` stores one parent `ChatItem` with structured child rows, while every
+underlying tool-call ID continues to map to the parent for O(1) live updates. A
+child row may itself own a grouped-read call list.
+
+The transcript widget renders child rows inside one message and computes status
+color per child rather than assigning one color to the container. Expansion and
+selection text are also derived from the structured children. Provider payloads,
+agent events, execution order, canonical messages, and session JSONL are
+unchanged.
+
+## Tests
+
+- `tests/test_tui_adapter.py` covers restored mixed-tool batches, nested read
+  groups, and call-ID lookup.
+- `tests/test_tui_app.py` covers one-widget rendering, expansion, bash results,
+  and suppressed grouped-read content.
+
+Run:
+
+```bash
+uv run pytest tests/test_tui_adapter.py tests/test_tui_app.py
+```

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -22,13 +22,14 @@ description. Commands, arguments, and paths remain neutral. Adjacent reads still
 collapse into one read row inside the larger batch.
 
 `Ctrl+O` expands every row using its tool-specific behavior. Bash rows retain
-their description and show the exact command and result beneath it. Grouped reads expand to individual read
-invocations without repeating file-content previews. Batch invocations and
+their description and show the exact command and result beneath it. Grouped reads
+expand to individual read invocations without repeating file-content previews. Batch invocations and
 results remain one selectable plain-text surface.
 
 Batches never cross assistant text, thinking blocks, model continuations, skill
-loads, or separate assistant responses. Calls with custom call-card rendering
-remain separate so an extension's layout is not flattened into a text row.
+loads, or separate assistant responses. Only the known `bash`, `read`, `edit`,
+and `write` tools are eligible; extension tools remain separate so custom call
+or result cards are never flattened into generic text rows.
 
 ## Architecture
 

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -21,8 +21,8 @@ Each line keeps its own running, success, or failure color on the semantic
 description. Commands, arguments, and paths remain neutral. Adjacent reads still
 collapse into one read row inside the larger batch.
 
-`Ctrl+O` expands every row using its tool-specific behavior. Bash rows recover
-the exact command and show their result. Grouped reads expand to individual read
+`Ctrl+O` expands every row using its tool-specific behavior. Bash rows retain
+their description and show the exact command and result beneath it. Grouped reads expand to individual read
 invocations without repeating file-content previews. Batch invocations and
 results remain one selectable plain-text surface.
 

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -21,11 +21,12 @@ Doing something else
 
 Each line keeps its own running, success, or failure color on the semantic
 description. Commands, arguments, and paths remain neutral. Adjacent reads still
-collapse into one read row inside the larger batch.
+collapse into file-list rows inside the larger batch, as do adjacent edits.
 
 `Ctrl+O` expands every row using its tool-specific behavior. Bash rows retain
 their description and show the exact command and result beneath it. Grouped reads
-expand to individual read invocations without repeating file-content previews. Batch invocations and
+expand to individual read invocations without repeating file-content previews;
+grouped edits retain each invocation and result. Batch invocations and
 results remain one selectable plain-text surface.
 
 Batches never cross assistant text, thinking blocks, model continuations, skill

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -13,7 +13,9 @@ message. Each logical action remains one line:
 ```text
 Doing thing one
 Doing thing two
-Read 5 files · a.py, b.py, c.py, +2
+Read 2 files
+  - a.py
+  - b.py
 Doing something else
 ```
 

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -11,10 +11,10 @@ Adjacent built-in tool calls from one assistant response now share one transcrip
 message. Each logical action remains one line:
 
 ```text
-Doing thing one     · $ command one
-Doing thing two     · $ command two
-Read 5 files        · a.py, b.py, c.py, +2
-Doing something else · $ command three
+Doing thing one
+Doing thing two
+Read 5 files · a.py, b.py, c.py, +2
+Doing something else
 ```
 
 Each line keeps its own running, success, or failure color on the semantic

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -23,8 +23,8 @@ collapse into one read row inside the larger batch.
 
 `Ctrl+O` expands every row using its tool-specific behavior. Bash rows recover
 the exact command and show their result. Grouped reads expand to individual read
-invocations without repeating file-content previews. Patch results retain their
-existing diff rendering.
+invocations without repeating file-content previews. Batch invocations and
+results remain one selectable plain-text surface.
 
 Batches never cross assistant text, thinking blocks, model continuations, skill
 loads, or separate assistant responses. Calls with custom call-card rendering
@@ -38,9 +38,11 @@ batch identifier to each contiguous tool-call run in an assistant message.
 underlying tool-call ID continues to map to the parent for O(1) live updates. A
 child row may itself own a grouped-read call list.
 
-The transcript widget renders child rows inside one message and computes status
-color per child rather than assigning one color to the container. Expansion and
-selection text are also derived from the structured children. Provider payloads,
+The transcript widget renders child rows as one Rich `Text` value with status
+spans per child rather than a `Group` of separate renderables. This preserves
+Textual's drag selection across lines while retaining independent colors.
+Expansion and selection text are derived from the same structured children.
+Provider payloads,
 agent events, execution order, canonical messages, and session JSONL are
 unchanged.
 

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -594,6 +594,12 @@ async def _codex_provider_events(
                 thinking_parts.append(delta)
                 yield ProviderThinkingDeltaEvent(delta=delta)
 
+        elif event_type == "response.reasoning_summary_part.done":
+            if thinking_parts:
+                separator = "\n\n"
+                thinking_parts.append(separator)
+                yield ProviderThinkingDeltaEvent(delta=separator)
+
         elif event_type in {
             "response.output_item.done",
             "response.output_item.completed",

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -604,6 +604,12 @@ class _ResponsesStreamParser:
                 self._thinking_parts.append(delta)
                 return [ProviderThinkingDeltaEvent(delta=delta)], False
 
+        elif chunk_type == "response.reasoning_summary_part.done":
+            if self._thinking_parts:
+                separator = "\n\n"
+                self._thinking_parts.append(separator)
+                return [ProviderThinkingDeltaEvent(delta=separator)], False
+
         elif chunk_type == "response.output_item.added":
             item = chunk.get("item")
             _register_reasoning_item(self._reasoning_items, item)

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -725,7 +725,7 @@ def create_bash_tool_definition(
                     "description": "Timeout in seconds (optional, no default timeout)",
                 },
             },
-            "required": ["command"],
+            "required": ["command", "description"],
         },
         executor=execute,
     )

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -97,17 +97,17 @@ class TuiEventAdapter:
                 else:
                     self._pending_overflow_error = None
                     self.state.add_assistant_message(message, include_tool_calls=False)
-                    previous_was_read = False
+                    previous_was_tool = False
                     batch_id: int | None = None
                     for block in message.content:
-                        if isinstance(block, ToolCall) and block.name == "read":
-                            if not previous_was_read:
+                        if isinstance(block, ToolCall):
+                            if not previous_was_tool:
                                 batch_id = self.state.new_tool_batch_id()
                             if batch_id is not None:
                                 self._tool_batch_ids[block.id] = batch_id
-                            previous_was_read = True
+                            previous_was_tool = True
                         else:
-                            previous_was_read = False
+                            previous_was_tool = False
                 self.state.assistant_buffer = ""
                 self._assistant_start_item_index = None
             return

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -29,6 +29,7 @@ class TuiEventAdapter:
         self.state = state
         self._assistant_start_item_index: int | None = None
         self._pending_overflow_error: AssistantMessage | None = None
+        self._tool_batch_ids: dict[str, int] = {}
 
     def apply(self, event: CodingSessionEvent) -> None:
         if isinstance(event, AgentStartEvent):
@@ -96,13 +97,25 @@ class TuiEventAdapter:
                 else:
                     self._pending_overflow_error = None
                     self.state.add_assistant_message(message, include_tool_calls=False)
+                    previous_was_read = False
+                    batch_id: int | None = None
+                    for block in message.content:
+                        if isinstance(block, ToolCall) and block.name == "read":
+                            if not previous_was_read:
+                                batch_id = self.state.new_tool_batch_id()
+                            if batch_id is not None:
+                                self._tool_batch_ids[block.id] = batch_id
+                            previous_was_read = True
+                        else:
+                            previous_was_read = False
                 self.state.assistant_buffer = ""
                 self._assistant_start_item_index = None
             return
         if isinstance(event, ToolExecutionStartEvent):
             self._flush()
             self.state.add_tool_call(
-                ToolCall(id=event.tool_call_id, name=event.tool_name, arguments=event.args)
+                ToolCall(id=event.tool_call_id, name=event.tool_name, arguments=event.args),
+                batch_id=self._tool_batch_ids.pop(event.tool_call_id, None),
             )
             return
         if isinstance(event, ToolExecutionUpdateEvent):

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4899,15 +4899,23 @@ class TauTuiApp(App[None]):
             return
         if isinstance(event, ToolExecutionStartEvent):
             await transcript.finish_assistant_message()
-            item = self.state.items[-1]
-            await transcript.append_item(
-                item,
-                theme=theme,
-                show_tool_results=self.state.show_tool_results,
-                invocation=self.state.resolve_tool_invocation(
-                    item, expanded=self.state.show_tool_results
-                ),
-            )
+            item = self.state.find_tool_item(event.tool_call_id)
+            if item is not None:
+                expanded = self.state.show_tool_results or item.always_show_tool_result
+                updated = await transcript.update_item(
+                    item,
+                    theme=theme,
+                    show_tool_results=expanded,
+                    invocation=self.state.resolve_tool_invocation(item, expanded=expanded),
+                    result_markup=self.state.resolve_tool_result(item, expanded=expanded),
+                )
+                if not updated:
+                    await transcript.append_item(
+                        item,
+                        theme=theme,
+                        show_tool_results=expanded,
+                        invocation=self.state.resolve_tool_invocation(item, expanded=expanded),
+                    )
             self._refresh_chrome()
             return
         if isinstance(event, ToolExecutionUpdateEvent):

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -604,14 +604,16 @@ def _format_bash_tool_call_invocation(
         return None
     timeout = _number_argument(arguments, "timeout")
     suffix = f" (timeout {timeout:g}s)" if timeout is not None else ""
-    if compact and _is_short_single_line_bash_command(command):
-        return f"$ {command}{suffix}"
     if compact:
         description = _string_argument(arguments, "description")
         if description is not None:
             displayed_description = _compact_bash_description(description)
             if displayed_description:
-                hint = _bash_command_hint(command)
+                hint = (
+                    command
+                    if _is_short_single_line_bash_command(command)
+                    else _bash_command_hint(command)
+                )
                 return f"→ {displayed_description} · $ {hint}{suffix}"
     displayed_command = _compact_bash_command(command) if compact else command
     return f"$ {displayed_command}{suffix}"

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -308,10 +308,7 @@ class TuiState:
             item.text = f"→ Read {len(members)} files{failure} · {labels}"
         if completed:
             status = "✗" if failures else ("✓" if all_complete else "…")
-            results = "\n\n".join(
-                member.tool_result_text for member in completed if member.tool_result_text
-            )
-            item.tool_result_text = f"{status} read group\n{results}"
+            item.tool_result_text = f"{status} read group"
         else:
             item.tool_result_text = None
         item.update_text = next(

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -37,10 +37,26 @@ TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_COMMAND_PREVIEW_CHARS = 120
 BASH_DESCRIPTION_PREVIEW_CHARS = 56
 BASH_COMMAND_HINT_CHARS = 32
+TOOL_GROUP_PREVIEW_ITEMS = 3
+TOOL_GROUP_PATH_CHARS = 32
 _INLINE_CODE_PATTERN = re.compile(
     r"(?:^|[;&|]\s*|\s)(?:(?:python(?:\d+(?:\.\d+)*)?|bash|sh|zsh)\s+-c|node\s+-e)\s+"
 )
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+@dataclass(slots=True)
+class GroupedToolCall:
+    """One underlying call represented by a grouped transcript row."""
+
+    tool_call_id: str
+    tool_name: str
+    tool_arguments: dict[str, JSONValue]
+    text: str
+    tool_result_text: str | None = None
+    tool_result: AgentToolResult | None = None
+    update_text: str | None = None
+    started_at: float | None = None
 
 
 @dataclass(slots=True)
@@ -58,6 +74,8 @@ class ChatItem:
     tool_name: str | None = None
     tool_arguments: dict[str, JSONValue] | None = None
     started_at: float | None = None
+    tool_batch_id: int | None = None
+    grouped_tool_calls: list[GroupedToolCall] | None = None
     always_show_tool_result: bool = False
     custom_type: str | None = None
     details: dict[str, JSONValue] | None = None
@@ -86,6 +104,13 @@ class TuiState:
         repr=False,
         compare=False,
     )
+    _grouped_calls_by_call_id: dict[str, GroupedToolCall] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _next_tool_batch_id: int = field(default=0, init=False, repr=False, compare=False)
 
     def add_item(
         self,
@@ -136,6 +161,16 @@ class TuiState:
         """
         if item.role != "tool":
             return None
+        if item.grouped_tool_calls is not None:
+            if not expanded:
+                return None
+            lines: list[str] = []
+            for member in item.grouped_tool_calls:
+                rendered_line = None
+                if self.tool_call_renderer is not None:
+                    rendered_line = self.tool_call_renderer(member.tool_name, member.tool_arguments)
+                lines.append(rendered_line if rendered_line is not None else member.text)
+            return "\n".join(lines)
         line: str | None = None
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
@@ -162,14 +197,24 @@ class TuiState:
         their tool's `render_result` on the next redraw. ``None`` means "no
         renderer" and the caller falls back to the generic result block.
         """
-        if item.role != "tool" or item.tool_result is None or self.tool_result_renderer is None:
+        if (
+            item.role != "tool"
+            or item.grouped_tool_calls is not None
+            or item.tool_result is None
+            or self.tool_result_renderer is None
+        ):
             return None
         if item.tool_name is None:
             return None
         return self.tool_result_renderer(item.tool_name, item.tool_result, expanded)
 
-    def add_tool_call(self, tool_call: ToolCall) -> None:
-        """Append a collapsed tool-call item."""
+    def new_tool_batch_id(self) -> int:
+        """Return a presentation-only id for calls from one assistant message."""
+        self._next_tool_batch_id += 1
+        return self._next_tool_batch_id
+
+    def add_tool_call(self, tool_call: ToolCall, *, batch_id: int | None = None) -> ChatItem:
+        """Append a collapsed tool call, grouping adjacent reads from one response."""
         skill_name = self._read_skill_name(tool_call)
         if skill_name is not None:
             self.add_item(
@@ -177,7 +222,11 @@ class TuiState:
                 f"Loading skill: {skill_name}",
                 tool_call_id=tool_call.id,
             )
-            return
+            return self.items[-1]
+        if self._can_group_read_call(tool_call, batch_id=batch_id):
+            item = self.items[-1]
+            self._append_grouped_read_call(item, tool_call)
+            return item
         item = ChatItem(
             role="tool",
             text=format_tool_call_block(tool_call),
@@ -185,9 +234,94 @@ class TuiState:
             tool_name=tool_call.name,
             tool_arguments=tool_call.arguments,
             started_at=time.monotonic(),
+            tool_batch_id=batch_id,
         )
         self.items.append(item)
         self._tool_items_by_call_id[tool_call.id] = item
+        return item
+
+    def _can_group_read_call(self, tool_call: ToolCall, *, batch_id: int | None) -> bool:
+        if tool_call.name != "read" or batch_id is None or not self.items:
+            return False
+        previous = self.items[-1]
+        return (
+            previous.role == "tool"
+            and previous.tool_name == "read"
+            and previous.tool_batch_id == batch_id
+        )
+
+    def _append_grouped_read_call(self, item: ChatItem, tool_call: ToolCall) -> None:
+        if item.grouped_tool_calls is None:
+            first = GroupedToolCall(
+                tool_call_id=item.tool_call_id or "display-call",
+                tool_name=item.tool_name or "read",
+                tool_arguments=item.tool_arguments or {},
+                text=format_tool_call_block(
+                    ToolCall(
+                        id=item.tool_call_id or "display-call",
+                        name=item.tool_name or "read",
+                        arguments=item.tool_arguments or {},
+                    )
+                ),
+                tool_result_text=item.tool_result_text,
+                tool_result=item.tool_result,
+                update_text=item.update_text,
+                started_at=item.started_at,
+            )
+            item.grouped_tool_calls = [first]
+            self._grouped_calls_by_call_id[first.tool_call_id] = first
+        member = GroupedToolCall(
+            tool_call_id=tool_call.id,
+            tool_name=tool_call.name,
+            tool_arguments=tool_call.arguments,
+            text=format_tool_call_block(tool_call),
+            started_at=time.monotonic(),
+        )
+        item.grouped_tool_calls.append(member)
+        self._tool_items_by_call_id[tool_call.id] = item
+        self._grouped_calls_by_call_id[tool_call.id] = member
+        self._refresh_tool_group(item)
+
+    def _refresh_tool_group(self, item: ChatItem) -> None:
+        members = item.grouped_tool_calls or []
+        completed = [member for member in members if member.tool_result_text is not None]
+        failures = [
+            member
+            for member in completed
+            if member.tool_result_text is not None and member.tool_result_text.startswith("✗")
+        ]
+        paths = [
+            _string_argument(member.tool_arguments, "path") or "[unknown path]"
+            for member in members
+        ]
+        labels = ", ".join(
+            _compact_tool_group_path(path) for path in paths[:TOOL_GROUP_PREVIEW_ITEMS]
+        )
+        if len(paths) > TOOL_GROUP_PREVIEW_ITEMS:
+            labels += f", +{len(paths) - TOOL_GROUP_PREVIEW_ITEMS}"
+        all_complete = len(completed) == len(members)
+        if not all_complete:
+            progress = f" · {len(completed)}/{len(members)} complete" if completed else ""
+            item.text = f"→ Reading {len(members)} files{progress} · {labels}"
+        else:
+            failure = f" · {len(failures)} failed" if failures else ""
+            item.text = f"→ Read {len(members)} files{failure} · {labels}"
+        if completed:
+            status = "✗" if failures else ("✓" if all_complete else "…")
+            results = "\n\n".join(
+                member.tool_result_text for member in completed if member.tool_result_text
+            )
+            item.tool_result_text = f"{status} read group\n{results}"
+        else:
+            item.tool_result_text = None
+        item.update_text = next(
+            (member.update_text for member in members if member.update_text),
+            None,
+        )
+        item.started_at = next(
+            (member.started_at for member in members if member.tool_result_text is None),
+            None,
+        )
 
     def add_user_message(
         self,
@@ -246,7 +380,16 @@ class TuiState:
     def record_tool_update(self, tool_call_id: str, message: str) -> ChatItem | None:
         """Attach live progress to its pending tool call; drop orphan updates."""
         item = self.find_tool_item(tool_call_id)
-        if item is None or item.tool_result_text is not None:
+        if item is None:
+            return None
+        member = self._grouped_calls_by_call_id.get(tool_call_id)
+        if member is not None:
+            if member.tool_result_text is not None:
+                return None
+            member.update_text = message
+            self._refresh_tool_group(item)
+            return item
+        if item.tool_result_text is not None:
             return None
         item.update_text = message
         return item
@@ -267,6 +410,14 @@ class TuiState:
         )
         item = self.find_tool_item(tool_call_id)
         if item is not None:
+            member = self._grouped_calls_by_call_id.get(tool_call_id)
+            if member is not None:
+                member.tool_result_text = result_text
+                member.tool_result = result
+                member.update_text = None
+                member.started_at = None
+                self._refresh_tool_group(item)
+                return
             item.tool_result_text = result_text
             item.tool_result = result
             item.update_text = None
@@ -305,6 +456,7 @@ class TuiState:
         """Clear visible transcript state without modifying durable session history."""
         self.items.clear()
         self._tool_items_by_call_id.clear()
+        self._grouped_calls_by_call_id.clear()
         self.assistant_buffer = ""
         self.error = None
 
@@ -355,6 +507,7 @@ class TuiState:
         include_tool_calls: bool = True,
     ) -> None:
         """Project canonical assistant blocks into display state in order."""
+        batch_id = self.new_tool_batch_id() if include_tool_calls and message.tool_calls else None
         for block in message.content:
             if isinstance(block, ThinkingContent):
                 if block.thinking:
@@ -363,7 +516,7 @@ class TuiState:
                 if block.text:
                     self.add_item("assistant", block.text)
             elif include_tool_calls:
-                self.add_tool_call(block)
+                self.add_tool_call(block, batch_id=batch_id)
 
     def add_assistant_error(self, message: AssistantMessage) -> None:
         """Project any partial response followed by its terminal error."""
@@ -561,6 +714,13 @@ def _fallback_tool_call_invocation(tool_call: ToolCall) -> str:
 def _string_argument(arguments: dict[str, JSONValue], key: str) -> str | None:
     value = arguments.get(key)
     return value if isinstance(value, str) else None
+
+
+def _compact_tool_group_path(path: str) -> str:
+    normalized = " ".join(path.split())
+    if len(normalized) <= TOOL_GROUP_PATH_CHARS:
+        return normalized
+    return "…" + normalized[-(TOOL_GROUP_PATH_CHARS - 1) :]
 
 
 def _normalized_path(path: str | Path) -> Path:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -33,7 +33,6 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # Show live elapsed time on an executing tool row once it stops being instant;
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
-BASH_DESCRIPTION_PREVIEW_CHARS = 56
 BATCHABLE_TOOL_NAMES = frozenset({"bash", "edit", "read", "write"})
 
 
@@ -708,18 +707,15 @@ def _format_bash_tool_call_invocation(
     if compact:
         description = _string_argument(arguments, "description")
         if description is not None:
-            displayed_description = _compact_bash_description(description)
+            displayed_description = _normalize_bash_description(description)
             if displayed_description:
                 return f"→ {displayed_description}{suffix}"
         return f"→ Running shell command{suffix}"
     return f"$ {command}{suffix}"
 
 
-def _compact_bash_description(description: str) -> str:
-    normalized = " ".join(description.split())
-    if len(normalized) <= BASH_DESCRIPTION_PREVIEW_CHARS:
-        return normalized
-    return normalized[: BASH_DESCRIPTION_PREVIEW_CHARS - 1].rstrip() + "…"
+def _normalize_bash_description(description: str) -> str:
+    return " ".join(description.split())
 
 
 def _read_line_suffix(arguments: dict[str, JSONValue]) -> str:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -36,7 +36,6 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_COMMAND_PREVIEW_CHARS = 120
 BASH_DESCRIPTION_PREVIEW_CHARS = 56
-BASH_COMMAND_HINT_CHARS = 32
 TOOL_GROUP_PREVIEW_ITEMS = 3
 TOOL_GROUP_PATH_CHARS = 32
 _INLINE_CODE_PATTERN = re.compile(
@@ -707,12 +706,9 @@ def _format_bash_tool_call_invocation(
         if description is not None:
             displayed_description = _compact_bash_description(description)
             if displayed_description:
-                hint = (
-                    command
-                    if _is_short_single_line_bash_command(command)
-                    else _bash_command_hint(command)
-                )
-                return f"→ {displayed_description} · $ {hint}{suffix}"
+                if _is_short_single_line_bash_command(command):
+                    return f"→ {displayed_description} · $ {command}{suffix}"
+                return f"→ {displayed_description}{suffix}"
     displayed_command = _compact_bash_command(command) if compact else command
     return f"$ {displayed_command}{suffix}"
 
@@ -721,14 +717,6 @@ def _is_short_single_line_bash_command(command: str) -> bool:
     return (
         "\n" not in command and "\r" not in command and len(command) <= BASH_COMMAND_PREVIEW_CHARS
     )
-
-
-def _bash_command_hint(command: str) -> str:
-    first_line = next((line.strip() for line in command.splitlines() if line.strip()), "")
-    normalized = " ".join(first_line.split()) or "[empty command]"
-    if len(normalized) <= BASH_COMMAND_HINT_CHARS:
-        return normalized
-    return normalized[: BASH_COMMAND_HINT_CHARS - 1].rstrip() + "…"
 
 
 def _compact_bash_description(description: str) -> str:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -34,8 +34,6 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_DESCRIPTION_PREVIEW_CHARS = 56
-TOOL_GROUP_PREVIEW_ITEMS = 3
-TOOL_GROUP_PATH_CHARS = 32
 BATCHABLE_TOOL_NAMES = frozenset({"bash", "edit", "read", "write"})
 
 
@@ -381,18 +379,15 @@ class TuiState:
             _string_argument(member.tool_arguments, "path") or "[unknown path]"
             for member in members
         ]
-        labels = ", ".join(
-            _compact_tool_group_path(path) for path in paths[:TOOL_GROUP_PREVIEW_ITEMS]
-        )
-        if len(paths) > TOOL_GROUP_PREVIEW_ITEMS:
-            labels += f", +{len(paths) - TOOL_GROUP_PREVIEW_ITEMS}"
+        path_list = "\n".join(f"  - {path}" for path in paths)
         all_complete = len(completed) == len(members)
         if not all_complete:
             progress = f" · {len(completed)}/{len(members)} complete" if completed else ""
-            item.text = f"→ Reading {len(members)} files{progress} · {labels}"
+            headline = f"→ Reading {len(members)} files{progress}"
         else:
             failure = f" · {len(failures)} failed" if failures else ""
-            item.text = f"→ Read {len(members)} files{failure} · {labels}"
+            headline = f"→ Read {len(members)} files{failure}"
+        item.text = f"{headline}\n{path_list}"
         if completed:
             status = "✗" if failures else ("✓" if all_complete else "…")
             item.tool_result_text = f"{status} read group"
@@ -742,13 +737,6 @@ def _fallback_tool_call_invocation(tool_call: ToolCall) -> str:
 def _string_argument(arguments: dict[str, JSONValue], key: str) -> str | None:
     value = arguments.get(key)
     return value if isinstance(value, str) else None
-
-
-def _compact_tool_group_path(path: str) -> str:
-    normalized = " ".join(path.split())
-    if len(normalized) <= TOOL_GROUP_PATH_CHARS:
-        return normalized
-    return "…" + normalized[-(TOOL_GROUP_PATH_CHARS - 1) :]
 
 
 def _normalized_path(path: str | Path) -> Path:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -34,14 +33,9 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # Show live elapsed time on an executing tool row once it stops being instant;
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
-BASH_COMMAND_PREVIEW_CHARS = 120
 BASH_DESCRIPTION_PREVIEW_CHARS = 56
 TOOL_GROUP_PREVIEW_ITEMS = 3
 TOOL_GROUP_PATH_CHARS = 32
-_INLINE_CODE_PATTERN = re.compile(
-    r"(?:^|[;&|]\s*|\s)(?:(?:python(?:\d+(?:\.\d+)*)?|bash|sh|zsh)\s+-c|node\s+-e)\s+"
-)
-_HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
 
 @dataclass(slots=True)
@@ -706,17 +700,9 @@ def _format_bash_tool_call_invocation(
         if description is not None:
             displayed_description = _compact_bash_description(description)
             if displayed_description:
-                if _is_short_single_line_bash_command(command):
-                    return f"→ {displayed_description} · $ {command}{suffix}"
                 return f"→ {displayed_description}{suffix}"
-    displayed_command = _compact_bash_command(command) if compact else command
-    return f"$ {displayed_command}{suffix}"
-
-
-def _is_short_single_line_bash_command(command: str) -> bool:
-    return (
-        "\n" not in command and "\r" not in command and len(command) <= BASH_COMMAND_PREVIEW_CHARS
-    )
+        return f"→ Running shell command{suffix}"
+    return f"$ {command}{suffix}"
 
 
 def _compact_bash_description(description: str) -> str:
@@ -724,53 +710,6 @@ def _compact_bash_description(description: str) -> str:
     if len(normalized) <= BASH_DESCRIPTION_PREVIEW_CHARS:
         return normalized
     return normalized[: BASH_DESCRIPTION_PREVIEW_CHARS - 1].rstrip() + "…"
-
-
-def _compact_bash_command(command: str) -> str:
-    lines = command.splitlines()
-    if len(lines) > 1:
-        meaningful_line = next(
-            ((index, line.strip()) for index, line in enumerate(lines) if line.strip()),
-            None,
-        )
-        if meaningful_line is None:
-            return f"[empty command: {len(lines)} lines]"
-        first_index, first_line = meaningful_line
-        preview = _truncate_bash_preview(first_line)
-        heredoc = _HEREDOC_PATTERN.search(first_line)
-        if heredoc is not None:
-            delimiter = heredoc.group(2)
-            closing_index = next(
-                (
-                    index
-                    for index in range(len(lines) - 1, first_index, -1)
-                    if lines[index].strip() == delimiter
-                ),
-                len(lines),
-            )
-            script_lines = max(0, closing_index - first_index - 1)
-            noun = "line" if script_lines == 1 else "lines"
-            return f"{preview} … [inline script: {script_lines} {noun}]"
-        return f"{preview} … [command: {len(lines)} lines]"
-
-    if len(command) <= BASH_COMMAND_PREVIEW_CHARS:
-        return command
-
-    inline_code = _INLINE_CODE_PATTERN.search(command)
-    if inline_code is not None:
-        prefix = command[: inline_code.end()].rstrip()
-        code_chars = len(command[inline_code.end() :].strip())
-        noun = "char" if code_chars == 1 else "chars"
-        return f"{prefix} … [inline code: {code_chars} {noun}]"
-
-    preview = _truncate_bash_preview(command)
-    return f"{preview}… [command: {len(command)} chars]"
-
-
-def _truncate_bash_preview(command: str) -> str:
-    if len(command) <= BASH_COMMAND_PREVIEW_CHARS:
-        return command
-    return command[:BASH_COMMAND_PREVIEW_CHARS].rstrip()
 
 
 def _read_line_suffix(arguments: dict[str, JSONValue]) -> str:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -182,7 +182,7 @@ class TuiState:
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
         if line is None and expanded and item.tool_name == "bash":
-            line = format_tool_call_invocation(
+            exact_command = format_tool_call_invocation(
                 ToolCall(
                     id=item.tool_call_id or "display-call",
                     name=item.tool_name,
@@ -190,6 +190,7 @@ class TuiState:
                 ),
                 expanded=True,
             )
+            line = f"{item.text}\n{exact_command}"
         if item.tool_result_text is None and item.started_at is not None:
             elapsed = time.monotonic() - item.started_at
             if elapsed >= TOOL_TIMER_MIN_SECONDS:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -76,6 +76,7 @@ class ChatItem:
     started_at: float | None = None
     tool_batch_id: int | None = None
     grouped_tool_calls: list[GroupedToolCall] | None = None
+    tool_batch_items: list[ChatItem] | None = None
     always_show_tool_result: bool = False
     custom_type: str | None = None
     details: dict[str, JSONValue] | None = None
@@ -105,6 +106,12 @@ class TuiState:
         compare=False,
     )
     _grouped_calls_by_call_id: dict[str, GroupedToolCall] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _batched_items_by_call_id: dict[str, ChatItem] = field(
         default_factory=dict,
         init=False,
         repr=False,
@@ -161,6 +168,13 @@ class TuiState:
         """
         if item.role != "tool":
             return None
+        if item.tool_batch_items is not None:
+            if not expanded:
+                return None
+            return "\n".join(
+                self.resolve_tool_invocation(row, expanded=True) or row.text
+                for row in item.tool_batch_items
+            )
         if item.grouped_tool_calls is not None:
             if not expanded:
                 return None
@@ -199,6 +213,7 @@ class TuiState:
         """
         if (
             item.role != "tool"
+            or item.tool_batch_items is not None
             or item.grouped_tool_calls is not None
             or item.tool_result is None
             or self.tool_result_renderer is None
@@ -214,7 +229,7 @@ class TuiState:
         return self._next_tool_batch_id
 
     def add_tool_call(self, tool_call: ToolCall, *, batch_id: int | None = None) -> ChatItem:
-        """Append a collapsed tool call, grouping adjacent reads from one response."""
+        """Append a tool call, batching adjacent calls from one assistant response."""
         skill_name = self._read_skill_name(tool_call)
         if skill_name is not None:
             self.add_item(
@@ -223,11 +238,17 @@ class TuiState:
                 tool_call_id=tool_call.id,
             )
             return self.items[-1]
-        if self._can_group_read_call(tool_call, batch_id=batch_id):
+        if self._can_append_tool_batch(tool_call, batch_id=batch_id):
             item = self.items[-1]
-            self._append_grouped_read_call(item, tool_call)
+            self._append_batched_tool_call(item, tool_call)
             return item
-        item = ChatItem(
+        item = self._new_tool_item(tool_call, batch_id=batch_id)
+        self.items.append(item)
+        self._tool_items_by_call_id[tool_call.id] = item
+        return item
+
+    def _new_tool_item(self, tool_call: ToolCall, *, batch_id: int | None) -> ChatItem:
+        return ChatItem(
             role="tool",
             text=format_tool_call_block(tool_call),
             tool_call_id=tool_call.id,
@@ -236,19 +257,70 @@ class TuiState:
             started_at=time.monotonic(),
             tool_batch_id=batch_id,
         )
-        self.items.append(item)
-        self._tool_items_by_call_id[tool_call.id] = item
-        return item
 
-    def _can_group_read_call(self, tool_call: ToolCall, *, batch_id: int | None) -> bool:
-        if tool_call.name != "read" or batch_id is None or not self.items:
+    def _can_append_tool_batch(self, tool_call: ToolCall, *, batch_id: int | None) -> bool:
+        if batch_id is None or not self.items:
             return False
         previous = self.items[-1]
-        return (
-            previous.role == "tool"
-            and previous.tool_name == "read"
-            and previous.tool_batch_id == batch_id
+        if previous.role != "tool" or previous.tool_batch_id != batch_id:
+            return False
+        if self._has_custom_call_rendering(tool_call.name, tool_call.arguments):
+            return False
+        previous_row = (
+            previous.tool_batch_items[-1] if previous.tool_batch_items is not None else previous
         )
+        return not self._has_custom_call_rendering(
+            previous_row.tool_name,
+            previous_row.tool_arguments or {},
+        )
+
+    def _has_custom_call_rendering(
+        self,
+        tool_name: str | None,
+        arguments: dict[str, JSONValue],
+    ) -> bool:
+        if tool_name is None or self.tool_call_renderer is None:
+            return False
+        return self.tool_call_renderer(tool_name, arguments) is not None
+
+    def _append_batched_tool_call(self, item: ChatItem, tool_call: ToolCall) -> None:
+        if item.tool_batch_items is None and item.tool_name == "read" and tool_call.name == "read":
+            self._append_grouped_read_call(item, tool_call)
+            return
+        if item.tool_batch_items is None:
+            first = ChatItem(
+                role="tool",
+                text=item.text,
+                tool_call_id=item.tool_call_id,
+                tool_result_text=item.tool_result_text,
+                tool_result=item.tool_result,
+                update_text=item.update_text,
+                tool_name=item.tool_name,
+                tool_arguments=item.tool_arguments,
+                started_at=item.started_at,
+                tool_batch_id=item.tool_batch_id,
+                grouped_tool_calls=item.grouped_tool_calls,
+            )
+            item.tool_batch_items = [first]
+            item.grouped_tool_calls = None
+            item.tool_result = None
+            for call_id in self._tool_call_ids(first):
+                self._batched_items_by_call_id[call_id] = first
+        last = item.tool_batch_items[-1]
+        if last.tool_name == "read" and tool_call.name == "read":
+            self._append_grouped_read_call(last, tool_call)
+            row = last
+        else:
+            row = self._new_tool_item(tool_call, batch_id=item.tool_batch_id)
+            item.tool_batch_items.append(row)
+        self._tool_items_by_call_id[tool_call.id] = item
+        self._batched_items_by_call_id[tool_call.id] = row
+        self._refresh_tool_batch(item)
+
+    def _tool_call_ids(self, item: ChatItem) -> list[str]:
+        if item.grouped_tool_calls is not None:
+            return [member.tool_call_id for member in item.grouped_tool_calls]
+        return [item.tool_call_id] if item.tool_call_id is not None else []
 
     def _append_grouped_read_call(self, item: ChatItem, tool_call: ToolCall) -> None:
         if item.grouped_tool_calls is None:
@@ -281,6 +353,24 @@ class TuiState:
         self._tool_items_by_call_id[tool_call.id] = item
         self._grouped_calls_by_call_id[tool_call.id] = member
         self._refresh_tool_group(item)
+
+    def _refresh_tool_batch(self, item: ChatItem) -> None:
+        rows = item.tool_batch_items or []
+        item.text = "\n".join(row.text for row in rows)
+        pending = [row for row in rows if row.started_at is not None]
+        failures = [
+            row
+            for row in rows
+            if row.tool_result_text is not None and row.tool_result_text.startswith("✗")
+        ]
+        if failures:
+            item.tool_result_text = "✗ tool batch"
+        elif not pending:
+            item.tool_result_text = "✓ tool batch"
+        else:
+            item.tool_result_text = None
+        item.update_text = None
+        item.started_at = next((row.started_at for row in pending), None)
 
     def _refresh_tool_group(self, item: ChatItem) -> None:
         members = item.grouped_tool_calls or []
@@ -379,16 +469,19 @@ class TuiState:
         item = self.find_tool_item(tool_call_id)
         if item is None:
             return None
+        row = self._batched_items_by_call_id.get(tool_call_id, item)
         member = self._grouped_calls_by_call_id.get(tool_call_id)
         if member is not None:
             if member.tool_result_text is not None:
                 return None
             member.update_text = message
-            self._refresh_tool_group(item)
-            return item
-        if item.tool_result_text is not None:
-            return None
-        item.update_text = message
+            self._refresh_tool_group(row)
+        else:
+            if row.tool_result_text is not None:
+                return None
+            row.update_text = message
+        if item.tool_batch_items is not None:
+            self._refresh_tool_batch(item)
         return item
 
     def record_tool_result(
@@ -407,17 +500,21 @@ class TuiState:
         )
         item = self.find_tool_item(tool_call_id)
         if item is not None:
+            row = self._batched_items_by_call_id.get(tool_call_id, item)
             member = self._grouped_calls_by_call_id.get(tool_call_id)
             if member is not None:
                 member.tool_result_text = result_text
                 member.tool_result = result
                 member.update_text = None
                 member.started_at = None
-                self._refresh_tool_group(item)
-                return
-            item.tool_result_text = result_text
-            item.tool_result = result
-            item.update_text = None
+                self._refresh_tool_group(row)
+            else:
+                row.tool_result_text = result_text
+                row.tool_result = result
+                row.update_text = None
+                row.started_at = None
+            if item.tool_batch_items is not None:
+                self._refresh_tool_batch(item)
             return
         item = ChatItem(
             role="tool",
@@ -454,6 +551,7 @@ class TuiState:
         self.items.clear()
         self._tool_items_by_call_id.clear()
         self._grouped_calls_by_call_id.clear()
+        self._batched_items_by_call_id.clear()
         self.assistant_buffer = ""
         self.error = None
 

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -36,6 +36,7 @@ TOOL_TIMER_MIN_SECONDS = 1.0
 BASH_DESCRIPTION_PREVIEW_CHARS = 56
 TOOL_GROUP_PREVIEW_ITEMS = 3
 TOOL_GROUP_PATH_CHARS = 32
+BATCHABLE_TOOL_NAMES = frozenset({"bash", "edit", "read", "write"})
 
 
 @dataclass(slots=True)
@@ -253,7 +254,7 @@ class TuiState:
         )
 
     def _can_append_tool_batch(self, tool_call: ToolCall, *, batch_id: int | None) -> bool:
-        if batch_id is None or not self.items:
+        if batch_id is None or not self.items or tool_call.name not in BATCHABLE_TOOL_NAMES:
             return False
         previous = self.items[-1]
         if previous.role != "tool" or previous.tool_batch_id != batch_id:
@@ -263,6 +264,8 @@ class TuiState:
         previous_row = (
             previous.tool_batch_items[-1] if previous.tool_batch_items is not None else previous
         )
+        if previous_row.tool_name not in BATCHABLE_TOOL_NAMES:
+            return False
         return not self._has_custom_call_rendering(
             previous_row.tool_name,
             previous_row.tool_arguments or {},

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -170,13 +170,17 @@ class TuiState:
         if item.grouped_tool_calls is not None:
             if not expanded:
                 return None
-            lines: list[str] = []
+            blocks: list[str] = []
             for member in item.grouped_tool_calls:
                 rendered_line = None
                 if self.tool_call_renderer is not None:
                     rendered_line = self.tool_call_renderer(member.tool_name, member.tool_arguments)
-                lines.append(rendered_line if rendered_line is not None else member.text)
-            return "\n".join(lines)
+                block = rendered_line if rendered_line is not None else member.text
+                if item.tool_name == "edit" and member.tool_result_text is not None:
+                    block = f"{block}\n\n{member.tool_result_text}"
+                blocks.append(block)
+            separator = "\n\n" if item.tool_name == "edit" else "\n"
+            return separator.join(blocks)
         line: str | None = None
         if item.tool_name is not None and self.tool_call_renderer is not None:
             line = self.tool_call_renderer(item.tool_name, item.tool_arguments or {})
@@ -279,8 +283,12 @@ class TuiState:
         return self.tool_call_renderer(tool_name, arguments) is not None
 
     def _append_batched_tool_call(self, item: ChatItem, tool_call: ToolCall) -> None:
-        if item.tool_batch_items is None and item.tool_name == "read" and tool_call.name == "read":
-            self._append_grouped_read_call(item, tool_call)
+        if (
+            item.tool_batch_items is None
+            and item.tool_name in {"edit", "read"}
+            and tool_call.name == item.tool_name
+        ):
+            self._append_grouped_file_call(item, tool_call)
             return
         if item.tool_batch_items is None:
             first = ChatItem(
@@ -302,8 +310,8 @@ class TuiState:
             for call_id in self._tool_call_ids(first):
                 self._batched_items_by_call_id[call_id] = first
         last = item.tool_batch_items[-1]
-        if last.tool_name == "read" and tool_call.name == "read":
-            self._append_grouped_read_call(last, tool_call)
+        if last.tool_name in {"edit", "read"} and tool_call.name == last.tool_name:
+            self._append_grouped_file_call(last, tool_call)
             row = last
         else:
             row = self._new_tool_item(tool_call, batch_id=item.tool_batch_id)
@@ -317,7 +325,7 @@ class TuiState:
             return [member.tool_call_id for member in item.grouped_tool_calls]
         return [item.tool_call_id] if item.tool_call_id is not None else []
 
-    def _append_grouped_read_call(self, item: ChatItem, tool_call: ToolCall) -> None:
+    def _append_grouped_file_call(self, item: ChatItem, tool_call: ToolCall) -> None:
         if item.grouped_tool_calls is None:
             first = GroupedToolCall(
                 tool_call_id=item.tool_call_id or "display-call",
@@ -381,16 +389,19 @@ class TuiState:
         ]
         path_list = "\n".join(f"  - {path}" for path in paths)
         all_complete = len(completed) == len(members)
+        action = "edit" if item.tool_name == "edit" else "read"
         if not all_complete:
             progress = f" · {len(completed)}/{len(members)} complete" if completed else ""
-            headline = f"→ Reading {len(members)} files{progress}"
+            verb = "Editing" if action == "edit" else "Reading"
+            headline = f"→ {verb} {len(members)} files{progress}"
         else:
             failure = f" · {len(failures)} failed" if failures else ""
-            headline = f"→ Read {len(members)} files{failure}"
+            verb = "Edited" if action == "edit" else "Read"
+            headline = f"→ {verb} {len(members)} files{failure}"
         item.text = f"{headline}\n{path_list}"
         if completed:
             status = "✗" if failures else ("✓" if all_complete else "…")
-            item.tool_result_text = f"{status} read group"
+            item.tool_result_text = f"{status} {action} group"
         else:
             item.tool_result_text = None
         item.update_text = next(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1687,7 +1687,7 @@ def _tool_accent_style(item: ChatItem, *, theme: TuiTheme) -> str | None:
     # style, so it blends with any theme's transcript background.
     if item.role != "tool":
         return None
-    if item.tool_result_text is None:
+    if item.tool_result_text is None or item.tool_result_text.startswith("…"):
         return theme.role_styles["tool"].border
     if item.tool_result_text.startswith("✓"):
         return theme.tool_success_text

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -40,6 +40,7 @@ from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import (
+    BASH_COMMAND_PREVIEW_CHARS,
     TOOL_TIMER_MIN_SECONDS,
     ChatItem,
     TuiState,
@@ -1401,6 +1402,7 @@ def _transcript_plain_body_text(
         invocation if invocation else item.text,
         body_style=body_style,
         accent_style=_tool_accent_style(item, theme=theme),
+        description_only=_bash_row_hides_command(item),
     )
     if item.grouped_tool_calls is not None:
         return invocation_text
@@ -1441,12 +1443,14 @@ def _render_transcript_tool_invocation(
     *,
     body_style: str,
     accent_style: str | None,
+    description_only: bool = False,
 ) -> Text:
     """Render tool descriptions in status color and argument details in gray."""
     return _styled_tool_invocation(
         text,
         body_style=body_style,
         accent_style=accent_style,
+        description_only=description_only,
     )
 
 
@@ -1693,6 +1697,19 @@ def _tool_accent_style(item: ChatItem, *, theme: TuiTheme) -> str | None:
     return None
 
 
+def _bash_row_hides_command(item: ChatItem) -> bool:
+    if item.tool_name != "bash" or item.tool_arguments is None:
+        return False
+    command = item.tool_arguments.get("command")
+    description = item.tool_arguments.get("description")
+    return (
+        isinstance(command, str)
+        and isinstance(description, str)
+        and bool(description.strip())
+        and ("\n" in command or "\r" in command or len(command) > BASH_COMMAND_PREVIEW_CHARS)
+    )
+
+
 def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
     if row.grouped_tool_calls is not None:
         if expanded:
@@ -1745,6 +1762,7 @@ def _render_transcript_tool_batch(
                 _tool_batch_row_invocation(row, expanded=expanded),
                 body_style=body_style,
                 accent_style=_tool_accent_style(row, theme=theme),
+                description_only=_bash_row_hides_command(row),
             )
         )
         if expanded and row.grouped_tool_calls is None and row.tool_result_text:
@@ -1771,7 +1789,12 @@ def _render_tool_chat_body(
             theme=theme,
             expanded=show_tool_results,
         )
-    text = _render_tool_invocation(item.text, body_style=body_style, accent_style=accent_style)
+    text = _render_tool_invocation(
+        item.text,
+        body_style=body_style,
+        accent_style=accent_style,
+        description_only=_bash_row_hides_command(item),
+    )
     if item.grouped_tool_calls is not None or not show_tool_results or not item.tool_result_text:
         return text
 
@@ -1785,11 +1808,18 @@ def _render_tool_chat_body(
     return Group(text, Text(""), result_body)
 
 
-def _render_tool_invocation(text: str, *, body_style: str, accent_style: str | None) -> Text:
+def _render_tool_invocation(
+    text: str,
+    *,
+    body_style: str,
+    accent_style: str | None,
+    description_only: bool = False,
+) -> Text:
     return _styled_tool_invocation(
         text,
         body_style=body_style,
         accent_style=accent_style,
+        description_only=description_only,
     )
 
 
@@ -1803,21 +1833,28 @@ def _styled_tool_invocation(
     *,
     body_style: str,
     accent_style: str | None,
+    description_only: bool = False,
 ) -> Text:
     rendered = Text(style=body_style, overflow="fold", no_wrap=False)
     accent_style = accent_style or body_style
     for index, line in enumerate(text.splitlines() or [""]):
         if index:
             rendered.append("\n", style=body_style)
-        prefix, description, details = _split_tool_invocation_sections(line)
+        prefix, description, details = _split_tool_invocation_sections(
+            line, description_only=description_only
+        )
         rendered.append(prefix, style=body_style)
         rendered.append(description, style=accent_style)
         rendered.append(details, style=body_style)
     return rendered
 
 
-def _split_tool_invocation_sections(text: str) -> tuple[str, str, str]:
+def _split_tool_invocation_sections(
+    text: str, *, description_only: bool = False
+) -> tuple[str, str, str]:
     """Split an invocation into neutral prefix, status description, and gray details."""
+    if description_only and text.startswith("→ "):
+        return "→ ", text[2:], ""
     group = _TOOL_GROUP_INVOCATION_PATTERN.fullmatch(text)
     if group is not None:
         return "→ ", group.group(1), f" · {group.group(2)}"

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1734,11 +1734,12 @@ def _render_transcript_tool_batch(
     body_style: str,
     theme: TuiTheme,
     expanded: bool,
-) -> RenderableType:
-    rendered: list[RenderableType] = []
+) -> Text:
+    """Render a batch as one selectable Text value with per-row style spans."""
+    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
     for index, row in enumerate(item.tool_batch_items or []):
-        if index and expanded:
-            rendered.append(Text("", style=body_style))
+        if index:
+            rendered.append("\n\n" if expanded else "\n", style=body_style)
         rendered.append(
             _styled_tool_invocation(
                 _tool_batch_row_invocation(row, expanded=expanded),
@@ -1747,26 +1748,11 @@ def _render_transcript_tool_batch(
             )
         )
         if expanded and row.grouped_tool_calls is None and row.tool_result_text:
-            rendered.append(Text("", style=body_style))
-            result_body = _render_patch_body(
-                row.tool_result_text,
-                body_style=body_style,
-                syntax_theme=theme.syntax_theme,
-                code_block_background=theme.markdown_code_block_background,
-            )
-            rendered.append(
-                result_body
-                if result_body is not None
-                else Text(
-                    row.tool_result_text,
-                    style=body_style,
-                    overflow="fold",
-                    no_wrap=False,
-                )
-            )
+            rendered.append("\n\n", style=body_style)
+            rendered.append(row.tool_result_text, style=body_style)
         elif row.update_text and not row.tool_result_text:
-            rendered.append(Text(f"… {row.update_text}", style=body_style))
-    return Group(*rendered)
+            rendered.append(f"\n… {row.update_text}", style=body_style)
+    return rendered
 
 
 def _render_tool_chat_body(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -1425,14 +1426,12 @@ def _render_transcript_tool_invocation(
     body_style: str,
     accent_style: str | None,
 ) -> Text:
-    """Render a selectable tool invocation with status color after the prefix."""
-    rendered = Text(style=body_style, overflow="fold", no_wrap=False)
-    accent_style = accent_style or body_style
-    prefix, name, remainder = _split_tool_invocation(text)
-    rendered.append(prefix, style=body_style)
-    rendered.append(name, style=accent_style)
-    rendered.append(remainder, style=accent_style)
-    return rendered
+    """Render tool descriptions in status color and argument details in gray."""
+    return _styled_tool_invocation(
+        text,
+        body_style=body_style,
+        accent_style=accent_style,
+    )
 
 
 def _transcript_item_markdown(
@@ -1702,24 +1701,49 @@ def _render_tool_chat_body(
 
 
 def _render_tool_invocation(text: str, *, body_style: str, accent_style: str | None) -> Text:
+    return _styled_tool_invocation(
+        text,
+        body_style=body_style,
+        accent_style=accent_style,
+    )
+
+
+_TOOL_GROUP_INVOCATION_PATTERN = re.compile(
+    r"^→ ((?:Reading|Read) \d+ files(?: · (?:\d+/\d+ complete|\d+ failed))?) · (.+)$"
+)
+
+
+def _styled_tool_invocation(
+    text: str,
+    *,
+    body_style: str,
+    accent_style: str | None,
+) -> Text:
     rendered = Text(style=body_style, overflow="fold", no_wrap=False)
     accent_style = accent_style or body_style
-    prefix, name, remainder = _split_tool_invocation(text)
-    rendered.append(prefix, style=body_style)
-    rendered.append(name, style=body_style)
-    rendered.append(remainder, style=accent_style)
+    for index, line in enumerate(text.splitlines() or [""]):
+        if index:
+            rendered.append("\n", style=body_style)
+        prefix, description, details = _split_tool_invocation_sections(line)
+        rendered.append(prefix, style=body_style)
+        rendered.append(description, style=accent_style)
+        rendered.append(details, style=body_style)
     return rendered
 
 
-def _split_tool_invocation(text: str) -> tuple[str, str, str]:
+def _split_tool_invocation_sections(text: str) -> tuple[str, str, str]:
+    """Split an invocation into neutral prefix, status description, and gray details."""
+    group = _TOOL_GROUP_INVOCATION_PATTERN.fullmatch(text)
+    if group is not None:
+        return "→ ", group.group(1), f" · {group.group(2)}"
     if text.startswith("→ "):
         rest = text[2:]
-        name, separator, remainder = rest.partition(" ")
-        return "→ ", name, f"{separator}{remainder}" if separator else ""
-    if text.startswith("$ "):
-        return "$", "", text[1:]
-    name, separator, remainder = text.partition(" ")
-    return "", name, f"{separator}{remainder}" if separator else ""
+        description, separator, command = rest.rpartition(" · $ ")
+        if separator:
+            return "→ ", description, f"{separator}{command}"
+        name, space, arguments = rest.partition(" ")
+        return "→ ", name, f"{space}{arguments}" if space else ""
+    return "", "", text
 
 
 def _visible_chat_text(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -40,7 +40,6 @@ from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import (
-    BASH_COMMAND_PREVIEW_CHARS,
     TOOL_TIMER_MIN_SECONDS,
     ChatItem,
     TuiState,
@@ -1402,7 +1401,7 @@ def _transcript_plain_body_text(
         invocation if invocation else item.text,
         body_style=body_style,
         accent_style=_tool_accent_style(item, theme=theme),
-        description_only=_bash_row_hides_command(item),
+        description_only=_bash_row_is_description_only(item),
     )
     if item.grouped_tool_calls is not None:
         return invocation_text
@@ -1697,17 +1696,8 @@ def _tool_accent_style(item: ChatItem, *, theme: TuiTheme) -> str | None:
     return None
 
 
-def _bash_row_hides_command(item: ChatItem) -> bool:
-    if item.tool_name != "bash" or item.tool_arguments is None:
-        return False
-    command = item.tool_arguments.get("command")
-    description = item.tool_arguments.get("description")
-    return (
-        isinstance(command, str)
-        and isinstance(description, str)
-        and bool(description.strip())
-        and ("\n" in command or "\r" in command or len(command) > BASH_COMMAND_PREVIEW_CHARS)
-    )
+def _bash_row_is_description_only(item: ChatItem) -> bool:
+    return item.tool_name == "bash" and item.text.startswith("→ ")
 
 
 def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
@@ -1762,7 +1752,7 @@ def _render_transcript_tool_batch(
                 _tool_batch_row_invocation(row, expanded=expanded),
                 body_style=body_style,
                 accent_style=_tool_accent_style(row, theme=theme),
-                description_only=_bash_row_hides_command(row),
+                description_only=_bash_row_is_description_only(row),
             )
         )
         if expanded and row.grouped_tool_calls is None and row.tool_result_text:
@@ -1793,7 +1783,7 @@ def _render_tool_chat_body(
         item.text,
         body_style=body_style,
         accent_style=accent_style,
-        description_only=_bash_row_hides_command(item),
+        description_only=_bash_row_is_description_only(item),
     )
     if item.grouped_tool_calls is not None or not show_tool_results or not item.tool_result_text:
         return text

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1815,7 +1815,8 @@ def _render_tool_invocation(
 
 
 _TOOL_GROUP_INVOCATION_PATTERN = re.compile(
-    r"^→ ((?:Reading|Read) \d+ files(?: · (?:\d+/\d+ complete|\d+ failed))?) · (.+)$"
+    r"^→ ((?:Reading|Read) \d+ files(?: · (?:\d+/\d+ complete|\d+ failed))?)"
+    r"(?: · (.+))?$"
 )
 
 
@@ -1848,7 +1849,8 @@ def _split_tool_invocation_sections(
         return "→ ", text[2:], ""
     group = _TOOL_GROUP_INVOCATION_PATTERN.fullmatch(text)
     if group is not None:
-        return "→ ", group.group(1), f" · {group.group(2)}"
+        details = f" · {group.group(2)}" if group.group(2) is not None else ""
+        return "→ ", group.group(1), details
     if text.startswith("→ "):
         rest = text[2:]
         description, separator, command = rest.rpartition(" · $ ")

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,14 +32,20 @@ from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets import Static
 from textual.widgets.markdown import MarkdownBlock, MarkdownStream
 
-from tau_agent.tools import AgentTool
+from tau_agent.tools import AgentTool, ToolCall
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.session_stats import SessionStats
 from tau_coding.skills import Skill
 from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
-from tau_coding.tui.state import ChatItem, TuiState
+from tau_coding.tui.state import (
+    TOOL_TIMER_MIN_SECONDS,
+    ChatItem,
+    TuiState,
+    format_elapsed,
+    format_tool_call_invocation,
+)
 from tau_coding.version import current_version
 
 TAU_SIDEBAR_LOGO = "τ = 2π"
@@ -1316,6 +1323,8 @@ def transcript_item_selection_text(
     """Return the plain text represented by a selectable transcript item."""
     if item.role == "custom":
         return _custom_selection_text(custom_markup, item.text)
+    if item.role == "tool" and item.tool_batch_items is not None:
+        return _tool_batch_selection_text(item, expanded=show_tool_results)
     if item.role == "tool" and result_markup is not None:
         # A tool-rendered result replaces the generic block: invocation line
         # plus the markup-stripped card.
@@ -1380,6 +1389,13 @@ def _transcript_plain_body_text(
     """Return styled transcript text for selectable plain rows."""
     if item.role != "tool":
         return Text(text, style=body_style, overflow="fold", no_wrap=False)
+    if item.tool_batch_items is not None:
+        return _render_transcript_tool_batch(
+            item,
+            body_style=body_style,
+            theme=theme,
+            expanded=show_tool_results,
+        )
 
     invocation_text = _render_transcript_tool_invocation(
         invocation if invocation else item.text,
@@ -1677,6 +1693,82 @@ def _tool_accent_style(item: ChatItem, *, theme: TuiTheme) -> str | None:
     return None
 
 
+def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
+    if row.grouped_tool_calls is not None:
+        if expanded:
+            return "\n".join(member.text for member in row.grouped_tool_calls)
+        return row.text
+    if expanded and row.tool_name == "bash":
+        invocation = format_tool_call_invocation(
+            ToolCall(
+                id=row.tool_call_id or "display-call",
+                name=row.tool_name,
+                arguments=row.tool_arguments or {},
+            ),
+            expanded=True,
+        )
+    else:
+        invocation = row.text
+    if row.tool_result_text is None and row.started_at is not None:
+        elapsed = time.monotonic() - row.started_at
+        if elapsed >= TOOL_TIMER_MIN_SECONDS:
+            return f"{invocation} ({format_elapsed(elapsed)})"
+    return invocation
+
+
+def _tool_batch_selection_text(item: ChatItem, *, expanded: bool) -> str:
+    rows: list[str] = []
+    for row in item.tool_batch_items or []:
+        text = _tool_batch_row_invocation(row, expanded=expanded)
+        if expanded and row.grouped_tool_calls is None and row.tool_result_text:
+            text = f"{text}\n\n{row.tool_result_text}"
+        elif row.update_text and not row.tool_result_text:
+            text = f"{text}\n… {row.update_text}"
+        rows.append(text)
+    return ("\n\n" if expanded else "\n").join(rows)
+
+
+def _render_transcript_tool_batch(
+    item: ChatItem,
+    *,
+    body_style: str,
+    theme: TuiTheme,
+    expanded: bool,
+) -> RenderableType:
+    rendered: list[RenderableType] = []
+    for index, row in enumerate(item.tool_batch_items or []):
+        if index and expanded:
+            rendered.append(Text("", style=body_style))
+        rendered.append(
+            _styled_tool_invocation(
+                _tool_batch_row_invocation(row, expanded=expanded),
+                body_style=body_style,
+                accent_style=_tool_accent_style(row, theme=theme),
+            )
+        )
+        if expanded and row.grouped_tool_calls is None and row.tool_result_text:
+            rendered.append(Text("", style=body_style))
+            result_body = _render_patch_body(
+                row.tool_result_text,
+                body_style=body_style,
+                syntax_theme=theme.syntax_theme,
+                code_block_background=theme.markdown_code_block_background,
+            )
+            rendered.append(
+                result_body
+                if result_body is not None
+                else Text(
+                    row.tool_result_text,
+                    style=body_style,
+                    overflow="fold",
+                    no_wrap=False,
+                )
+            )
+        elif row.update_text and not row.tool_result_text:
+            rendered.append(Text(f"… {row.update_text}", style=body_style))
+    return Group(*rendered)
+
+
 def _render_tool_chat_body(
     item: ChatItem,
     *,
@@ -1686,6 +1778,13 @@ def _render_tool_chat_body(
     syntax_theme: str,
     theme: TuiTheme,
 ) -> RenderableType:
+    if item.tool_batch_items is not None:
+        return _render_transcript_tool_batch(
+            item,
+            body_style=body_style,
+            theme=theme,
+            expanded=show_tool_results,
+        )
     text = _render_tool_invocation(item.text, body_style=body_style, accent_style=accent_style)
     if item.grouped_tool_calls is not None or not show_tool_results or not item.tool_result_text:
         return text
@@ -1762,6 +1861,8 @@ def _visible_chat_text(
         return item.text
     if item.role not in {"tool", "skill"}:
         return item.text
+    if item.role == "tool" and item.tool_batch_items is not None:
+        return _tool_batch_selection_text(item, expanded=show_tool_results)
     text = invocation if item.role == "tool" and invocation else item.text
     if item.grouped_tool_calls is not None:
         return text

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1706,7 +1706,7 @@ def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
             return "\n".join(member.text for member in row.grouped_tool_calls)
         return row.text
     if expanded and row.tool_name == "bash":
-        invocation = format_tool_call_invocation(
+        exact_command = format_tool_call_invocation(
             ToolCall(
                 id=row.tool_call_id or "display-call",
                 name=row.tool_name,
@@ -1714,6 +1714,7 @@ def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
             ),
             expanded=True,
         )
+        invocation = f"{row.text}\n{exact_command}"
     else:
         invocation = row.text
     if row.tool_result_text is None and row.started_at is not None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1703,7 +1703,13 @@ def _bash_row_is_description_only(item: ChatItem) -> bool:
 def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
     if row.grouped_tool_calls is not None:
         if expanded:
-            return "\n".join(member.text for member in row.grouped_tool_calls)
+            blocks = []
+            for member in row.grouped_tool_calls:
+                block = member.text
+                if row.tool_name == "edit" and member.tool_result_text is not None:
+                    block = f"{block}\n\n{member.tool_result_text}"
+                blocks.append(block)
+            return ("\n\n" if row.tool_name == "edit" else "\n").join(blocks)
         return row.text
     if expanded and row.tool_name == "bash":
         exact_command = format_tool_call_invocation(
@@ -1815,8 +1821,8 @@ def _render_tool_invocation(
 
 
 _TOOL_GROUP_INVOCATION_PATTERN = re.compile(
-    r"^→ ((?:Reading|Read) \d+ files(?: · (?:\d+/\d+ complete|\d+ failed))?)"
-    r"(?: · (.+))?$"
+    r"^→ ((?:Reading|Read|Editing|Edited) \d+ files"
+    r"(?: · (?:\d+/\d+ complete|\d+ failed))?)(?: · (.+))?$"
 )
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1385,6 +1385,8 @@ def _transcript_plain_body_text(
         body_style=body_style,
         accent_style=_tool_accent_style(item, theme=theme),
     )
+    if item.grouped_tool_calls is not None:
+        return invocation_text
     if result_markup is not None:
         # The tool's `render_result` markup replaces the generic result block;
         # the invocation line keeps its usual status-accented rendering.
@@ -1686,7 +1688,7 @@ def _render_tool_chat_body(
     theme: TuiTheme,
 ) -> RenderableType:
     text = _render_tool_invocation(item.text, body_style=body_style, accent_style=accent_style)
-    if not show_tool_results or not item.tool_result_text:
+    if item.grouped_tool_calls is not None or not show_tool_results or not item.tool_result_text:
         return text
 
     result_body = _render_chat_body(
@@ -1737,6 +1739,8 @@ def _visible_chat_text(
     if item.role not in {"tool", "skill"}:
         return item.text
     text = invocation if item.role == "tool" and invocation else item.text
+    if item.grouped_tool_calls is not None:
+        return text
     if show_tool_results and item.tool_result_text:
         return f"{text}\n\n{item.tool_result_text}"
     if item.update_text and not item.tool_result_text:

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -59,14 +59,14 @@ async def test_create_coding_tools_returns_initial_tool_set(tmp_path: Path) -> N
     assert "present-participle description" in tools[3].prompt_guidelines[0]
 
 
-def test_bash_tool_schema_requests_optional_display_description(tmp_path: Path) -> None:
+def test_bash_tool_schema_requires_display_description(tmp_path: Path) -> None:
     definition = create_bash_tool_definition(cwd=tmp_path)
     properties = definition.input_schema["properties"]
 
     assert isinstance(properties, dict)
     assert properties["description"]["type"] == "string"
     assert "present-participle summary" in properties["description"]["description"]
-    assert definition.input_schema["required"] == ["command"]
+    assert definition.input_schema["required"] == ["command", "description"]
 
 
 def test_tool_definitions_expose_pi_style_prompt_metadata(tmp_path: Path) -> None:
@@ -357,7 +357,7 @@ async def test_edit_tool_requires_unique_matches(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_bash_tool_captures_stdout_and_exit_code(tmp_path: Path) -> None:
+async def test_bash_tool_tolerates_missing_required_display_description(tmp_path: Path) -> None:
     tool = create_bash_tool(cwd=tmp_path)
 
     result = await tool.execute("test-call", {"command": "printf hello"})

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1637,6 +1637,59 @@ async def test_openai_codex_provider_streams_reasoning_deltas() -> None:
 
 
 @pytest.mark.anyio
+async def test_openai_codex_provider_preserves_reasoning_summary_part_boundaries() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.reasoning_summary_text.delta",'
+                '"delta":"**First step**"}\n\n'
+                'data: {"type":"response.reasoning_summary_part.done"}\n\n'
+                'data: {"type":"response.reasoning_summary_text.delta",'
+                '"delta":"**Second step**"}\n\n'
+                'data: {"type":"response.reasoning_summary_part.done"}\n\n'
+                'data: {"type":"response.output_text.delta","delta":"Done"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say done")],
+                tools=[],
+            )
+        )
+
+    thinking_events = [event for event in events if isinstance(event, ThinkingDeltaEvent)]
+    assert [event.delta for event in thinking_events] == [
+        "**First step**",
+        "\n\n",
+        "**Second step**",
+        "\n\n",
+    ]
+    end = events[-1]
+    assert isinstance(end, AssistantDoneEvent)
+    thinking = end.message.content[0]
+    assert isinstance(thinking, ThinkingContent)
+    assert thinking.thinking == "**First step**\n\n**Second step**\n\n"
+
+
+@pytest.mark.anyio
 async def test_openai_codex_provider_streams_tool_calls() -> None:
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
@@ -2645,6 +2698,57 @@ async def test_responses_api_streams_reasoning_summary_as_thinking() -> None:
     ]
     thinking = next(e for e in events if isinstance(e, ThinkingDeltaEvent))
     assert thinking.delta == "Considering"
+
+
+@pytest.mark.anyio
+async def test_responses_api_preserves_reasoning_summary_part_boundaries() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.reasoning_summary_text.delta",'
+                '"delta":"**First step**"}\n\n'
+                'data: {"type":"response.reasoning_summary_part.done"}\n\n'
+                'data: {"type":"response.reasoning_summary_text.delta",'
+                '"delta":"**Second step**"}\n\n'
+                'data: {"type":"response.reasoning_summary_part.done"}\n\n'
+                'data: {"type":"response.output_text.delta","delta":"Answer"}\n\n'
+                'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                reasoning_effort="high",
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="think")],
+                tools=[],
+            )
+        )
+
+    thinking_events = [event for event in events if isinstance(event, ThinkingDeltaEvent)]
+    assert [event.delta for event in thinking_events] == [
+        "**First step**",
+        "\n\n",
+        "**Second step**",
+        "\n\n",
+    ]
+    end = events[-1]
+    assert isinstance(end, AssistantDoneEvent)
+    thinking = end.message.content[0]
+    assert isinstance(thinking, ThinkingContent)
+    assert thinking.thinking == "**First step**\n\n**Second step**\n\n"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -569,7 +569,9 @@ def test_tui_state_recovers_full_bash_command_when_tool_output_expands() -> None
 
     assert item.text == "→ Running shell command"
     assert state.resolve_tool_invocation(item) is None
-    assert state.resolve_tool_invocation(item, expanded=True) == f"$ {command}"
+    assert state.resolve_tool_invocation(item, expanded=True) == (
+        f"→ Running shell command\n$ {command}"
+    )
 
 
 def test_tui_adapter_uses_canonical_result_details_for_patch() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -510,7 +510,7 @@ def test_bash_tool_formatter_pairs_description_with_full_short_command() -> None
     assert format_tool_call_block(call) == f"→ Listing files · $ {command}"
 
 
-def test_bash_tool_formatter_pairs_description_with_real_command_hint() -> None:
+def test_bash_tool_formatter_hides_long_command_behind_description() -> None:
     command = "git diff --check && git commit -m 'Finish work' && " + "echo done " * 12
     call = ToolCall(
         id="call-1",
@@ -523,14 +523,14 @@ def test_bash_tool_formatter_pairs_description_with_real_command_hint() -> None:
     )
 
     collapsed = format_tool_call_block(call)
-    assert collapsed.startswith("→ Validating and committing changes · $ git diff --check")
-    assert collapsed.endswith("… (timeout 120s)")
+    assert collapsed == "→ Validating and committing changes (timeout 120s)"
+    assert "$" not in collapsed
     assert "\n" not in collapsed
     assert format_tool_call_block(call, compact=False) == f"$ {command} (timeout 120s)"
     assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 120s)"
 
 
-def test_bash_tool_formatter_keeps_hint_after_long_description() -> None:
+def test_bash_tool_formatter_truncates_description_without_command_hint() -> None:
     command = "python - <<'PY'\nprint('hello')\nPY"
     description = "Describing a deliberately overlong inline script operation " * 2
     call = ToolCall(
@@ -540,7 +540,9 @@ def test_bash_tool_formatter_keeps_hint_after_long_description() -> None:
     )
 
     collapsed = format_tool_call_block(call)
-    assert collapsed.endswith("… · $ python - <<'PY'")
+    assert collapsed.startswith("→ Describing a deliberately overlong inline script")
+    assert collapsed.endswith("…")
+    assert "$" not in collapsed
     assert "\n" not in collapsed
 
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -201,6 +201,87 @@ def test_tui_state_groups_adjacent_reads_from_one_assistant_message() -> None:
     assert item.tool_result_text == "✓ read group"
 
 
+def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="bash-1",
+                        name="bash",
+                        arguments={"command": "echo one", "description": "Doing thing one"},
+                    ),
+                    ToolCall(
+                        id="bash-2",
+                        name="bash",
+                        arguments={"command": "echo two", "description": "Doing thing two"},
+                    ),
+                    ToolCall(id="read-1", name="read", arguments={"path": "a.py"}),
+                    ToolCall(id="read-2", name="read", arguments={"path": "b.py"}),
+                    ToolCall(
+                        id="bash-3",
+                        name="bash",
+                        arguments={"command": "echo three", "description": "Doing thing three"},
+                    ),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="bash-1", tool_name="bash", content="one"),
+            ToolResultMessage(tool_call_id="bash-2", tool_name="bash", content="two"),
+            ToolResultMessage(tool_call_id="read-1", tool_name="read", content="a"),
+            ToolResultMessage(tool_call_id="read-2", tool_name="read", content="b"),
+            ToolResultMessage(tool_call_id="bash-3", tool_name="bash", content="three"),
+        ]
+    )
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.tool_batch_items is not None
+    assert len(item.tool_batch_items) == 4
+    assert item.tool_batch_items[2].grouped_tool_calls is not None
+    assert item.text.splitlines() == [
+        "→ Doing thing one · $ echo one",
+        "→ Doing thing two · $ echo two",
+        "→ Read 2 files · a.py, b.py",
+        "→ Doing thing three · $ echo three",
+    ]
+    assert all(
+        state.find_tool_item(call_id) is item
+        for call_id in (
+            "bash-1",
+            "bash-2",
+            "read-1",
+            "read-2",
+            "bash-3",
+        )
+    )
+
+
+def test_tui_state_keeps_custom_rendered_calls_out_of_tool_batches() -> None:
+    state = TuiState(
+        tool_call_renderer=lambda name, _arguments: (
+            "[bold]agent card[/bold]" if name == "agent" else None
+        )
+    )
+    batch_id = state.new_tool_batch_id()
+
+    state.add_tool_call(
+        ToolCall(id="custom", name="agent", arguments={"prompt": "explore"}),
+        batch_id=batch_id,
+    )
+    state.add_tool_call(
+        ToolCall(
+            id="bash",
+            name="bash",
+            arguments={"command": "pwd", "description": "Checking location"},
+        ),
+        batch_id=batch_id,
+    )
+
+    assert len(state.items) == 2
+    assert all(item.tool_batch_items is None for item in state.items)
+
+
 def test_tui_state_marks_group_failed_when_any_read_fails() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -582,7 +582,7 @@ def test_bash_tool_formatter_hides_long_command_behind_description() -> None:
     assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 120s)"
 
 
-def test_bash_tool_formatter_truncates_description_without_command_hint() -> None:
+def test_bash_tool_formatter_shows_complete_description_without_command_hint() -> None:
     command = "python - <<'PY'\nprint('hello')\nPY"
     description = "Describing a deliberately overlong inline script operation " * 2
     call = ToolCall(
@@ -592,8 +592,7 @@ def test_bash_tool_formatter_truncates_description_without_command_hint() -> Non
     )
 
     collapsed = format_tool_call_block(call)
-    assert collapsed.startswith("→ Describing a deliberately overlong inline script")
-    assert collapsed.endswith("…")
+    assert collapsed == f"→ {description.strip()}"
     assert "$" not in collapsed
     assert "\n" not in collapsed
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -200,6 +200,32 @@ def test_tui_state_groups_adjacent_reads_from_one_assistant_message() -> None:
     assert item.tool_result_text == "✓ read group"
 
 
+def test_tui_state_clusters_edits_and_lists_every_path() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(id="edit-1", name="edit", arguments={"path": "a.py", "edits": []}),
+                    ToolCall(id="edit-2", name="edit", arguments={"path": "b.py", "edits": []}),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="edit-1", tool_name="edit", content="changed a"),
+            ToolResultMessage(tool_call_id="edit-2", tool_name="edit", content="changed b"),
+        ]
+    )
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.text == "→ Edited 2 files\n  - a.py\n  - b.py"
+    assert item.grouped_tool_calls is not None
+    assert item.tool_result_text == "✓ edit group"
+    expanded = state.resolve_tool_invocation(item, expanded=True)
+    assert expanded is not None
+    assert "→ edit a.py\n\n✓ edit\nchanged a" in expanded
+    assert "→ edit b.py\n\n✓ edit\nchanged b" in expanded
+
+
 def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -14,6 +14,7 @@ from tau_agent import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
+    ToolResultMessage,
     UserMessage,
 )
 from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
@@ -164,6 +165,108 @@ def test_tui_state_restores_persisted_assistant_blocks_in_order() -> None:
         "thinking",
         "assistant",
     ]
+
+
+def test_tui_state_groups_adjacent_reads_from_one_assistant_message() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                    ToolCall(id="call-2", name="read", arguments={"path": "b.py"}),
+                ]
+            ),
+            ToolResultMessage(
+                tool_call_id="call-1",
+                tool_name="read",
+                content="one",
+            ),
+            ToolResultMessage(
+                tool_call_id="call-2",
+                tool_name="read",
+                content="two",
+            ),
+        ]
+    )
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.text == "→ Read 2 files · a.py, b.py"
+    assert item.grouped_tool_calls is not None
+    assert [member.tool_call_id for member in item.grouped_tool_calls] == ["call-1", "call-2"]
+    assert state.find_tool_item("call-1") is item
+    assert state.find_tool_item("call-2") is item
+    assert state.resolve_tool_invocation(item, expanded=True) == "→ read a.py\n→ read b.py"
+    assert item.tool_result_text == "✓ read group\n✓ read\none\n\n✓ read\ntwo"
+
+
+def test_tui_state_marks_group_failed_when_any_read_fails() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                    ToolCall(id="call-2", name="read", arguments={"path": "missing.py"}),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="call-1", tool_name="read", content="one"),
+            ToolResultMessage(
+                tool_call_id="call-2",
+                tool_name="read",
+                content="not found",
+                is_error=True,
+            ),
+        ]
+    )
+
+    item = state.items[0]
+    assert item.text == "→ Read 2 files · 1 failed · a.py, missing.py"
+    assert item.tool_result_text is not None
+    assert item.tool_result_text.startswith("✗ read group")
+
+
+def test_tui_adapter_does_not_group_reads_separated_by_assistant_text() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(
+        MessageEndEvent(
+            message=AssistantMessage(
+                content=[
+                    ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                    TextContent(text="then"),
+                    ToolCall(id="call-2", name="read", arguments={"path": "b.py"}),
+                ]
+            )
+        )
+    )
+    adapter.apply(
+        ToolExecutionStartEvent(tool_call_id="call-1", tool_name="read", args={"path": "a.py"})
+    )
+    adapter.apply(
+        ToolExecutionStartEvent(tool_call_id="call-2", tool_name="read", args={"path": "b.py"})
+    )
+
+    assert [item.text for item in state.items] == ["then", "→ read a.py", "→ read b.py"]
+
+
+def test_tui_state_does_not_group_reads_from_different_assistant_messages() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[ToolCall(id="call-1", name="read", arguments={"path": "a.py"})]
+            ),
+            ToolResultMessage(tool_call_id="call-1", tool_name="read", content="one"),
+            AssistantMessage(
+                content=[ToolCall(id="call-2", name="read", arguments={"path": "b.py"})]
+            ),
+            ToolResultMessage(tool_call_id="call-2", tool_name="read", content="two"),
+        ]
+    )
+
+    assert [item.text for item in state.items] == ["→ read a.py", "→ read b.py"]
 
 
 def test_tui_adapter_records_tool_progress_and_result() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -418,7 +418,7 @@ def test_bash_tool_formatter_keeps_short_commands_visible() -> None:
     )
 
 
-def test_bash_tool_formatter_keeps_short_command_instead_of_description() -> None:
+def test_bash_tool_formatter_pairs_description_with_full_short_command() -> None:
     command = "rm -rf /tmp/x"
     call = ToolCall(
         id="call-1",
@@ -426,7 +426,7 @@ def test_bash_tool_formatter_keeps_short_command_instead_of_description() -> Non
         arguments={"command": command, "description": "Listing files"},
     )
 
-    assert format_tool_call_block(call) == f"$ {command}"
+    assert format_tool_call_block(call) == f"→ Listing files · $ {command}"
 
 
 def test_bash_tool_formatter_pairs_description_with_real_command_hint() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -198,7 +198,7 @@ def test_tui_state_groups_adjacent_reads_from_one_assistant_message() -> None:
     assert state.find_tool_item("call-1") is item
     assert state.find_tool_item("call-2") is item
     assert state.resolve_tool_invocation(item, expanded=True) == "→ read a.py\n→ read b.py"
-    assert item.tool_result_text == "✓ read group\n✓ read\none\n\n✓ read\ntwo"
+    assert item.tool_result_text == "✓ read group"
 
 
 def test_tui_state_marks_group_failed_when_any_read_fails() -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -281,6 +281,31 @@ def test_tui_state_keeps_custom_rendered_calls_out_of_tool_batches() -> None:
     assert all(item.tool_batch_items is None for item in state.items)
 
 
+def test_tui_state_keeps_result_only_extension_tools_out_of_batches() -> None:
+    state = TuiState(
+        tool_result_renderer=lambda name, _result, _expanded: f"[bold]{name} card[/bold]"
+    )
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(id="custom-1", name="extension-tool", arguments={}),
+                    ToolCall(id="custom-2", name="extension-tool", arguments={}),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="custom-1", tool_name="extension-tool", content="one"),
+            ToolResultMessage(tool_call_id="custom-2", tool_name="extension-tool", content="two"),
+        ]
+    )
+
+    assert len(state.items) == 2
+    assert all(item.tool_batch_items is None for item in state.items)
+    assert [state.resolve_tool_result(item, expanded=False) for item in state.items] == [
+        "[bold]extension-tool card[/bold]",
+        "[bold]extension-tool card[/bold]",
+    ]
+
+
 def test_tui_state_marks_group_failed_when_any_read_fails() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -191,7 +191,7 @@ def test_tui_state_groups_adjacent_reads_from_one_assistant_message() -> None:
 
     assert len(state.items) == 1
     item = state.items[0]
-    assert item.text == "→ Read 2 files · a.py, b.py"
+    assert item.text == "→ Read 2 files\n  - a.py\n  - b.py"
     assert item.grouped_tool_calls is not None
     assert [member.tool_call_id for member in item.grouped_tool_calls] == ["call-1", "call-2"]
     assert state.find_tool_item("call-1") is item
@@ -241,7 +241,9 @@ def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
     assert item.text.splitlines() == [
         "→ Doing thing one",
         "→ Doing thing two",
-        "→ Read 2 files · a.py, b.py",
+        "→ Read 2 files",
+        "  - a.py",
+        "  - b.py",
         "→ Doing thing three",
     ]
     assert all(
@@ -327,7 +329,7 @@ def test_tui_state_marks_group_failed_when_any_read_fails() -> None:
     )
 
     item = state.items[0]
-    assert item.text == "→ Read 2 files · 1 failed · a.py, missing.py"
+    assert item.text == "→ Read 2 files · 1 failed\n  - a.py\n  - missing.py"
     assert item.tool_result_text is not None
     assert item.tool_result_text.startswith("✗ read group")
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -29,7 +29,6 @@ from tau_coding.events import (
 from tau_coding.skills import Skill, format_skill_invocation
 from tau_coding.tui import TuiEventAdapter, TuiState
 from tau_coding.tui.state import (
-    BASH_COMMAND_PREVIEW_CHARS,
     format_tool_call_block,
     format_tool_call_invocation,
     format_tool_result_block,
@@ -240,10 +239,10 @@ def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
     assert len(item.tool_batch_items) == 4
     assert item.tool_batch_items[2].grouped_tool_calls is not None
     assert item.text.splitlines() == [
-        "→ Doing thing one · $ echo one",
-        "→ Doing thing two · $ echo two",
+        "→ Doing thing one",
+        "→ Doing thing two",
         "→ Read 2 files · a.py, b.py",
-        "→ Doing thing three · $ echo three",
+        "→ Doing thing three",
     ]
     assert all(
         state.find_tool_item(call_id) is item
@@ -486,20 +485,19 @@ def test_tool_formatters_keep_human_readable_output() -> None:
     assert "3 more lines" in block
 
 
-def test_bash_tool_formatter_keeps_short_commands_visible() -> None:
+def test_bash_tool_formatter_hides_short_command_until_expanded() -> None:
+    command = 'rg -n "ToolCall" src'
     call = ToolCall(
         id="call-1",
         name="bash",
-        arguments={"command": 'rg -n "ToolCall" src', "timeout": 10},
+        arguments={"command": command, "timeout": 10},
     )
 
-    assert format_tool_call_block(call) == '$ rg -n "ToolCall" src (timeout 10s)'
-    assert format_tool_call_invocation(call, expanded=True) == (
-        '$ rg -n "ToolCall" src (timeout 10s)'
-    )
+    assert format_tool_call_block(call) == "→ Running shell command (timeout 10s)"
+    assert format_tool_call_invocation(call, expanded=True) == f"$ {command} (timeout 10s)"
 
 
-def test_bash_tool_formatter_pairs_description_with_full_short_command() -> None:
+def test_bash_tool_formatter_hides_described_short_command_until_expanded() -> None:
     command = "rm -rf /tmp/x"
     call = ToolCall(
         id="call-1",
@@ -507,7 +505,8 @@ def test_bash_tool_formatter_pairs_description_with_full_short_command() -> None
         arguments={"command": command, "description": "Listing files"},
     )
 
-    assert format_tool_call_block(call) == f"→ Listing files · $ {command}"
+    assert format_tool_call_block(call) == "→ Listing files"
+    assert format_tool_call_invocation(call, expanded=True) == f"$ {command}"
 
 
 def test_bash_tool_formatter_hides_long_command_behind_description() -> None:
@@ -546,52 +545,19 @@ def test_bash_tool_formatter_truncates_description_without_command_hint() -> Non
     assert "\n" not in collapsed
 
 
-def test_bash_tool_formatter_collapses_heredoc_and_expands_exact_command() -> None:
-    command = "python - <<'PY'\nprint('one')\nprint('two')\nPY"
-    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
+def test_bash_tool_formatter_never_previews_undescribed_commands() -> None:
+    commands = [
+        "python - <<'PY'\nprint('one')\nPY",
+        "git status &&\ngit diff",
+        "echo " + "x" * 200,
+        'uv run python -c "print(1)"',
+        "\n\n",
+    ]
 
-    assert format_tool_call_block(call) == ("$ python - <<'PY' … [inline script: 2 lines]")
-    assert format_tool_call_invocation(call, expanded=True) == f"$ {command}"
-
-
-def test_bash_tool_formatter_collapses_multiline_and_long_commands() -> None:
-    multiline = ToolCall(
-        id="call-1",
-        name="bash",
-        arguments={"command": "git status &&\ngit diff"},
-    )
-    long_command = "echo " + "x" * BASH_COMMAND_PREVIEW_CHARS
-    long_call = ToolCall(id="call-2", name="bash", arguments={"command": long_command})
-
-    assert format_tool_call_block(multiline) == "$ git status && … [command: 2 lines]"
-    assert format_tool_call_block(long_call) == (
-        f"$ {long_command[:BASH_COMMAND_PREVIEW_CHARS]}… [command: {len(long_command)} chars]"
-    )
-
-
-def test_bash_tool_formatter_identifies_long_inline_code() -> None:
-    code = "print('x');" * 20
-    command = f'uv run python -c "{code}"'
-    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
-
-    assert format_tool_call_block(call) == (
-        f"$ uv run python -c … [inline code: {len(code) + 2} chars]"
-    )
-
-
-def test_bash_tool_formatter_does_not_treat_shell_errexit_as_inline_code() -> None:
-    command = "sh -e ./deploy.sh " + "production " * 15
-    call = ToolCall(id="call-1", name="bash", arguments={"command": command})
-
-    collapsed = format_tool_call_block(call)
-    assert "inline code" not in collapsed
-    assert "sh -e ./deploy.sh" in collapsed
-
-
-def test_bash_tool_formatter_compacts_whitespace_only_multiline_command() -> None:
-    call = ToolCall(id="call-1", name="bash", arguments={"command": "\n\n"})
-
-    assert format_tool_call_block(call) == "$ [empty command: 2 lines]"
+    for index, command in enumerate(commands):
+        call = ToolCall(id=f"call-{index}", name="bash", arguments={"command": command})
+        assert format_tool_call_block(call) == "→ Running shell command"
+        assert format_tool_call_invocation(call, expanded=True) == f"$ {command}"
 
 
 def test_tui_state_recovers_full_bash_command_when_tool_output_expands() -> None:
@@ -601,7 +567,7 @@ def test_tui_state_recovers_full_bash_command_when_tool_output_expands() -> None
     item = state.items[0]
     item.started_at = None
 
-    assert item.text == "$ python - <<'PY' … [inline script: 1 line]"
+    assert item.text == "→ Running shell command"
     assert state.resolve_tool_invocation(item) is None
     assert state.resolve_tool_invocation(item, expanded=True) == f"$ {command}"
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1529,6 +1529,42 @@ def test_semantic_bash_and_grouped_read_details_stay_neutral() -> None:
         assert f"{green}{details}" not in output
 
 
+def test_tool_batch_colors_each_description_by_its_own_status() -> None:
+    item = ChatItem(
+        role="tool",
+        text="batch",
+        tool_result_text="✗ tool batch",
+        tool_batch_items=[
+            ChatItem(
+                role="tool",
+                text="→ Finished action · $ true",
+                tool_result_text="✓ bash",
+            ),
+            ChatItem(
+                role="tool",
+                text="→ Failed action · $ false",
+                tool_result_text="✗ bash",
+            ),
+            ChatItem(role="tool", text="→ Running action · $ sleep 1", started_at=1.0),
+        ],
+    )
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=item.text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
+        )
+    )
+    output = console.export_text(styles=True)
+
+    assert "38;2;156;255;177;48;2;0;0;0mFinished action" in output
+    assert "38;2;255;79;79;48;2;0;0;0mFailed action" in output
+    assert "38;2;138;122;82;48;2;0;0;0mRunning action" in output
+    assert "38;2;203;213;225;48;2;0;0;0m · $ false" in output
+
+
 def test_assistant_chat_items_render_markdown_lists() -> None:
     console = Console(record=True, width=60)
     item = ChatItem(role="assistant", text="Plan:\n\n- inspect\n- patch")
@@ -1786,6 +1822,54 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
         assert tool_widgets[0].selection_text == "→ read a.py\n→ read b.py"
         assert "one" not in tool_widgets[0].selection_text
         assert "two" not in tool_widgets[0].selection_text
+
+
+@pytest.mark.anyio
+async def test_mixed_tool_batch_uses_one_widget_and_expands_each_row() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="bash-1",
+                            name="bash",
+                            arguments={"command": "echo one", "description": "Doing thing one"},
+                        ),
+                        ToolCall(id="read-1", name="read", arguments={"path": "a.py"}),
+                        ToolCall(id="read-2", name="read", arguments={"path": "b.py"}),
+                        ToolCall(
+                            id="bash-2",
+                            name="bash",
+                            arguments={"command": "echo two", "description": "Doing thing two"},
+                        ),
+                    ]
+                ),
+                ToolResultMessage(tool_call_id="bash-1", tool_name="bash", content="one"),
+                ToolResultMessage(tool_call_id="read-1", tool_name="read", content="alpha"),
+                ToolResultMessage(tool_call_id="read-2", tool_name="read", content="beta"),
+                ToolResultMessage(tool_call_id="bash-2", tool_name="bash", content="two"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
+        assert len([w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]) == 1
+        assert widget.selection_text == (
+            "→ Doing thing one · $ echo one\n"
+            "→ Read 2 files · a.py, b.py\n"
+            "→ Doing thing two · $ echo two"
+        )
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+
+        assert widget.selection_text == (
+            "$ echo one\n\n✓ bash\none\n\n→ read a.py\n→ read b.py\n\n$ echo two\n\n✓ bash\ntwo"
+        )
+        assert "alpha" not in widget.selection_text
+        assert "beta" not in widget.selection_text
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from rich.console import Console
 from rich.panel import Panel
+from rich.text import Text
 from textual import events
 from textual.color import Color
 from textual.containers import Container, VerticalScroll
@@ -1563,6 +1564,27 @@ def test_tool_batch_colors_each_description_by_its_own_status() -> None:
     assert "38;2;255;79;79;48;2;0;0;0mFailed action" in output
     assert "38;2;138;122;82;48;2;0;0;0mRunning action" in output
     assert "38;2;203;213;225;48;2;0;0;0m · $ false" in output
+
+
+def test_tool_batch_body_stays_one_selectable_text_renderable() -> None:
+    item = ChatItem(
+        role="tool",
+        text="batch",
+        tool_batch_items=[
+            ChatItem(role="tool", text="→ First action · $ true"),
+            ChatItem(role="tool", text="→ Second action · $ false"),
+        ],
+    )
+
+    body = _transcript_plain_body_text(
+        item,
+        text=item.text,
+        body_style=TAU_DARK_THEME.role_styles["tool"].body,
+        theme=TAU_DARK_THEME,
+    )
+
+    assert isinstance(body, Text)
+    assert body.plain == "→ First action · $ true\n→ Second action · $ false"
 
 
 def test_assistant_chat_items_render_markdown_lists() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1585,6 +1585,29 @@ def test_tool_batch_colors_each_description_by_its_own_status() -> None:
     assert "$ false" not in console.export_text()
 
 
+def test_partially_completed_read_group_keeps_running_color() -> None:
+    item = ChatItem(
+        role="tool",
+        text="→ Reading 2 files · 1/2 complete · a.py, b.py",
+        tool_name="read",
+        tool_result_text="… read group",
+        started_at=1.0,
+    )
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=item.text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
+        )
+    )
+
+    output = console.export_text(styles=True)
+    running_color = _style_color_escape(TAU_DARK_THEME.role_styles["tool"].border)
+    assert f"{running_color};48;2;0;0;0mReading 2 files" in output
+
+
 def test_tool_batch_body_stays_one_selectable_text_renderable() -> None:
     item = ChatItem(
         role="tool",

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1500,7 +1500,7 @@ def test_tool_chat_items_color_description_not_details_or_results() -> None:
 def test_grouped_read_details_stay_neutral() -> None:
     green = "38;2;156;255;177;48;2;0;0;0m"
     body = "38;2;203;213;225;48;2;0;0;0m"
-    text = "→ Read 5 files · a.py, b.py, c.py, +2"
+    text = "→ Read 5 files\n  - a.py\n  - b.py\n  - c.py\n  - d.py\n  - e.py"
     console = Console(record=True, width=100, color_system="truecolor")
     item = ChatItem(role="tool", text=text, tool_result_text="✓ tool")
     console.print(
@@ -1514,8 +1514,9 @@ def test_grouped_read_details_stay_neutral() -> None:
     output = console.export_text(styles=True)
 
     assert f"{green}Read 5 files" in output
-    assert f"{body} · a.py, b.py, c.py, +2" in output
-    assert f"{green} · a.py, b.py, c.py, +2" not in output
+    assert f"{body}  - a.py" in output
+    assert f"{body}  - e.py" in output
+    assert f"{green}  - a.py" not in output
 
 
 def test_bash_description_without_command_keeps_full_status_color() -> None:
@@ -1588,7 +1589,7 @@ def test_tool_batch_colors_each_description_by_its_own_status() -> None:
 def test_partially_completed_read_group_keeps_running_color() -> None:
     item = ChatItem(
         role="tool",
-        text="→ Reading 2 files · 1/2 complete · a.py, b.py",
+        text="→ Reading 2 files · 1/2 complete\n  - a.py\n  - b.py",
         tool_name="read",
         tool_result_text="… read group",
         started_at=1.0,
@@ -1857,7 +1858,7 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
 
         tool_widgets = [w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]
         assert len(tool_widgets) == 1
-        assert tool_widgets[0].selection_text == "→ Reading 2 files · a.py, b.py"
+        assert tool_widgets[0].selection_text == "→ Reading 2 files\n  - a.py\n  - b.py"
 
         await stream(
             ToolExecutionEndEvent(
@@ -1868,7 +1869,9 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
             )
         )
         await pilot.pause()
-        assert tool_widgets[0].selection_text == "→ Reading 2 files · 1/2 complete · a.py, b.py"
+        assert tool_widgets[0].selection_text == (
+            "→ Reading 2 files · 1/2 complete\n  - a.py\n  - b.py"
+        )
 
         await stream(
             ToolExecutionEndEvent(
@@ -1879,7 +1882,7 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
             )
         )
         await pilot.pause()
-        assert tool_widgets[0].selection_text == "→ Read 2 files · a.py, b.py"
+        assert tool_widgets[0].selection_text == "→ Read 2 files\n  - a.py\n  - b.py"
 
         await pilot.press("ctrl+o")
         await pilot.pause()
@@ -1921,7 +1924,7 @@ async def test_mixed_tool_batch_uses_one_widget_and_expands_each_row() -> None:
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert len([w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]) == 1
         assert widget.selection_text == (
-            "→ Doing thing one\n→ Read 2 files · a.py, b.py\n→ Doing thing two"
+            "→ Doing thing one\n→ Read 2 files\n  - a.py\n  - b.py\n→ Doing thing two"
         )
 
         await pilot.press("ctrl+o")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1530,6 +1530,30 @@ def test_semantic_bash_and_grouped_read_details_stay_neutral() -> None:
         assert f"{green}{details}" not in output
 
 
+def test_long_bash_description_without_hint_keeps_full_status_color() -> None:
+    command = "echo " + "x" * 120
+    item = ChatItem(
+        role="tool",
+        text="→ Running long command",
+        tool_name="bash",
+        tool_arguments={"command": command, "description": "Running long command"},
+        tool_result_text="✓ bash",
+    )
+    console = Console(record=True, width=100, color_system="truecolor")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=item.text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
+        )
+    )
+
+    output = console.export_text(styles=True)
+    assert "38;2;156;255;177;48;2;0;0;0mRunning long command" in output
+    assert command not in console.export_text()
+
+
 def test_tool_batch_colors_each_description_by_its_own_status() -> None:
     item = ChatItem(
         role="tool",
@@ -7313,7 +7337,7 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
 
     async with app.run_test() as pilot:
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
-        assert widget.selection_text == "→ Running inline script · $ python - <<'PY'"
+        assert widget.selection_text == "→ Running inline script"
 
         await pilot.press("ctrl+o")
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1439,7 +1439,7 @@ def test_expanded_tool_invocation_blank_line_stays_separate_from_result() -> Non
     assert "\x1b[91" not in console.export_text(styles=True)
 
 
-def test_pending_tool_invocation_uses_tool_accent_color() -> None:
+def test_pending_tool_invocation_colors_tool_name_but_not_arguments() -> None:
     console = Console(record=True, width=80)
     item = ChatItem(role="tool", text="→ read README.md")
     console.print(
@@ -1454,11 +1454,13 @@ def test_pending_tool_invocation_uses_tool_accent_color() -> None:
     output = console.export_text(styles=True)
 
     accent = "38;2;138;122;82;48;2;0;0;0m"
+    body = "38;2;203;213;225;48;2;0;0;0m"
     assert f"{accent}read" in output
-    assert f"{accent} README.md" in output
+    assert f"{body} README.md" in output
+    assert f"{accent} README.md" not in output
 
 
-def test_tool_chat_items_color_status_metadata_not_tool_name_or_results() -> None:
+def test_tool_chat_items_color_description_not_details_or_results() -> None:
     success_console = Console(record=True, width=80)
     success_console.print(
         render_chat_item(
@@ -1482,8 +1484,9 @@ def test_tool_chat_items_color_status_metadata_not_tool_name_or_results() -> Non
     white = "38;2;203;213;225"
 
     assert green in success_output
-    assert f"{white};48;2;0;0;0mread" in success_output
-    assert f"{green};48;2;0;0;0mread" not in success_output
+    assert f"{green};48;2;0;0;0mread" in success_output
+    assert f"{white};48;2;0;0;0m README.md" in success_output
+    assert f"{green};48;2;0;0;0m README.md" not in success_output
     assert f"{green};48;2;0;0;0m✓ read" not in success_output
     assert f"{green};48;2;0;0;0mcontents" not in success_output
 
@@ -1491,6 +1494,39 @@ def test_tool_chat_items_color_status_metadata_not_tool_name_or_results() -> Non
     assert f"{white};48;2;0;0;0m✗ bash" in error_output
     assert f"{red};48;2;0;0;0m✗ bash" not in error_output
     assert f"{red};48;2;0;0;0mfailed" not in error_output
+
+
+def test_semantic_bash_and_grouped_read_details_stay_neutral() -> None:
+    green = "38;2;156;255;177;48;2;0;0;0m"
+    body = "38;2;203;213;225;48;2;0;0;0m"
+
+    for text, description, details in (
+        (
+            "→ Listing documentation · $ find docs -type f",
+            "Listing documentation",
+            " · $ find docs -type f",
+        ),
+        (
+            "→ Read 5 files · a.py, b.py, c.py, +2",
+            "Read 5 files",
+            " · a.py, b.py, c.py, +2",
+        ),
+    ):
+        console = Console(record=True, width=100, color_system="truecolor")
+        item = ChatItem(role="tool", text=text, tool_result_text="✓ tool")
+        console.print(
+            _transcript_plain_body_text(
+                item,
+                text=text,
+                body_style=TAU_DARK_THEME.role_styles["tool"].body,
+                theme=TAU_DARK_THEME,
+            )
+        )
+        output = console.export_text(styles=True)
+
+        assert f"{green}{description}" in output
+        assert f"{body}{details}" in output
+        assert f"{green}{details}" not in output
 
 
 def test_assistant_chat_items_render_markdown_lists() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1692,6 +1692,67 @@ async def test_tool_execution_updates_render_in_place() -> None:
 
 
 @pytest.mark.anyio
+async def test_batched_reads_share_one_live_transcript_row() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async def stream(event: AgentEvent) -> None:
+        app.adapter.apply(event)
+        await app._apply_streaming_transcript_event(event)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await stream(
+            MessageEndEvent(
+                message=AssistantMessage(
+                    content=[
+                        ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                        ToolCall(id="call-2", name="read", arguments={"path": "b.py"}),
+                    ]
+                )
+            )
+        )
+        await stream(
+            ToolExecutionStartEvent(tool_call_id="call-1", tool_name="read", args={"path": "a.py"})
+        )
+        await stream(
+            ToolExecutionStartEvent(tool_call_id="call-2", tool_name="read", args={"path": "b.py"})
+        )
+        await pilot.pause()
+
+        tool_widgets = [w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]
+        assert len(tool_widgets) == 1
+        assert tool_widgets[0].selection_text == "→ Reading 2 files · a.py, b.py"
+
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-1",
+                tool_name="read",
+                result=AgentToolResult(content="one"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+        assert tool_widgets[0].selection_text == "→ Reading 2 files · 1/2 complete · a.py, b.py"
+
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-2",
+                tool_name="read",
+                result=AgentToolResult(content="two"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+        assert tool_widgets[0].selection_text == "→ Read 2 files · a.py, b.py"
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert tool_widgets[0].selection_text == (
+            "→ read a.py\n→ read b.py\n\n✓ read group\n✓ read\none\n\n✓ read\ntwo"
+        )
+
+
+@pytest.mark.anyio
 async def test_tool_completion_updates_row_without_redrawing_history() -> None:
     app = TauTuiApp(FakeSession(messages=[UserMessage(content="earlier")]))
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1905,7 +1905,9 @@ async def test_mixed_tool_batch_uses_one_widget_and_expands_each_row() -> None:
         await pilot.pause()
 
         assert widget.selection_text == (
-            "$ echo one\n\n✓ bash\none\n\n→ read a.py\n→ read b.py\n\n$ echo two\n\n✓ bash\ntwo"
+            "→ Doing thing one\n$ echo one\n\n✓ bash\none\n\n"
+            "→ read a.py\n→ read b.py\n\n"
+            "→ Doing thing two\n$ echo two\n\n✓ bash\ntwo"
         )
         assert "alpha" not in widget.selection_text
         assert "beta" not in widget.selection_text
@@ -7336,7 +7338,9 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
         await pilot.pause()
 
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
-        assert widget.selection_text == f"$ {command}\n\n✓ bash\nfinished"
+        assert widget.selection_text == (
+            f"→ Running inline script\n$ {command}\n\n✓ bash\nfinished"
+        )
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1747,9 +1747,9 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
 
         await pilot.press("ctrl+o")
         await pilot.pause()
-        assert tool_widgets[0].selection_text == (
-            "→ read a.py\n→ read b.py\n\n✓ read group\n✓ read\none\n\n✓ read\ntwo"
-        )
+        assert tool_widgets[0].selection_text == "→ read a.py\n→ read b.py"
+        assert "one" not in tool_widgets[0].selection_text
+        assert "two" not in tool_widgets[0].selection_text
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1497,40 +1497,28 @@ def test_tool_chat_items_color_description_not_details_or_results() -> None:
     assert f"{red};48;2;0;0;0mfailed" not in error_output
 
 
-def test_semantic_bash_and_grouped_read_details_stay_neutral() -> None:
+def test_grouped_read_details_stay_neutral() -> None:
     green = "38;2;156;255;177;48;2;0;0;0m"
     body = "38;2;203;213;225;48;2;0;0;0m"
-
-    for text, description, details in (
-        (
-            "→ Listing documentation · $ find docs -type f",
-            "Listing documentation",
-            " · $ find docs -type f",
-        ),
-        (
-            "→ Read 5 files · a.py, b.py, c.py, +2",
-            "Read 5 files",
-            " · a.py, b.py, c.py, +2",
-        ),
-    ):
-        console = Console(record=True, width=100, color_system="truecolor")
-        item = ChatItem(role="tool", text=text, tool_result_text="✓ tool")
-        console.print(
-            _transcript_plain_body_text(
-                item,
-                text=text,
-                body_style=TAU_DARK_THEME.role_styles["tool"].body,
-                theme=TAU_DARK_THEME,
-            )
+    text = "→ Read 5 files · a.py, b.py, c.py, +2"
+    console = Console(record=True, width=100, color_system="truecolor")
+    item = ChatItem(role="tool", text=text, tool_result_text="✓ tool")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
         )
-        output = console.export_text(styles=True)
+    )
+    output = console.export_text(styles=True)
 
-        assert f"{green}{description}" in output
-        assert f"{body}{details}" in output
-        assert f"{green}{details}" not in output
+    assert f"{green}Read 5 files" in output
+    assert f"{body} · a.py, b.py, c.py, +2" in output
+    assert f"{green} · a.py, b.py, c.py, +2" not in output
 
 
-def test_long_bash_description_without_hint_keeps_full_status_color() -> None:
+def test_bash_description_without_command_keeps_full_status_color() -> None:
     command = "echo " + "x" * 120
     item = ChatItem(
         role="tool",
@@ -1562,15 +1550,22 @@ def test_tool_batch_colors_each_description_by_its_own_status() -> None:
         tool_batch_items=[
             ChatItem(
                 role="tool",
-                text="→ Finished action · $ true",
+                text="→ Finished action",
+                tool_name="bash",
                 tool_result_text="✓ bash",
             ),
             ChatItem(
                 role="tool",
-                text="→ Failed action · $ false",
+                text="→ Failed action",
+                tool_name="bash",
                 tool_result_text="✗ bash",
             ),
-            ChatItem(role="tool", text="→ Running action · $ sleep 1", started_at=1.0),
+            ChatItem(
+                role="tool",
+                text="→ Running action",
+                tool_name="bash",
+                started_at=1.0,
+            ),
         ],
     )
     console = Console(record=True, width=100, color_system="truecolor")
@@ -1587,7 +1582,7 @@ def test_tool_batch_colors_each_description_by_its_own_status() -> None:
     assert "38;2;156;255;177;48;2;0;0;0mFinished action" in output
     assert "38;2;255;79;79;48;2;0;0;0mFailed action" in output
     assert "38;2;138;122;82;48;2;0;0;0mRunning action" in output
-    assert "38;2;203;213;225;48;2;0;0;0m · $ false" in output
+    assert "$ false" not in console.export_text()
 
 
 def test_tool_batch_body_stays_one_selectable_text_renderable() -> None:
@@ -1595,8 +1590,8 @@ def test_tool_batch_body_stays_one_selectable_text_renderable() -> None:
         role="tool",
         text="batch",
         tool_batch_items=[
-            ChatItem(role="tool", text="→ First action · $ true"),
-            ChatItem(role="tool", text="→ Second action · $ false"),
+            ChatItem(role="tool", text="→ First action", tool_name="bash"),
+            ChatItem(role="tool", text="→ Second action", tool_name="bash"),
         ],
     )
 
@@ -1608,7 +1603,7 @@ def test_tool_batch_body_stays_one_selectable_text_renderable() -> None:
     )
 
     assert isinstance(body, Text)
-    assert body.plain == "→ First action · $ true\n→ Second action · $ false"
+    assert body.plain == "→ First action\n→ Second action"
 
 
 def test_assistant_chat_items_render_markdown_lists() -> None:
@@ -1903,9 +1898,7 @@ async def test_mixed_tool_batch_uses_one_widget_and_expands_each_row() -> None:
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert len([w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]) == 1
         assert widget.selection_text == (
-            "→ Doing thing one · $ echo one\n"
-            "→ Read 2 files · a.py, b.py\n"
-            "→ Doing thing two · $ echo two"
+            "→ Doing thing one\n→ Read 2 files · a.py, b.py\n→ Doing thing two"
         )
 
         await pilot.press("ctrl+o")

--- a/tests/test_tui_themes.py
+++ b/tests/test_tui_themes.py
@@ -368,7 +368,11 @@ def test_tool_result_accents_derive_from_theme() -> None:
     )
     console.print(
         render_chat_item(
-            ChatItem(role="tool", text="$ false", tool_result_text="✗ bash\nfailed"),
+            ChatItem(
+                role="tool",
+                text="→ Running failure · $ false",
+                tool_result_text="✗ bash\nfailed",
+            ),
             theme=theme,
             show_tool_results=True,
         )

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -126,9 +126,14 @@ deterministic fallback. Multiline commands and heredocs show their first line pl
 a line count, inline code shows its interpreter plus a character count, and other
 commands over 120 characters show a shortened preview.
 
-Toggle the exact commands and full tool output with **Ctrl+O**. Command compaction
-affects only the TUI display; execution, session history, and print-mode
-transcripts retain the complete command.
+When one model response reads several files, adjacent `read` calls share one row.
+The row previews up to three paths, reports progress as results arrive, and shows
+an aggregate failure count when needed. Reads from different model responses are
+never combined, and shell or file-mutating tools always remain separate.
+
+Toggle the individual read calls, exact shell commands, and full tool output with
+**Ctrl+O**. Compaction and grouping affect only the TUI display; execution,
+session history, and print-mode transcripts retain every complete call.
 
 Markdown link hover styling underlines only the linked text, never the rest of its
 row. User message blocks use the same theme background as the prompt field and sidebar,

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -129,7 +129,8 @@ custom rendered call cards and skill loads remain separate.
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a
 brief description such as `Running tests`. Collapsed rows never show command
-text; press **Ctrl+O** to reveal the exact command. Malformed provider output,
+text; press **Ctrl+O** to keep the description visible and reveal the exact command
+and result beneath it. Malformed provider output,
 custom integrations, and older sessions can still lack a description; those calls
 show the generic `Running shell command` label until expanded.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -137,10 +137,11 @@ and result beneath it. Malformed provider output,
 custom integrations, and older sessions can still lack a description; those calls
 show the generic `Running shell command` label until expanded.
 
-When one model response reads several files, adjacent `read` calls share one row.
-The row previews up to three paths, reports progress as results arrive, and shows
-an aggregate failure count when needed. Reads from different model responses are
-never combined, and shell or file-mutating tools always remain separate.
+When one model response reads or edits several files, adjacent calls of the same
+type share one group. The group lists every path, reports progress as results
+arrive, and shows an aggregate failure count when needed. Calls from different
+model responses are never combined; shell calls and extension tools remain
+separate.
 
 Toggle grouped reads into their individual call list with **Ctrl+O**. Grouped read
 rows omit file-content previews even when expanded, keeping the transcript focused

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -130,8 +130,9 @@ extension tools, custom rendered call cards, and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a
-brief description such as `Running tests`. Collapsed rows never show command
-text; press **Ctrl+O** to keep the description visible and reveal the exact command
+brief description such as `Running tests`. Tau shows that description in full;
+collapsed rows never show command text. Press **Ctrl+O** to keep the description
+visible and reveal the exact command
 and result beneath it. Malformed provider output,
 custom integrations, and older sessions can still lack a description; those calls
 show the generic `Running shell command` label until expanded.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -131,9 +131,12 @@ The row previews up to three paths, reports progress as results arrive, and show
 an aggregate failure count when needed. Reads from different model responses are
 never combined, and shell or file-mutating tools always remain separate.
 
-Toggle the individual read calls, exact shell commands, and full tool output with
-**Ctrl+O**. Compaction and grouping affect only the TUI display; execution,
-session history, and print-mode transcripts retain every complete call.
+Toggle grouped reads into their individual call list with **Ctrl+O**. Grouped read
+rows omit file-content previews even when expanded, keeping the transcript focused
+on which files were read. The same toggle reveals exact shell commands and full
+output for other tools. Compaction and grouping affect only the TUI display;
+execution, session history, and print-mode transcripts retain every complete call
+and result.
 
 Markdown link hover styling underlines only the linked text, never the rest of its
 row. User message blocks use the same theme background as the prompt field and sidebar,

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -124,7 +124,7 @@ with one compact line per logical action. Each line retains its own status color
 and adjacent reads remain clustered as one line inside the block. The complete
 block remains one selectable text surface, including across line boundaries.
 Batches never cross assistant text, model continuations, or separate responses;
-custom rendered call cards and skill loads remain separate.
+extension tools, custom rendered call cards, and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -121,9 +121,10 @@ tool row.
 
 Adjacent built-in tool calls from one model response share one transcript block,
 with one compact line per logical action. Each line retains its own status color,
-and adjacent reads remain clustered as one line inside the block. Batches never
-cross assistant text, model continuations, or separate responses; custom rendered
-call cards and skill loads remain separate.
+and adjacent reads remain clustered as one line inside the block. The complete
+block remains one selectable text surface, including across line boundaries.
+Batches never cross assistant text, model continuations, or separate responses;
+custom rendered call cards and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -121,8 +121,9 @@ tool row.
 
 Adjacent built-in tool calls from one model response share one transcript block,
 with one compact line per logical action. Each line retains its own status color,
-and adjacent reads remain clustered as one line inside the block. The complete
-block remains one selectable text surface, including across line boundaries.
+and adjacent reads remain clustered under one headline with every file path
+listed beneath it. The complete block remains one selectable text surface,
+including across line boundaries.
 Batches never cross assistant text, model continuations, or separate responses;
 extension tools, custom rendered call cards, and skill loads remain separate.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -120,8 +120,8 @@ the transcript stays readable. Tau requires the model to give each `bash` call a
 brief description such as `Running tests`. Long or multiline calls pair that
 description with a short prefix taken from the real command, so model-generated
 text is always accompanied by deterministic command text. Short shell commands
-remain visible and ignore the description. Malformed provider output, custom
-integrations, and older sessions can still lack a description; those calls use a
+show the description alongside the complete command. Malformed provider output,
+custom integrations, and older sessions can still lack a description; those calls use a
 deterministic fallback. Multiline commands and heredocs show their first line plus
 a line count, inline code shows its interpreter plus a character count, and other
 commands over 120 characters show a shortened preview.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -128,10 +128,9 @@ custom rendered call cards and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a
-brief description such as `Running tests`. Long or multiline calls pair that
-description with a short prefix taken from the real command, so model-generated
-text is always accompanied by deterministic command text. Short shell commands
-show the description alongside the complete command. Malformed provider output,
+brief description such as `Running tests`. Long or multiline calls show only that
+description while collapsed; press **Ctrl+O** to reveal the exact command. Short
+shell commands show the description alongside the complete command. Malformed provider output,
 custom integrations, and older sessions can still lack a description; those calls use a
 deterministic fallback. Multiline commands and heredocs show their first line plus
 a line count, inline code shows its interpreter plus a character count, and other

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -121,8 +121,9 @@ tool row.
 
 Adjacent built-in tool calls from one model response share one transcript block,
 with one compact line per logical action. Each line retains its own status color,
-and adjacent reads remain clustered under one headline with every file path
-listed beneath it. The complete block remains one selectable text surface,
+and adjacent reads or edits remain clustered under one headline with every file
+path listed beneath it. Expanded edit groups retain each invocation and result;
+expanded read groups omit repeated file contents. The complete block remains one selectable text surface,
 including across line boundaries.
 Batches never cross assistant text, model continuations, or separate responses;
 extension tools, custom rendered call cards, and skill loads remain separate.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -13,8 +13,10 @@ Type into the prompt box at the bottom and press **Enter** to submit. The editor
 keeps its padded block size and background, while a single left border changes
 color to reflect focus, shell mode, and active runs without boxing it in.
 **Shift+Enter** inserts a newline for multi-line prompts. Tau streams the
-assistant's reply above the prompt, showing tool calls as they run. In supported
-terminal emulators, Tau also updates the tab title: named sessions show as
+assistant's reply above the prompt, showing tool calls as they run. When OpenAI
+returns several reasoning-summary parts, Tau keeps them as separate Markdown
+paragraphs rather than joining their headings together. In supported terminal
+emulators, Tau also updates the tab title: named sessions show as
 `τ | <name>`, and active runs add an animated running indicator so you can see
 work continuing from another tab. When a run fully settles while Tau's terminal
 surface is unfocused, Tau emits a desktop notification by default on supported

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -117,6 +117,12 @@ snippets, arguments, and file lists stay neutral gray. The prompt-area activity
 indicator provides the run-wide animation without adding a second spinner to each
 tool row.
 
+Adjacent built-in tool calls from one model response share one transcript block,
+with one compact line per logical action. Each line retains its own status color,
+and adjacent reads remain clustered as one line inside the block. Batches never
+cross assistant text, model continuations, or separate responses; custom rendered
+call cards and skill loads remain separate.
+
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a
 brief description such as `Running tests`. Long or multiline calls pair that

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -111,7 +111,9 @@ first, such as the macOS Dock's Downloads stack.
 ## Tool output
 
 Tool calls keep a static marker in the transcript while they run: orange means
-in progress, green means success, and red means failure. The prompt-area activity
+in progress, green means success, and red means failure. That status color applies
+to the semantic description, such as `Running tests` or `Read 5 files`; command
+snippets, arguments, and file lists stay neutral gray. The prompt-area activity
 indicator provides the run-wide animation without adding a second spinner to each
 tool row.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -116,14 +116,15 @@ indicator provides the run-wide animation without adding a second spinner to eac
 tool row.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
-the transcript stays readable. Tau asks the model to give each `bash` call a brief
-description such as `Running tests`. Long or multiline calls pair that description
-with a short prefix taken from the real command, so model-generated text is always
-accompanied by deterministic command text. Short shell commands remain visible and ignore the
-description. Calls without a description use a deterministic fallback: multiline
-commands and heredocs show their first line plus a line count, inline code shows
-its interpreter plus a character count, and other commands over 120 characters
-show a shortened preview.
+the transcript stays readable. Tau requires the model to give each `bash` call a
+brief description such as `Running tests`. Long or multiline calls pair that
+description with a short prefix taken from the real command, so model-generated
+text is always accompanied by deterministic command text. Short shell commands
+remain visible and ignore the description. Malformed provider output, custom
+integrations, and older sessions can still lack a description; those calls use a
+deterministic fallback. Multiline commands and heredocs show their first line plus
+a line count, inline code shows its interpreter plus a character count, and other
+commands over 120 characters show a shortened preview.
 
 Toggle the exact commands and full tool output with **Ctrl+O**. Command compaction
 affects only the TUI display; execution, session history, and print-mode

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -128,13 +128,10 @@ custom rendered call cards and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a
-brief description such as `Running tests`. Long or multiline calls show only that
-description while collapsed; press **Ctrl+O** to reveal the exact command. Short
-shell commands show the description alongside the complete command. Malformed provider output,
-custom integrations, and older sessions can still lack a description; those calls use a
-deterministic fallback. Multiline commands and heredocs show their first line plus
-a line count, inline code shows its interpreter plus a character count, and other
-commands over 120 characters show a shortened preview.
+brief description such as `Running tests`. Collapsed rows never show command
+text; press **Ctrl+O** to reveal the exact command. Malformed provider output,
+custom integrations, and older sessions can still lack a description; those calls
+show the generic `Running shell command` label until expanded.
 
 When one model response reads several files, adjacent `read` calls share one row.
 The row previews up to three paths, reports progress as results arrive, and shows


### PR DESCRIPTION
## Summary

- require semantic descriptions in provider-facing `bash` tool calls while retaining omission-safe execution
- hide every bash command while collapsed; show the description or a generic fallback until expansion
- batch adjacent built-in tool calls from one assistant response into one selectable transcript block
- keep one independently colored status line per logical action and cluster adjacent reads within mixed batches
- expand batched rows by tool rule: retained bash descriptions with exact commands/results beneath, individual read invocations without repeated file contents
- apply running/success/failure colors to semantic descriptions while file paths remain neutral
- preserve blank-line boundaries between streamed OpenAI reasoning-summary parts

## User experience

Tool-heavy turns are denser and easier to scan. One logical burst of work occupies one selectable transcript block without hiding individual actions or statuses. Shell commands never appear in collapsed rows; `Ctrl+O` keeps each description visible and reveals exact commands and results beneath it. Calls without a description show `Running shell command`. Custom-rendered call cards, skill loads, and separate model continuations remain independent.

OpenAI reasoning summaries keep each returned summary part as a separate Markdown paragraph instead of joining headings together.

## Validation

- `uv run pytest` — 1505 passed, 2 Windows-only skipped
- `uv run pytest tests/test_tau_ai.py -k reasoning_summary` — 3 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`

## Manual validation

1. Ask Tau to run several adjacent shell and read calls in one response; confirm they share one transcript block with one line per action.
2. Confirm no collapsed bash row exposes command text, including calls without descriptions.
3. Drag-select text across multiple tool rows and confirm selection remains continuous.
4. Confirm every line independently changes from running to success/failure coloring while file paths remain neutral.
5. Press `Ctrl+O`; confirm bash descriptions remain visible above exact commands/results and read clusters reveal individual invocations without file-content previews.
6. Confirm calls separated by assistant text or model continuations remain in separate blocks.
7. With an OpenAI reasoning model, confirm multiple returned reasoning-summary headings render as separate paragraphs.

