### PR TITLE
Alert on resource conflicts and group sidebar resources

### DIFF
--- a/dev-notes/resource-conflict-startup-alert.md
+++ b/dev-notes/resource-conflict-startup-alert.md
@@ -2,7 +2,7 @@
 
 ## What changed
 
-The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths. The sidebar also groups loaded skills by their user or project resource directory, making each skill's origin visible at a glance.
+The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths. The sidebar also groups loaded skills by their user or project resource directory, shows every loaded skill, and scrolls its content independently when the groups overflow while keeping the Tau brand pinned.
 
 ## Why
 

--- a/dev-notes/resource-conflict-startup-alert.md
+++ b/dev-notes/resource-conflict-startup-alert.md
@@ -1,0 +1,22 @@
+# Resource conflict startup alert
+
+## What changed
+
+The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths.
+
+## Why
+
+Tau supports user and project resources under both `.tau` and `.agents`. Precedence keeps duplicate names non-fatal, but the prior diagnostics were easy to miss. Surfacing conflicts at startup makes accidental shadowing visible without changing loading behavior.
+
+## Architecture
+
+Resource discovery and precedence remain in `tau_coding.skills` and `tau_coding.prompt_templates`. The Textual adapter formats relevant `ResourceDiagnostic` values and adds display-only alert items. No TUI behavior enters `tau_agent`.
+
+## Verification
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/dev-notes/resource-conflict-startup-alert.md
+++ b/dev-notes/resource-conflict-startup-alert.md
@@ -2,7 +2,7 @@
 
 ## What changed
 
-The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths. The sidebar also groups loaded skills by their user or project resource directory, shows every loaded skill, and scrolls its content independently when the groups overflow while keeping the Tau brand pinned.
+The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths. The sidebar also groups loaded skills and prompt templates by their user or project resource directory, shows every loaded resource, and scrolls its content independently when the groups overflow while keeping the Tau brand pinned.
 
 ## Why
 

--- a/dev-notes/resource-conflict-startup-alert.md
+++ b/dev-notes/resource-conflict-startup-alert.md
@@ -2,7 +2,7 @@
 
 ## What changed
 
-The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths.
+The TUI now turns existing skill and prompt-template override diagnostics into one red startup alert in the transcript. Each entry names the resource and shows the winning and shadowed paths. The sidebar also groups loaded skills by their user or project resource directory, making each skill's origin visible at a glance.
 
 ## Why
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2974,8 +2974,13 @@ class TauTuiApp(App[None]):
         border: none;
     }
 
-    #sidebar-content {
+    #sidebar-scroll {
         height: 1fr;
+        scrollbar-size-vertical: 1;
+    }
+
+    #sidebar-content {
+        height: auto;
     }
 
     #sidebar-brand {

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -118,7 +118,7 @@ from tau_coding.provider_config import (
     upsert_saved_provider,
 )
 from tau_coding.provider_runtime import create_model_provider
-from tau_coding.resources import TauResourcePaths
+from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
 from tau_coding.session import (
     TREE_RUNNING_MESSAGE,
     CodingSession,
@@ -3518,6 +3518,7 @@ class TauTuiApp(App[None]):
         startup_message: str | None = None,
         startup_notice: str | None = None,
         startup_update_notice: str | None = None,
+        startup_alerts: Sequence[str] = (),
         startup_notices: Sequence[str] = (),
         initial_prompt: str | None = None,
     ) -> None:
@@ -3540,6 +3541,8 @@ class TauTuiApp(App[None]):
         self.state = TuiState(skills=session.skills)
         if startup_update_notice is not None:
             self.state.add_item("status", startup_update_notice, highlight="update")
+        for alert in startup_alerts:
+            self.state.add_item("status", alert, highlight="alert")
         for notice in self.startup_notices:
             self.state.add_item("status", notice)
         if self.tui_settings.theme != self.tui_settings.resolved_theme.name:
@@ -6885,6 +6888,33 @@ def _usable_scoped_startup_choices(settings: Any) -> tuple[ModelChoice, ...]:
     return tuple(choices)
 
 
+def _resource_conflict_alert(
+    diagnostics: Sequence[ResourceDiagnostic],
+) -> str | None:
+    """Format skill and prompt precedence conflicts as one startup alert."""
+    prefix = "overrides lower-precedence resource at "
+    conflicts = [
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.kind in {"skill", "prompt"}
+        and diagnostic.name is not None
+        and diagnostic.path is not None
+        and diagnostic.message.startswith(prefix)
+    ]
+    if not conflicts:
+        return None
+
+    lines = ["Conflicting skills/prompts detected:"]
+    for diagnostic in conflicts:
+        resource_kind = "skill" if diagnostic.kind == "skill" else "prompt template"
+        shadowed_path = diagnostic.message.removeprefix(prefix)
+        lines.append(
+            f"- {resource_kind} '{diagnostic.name}': {diagnostic.path} overrides {shadowed_path}"
+        )
+    lines.append("Rename or remove duplicate resources to clear this alert.")
+    return "\n".join(lines)
+
+
 def _startup_inference_provider(
     selection: ProviderSelection,
     record: CodingSessionRecord | None,
@@ -7020,11 +7050,16 @@ async def run_tui_app(
         all_startup_notices = tuple(
             (*error_notices, *startup_notices, *legacy_notices, *theme_notices)
         )
+        resource_conflict_alert = _resource_conflict_alert(
+            getattr(session, "resource_diagnostics", ())
+        )
+        startup_alerts = (resource_conflict_alert,) if resource_conflict_alert is not None else ()
         app = TauTuiApp(
             session,
             tui_settings=load_tui_settings(),
             startup_message=startup_message,
             startup_update_notice=startup_update_notice,
+            startup_alerts=startup_alerts,
             startup_notices=all_startup_notices,
             initial_prompt=initial_prompt,
         )

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -61,7 +61,7 @@ class ChatItem:
     always_show_tool_result: bool = False
     custom_type: str | None = None
     details: dict[str, JSONValue] | None = None
-    highlight: Literal["update"] | None = None
+    highlight: Literal["alert", "update"] | None = None
 
 
 @dataclass(slots=True)
@@ -97,7 +97,7 @@ class TuiState:
         always_show_tool_result: bool = False,
         custom_type: str | None = None,
         details: dict[str, JSONValue] | None = None,
-        highlight: Literal["update"] | None = None,
+        highlight: Literal["alert", "update"] | None = None,
     ) -> None:
         """Append a transcript item."""
         item = ChatItem(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1363,7 +1363,12 @@ def _split_rich_style_colors(style: str) -> tuple[str | None, str | None]:
 
 def _use_plain_transcript_body(item: ChatItem) -> bool:
     """Return whether a transcript item can use fast selectable plain text."""
-    return item.highlight == "update" or item.role in {"user", "tool", "skill", "error"}
+    return item.highlight in {"alert", "update"} or item.role in {
+        "user",
+        "tool",
+        "skill",
+        "error",
+    }
 
 
 def _transcript_plain_body_text(
@@ -1652,6 +1657,8 @@ def render_chat_item(
 
 
 def _chat_item_role_style(item: ChatItem, theme: TuiTheme) -> TuiRoleStyle:
+    if item.highlight == "alert":
+        return TuiRoleStyle(border=theme.error, body=f"bold {theme.error}")
     if item.highlight == "update":
         return TuiRoleStyle(border="#ffff00", body="bold #ffff00")
     if item.role == "tool" and item.tool_result_text:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -105,7 +105,8 @@ class SessionSidebar(Vertical):
     """Compact sidebar with session metadata and bottom-aligned branding."""
 
     def compose(self) -> Any:
-        yield Static("", id="sidebar-content")
+        with VerticalScroll(id="sidebar-scroll"):
+            yield Static("", id="sidebar-content")
         yield Static("", id="sidebar-brand")
 
     _summary_fingerprint: tuple[object, ...] | None = None
@@ -2260,23 +2261,14 @@ def _grouped_skill_list(
         grouped,
         key=lambda origin: (origin_precedence.get(origin, len(origin_precedence)), origin),
     )
-    remaining = SIDEBAR_BULLET_LIST_LIMIT
     text = Text()
     for origin in ordered_origins:
-        visible_names = sorted(grouped[origin])[:remaining]
-        if not visible_names:
-            continue
         if text:
             text.append("\n")
         text.append(origin, style=theme.completion_description)
-        for name in visible_names:
+        for name in sorted(grouped[origin]):
             text.append("\n  • ", style=theme.completion_description)
             text.append(name, style=theme.completion_description)
-        remaining -= len(visible_names)
-
-    hidden_count = len(skills) - SIDEBAR_BULLET_LIST_LIMIT
-    if hidden_count > 0:
-        text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
     return text
 
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -170,8 +170,8 @@ def _session_summary_fingerprint(
         session.session_stats,
         tuple(session.extension_names),
         tuple(tool.name for tool in session.tools),
-        tuple(skill.name for skill in session.skills),
-        tuple(template.name for template in session.prompt_templates),
+        tuple((skill.name, skill.path) for skill in session.skills),
+        tuple((template.name, template.path) for template in session.prompt_templates),
         tuple(context.path for context in session.context_files),
     )
 
@@ -1529,11 +1529,7 @@ def render_session_sidebar(
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
     skills = _grouped_skill_list(session.skills, cwd=session.cwd, theme=theme)
-    prompts = _comma_list(
-        [template.name for template in session.prompt_templates],
-        empty="No prompt templates",
-        theme=theme,
-    )
+    prompts = _grouped_prompt_list(session.prompt_templates, cwd=session.cwd, theme=theme)
     extensions = _comma_list(
         list(session.extension_names),
         empty="No extensions",
@@ -2248,14 +2244,39 @@ def _grouped_skill_list(
 
     grouped: dict[str, list[str]] = {}
     for skill in skills:
-        origin = _skill_origin_label(skill.path, cwd=cwd)
-        grouped.setdefault(origin, []).append(skill.name)
+        origin = skill.path.parent.parent if skill.path.name == "SKILL.md" else skill.path.parent
+        label = _resource_origin_label(origin, cwd=cwd)
+        grouped.setdefault(label, []).append(skill.name)
+    return _grouped_resource_names(grouped, directory="skills", theme=theme)
 
+
+def _grouped_prompt_list(
+    templates: Sequence[PromptTemplate],
+    *,
+    cwd: Path,
+    theme: TuiTheme,
+) -> Text:
+    if not templates:
+        return Text("No prompt templates", style=theme.completion_description)
+
+    grouped: dict[str, list[str]] = {}
+    for template in templates:
+        label = _resource_origin_label(template.path.parent, cwd=cwd)
+        grouped.setdefault(label, []).append(template.name)
+    return _grouped_resource_names(grouped, directory="prompts", theme=theme)
+
+
+def _grouped_resource_names(
+    grouped: dict[str, list[str]],
+    *,
+    directory: str,
+    theme: TuiTheme,
+) -> Text:
     origin_precedence = {
-        "~/.tau/skills": 0,
-        "~/.agents/skills": 1,
-        "./.tau/skills": 2,
-        "./.agents/skills": 3,
+        f"~/.tau/{directory}": 0,
+        f"~/.agents/{directory}": 1,
+        f"./.tau/{directory}": 2,
+        f"./.agents/{directory}": 3,
     }
     ordered_origins = sorted(
         grouped,
@@ -2272,8 +2293,7 @@ def _grouped_skill_list(
     return text
 
 
-def _skill_origin_label(path: Path, *, cwd: Path) -> str:
-    origin = path.parent.parent if path.name == "SKILL.md" else path.parent
+def _resource_origin_label(origin: Path, *, cwd: Path) -> str:
     expanded_origin = origin.expanduser()
     if not expanded_origin.is_absolute():
         expanded_origin = cwd / expanded_origin

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1527,11 +1527,7 @@ def render_session_sidebar(
         style=theme.completion_description,
     )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _limited_bullet_list(
-        [skill.name for skill in session.skills],
-        empty="No skills loaded",
-        theme=theme,
-    )
+    skills = _grouped_skill_list(session.skills, cwd=session.cwd, theme=theme)
     prompts = _comma_list(
         [template.name for template in session.prompt_templates],
         empty="No prompt templates",
@@ -2238,6 +2234,71 @@ def _format_cost(value: float) -> str:
 
 def _plural(count: int, singular: str) -> str:
     return singular if count == 1 else f"{singular}s"
+
+
+def _grouped_skill_list(
+    skills: Sequence[Skill],
+    *,
+    cwd: Path,
+    theme: TuiTheme,
+) -> Text:
+    if not skills:
+        return Text("No skills loaded", style=theme.completion_description)
+
+    grouped: dict[str, list[str]] = {}
+    for skill in skills:
+        origin = _skill_origin_label(skill.path, cwd=cwd)
+        grouped.setdefault(origin, []).append(skill.name)
+
+    origin_precedence = {
+        "~/.tau/skills": 0,
+        "~/.agents/skills": 1,
+        "./.tau/skills": 2,
+        "./.agents/skills": 3,
+    }
+    ordered_origins = sorted(
+        grouped,
+        key=lambda origin: (origin_precedence.get(origin, len(origin_precedence)), origin),
+    )
+    remaining = SIDEBAR_BULLET_LIST_LIMIT
+    text = Text()
+    for origin in ordered_origins:
+        visible_names = sorted(grouped[origin])[:remaining]
+        if not visible_names:
+            continue
+        if text:
+            text.append("\n")
+        text.append(origin, style=theme.completion_description)
+        for name in visible_names:
+            text.append("\n  • ", style=theme.completion_description)
+            text.append(name, style=theme.completion_description)
+        remaining -= len(visible_names)
+
+    hidden_count = len(skills) - SIDEBAR_BULLET_LIST_LIMIT
+    if hidden_count > 0:
+        text.append(f"\n...({hidden_count} more)", style=theme.completion_description)
+    return text
+
+
+def _skill_origin_label(path: Path, *, cwd: Path) -> str:
+    origin = path.parent.parent if path.name == "SKILL.md" else path.parent
+    expanded_origin = origin.expanduser()
+    if not expanded_origin.is_absolute():
+        expanded_origin = cwd / expanded_origin
+    absolute_origin = expanded_origin.absolute()
+    absolute_cwd = cwd.expanduser().absolute()
+    try:
+        relative = absolute_origin.relative_to(absolute_cwd)
+    except ValueError:
+        pass
+    else:
+        return f"./{relative.as_posix()}"
+
+    home = Path.home().absolute()
+    try:
+        return f"~/{absolute_origin.relative_to(home).as_posix()}"
+    except ValueError:
+        return str(absolute_origin)
 
 
 def _limited_bullet_list(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -124,7 +124,6 @@ class SessionSidebar(Vertical):
         self._summary_fingerprint = fingerprint
         self.query_one("#sidebar-content", Static).update(
             render_session_sidebar(session, theme=theme),
-            layout=False,
         )
         self.query_one("#sidebar-brand", Static).update(
             _sidebar_brand(theme=theme),

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -62,6 +62,7 @@ from tau_coding.provider_config import (
     ScopedModelConfig,
     save_provider_settings,
 )
+from tau_coding.resources import ResourceDiagnostic
 from tau_coding.session import (
     ModelChoice,
     SessionTreeBranchResult,
@@ -101,6 +102,7 @@ from tau_coding.tui.app import (
     _activity_prompt_border_color,
     _completion_selected_render_line,
     _render_activity_indicator,
+    _resource_conflict_alert,
     _terminal_command_prefix_span,
     _textual_theme_for_tau_theme,
     _theme_css_variables,
@@ -7912,6 +7914,7 @@ async def test_tui_app_shows_startup_update_notice_first_in_bright_yellow() -> N
     app = TauTuiApp(
         session,
         startup_update_notice="Tau 0.2.0 is available",
+        startup_alerts=("Conflicting skills/prompts detected",),
         startup_notices=("Tau updated to 0.2.0",),
     )
     notifications: list[tuple[str, str | None]] = []
@@ -7927,16 +7930,57 @@ async def test_tui_app_shows_startup_update_notice_first_in_bright_yellow() -> N
         transcript = app.query_one("#transcript", TranscriptView)
         assert [line.text for line in transcript.lines] == [
             "Tau 0.2.0 is available",
+            "Conflicting skills/prompts detected",
             "Tau updated to 0.2.0",
             "Earlier prompt",
         ]
-        update_widget = transcript.query(TranscriptMessageWidget).first()
+        widgets = list(transcript.query(TranscriptMessageWidget))
+        update_widget = widgets[0]
         assert update_widget.item.highlight == "update"
         assert update_widget._role_style.border == "#ffff00"
         assert update_widget._role_style.body == "bold #ffff00"
+        alert_widget = widgets[1]
+        assert alert_widget.item.highlight == "alert"
+        assert alert_widget._role_style.border == TAU_DARK_THEME.error
+        assert alert_widget._role_style.body == f"bold {TAU_DARK_THEME.error}"
 
     assert notifications == []
     assert [message.text for message in session.messages] == ["Earlier prompt"]
+
+
+def test_resource_conflict_alert_includes_skill_and_prompt_locations(tmp_path: Path) -> None:
+    diagnostics = (
+        ResourceDiagnostic(
+            kind="skill",
+            name="review",
+            path=tmp_path / "project" / ".agents" / "skills" / "review" / "SKILL.md",
+            message=(
+                "overrides lower-precedence resource at "
+                f"{tmp_path / 'home' / '.tau' / 'skills' / 'review' / 'SKILL.md'}"
+            ),
+        ),
+        ResourceDiagnostic(
+            kind="prompt",
+            name="ship",
+            path=tmp_path / "project" / ".tau" / "prompts" / "ship.md",
+            message=(
+                "overrides lower-precedence resource at "
+                f"{tmp_path / 'home' / '.agents' / 'prompts' / 'ship.md'}"
+            ),
+        ),
+        ResourceDiagnostic(kind="context", message="unrelated warning"),
+    )
+
+    alert = _resource_conflict_alert(diagnostics)
+
+    assert alert is not None
+    assert "Conflicting skills/prompts detected:" in alert
+    assert "skill 'review'" in alert
+    assert "prompt template 'ship'" in alert
+    assert str(diagnostics[0].path) in alert
+    assert str(diagnostics[1].path) in alert
+    assert "unrelated warning" not in alert
+    assert alert.endswith("Rename or remove duplicate resources to clear this alert.")
 
 
 @pytest.mark.anyio
@@ -8193,14 +8237,28 @@ async def test_run_tui_app_surfaces_startup_provider_error_in_login_message(
         def get_session(self, session_id: str) -> CodingSessionRecord | None:
             return None
 
+    class LoadedSession:
+        resource_diagnostics = (
+            ResourceDiagnostic(
+                kind="skill",
+                name="review",
+                path=tmp_path / ".agents" / "skills" / "review" / "SKILL.md",
+                message=(
+                    "overrides lower-precedence resource at "
+                    f"{tmp_path / '.tau' / 'skills' / 'review' / 'SKILL.md'}"
+                ),
+            ),
+        )
+
     class FakeCodingSession:
         @classmethod
-        async def load(cls, config: object) -> str:
-            return "session"
+        async def load(cls, config: object) -> LoadedSession:
+            return LoadedSession()
 
     class FakeApp:
-        def __init__(self, session: str, **kwargs: object) -> None:
+        def __init__(self, session: LoadedSession, **kwargs: object) -> None:
             captured["startup_message"] = kwargs["startup_message"]
+            captured["startup_alerts"] = kwargs["startup_alerts"]
             captured["startup_notices"] = kwargs["startup_notices"]
 
         async def run_async(self) -> None:
@@ -8235,6 +8293,9 @@ async def test_run_tui_app_surfaces_startup_provider_error_in_login_message(
     startup_message = captured["startup_message"]
     assert "Login required" in startup_message
     assert "connection to provider backend refused" in startup_message
+    alerts = captured["startup_alerts"]
+    assert len(alerts) == 1
+    assert "skill 'review'" in alerts[0]
     notices = captured["startup_notices"]
     assert any("connection to provider backend refused" in n for n in notices)
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -523,11 +523,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "permission-gate, subagents" in output
 
 
-@pytest.mark.parametrize(("skill_count", "hidden_label"), [(5, None), (7, "...(2 more)")])
-def test_session_sidebar_limits_skills_to_five(
-    skill_count: int,
-    hidden_label: str | None,
-) -> None:
+def test_session_sidebar_shows_all_skills() -> None:
     session = FakeSession()
     session.skills = tuple(
         Skill(
@@ -535,21 +531,16 @@ def test_session_sidebar_limits_skills_to_five(
             path=session.cwd / ".tau" / "skills" / f"skill-{index}" / "SKILL.md",
             content="Skill",
         )
-        for index in range(1, skill_count + 1)
+        for index in range(1, 8)
     )
     console = Console(record=True, width=80)
 
     console.print(render_session_sidebar(session))
 
     output = console.export_text()
-    for index in range(1, 6):
+    for index in range(1, 8):
         assert f"• skill-{index}" in output
-    assert "skill-6" not in output
-    assert "skill-7" not in output
-    if hidden_label is None:
-        assert "more)" not in output
-    else:
-        assert hidden_label in output
+    assert "more)" not in output
 
 
 def test_session_sidebar_groups_skills_by_origin(
@@ -2711,6 +2702,31 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
         assert sidebar.styles.background == Color.parse(TAU_DARK_THEME.prompt_background)
         assert compact_info.display is True
         assert not app.has_class("-hide-sidebar")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
+    session = FakeSession()
+    session.skills = tuple(
+        Skill(
+            name=f"skill-{index}",
+            path=session.cwd / ".tau" / "skills" / f"skill-{index}" / "SKILL.md",
+            content="Skill",
+        )
+        for index in range(1, 31)
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        scroll = app.query_one("#sidebar-scroll", VerticalScroll)
+        brand = app.query_one("#sidebar-brand", Static)
+        await pilot.pause()
+
+        assert scroll.max_scroll_y > 0
+        assert brand.region.bottom == app.query_one("#sidebar").content_region.bottom
+        scroll.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert scroll.scroll_y == scroll.max_scroll_y
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -186,7 +186,13 @@ class FakeSession:
         self.available_providers = ("openai",)
         self.tools = tuple(create_coding_tools(cwd=self.cwd))
         self.extension_tool_sources: dict[str, str] = {}
-        self.skills = (Skill(name="review", path=self.cwd / "review.md", content="Review code"),)
+        self.skills = (
+            Skill(
+                name="review",
+                path=self.cwd / ".tau" / "skills" / "review" / "SKILL.md",
+                content="Review code",
+            ),
+        )
         self.prompt_templates = ()
         self.context_files = (
             ProjectContextFile(path=str(self.cwd / "AGENTS.md"), content="Follow rules."),
@@ -513,7 +519,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "cache: 99% latest · 95% session" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
-    assert "• review" in output
+    assert re.search(r"\./\.tau/skills\s+• review", output)
     assert "permission-gate, subagents" in output
 
 
@@ -524,7 +530,11 @@ def test_session_sidebar_limits_skills_to_five(
 ) -> None:
     session = FakeSession()
     session.skills = tuple(
-        Skill(name=f"skill-{index}", path=session.cwd / f"skill-{index}.md", content="Skill")
+        Skill(
+            name=f"skill-{index}",
+            path=session.cwd / ".tau" / "skills" / f"skill-{index}" / "SKILL.md",
+            content="Skill",
+        )
         for index in range(1, skill_count + 1)
     )
     console = Console(record=True, width=80)
@@ -540,6 +550,38 @@ def test_session_sidebar_limits_skills_to_five(
         assert "more)" not in output
     else:
         assert hidden_label in output
+
+
+def test_session_sidebar_groups_skills_by_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    session = FakeSession()
+    session.cwd = tmp_path / "project"
+    session.skills = (
+        Skill("project-agents", session.cwd / ".agents/skills/project-agents/SKILL.md", ""),
+        Skill("user-tau", tmp_path / ".tau/skills/user-tau/SKILL.md", ""),
+        Skill("project-tau", session.cwd / ".tau/skills/project-tau/SKILL.md", ""),
+        Skill("user-agents", tmp_path / ".agents/skills/user-agents/SKILL.md", ""),
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    expected_groups = (
+        ("~/.tau/skills", "user-tau"),
+        ("~/.agents/skills", "user-agents"),
+        ("./.tau/skills", "project-tau"),
+        ("./.agents/skills", "project-agents"),
+    )
+    assert all(
+        re.search(rf"{re.escape(origin)}\s+• {name}", output) for origin, name in expected_groups
+    )
+    assert [output.index(origin) for origin, _name in expected_groups] == sorted(
+        output.index(origin) for origin, _name in expected_groups
+    )
 
 
 def test_session_sidebar_limits_context_files_to_five() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -127,6 +127,7 @@ from tau_coding.tui.widgets import (
     TRANSCRIPT_WINDOW_OVERSCAN_ITEMS,
     CompactSessionInfo,
     LeftAlignedMarkdownHeading,
+    SessionSidebar,
     StreamingTranscriptMessageWidget,
     TauMarkdownBlock,
     ThemedMarkdownWidget,
@@ -2771,6 +2772,41 @@ async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
         scroll.scroll_end(animate=False, immediate=True)
         await pilot.pause()
         assert scroll.scroll_y == scroll.max_scroll_y
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        sidebar = app.query_one("#sidebar", SessionSidebar)
+        scroll = app.query_one("#sidebar-scroll", VerticalScroll)
+        await pilot.pause()
+        initial_virtual_height = scroll.virtual_size.height
+        assert scroll.max_scroll_y == 0
+
+        session.skills = tuple(
+            Skill(
+                name=f"skill-{index}",
+                path=session.cwd / ".tau" / "skills" / f"skill-{index}" / "SKILL.md",
+                content="Skill",
+            )
+            for index in range(1, 31)
+        )
+        sidebar.update_from_session(session)
+        await pilot.pause()
+
+        expanded_virtual_height = scroll.virtual_size.height
+        assert expanded_virtual_height > initial_virtual_height
+        assert scroll.max_scroll_y > 0
+
+        session.skills = session.skills[:1]
+        sidebar.update_from_session(session)
+        await pilot.pause()
+
+        assert scroll.virtual_size.height < expanded_virtual_height
+        assert scroll.max_scroll_y == 0
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -575,6 +575,50 @@ def test_session_sidebar_groups_skills_by_origin(
     )
 
 
+def test_session_sidebar_groups_and_shows_all_prompts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    session = FakeSession()
+    session.cwd = tmp_path / "project"
+    session.prompt_templates = (
+        PromptTemplate("project-agents", session.cwd / ".agents/prompts/project-agents.md", ""),
+        PromptTemplate("user-tau", tmp_path / ".tau/prompts/user-tau.md", ""),
+        PromptTemplate("project-tau", session.cwd / ".tau/prompts/project-tau.md", ""),
+        PromptTemplate("user-agents", tmp_path / ".agents/prompts/user-agents.md", ""),
+        *tuple(
+            PromptTemplate(
+                f"extra-{index}",
+                session.cwd / f".tau/prompts/extra-{index}.md",
+                "",
+            )
+            for index in range(1, 5)
+        ),
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    expected_groups = (
+        ("~/.tau/prompts", "user-tau"),
+        ("~/.agents/prompts", "user-agents"),
+        ("./.tau/prompts", "extra-1"),
+        ("./.agents/prompts", "project-agents"),
+    )
+    assert all(
+        re.search(rf"{re.escape(origin)}\s+• {name}", output) for origin, name in expected_groups
+    )
+    assert "• project-tau" in output
+    for index in range(1, 5):
+        assert f"• extra-{index}" in output
+    assert "more)" not in output
+    assert [output.index(origin) for origin, _name in expected_groups] == sorted(
+        output.index(origin) for origin, _name in expected_groups
+    )
+
+
 def test_session_sidebar_limits_context_files_to_five() -> None:
     session = FakeSession()
     session.context_files = tuple(
@@ -641,7 +685,7 @@ def test_comma_list_represents_an_oversized_first_item(
 
 @pytest.mark.parametrize(
     ("attribute", "prefix"),
-    [("tools", "tool"), ("prompt_templates", "prompt"), ("extension_names", "extension")],
+    [("tools", "tool"), ("extension_names", "extension")],
 )
 def test_session_sidebar_limits_comma_separated_sections_to_three_lines(
     attribute: str,

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -30,7 +30,10 @@ Prompt templates load from:
 
 After adding or editing files while the TUI is open, run **`/reload`** to
 rediscover them. Duplicate/overridden resources are reported as diagnostics, not
-fatal errors.
+fatal errors. At TUI startup, Tau also shows a red transcript alert when skills or
+prompt templates in different locations share a name. The alert lists both paths
+so you can rename or remove the unintended duplicate; Tau still uses the
+higher-precedence resource.
 
 ## Skills
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -170,9 +170,11 @@ and loaded tools, skills, prompt templates, extensions, and context files such a
 `AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists limited to three rendered lines. Skills
 are grouped under their resource origin (for example, `./.tau/skills` or
-`~/.agents/skills`) and limited to five entries overall. Context files use a
-bullet list with one path per line, also limited to five entries. Truncated
-sections end with `...(X more)` showing how many entries are hidden. Project
+`~/.agents/skills`) and all loaded skills are shown. If the sidebar content is
+taller than the available space, scroll the sidebar to see the remaining groups
+and skills; the Tau version mark stays pinned at the bottom. Context files use a
+bullet list with one path per line, limited to five entries. Truncated sections
+end with `...(X more)` showing how many context entries are hidden. Project
 context paths are relative to the working directory; context
 loaded from the home directory starts with `~/`, while other context loaded from
 outside the project uses its full path.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -169,9 +169,11 @@ session prompt-cache hit rates, estimated cost, automatic-compaction threshold,
 and loaded tools, skills, prompt templates, extensions, and context files such as
 `AGENTS.md`. Tool, prompt, and extension
 names use compact comma-separated lists limited to three rendered lines. Skills
-and context files use bullet lists, with one item or path per line, limited to
-five entries. Truncated sections end with `...(X more)` showing how many entries
-are hidden. Project context paths are relative to the working directory; context
+are grouped under their resource origin (for example, `./.tau/skills` or
+`~/.agents/skills`) and limited to five entries overall. Context files use a
+bullet list with one path per line, also limited to five entries. Truncated
+sections end with `...(X more)` showing how many entries are hidden. Project
+context paths are relative to the working directory; context
 loaded from the home directory starts with `~/`, while other context loaded from
 outside the project uses its full path.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -167,13 +167,13 @@ redundant section label, followed by active-branch
 turn and tool-call totals, provider-reported token usage, latest-request and
 session prompt-cache hit rates, estimated cost, automatic-compaction threshold,
 and loaded tools, skills, prompt templates, extensions, and context files such as
-`AGENTS.md`. Tool, prompt, and extension
-names use compact comma-separated lists limited to three rendered lines. Skills
-are grouped under their resource origin (for example, `./.tau/skills` or
-`~/.agents/skills`) and all loaded skills are shown. If the sidebar content is
-taller than the available space, scroll the sidebar to see the remaining groups
-and skills; the Tau version mark stays pinned at the bottom. Context files use a
-bullet list with one path per line, limited to five entries. Truncated sections
+`AGENTS.md`. Tool and extension names use compact comma-separated lists limited
+to three rendered lines. Skills and prompt templates are grouped under their
+resource origins (for example, `./.tau/skills`, `~/.agents/skills`, or
+`./.tau/prompts`), and every loaded skill and prompt is shown. If the sidebar
+content is taller than the available space, scroll it to see the remaining
+resource groups; the Tau version mark stays pinned at the bottom. Context files
+use a bullet list with one path per line, limited to five entries. Truncated sections
 end with `...(X more)` showing how many context entries are hidden. Project
 context paths are relative to the working directory; context
 loaded from the home directory starts with `~/`, while other context loaded from


### PR DESCRIPTION
## Summary

- show a red transcript alert at TUI startup when skills or prompt templates shadow same-named resources in other locations
- group sidebar skills and prompt templates by user/project resource origin
- show all skills and prompts in an independently scrollable sidebar while keeping the Tau brand pinned
- document the updated resource and sidebar behavior

## User experience

Resource conflicts are immediately visible with both winning and shadowed paths. The sidebar makes resource origins clear and no longer hides skills or prompts behind truncation.

## Validation

- `uv run pytest` (1498 passed, 2 Windows-only skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`


