### PR TITLE
Group adjacent write calls by file

### DIFF
--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -1,4 +1,4 @@
-# Grouped read calls in the TUI
+# Grouped file calls in the TUI
 
 Models often request several files in one assistant response. Rendering every
 batched `read` as a separate collapsed row made exploration-heavy turns noisy,
@@ -30,33 +30,35 @@ existing row and result behavior. Reads separated by another tool, text block,
 or assistant response are not grouped. Skill-file reads retain their special
 skill presentation.
 
-Adjacent built-in `edit` calls use the same presentation: `Editing N files`
-becomes `Edited N files`, with every edited path listed below. Expanding an edit
-group preserves each invocation and result, unlike read groups whose file-content
-results stay suppressed.
+Adjacent built-in `edit` and `write` calls use the same presentation: `Editing N
+files` becomes `Edited N files`, while `Writing N files` becomes `Written N files`.
+Every affected path is listed below. Expanding edit and write groups preserves
+each invocation and result, unlike read groups whose file-content results stay
+suppressed.
 
 ## Architecture
 
 Grouping is display-only in `src/tau_coding/tui/`. `TuiEventAdapter` assigns a
 presentation batch identifier to tool calls from one completed assistant message.
 `TuiState` keeps each grouped call's ID, arguments, progress, result, and timing,
-while exposing one aggregate read row. That row can stand alone or live inside a
+while exposing one aggregate file row. That row can stand alone or live inside a
 larger mixed-tool batch. Every call ID maps back to its top-level item, so live
 updates continue to use O(1) lookup and refresh the existing Textual widget in
-place. Results still determine aggregate progress and error styling, but the
-widget suppresses their content when rendering a grouped row.
+place. Results still determine aggregate progress and error styling. Read-result
+contents stay suppressed, while edit and write results remain available on
+expansion.
 
 Restored canonical messages use the same assistant-message boundary to rebuild
 the group deterministically. Agent events, tool execution, provider payloads,
 and session JSONL remain unchanged. Existing custom call renderers are applied
 to each invocation when a group is expanded.
 
-Only built-in `read` and `edit` calls use file grouping. Shell commands and
-extension tools retain their own presentation semantics.
+Only built-in `read`, `edit`, and `write` calls use file grouping. Shell commands
+and extension tools retain their own presentation semantics.
 
 ## Tests
 
-- `tests/test_tui_adapter.py` covers restored read/edit groups, path lists,
+- `tests/test_tui_adapter.py` covers restored read/edit/write groups, path lists,
   call-ID lookup, expanded invocations/results, and assistant-message boundaries.
 - `tests/test_tui_app.py` covers live grouping, in-place progress updates,
   completion, and `Ctrl+O` expansion in Textual.

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -21,12 +21,13 @@ Doing something else
 
 Each line keeps its own running, success, or failure color on the semantic
 description. Commands, arguments, and paths remain neutral. Adjacent reads still
-collapse into file-list rows inside the larger batch, as do adjacent edits.
+collapse into file-list rows inside the larger batch, as do adjacent edits and
+writes.
 
 `Ctrl+O` expands every row using its tool-specific behavior. Bash rows retain
 their description and show the exact command and result beneath it. Grouped reads
 expand to individual read invocations without repeating file-content previews;
-grouped edits retain each invocation and result. Batch invocations and
+grouped edits and writes retain each invocation and result. Batch invocations and
 results remain one selectable plain-text surface.
 
 Batches never cross assistant text, thinking blocks, model continuations, skill

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -34,6 +34,8 @@ TERMINAL_COMMAND_OUTPUT_PREVIEW_LINES = 120
 # quick reads/edits never flash a "(0s)".
 TOOL_TIMER_MIN_SECONDS = 1.0
 BATCHABLE_TOOL_NAMES = frozenset({"bash", "edit", "read", "write"})
+GROUPABLE_FILE_TOOL_NAMES = frozenset({"edit", "read", "write"})
+RESULTFUL_FILE_GROUP_NAMES = frozenset({"edit", "write"})
 
 
 @dataclass(slots=True)
@@ -175,10 +177,13 @@ class TuiState:
                 if self.tool_call_renderer is not None:
                     rendered_line = self.tool_call_renderer(member.tool_name, member.tool_arguments)
                 block = rendered_line if rendered_line is not None else member.text
-                if item.tool_name == "edit" and member.tool_result_text is not None:
+                if (
+                    item.tool_name in RESULTFUL_FILE_GROUP_NAMES
+                    and member.tool_result_text is not None
+                ):
                     block = f"{block}\n\n{member.tool_result_text}"
                 blocks.append(block)
-            separator = "\n\n" if item.tool_name == "edit" else "\n"
+            separator = "\n\n" if item.tool_name in RESULTFUL_FILE_GROUP_NAMES else "\n"
             return separator.join(blocks)
         line: str | None = None
         if item.tool_name is not None and self.tool_call_renderer is not None:
@@ -284,7 +289,7 @@ class TuiState:
     def _append_batched_tool_call(self, item: ChatItem, tool_call: ToolCall) -> None:
         if (
             item.tool_batch_items is None
-            and item.tool_name in {"edit", "read"}
+            and item.tool_name in GROUPABLE_FILE_TOOL_NAMES
             and tool_call.name == item.tool_name
         ):
             self._append_grouped_file_call(item, tool_call)
@@ -309,7 +314,7 @@ class TuiState:
             for call_id in self._tool_call_ids(first):
                 self._batched_items_by_call_id[call_id] = first
         last = item.tool_batch_items[-1]
-        if last.tool_name in {"edit", "read"} and tool_call.name == last.tool_name:
+        if last.tool_name in GROUPABLE_FILE_TOOL_NAMES and tool_call.name == last.tool_name:
             self._append_grouped_file_call(last, tool_call)
             row = last
         else:
@@ -388,15 +393,15 @@ class TuiState:
         ]
         path_list = "\n".join(f"  - {path}" for path in paths)
         all_complete = len(completed) == len(members)
-        action = "edit" if item.tool_name == "edit" else "read"
+        action = item.tool_name if item.tool_name in GROUPABLE_FILE_TOOL_NAMES else "read"
+        running_verb = {"edit": "Editing", "read": "Reading", "write": "Writing"}[action]
+        completed_verb = {"edit": "Edited", "read": "Read", "write": "Written"}[action]
         if not all_complete:
             progress = f" · {len(completed)}/{len(members)} complete" if completed else ""
-            verb = "Editing" if action == "edit" else "Reading"
-            headline = f"→ {verb} {len(members)} files{progress}"
+            headline = f"→ {running_verb} {len(members)} files{progress}"
         else:
             failure = f" · {len(failures)} failed" if failures else ""
-            verb = "Edited" if action == "edit" else "Read"
-            headline = f"→ {verb} {len(members)} files{failure}"
+            headline = f"→ {completed_verb} {len(members)} files{failure}"
         item.text = f"{headline}\n{path_list}"
         if completed:
             status = "✗" if failures else ("✓" if all_complete else "…")

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -40,6 +40,7 @@ from tau_coding.system_prompt import ProjectContextFile
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import (
+    RESULTFUL_FILE_GROUP_NAMES,
     TOOL_TIMER_MIN_SECONDS,
     ChatItem,
     TuiState,
@@ -1705,10 +1706,14 @@ def _tool_batch_row_invocation(row: ChatItem, *, expanded: bool) -> str:
             blocks = []
             for member in row.grouped_tool_calls:
                 block = member.text
-                if row.tool_name == "edit" and member.tool_result_text is not None:
+                if (
+                    row.tool_name in RESULTFUL_FILE_GROUP_NAMES
+                    and member.tool_result_text is not None
+                ):
                     block = f"{block}\n\n{member.tool_result_text}"
                 blocks.append(block)
-            return ("\n\n" if row.tool_name == "edit" else "\n").join(blocks)
+            separator = "\n\n" if row.tool_name in RESULTFUL_FILE_GROUP_NAMES else "\n"
+            return separator.join(blocks)
         return row.text
     if expanded and row.tool_name == "bash":
         exact_command = format_tool_call_invocation(
@@ -1820,7 +1825,7 @@ def _render_tool_invocation(
 
 
 _TOOL_GROUP_INVOCATION_PATTERN = re.compile(
-    r"^→ ((?:Reading|Read|Editing|Edited) \d+ files"
+    r"^→ ((?:Reading|Read|Editing|Edited|Writing|Written) \d+ files"
     r"(?: · (?:\d+/\d+ complete|\d+ failed))?)(?: · (.+))?$"
 )
 

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -226,6 +226,40 @@ def test_tui_state_clusters_edits_and_lists_every_path() -> None:
     assert "→ edit b.py\n\n✓ edit\nchanged b" in expanded
 
 
+def test_tui_state_clusters_writes_and_lists_every_path() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="write-1",
+                        name="write",
+                        arguments={"path": "a.py", "content": "one"},
+                    ),
+                    ToolCall(
+                        id="write-2",
+                        name="write",
+                        arguments={"path": "b.py", "content": "two"},
+                    ),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="write-1", tool_name="write", content="wrote a"),
+            ToolResultMessage(tool_call_id="write-2", tool_name="write", content="wrote b"),
+        ]
+    )
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.text == "→ Written 2 files\n  - a.py\n  - b.py"
+    assert item.grouped_tool_calls is not None
+    assert item.tool_result_text == "✓ write group"
+    expanded = state.resolve_tool_invocation(item, expanded=True)
+    assert expanded is not None
+    assert "→ write a.py\n\n✓ write\nwrote a" in expanded
+    assert "→ write b.py\n\n✓ write\nwrote b" in expanded
+
+
 def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1599,6 +1599,27 @@ def test_grouped_read_details_stay_neutral() -> None:
     assert f"{green}  - a.py" not in output
 
 
+def test_grouped_write_paths_stay_neutral() -> None:
+    green = "38;2;156;255;177;48;2;0;0;0m"
+    body = "38;2;203;213;225;48;2;0;0;0m"
+    text = "→ Written 2 files\n  - a.py\n  - b.py"
+    console = Console(record=True, width=100, color_system="truecolor")
+    item = ChatItem(role="tool", text=text, tool_name="write", tool_result_text="✓ write group")
+    console.print(
+        _transcript_plain_body_text(
+            item,
+            text=text,
+            body_style=TAU_DARK_THEME.role_styles["tool"].body,
+            theme=TAU_DARK_THEME,
+        )
+    )
+    output = console.export_text(styles=True)
+
+    assert f"{green}Written 2 files" in output
+    assert f"{body}  - a.py" in output
+    assert f"{green}  - a.py" not in output
+
+
 def test_bash_description_without_command_keeps_full_status_color() -> None:
     command = "echo " + "x" * 120
     item = ChatItem(

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -121,9 +121,10 @@ tool row.
 
 Adjacent built-in tool calls from one model response share one transcript block,
 with one compact line per logical action. Each line retains its own status color,
-and adjacent reads or edits remain clustered under one headline with every file
-path listed beneath it. Expanded edit groups retain each invocation and result;
-expanded read groups omit repeated file contents. The complete block remains one selectable text surface,
+and adjacent reads, edits, or writes remain clustered under one headline with
+every file path listed beneath it. Expanded edit and write groups retain each
+invocation and result; expanded read groups omit repeated file contents. The
+complete block remains one selectable text surface,
 including across line boundaries.
 Batches never cross assistant text, model continuations, or separate responses;
 extension tools, custom rendered call cards, and skill loads remain separate.


### PR DESCRIPTION
## Summary

- cluster adjacent built-in `write` calls from one assistant response
- show `Writing N files` / `Written N files` with every path listed beneath
- preserve per-call write invocations and results when expanded with `Ctrl+O`
- support standalone write groups and write groups inside mixed tool batches

## User experience

Several consecutive writes now use the same compact file-list presentation as reads and edits:

```text
→ Written 2 files
  - src/one.py
  - src/two.py
```

Progress and failure counts retain existing status colors. Paths remain neutral and selectable.

## Validation

- `uv run pytest` (1513 passed, 2 Windows-only skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`

## Manual validation

1. Ask a model to emit two adjacent `write` calls.
2. Confirm one `Writing N files` row lists every path and updates to `Written N files`.
3. Press `Ctrl+O` and confirm each write invocation and result remains visible.
