### PR TITLE
Group serialized edit and write continuations

### DIFF
--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -34,9 +34,9 @@ Adjacent built-in `edit` and `write` calls use the same presentation: `Editing N
 files` becomes `Edited N files`, while `Writing N files` becomes `Written N files`.
 Every affected path is listed below. Expanding edit and write groups preserves
 each invocation and result, unlike read groups whose file-content results stay
-suppressed. Consecutive write-only model continuations also join the same group;
-this covers providers that emit one write, wait for its result, then emit the next.
-Assistant text or thinking still ends the group.
+suppressed. Consecutive edit-only or write-only model continuations also join the
+same group; this covers providers that emit one mutation, wait for its result,
+then emit the next. Assistant text or thinking still ends the group.
 
 ## Architecture
 
@@ -50,9 +50,9 @@ place. Results still determine aggregate progress and error styling. Read-result
 contents stay suppressed, while edit and write results remain available on
 expansion.
 
-Restored canonical messages rebuild groups deterministically. Read and edit
-groups retain assistant-message boundaries. Write groups may additionally span
-consecutive tool-only model continuations when each preceding write completed;
+Restored canonical messages rebuild groups deterministically. Read groups retain
+assistant-message boundaries. Edit and write groups may additionally span
+consecutive same-tool model continuations when each preceding mutation completed;
 assistant text, thinking, or another tool ends the group. Agent events, tool
 execution, provider payloads, and session JSONL remain unchanged. Existing custom
 call renderers are applied to each invocation when a group is expanded.
@@ -62,8 +62,9 @@ and extension tools retain their own presentation semantics.
 
 ## Tests
 
-- `tests/test_tui_adapter.py` covers restored read/edit/write groups, write-only
-  continuations, text boundaries, path lists, call-ID lookup, and expansion.
+- `tests/test_tui_adapter.py` covers restored read/edit/write groups, serialized
+  edit/write continuations, text boundaries, path lists, call-ID lookup, and
+  expansion.
 - `tests/test_tui_app.py` covers live grouping, in-place progress updates,
   completion, and `Ctrl+O` expansion in Textual.
 

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -34,7 +34,9 @@ Adjacent built-in `edit` and `write` calls use the same presentation: `Editing N
 files` becomes `Edited N files`, while `Writing N files` becomes `Written N files`.
 Every affected path is listed below. Expanding edit and write groups preserves
 each invocation and result, unlike read groups whose file-content results stay
-suppressed.
+suppressed. Consecutive write-only model continuations also join the same group;
+this covers providers that emit one write, wait for its result, then emit the next.
+Assistant text or thinking still ends the group.
 
 ## Architecture
 
@@ -48,18 +50,20 @@ place. Results still determine aggregate progress and error styling. Read-result
 contents stay suppressed, while edit and write results remain available on
 expansion.
 
-Restored canonical messages use the same assistant-message boundary to rebuild
-the group deterministically. Agent events, tool execution, provider payloads,
-and session JSONL remain unchanged. Existing custom call renderers are applied
-to each invocation when a group is expanded.
+Restored canonical messages rebuild groups deterministically. Read and edit
+groups retain assistant-message boundaries. Write groups may additionally span
+consecutive tool-only model continuations when each preceding write completed;
+assistant text, thinking, or another tool ends the group. Agent events, tool
+execution, provider payloads, and session JSONL remain unchanged. Existing custom
+call renderers are applied to each invocation when a group is expanded.
 
 Only built-in `read`, `edit`, and `write` calls use file grouping. Shell commands
 and extension tools retain their own presentation semantics.
 
 ## Tests
 
-- `tests/test_tui_adapter.py` covers restored read/edit/write groups, path lists,
-  call-ID lookup, expanded invocations/results, and assistant-message boundaries.
+- `tests/test_tui_adapter.py` covers restored read/edit/write groups, write-only
+  continuations, text boundaries, path lists, call-ID lookup, and expansion.
 - `tests/test_tui_app.py` covers live grouping, in-place progress updates,
   completion, and `Ctrl+O` expansion in Textual.
 

--- a/dev-notes/tui-grouped-read-calls.md
+++ b/dev-notes/tui-grouped-read-calls.md
@@ -53,7 +53,9 @@ expansion.
 Restored canonical messages rebuild groups deterministically. Read groups retain
 assistant-message boundaries. Edit and write groups may additionally span
 consecutive same-tool model continuations when each preceding mutation completed;
-assistant text, thinking, or another tool ends the group. Agent events, tool
+assistant text, thinking, or another tool ends the group. Eligibility comes from
+the canonical assistant block sequence rather than transient display adjacency,
+so live and restored sessions make the same grouping decision. Agent events, tool
 execution, provider payloads, and session JSONL remain unchanged. Existing custom
 call renderers are applied to each invocation when a group is expanded.
 

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -30,10 +30,12 @@ expand to individual read invocations without repeating file-content previews;
 grouped edits and writes retain each invocation and result. Batch invocations and
 results remain one selectable plain-text surface.
 
-Batches never cross assistant text, thinking blocks, model continuations, skill
-loads, or separate assistant responses. Only the known `bash`, `read`, `edit`,
-and `write` tools are eligible; extension tools remain separate so custom call
-or result cards are never flattened into generic text rows.
+Batches never cross assistant text, thinking blocks, skill loads, or unrelated
+assistant responses. A narrow exception joins consecutive completed `write` calls
+from tool-only model continuations, matching providers that serialize writes one
+at a time. Only the known `bash`, `read`, `edit`, and `write` tools are eligible;
+extension tools remain separate so custom call or result cards are never
+flattened into generic text rows.
 
 ## Architecture
 

--- a/dev-notes/tui-tool-batches.md
+++ b/dev-notes/tui-tool-batches.md
@@ -31,10 +31,11 @@ grouped edits and writes retain each invocation and result. Batch invocations an
 results remain one selectable plain-text surface.
 
 Batches never cross assistant text, thinking blocks, skill loads, or unrelated
-assistant responses. A narrow exception joins consecutive completed `write` calls
-from tool-only model continuations, matching providers that serialize writes one
-at a time. Only the known `bash`, `read`, `edit`, and `write` tools are eligible;
-extension tools remain separate so custom call or result cards are never
+assistant responses. A narrow exception joins consecutive completed `edit` or
+`write` calls from same-tool model continuations, matching providers that
+serialize file mutations one at a time. Only the known `bash`, `read`, `edit`,
+and `write` tools are eligible; extension tools remain separate so custom call or
+result cards are never
 flattened into generic text rows.
 
 ## Architecture

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -21,7 +21,7 @@ from tau_coding.events import (
     SessionAgentEndEvent,
 )
 from tau_coding.session import is_context_overflow_error
-from tau_coding.tui.state import TuiState
+from tau_coding.tui.state import TuiState, _is_file_mutation_only_message
 
 
 class TuiEventAdapter:
@@ -30,6 +30,7 @@ class TuiEventAdapter:
         self._assistant_start_item_index: int | None = None
         self._pending_overflow_error: AssistantMessage | None = None
         self._tool_batch_ids: dict[str, int] = {}
+        self._file_mutation_continuation_calls: set[str] = set()
 
     def apply(self, event: CodingSessionEvent) -> None:
         if isinstance(event, AgentStartEvent):
@@ -99,12 +100,15 @@ class TuiEventAdapter:
                     self.state.add_assistant_message(message, include_tool_calls=False)
                     previous_was_tool = False
                     batch_id: int | None = None
+                    allows_mutation_continuation = _is_file_mutation_only_message(message)
                     for block in message.content:
                         if isinstance(block, ToolCall):
                             if not previous_was_tool:
                                 batch_id = self.state.new_tool_batch_id()
                             if batch_id is not None:
                                 self._tool_batch_ids[block.id] = batch_id
+                            if allows_mutation_continuation:
+                                self._file_mutation_continuation_calls.add(block.id)
                             previous_was_tool = True
                         else:
                             previous_was_tool = False
@@ -116,7 +120,11 @@ class TuiEventAdapter:
             self.state.add_tool_call(
                 ToolCall(id=event.tool_call_id, name=event.tool_name, arguments=event.args),
                 batch_id=self._tool_batch_ids.pop(event.tool_call_id, None),
+                allows_file_mutation_continuation=(
+                    event.tool_call_id in self._file_mutation_continuation_calls
+                ),
             )
+            self._file_mutation_continuation_calls.discard(event.tool_call_id)
             return
         if isinstance(event, ToolExecutionUpdateEvent):
             self.state.record_tool_update(event.tool_call_id, event.partial_result.text)

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -230,7 +230,7 @@ class TuiState:
         return self._next_tool_batch_id
 
     def add_tool_call(self, tool_call: ToolCall, *, batch_id: int | None = None) -> ChatItem:
-        """Append a tool call, batching adjacent calls from one assistant response."""
+        """Append a tool call, batching adjacent calls for compact presentation."""
         skill_name = self._read_skill_name(tool_call)
         if skill_name is not None:
             self.add_item(
@@ -239,6 +239,11 @@ class TuiState:
                 tool_call_id=tool_call.id,
             )
             return self.items[-1]
+        if self._can_append_write_continuation(tool_call, batch_id=batch_id):
+            item = self.items[-1]
+            item.tool_batch_id = batch_id
+            self._append_batched_tool_call(item, tool_call)
+            return item
         if self._can_append_tool_batch(tool_call, batch_id=batch_id):
             item = self.items[-1]
             self._append_batched_tool_call(item, tool_call)
@@ -257,6 +262,30 @@ class TuiState:
             tool_arguments=tool_call.arguments,
             started_at=time.monotonic(),
             tool_batch_id=batch_id,
+        )
+
+    def _can_append_write_continuation(
+        self,
+        tool_call: ToolCall,
+        *,
+        batch_id: int | None,
+    ) -> bool:
+        """Group completed write-only model continuations across response boundaries."""
+        if batch_id is None or tool_call.name != "write" or not self.items:
+            return False
+        previous = self.items[-1]
+        if (
+            previous.role != "tool"
+            or previous.tool_name != "write"
+            or previous.tool_batch_items is not None
+            or previous.tool_result_text is None
+        ):
+            return False
+        if self._has_custom_call_rendering(tool_call.name, tool_call.arguments):
+            return False
+        return not self._has_custom_call_rendering(
+            previous.tool_name,
+            previous.tool_arguments or {},
         )
 
     def _can_append_tool_batch(self, tool_call: ToolCall, *, batch_id: int | None) -> bool:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -239,7 +239,7 @@ class TuiState:
                 tool_call_id=tool_call.id,
             )
             return self.items[-1]
-        if self._can_append_write_continuation(tool_call, batch_id=batch_id):
+        if self._can_append_file_mutation_continuation(tool_call, batch_id=batch_id):
             item = self.items[-1]
             item.tool_batch_id = batch_id
             self._append_batched_tool_call(item, tool_call)
@@ -264,19 +264,19 @@ class TuiState:
             tool_batch_id=batch_id,
         )
 
-    def _can_append_write_continuation(
+    def _can_append_file_mutation_continuation(
         self,
         tool_call: ToolCall,
         *,
         batch_id: int | None,
     ) -> bool:
-        """Group completed write-only model continuations across response boundaries."""
-        if batch_id is None or tool_call.name != "write" or not self.items:
+        """Group completed edit/write-only continuations across response boundaries."""
+        if batch_id is None or tool_call.name not in RESULTFUL_FILE_GROUP_NAMES or not self.items:
             return False
         previous = self.items[-1]
         if (
             previous.role != "tool"
-            or previous.tool_name != "write"
+            or previous.tool_name != tool_call.name
             or previous.tool_batch_items is not None
             or previous.tool_result_text is None
         ):

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -68,6 +68,7 @@ class ChatItem:
     tool_arguments: dict[str, JSONValue] | None = None
     started_at: float | None = None
     tool_batch_id: int | None = None
+    allows_file_mutation_continuation: bool = False
     grouped_tool_calls: list[GroupedToolCall] | None = None
     tool_batch_items: list[ChatItem] | None = None
     always_show_tool_result: bool = False
@@ -229,7 +230,13 @@ class TuiState:
         self._next_tool_batch_id += 1
         return self._next_tool_batch_id
 
-    def add_tool_call(self, tool_call: ToolCall, *, batch_id: int | None = None) -> ChatItem:
+    def add_tool_call(
+        self,
+        tool_call: ToolCall,
+        *,
+        batch_id: int | None = None,
+        allows_file_mutation_continuation: bool = False,
+    ) -> ChatItem:
         """Append a tool call, batching adjacent calls for compact presentation."""
         skill_name = self._read_skill_name(tool_call)
         if skill_name is not None:
@@ -239,7 +246,11 @@ class TuiState:
                 tool_call_id=tool_call.id,
             )
             return self.items[-1]
-        if self._can_append_file_mutation_continuation(tool_call, batch_id=batch_id):
+        if self._can_append_file_mutation_continuation(
+            tool_call,
+            batch_id=batch_id,
+            allowed=allows_file_mutation_continuation,
+        ):
             item = self.items[-1]
             item.tool_batch_id = batch_id
             self._append_batched_tool_call(item, tool_call)
@@ -248,12 +259,22 @@ class TuiState:
             item = self.items[-1]
             self._append_batched_tool_call(item, tool_call)
             return item
-        item = self._new_tool_item(tool_call, batch_id=batch_id)
+        item = self._new_tool_item(
+            tool_call,
+            batch_id=batch_id,
+            allows_file_mutation_continuation=allows_file_mutation_continuation,
+        )
         self.items.append(item)
         self._tool_items_by_call_id[tool_call.id] = item
         return item
 
-    def _new_tool_item(self, tool_call: ToolCall, *, batch_id: int | None) -> ChatItem:
+    def _new_tool_item(
+        self,
+        tool_call: ToolCall,
+        *,
+        batch_id: int | None,
+        allows_file_mutation_continuation: bool = False,
+    ) -> ChatItem:
         return ChatItem(
             role="tool",
             text=format_tool_call_block(tool_call),
@@ -262,6 +283,7 @@ class TuiState:
             tool_arguments=tool_call.arguments,
             started_at=time.monotonic(),
             tool_batch_id=batch_id,
+            allows_file_mutation_continuation=allows_file_mutation_continuation,
         )
 
     def _can_append_file_mutation_continuation(
@@ -269,13 +291,20 @@ class TuiState:
         tool_call: ToolCall,
         *,
         batch_id: int | None,
+        allowed: bool,
     ) -> bool:
         """Group completed edit/write-only continuations across response boundaries."""
-        if batch_id is None or tool_call.name not in RESULTFUL_FILE_GROUP_NAMES or not self.items:
+        if (
+            not allowed
+            or batch_id is None
+            or tool_call.name not in RESULTFUL_FILE_GROUP_NAMES
+            or not self.items
+        ):
             return False
         previous = self.items[-1]
         if (
             previous.role != "tool"
+            or not previous.allows_file_mutation_continuation
             or previous.tool_name != tool_call.name
             or previous.tool_batch_items is not None
             or previous.tool_result_text is None
@@ -335,6 +364,7 @@ class TuiState:
                 tool_arguments=item.tool_arguments,
                 started_at=item.started_at,
                 tool_batch_id=item.tool_batch_id,
+                allows_file_mutation_continuation=item.allows_file_mutation_continuation,
                 grouped_tool_calls=item.grouped_tool_calls,
             )
             item.tool_batch_items = [first]
@@ -639,6 +669,7 @@ class TuiState:
     ) -> None:
         """Project canonical assistant blocks into display state in order."""
         batch_id = self.new_tool_batch_id() if include_tool_calls and message.tool_calls else None
+        allows_mutation_continuation = _is_file_mutation_only_message(message)
         for block in message.content:
             if isinstance(block, ThinkingContent):
                 if block.thinking:
@@ -647,7 +678,11 @@ class TuiState:
                 if block.text:
                     self.add_item("assistant", block.text)
             elif include_tool_calls:
-                self.add_tool_call(block, batch_id=batch_id)
+                self.add_tool_call(
+                    block,
+                    batch_id=batch_id,
+                    allows_file_mutation_continuation=allows_mutation_continuation,
+                )
 
     def add_assistant_error(self, message: AssistantMessage) -> None:
         """Project any partial response followed by its terminal error."""
@@ -667,6 +702,17 @@ class TuiState:
             if _normalized_path(skill.path) == read_path:
                 return skill.name
         return None
+
+
+def _is_file_mutation_only_message(message: AssistantMessage) -> bool:
+    calls = [block for block in message.content if isinstance(block, ToolCall)]
+    return (
+        bool(calls)
+        and len(calls) == len(message.content)
+        and all(
+            call.name == calls[0].name and call.name in RESULTFUL_FILE_GROUP_NAMES for call in calls
+        )
+    )
 
 
 def _parse_branch_summary_message(content: str) -> str | None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -260,6 +260,86 @@ def test_tui_state_clusters_writes_and_lists_every_path() -> None:
     assert "→ write b.py\n\n✓ write\nwrote b" in expanded
 
 
+def test_tui_state_restores_write_only_model_continuations_as_one_group() -> None:
+    messages = []
+    for index in range(1, 6):
+        messages.extend(
+            [
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id=f"write-{index}",
+                            name="write",
+                            arguments={"path": f"file-{index}.md", "content": str(index)},
+                        )
+                    ]
+                ),
+                ToolResultMessage(
+                    tool_call_id=f"write-{index}",
+                    tool_name="write",
+                    content=f"wrote {index}",
+                ),
+            ]
+        )
+    state = TuiState()
+    state.load_messages(messages)
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.text == (
+        "→ Written 5 files\n"
+        "  - file-1.md\n"
+        "  - file-2.md\n"
+        "  - file-3.md\n"
+        "  - file-4.md\n"
+        "  - file-5.md"
+    )
+    assert item.grouped_tool_calls is not None
+    assert [member.tool_call_id for member in item.grouped_tool_calls] == [
+        "write-1",
+        "write-2",
+        "write-3",
+        "write-4",
+        "write-5",
+    ]
+    assert all(state.find_tool_item(f"write-{index}") is item for index in range(1, 6))
+
+
+def test_tui_state_keeps_write_continuations_separate_across_assistant_text() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="write-1",
+                        name="write",
+                        arguments={"path": "a.md", "content": "one"},
+                    )
+                ]
+            ),
+            ToolResultMessage(tool_call_id="write-1", tool_name="write", content="wrote a"),
+            AssistantMessage(
+                content=[
+                    TextContent(text="Now writing the next file."),
+                    ToolCall(
+                        id="write-2",
+                        name="write",
+                        arguments={"path": "b.md", "content": "two"},
+                    ),
+                ]
+            ),
+            ToolResultMessage(tool_call_id="write-2", tool_name="write", content="wrote b"),
+        ]
+    )
+
+    assert len(state.items) == 3
+    assert state.items[0].text == "→ write a.md"
+    assert state.items[1].role == "assistant"
+    assert state.items[2].text == "→ write b.md"
+    assert all(item.grouped_tool_calls is None for item in (state.items[0], state.items[2]))
+
+
 def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -305,6 +305,55 @@ def test_tui_state_restores_write_only_model_continuations_as_one_group() -> Non
     assert all(state.find_tool_item(f"write-{index}") is item for index in range(1, 6))
 
 
+def test_tui_state_restores_edit_only_model_continuations_as_one_group() -> None:
+    state = TuiState()
+    state.load_messages(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="edit-1",
+                        name="edit",
+                        arguments={"path": "a.py", "edits": []},
+                    )
+                ]
+            ),
+            ToolResultMessage(tool_call_id="edit-1", tool_name="edit", content="edited a"),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="edit-2",
+                        name="edit",
+                        arguments={"path": "b.py", "edits": []},
+                    )
+                ]
+            ),
+            ToolResultMessage(tool_call_id="edit-2", tool_name="edit", content="edited b"),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="edit-3",
+                        name="edit",
+                        arguments={"path": "c.py", "edits": []},
+                    )
+                ]
+            ),
+            ToolResultMessage(tool_call_id="edit-3", tool_name="edit", content="edited c"),
+        ]
+    )
+
+    assert len(state.items) == 1
+    item = state.items[0]
+    assert item.text == "→ Edited 3 files\n  - a.py\n  - b.py\n  - c.py"
+    assert item.grouped_tool_calls is not None
+    assert [member.tool_call_id for member in item.grouped_tool_calls] == [
+        "edit-1",
+        "edit-2",
+        "edit-3",
+    ]
+    assert all(state.find_tool_item(f"edit-{index}") is item for index in range(1, 4))
+
+
 def test_tui_state_keeps_write_continuations_separate_across_assistant_text() -> None:
     state = TuiState()
     state.load_messages(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from tau_agent import (
     AgentEndEvent,
     AgentStartEvent,
@@ -387,6 +389,85 @@ def test_tui_state_keeps_write_continuations_separate_across_assistant_text() ->
     assert state.items[1].role == "assistant"
     assert state.items[2].text == "→ write b.md"
     assert all(item.grouped_tool_calls is None for item in (state.items[0], state.items[2]))
+
+
+@pytest.mark.parametrize(
+    ("boundary", "boundary_before_call"),
+    [
+        (TextContent(text="boundary text"), True),
+        (TextContent(text="boundary text"), False),
+        (ThinkingContent(thinking="boundary thinking"), True),
+        (ThinkingContent(thinking="boundary thinking"), False),
+    ],
+)
+def test_file_mutation_continuation_boundaries_match_live_and_restored(
+    boundary: TextContent | ThinkingContent,
+    boundary_before_call: bool,
+) -> None:
+    first_call = ToolCall(
+        id="write-1",
+        name="write",
+        arguments={"path": "a.md", "content": "one"},
+    )
+    second_call = ToolCall(
+        id="write-2",
+        name="write",
+        arguments={"path": "b.md", "content": "two"},
+    )
+    first_content = [boundary, first_call] if boundary_before_call else [first_call, boundary]
+    messages = [
+        AssistantMessage(content=first_content),
+        ToolResultMessage(tool_call_id="write-1", tool_name="write", content="wrote a"),
+        AssistantMessage(content=[second_call]),
+        ToolResultMessage(tool_call_id="write-2", tool_name="write", content="wrote b"),
+    ]
+
+    restored = TuiState()
+    restored.load_messages(messages)
+
+    live = TuiState()
+    adapter = TuiEventAdapter(live)
+    adapter.apply(MessageEndEvent(message=messages[0]))
+    adapter.apply(
+        ToolExecutionStartEvent(
+            tool_call_id="write-1",
+            tool_name="write",
+            args={"path": "a.md", "content": "one"},
+        )
+    )
+    adapter.apply(
+        ToolExecutionEndEvent(
+            tool_call_id="write-1",
+            tool_name="write",
+            result=AgentToolResult(content="wrote a"),
+            is_error=False,
+        )
+    )
+    adapter.apply(MessageEndEvent(message=messages[2]))
+    adapter.apply(
+        ToolExecutionStartEvent(
+            tool_call_id="write-2",
+            tool_name="write",
+            args={"path": "b.md", "content": "two"},
+        )
+    )
+    adapter.apply(
+        ToolExecutionEndEvent(
+            tool_call_id="write-2",
+            tool_name="write",
+            result=AgentToolResult(content="wrote b"),
+            is_error=False,
+        )
+    )
+
+    for state in (restored, live):
+        first_item = state.find_tool_item("write-1")
+        second_item = state.find_tool_item("write-2")
+        assert first_item is not None
+        assert second_item is not None
+        assert first_item is not second_item
+        assert first_item.grouped_tool_calls is None
+        assert second_item.grouped_tool_calls is None
 
 
 def test_tui_state_batches_mixed_tools_and_clusters_adjacent_reads() -> None:

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -126,8 +126,10 @@ every file path listed beneath it. Expanded edit and write groups retain each
 invocation and result; expanded read groups omit repeated file contents. The
 complete block remains one selectable text surface,
 including across line boundaries.
-Batches never cross assistant text, model continuations, or separate responses;
-extension tools, custom rendered call cards, and skill loads remain separate.
+Batches never cross assistant text, thinking, or unrelated responses. Consecutive write-only
+model continuations are grouped so providers that serialize writes one at a time
+still produce one file list. Extension tools, custom rendered call cards, and
+skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -126,10 +126,10 @@ every file path listed beneath it. Expanded edit and write groups retain each
 invocation and result; expanded read groups omit repeated file contents. The
 complete block remains one selectable text surface,
 including across line boundaries.
-Batches never cross assistant text, thinking, or unrelated responses. Consecutive write-only
-model continuations are grouped so providers that serialize writes one at a time
-still produce one file list. Extension tools, custom rendered call cards, and
-skill loads remain separate.
+Batches never cross assistant text, thinking, or unrelated responses. Consecutive
+same-tool edit or write continuations are grouped so providers that serialize
+file mutations one at a time still produce one file list. Extension tools, custom
+rendered call cards, and skill loads remain separate.
 
 Tool results (like long `read` or `bash` output) render as compact previews so
 the transcript stays readable. Tau requires the model to give each `bash` call a


### PR DESCRIPTION
## Summary

- group consecutive completed `edit` or `write` calls emitted by same-tool model continuations
- rebuild the same grouping when older sessions are restored
- derive eligibility from canonical assistant blocks, preserving assistant text, thinking, different-tool, and custom-renderer boundaries in live and restored views
- retain every edit/write invocation and result under `Ctrl+O`
- keep grouping entirely in TUI state; canonical messages and JSONL persistence remain unchanged

## Motivation

Some providers serialize tool use as one assistant file-mutation call, one tool result, then another assistant call of the same type. Although these edits or writes are visually consecutive, response-local batching leaves each in a separate transcript row. This follow-up makes that common sequence one `Edited N files` or `Written N files` group.

## User experience

A restored sequence such as:

```text
assistant(edit a) → result → assistant(edit b) → result
```

now renders as:

```text
→ Edited 2 files
  - a
  - b
```

The same applies to writes. Assistant text, thinking, or a different tool still starts a new transcript boundary.

## Validation

- `uv run pytest` (1520 passed, 2 Windows-only skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`

## Manual validation

1. Open a session containing consecutive same-tool edit or write continuations.
2. Confirm they restore as one file group with all paths listed.
3. Press `Ctrl+O` and confirm every invocation and result remains visible.
4. Confirm assistant text, thinking, or a different tool keeps subsequent calls separate.

