### PR TITLE
Support disable-model-invocation in skill frontmatter

### DIFF
--- a/src/tau_coding/data/docs/skills.md
+++ b/src/tau_coding/data/docs/skills.md
@@ -21,6 +21,8 @@ Tau's own product knowledge is regular packaged documentation, not a built-in sk
 
 A higher-precedence skill with the same name overrides the lower one. Tau places only each skill's name, description, and path in the system prompt; the model reads the full file when its description matches the task. Use `/skill:<name>` for explicit invocation.
 
+A skill with `disable-model-invocation: true` in its `SKILL.md` frontmatter is excluded from the system prompt entirely, so the model cannot invoke it on its own. The skill stays loaded and remains available through explicit `/skill:<name>` invocation and the `/skills` picker.
+
 ## Prompt templates
 
 Templates load from user and project `.tau/prompts/` and `.agents/prompts/` directories. They are prompt shortcuts, not background knowledge, and may contain `{{ variable }}` placeholders.

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -3121,7 +3121,14 @@ def _category_summary(
 
 def _skill_signatures(skills: tuple[Skill, ...]) -> tuple[tuple[object, ...], ...]:
     return tuple(
-        (skill.name, str(skill.path), skill.description, skill.content) for skill in skills
+        (
+            skill.name,
+            str(skill.path),
+            skill.description,
+            skill.content,
+            skill.disable_model_invocation,
+        )
+        for skill in skills
     )
 
 
@@ -3169,7 +3176,7 @@ def _system_prompt_resource_signatures(
     append_system_prompt_path: Path | None,
 ) -> tuple[object, ...]:
     prompt_skills = tuple(
-        (skill.name, str(skill.path), skill.description)
+        (skill.name, str(skill.path), skill.description, skill.disable_model_invocation)
         for skill in sorted(skills, key=lambda item: item.name)
     )
     return (

--- a/src/tau_coding/skills.py
+++ b/src/tau_coding/skills.py
@@ -24,6 +24,7 @@ class Skill:
     path: Path
     content: str
     description: str | None = None
+    disable_model_invocation: bool = False
 
 
 def is_skill_candidate(path: Path) -> bool:
@@ -147,10 +148,11 @@ def parse_skill_invocation(text: str) -> SkillInvocation | None:
 
 def build_skill_index(skills: Sequence[Skill]) -> str:
     """Build a concise index of available skills for future system prompt assembly."""
-    if not skills:
+    visible_skills = [skill for skill in skills if not skill.disable_model_invocation]
+    if not visible_skills:
         return "Available skills: none"
     lines = ["Available skills:"]
-    for skill in sorted(skills, key=lambda item: item.name):
+    for skill in sorted(visible_skills, key=lambda item: item.name):
         description = skill.description or "No description"
         lines.append(f"- {skill.name}: {description}")
     return "\n".join(lines)
@@ -241,4 +243,13 @@ def _load_skill(name: str, path: Path) -> Skill:
     raw = path.read_text(encoding="utf-8")
     metadata, content = parse_markdown_resource(raw)
     description = metadata.get("description") or derive_description(content)
-    return Skill(name=name, path=path, content=content, description=description)
+    disable_model_invocation = (
+        metadata.get("disable-model-invocation", "").strip().lower() == "true"
+    )
+    return Skill(
+        name=name,
+        path=path,
+        content=content,
+        description=description,
+        disable_model_invocation=disable_model_invocation,
+    )

--- a/src/tau_coding/system_prompt.py
+++ b/src/tau_coding/system_prompt.py
@@ -170,8 +170,13 @@ def format_project_context(context_files: Sequence[ProjectContextFile]) -> str:
 
 
 def format_skills_for_prompt(skills: Sequence[Skill]) -> str:
-    """Format skills for inclusion in a system prompt using Pi's XML style."""
-    if not skills:
+    """Format skills for inclusion in a system prompt using Pi's XML style.
+
+    Skills with ``disable_model_invocation`` set are excluded from the prompt;
+    they remain invocable explicitly via ``/skill:<name>``.
+    """
+    visible_skills = [skill for skill in skills if not skill.disable_model_invocation]
+    if not visible_skills:
         return ""
 
     lines = [
@@ -182,7 +187,7 @@ def format_skills_for_prompt(skills: Sequence[Skill]) -> str:
         "",
         "<available_skills>",
     ]
-    for skill in sorted(skills, key=lambda item: item.name):
+    for skill in sorted(visible_skills, key=lambda item: item.name):
         description = skill.description or "No description"
         lines.extend(
             [

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -2488,11 +2488,11 @@ def _grouped_skill_list(
     if not skills:
         return Text("No skills loaded", style=theme.completion_description)
 
-    grouped: dict[str, list[str]] = {}
+    grouped: dict[str, list[tuple[str, bool]]] = {}
     for skill in skills:
         origin = skill.path.parent.parent if skill.path.name == "SKILL.md" else skill.path.parent
         label = _resource_origin_label(origin, cwd=cwd)
-        grouped.setdefault(label, []).append(skill.name)
+        grouped.setdefault(label, []).append((skill.name, skill.disable_model_invocation))
     return _grouped_resource_names(grouped, directory="skills", theme=theme)
 
 
@@ -2505,15 +2505,15 @@ def _grouped_prompt_list(
     if not templates:
         return Text("No prompt templates", style=theme.completion_description)
 
-    grouped: dict[str, list[str]] = {}
+    grouped: dict[str, list[tuple[str, bool]]] = {}
     for template in templates:
         label = _resource_origin_label(template.path.parent, cwd=cwd)
-        grouped.setdefault(label, []).append(template.name)
+        grouped.setdefault(label, []).append((template.name, False))
     return _grouped_resource_names(grouped, directory="prompts", theme=theme)
 
 
 def _grouped_resource_names(
-    grouped: dict[str, list[str]],
+    grouped: dict[str, list[tuple[str, bool]]],
     *,
     directory: str,
     theme: TuiTheme,
@@ -2533,8 +2533,9 @@ def _grouped_resource_names(
         if text:
             text.append("\n")
         text.append(origin, style=theme.completion_description)
-        for name in sorted(grouped[origin]):
-            text.append("\n  • ", style=theme.completion_description)
+        for name, hollow_bullet in sorted(grouped[origin]):
+            bullet = "◦" if hollow_bullet else "•"
+            text.append(f"\n  {bullet} ", style=theme.completion_description)
             text.append(name, style=theme.completion_description)
     return text
 

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -237,7 +237,10 @@ def _session_summary_fingerprint(
         session.session_stats,
         tuple(session.extension_names),
         tuple(tool.name for tool in session.tools),
-        tuple((skill.name, skill.path, skill.description) for skill in session.skills),
+        tuple(
+            (skill.name, skill.path, skill.description, skill.disable_model_invocation)
+            for skill in session.skills
+        ),
         tuple((template.name, template.path) for template in session.prompt_templates),
         tuple(context.path for context in session.context_files),
     )

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3089,6 +3089,41 @@ async def test_session_reload_refreshes_resources_and_system_prompt(tmp_path: Pa
 
 
 @pytest.mark.anyio
+async def test_session_reload_detects_disable_model_invocation_change(tmp_path: Path) -> None:
+    resource_root = tmp_path / "resources"
+    skills_dir = resource_root / "skills" / "testing"
+    skills_dir.mkdir(parents=True)
+    skill_path = skills_dir / "SKILL.md"
+    skill_path.write_text(
+        "---\ndescription: Test code\n---\n# Testing\nRun pytest.",
+        encoding="utf-8",
+    )
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            storage=storage,
+            cwd=tmp_path,
+            trust_default="always",
+            resource_paths=TauResourcePaths(root=resource_root, agents_root=None),
+        )
+    )
+    assert "<name>testing</name>" in session.system_prompt
+
+    skill_path.write_text(
+        "---\ndescription: Test code\ndisable-model-invocation: true\n---\n# Testing\nRun pytest.",
+        encoding="utf-8",
+    )
+    summary = await session.reload()
+
+    assert summary.system_prompt_rebuilt is True
+    assert "<name>testing</name>" not in session.system_prompt
+    # The skill stays loaded for explicit /skill:testing invocation.
+    assert {skill.name for skill in session.skills} == {"testing"}
+
+
+@pytest.mark.anyio
 async def test_session_reload_skips_provider_settings_refresh(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -296,3 +296,86 @@ def test_build_skill_index(tmp_path: Path) -> None:
     assert "- testing: Test things" in index
     assert "create-tau-extension" not in index
     assert "tau-model-catalog" not in index
+
+
+def test_load_skill_parses_disable_model_invocation(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "hidden").mkdir(parents=True)
+    (skills_dir / "hidden" / "SKILL.md").write_text(
+        "---\ndescription: Hidden skill\ndisable-model-invocation: true\n---\nBody",
+        encoding="utf-8",
+    )
+    (skills_dir / "visible").mkdir()
+    (skills_dir / "visible" / "SKILL.md").write_text(
+        "---\ndescription: Visible skill\n---\nBody",
+        encoding="utf-8",
+    )
+    (skills_dir / "explicit-false").mkdir()
+    (skills_dir / "explicit-false" / "SKILL.md").write_text(
+        "---\ndescription: Explicitly enabled\ndisable-model-invocation: false\n---\nBody",
+        encoding="utf-8",
+    )
+    (skills_dir / "invalid-value").mkdir()
+    (skills_dir / "invalid-value" / "SKILL.md").write_text(
+        "---\ndescription: Invalid flag value\ndisable-model-invocation: yes\n---\nBody",
+        encoding="utf-8",
+    )
+
+    skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
+
+    skill_by_name = {skill.name: skill for skill in skills}
+    assert skill_by_name["hidden"].disable_model_invocation is True
+    assert skill_by_name["visible"].disable_model_invocation is False
+    assert skill_by_name["explicit-false"].disable_model_invocation is False
+    assert skill_by_name["invalid-value"].disable_model_invocation is False
+
+
+def test_disable_model_invocation_accepts_case_insensitive_true(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills" / "hidden"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text(
+        "---\ndescription: Hidden skill\ndisable-model-invocation: True\n---\nBody",
+        encoding="utf-8",
+    )
+
+    skills = load_skills(TauResourcePaths(root=tmp_path, agents_root=None))
+
+    assert skills[0].disable_model_invocation is True
+
+
+def test_disabled_skill_remains_invocable_via_skill_command(tmp_path: Path) -> None:
+    skill = Skill(
+        name="hidden",
+        path=tmp_path / "skills" / "hidden" / "SKILL.md",
+        content="Hidden body",
+        description="Hidden skill",
+        disable_model_invocation=True,
+    )
+
+    expanded = expand_skill_command("/skill:hidden", [skill])
+
+    assert expanded is not None
+    assert "Hidden body" in expanded
+
+
+def test_build_skill_index_excludes_disabled_skills(tmp_path: Path) -> None:
+    visible = Skill(
+        name="visible",
+        path=tmp_path / "visible" / "SKILL.md",
+        content="Body",
+        description="Visible skill",
+    )
+    hidden = Skill(
+        name="hidden",
+        path=tmp_path / "hidden" / "SKILL.md",
+        content="Body",
+        description="Hidden skill",
+        disable_model_invocation=True,
+    )
+
+    index = build_skill_index([visible, hidden])
+
+    assert "- visible: Visible skill" in index
+    assert "hidden" not in index
+
+    assert build_skill_index([hidden]) == "Available skills: none"

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -123,6 +123,29 @@ def test_skills_are_formatted_as_xml_and_escaped(tmp_path: Path) -> None:
     assert f"<location>{skill_path}</location>" in formatted
 
 
+def test_format_skills_for_prompt_excludes_disabled_skills(tmp_path: Path) -> None:
+    visible = Skill(
+        name="visible",
+        path=tmp_path / "skills" / "visible" / "SKILL.md",
+        content="",
+        description="Visible skill",
+    )
+    hidden = Skill(
+        name="hidden",
+        path=tmp_path / "skills" / "hidden" / "SKILL.md",
+        content="",
+        description="Hidden skill",
+        disable_model_invocation=True,
+    )
+
+    formatted = format_skills_for_prompt([visible, hidden])
+
+    assert "<name>visible</name>" in formatted
+    assert "hidden" not in formatted
+
+    assert format_skills_for_prompt([hidden]) == ""
+
+
 def test_skills_are_included_only_when_read_tool_is_available(tmp_path: Path) -> None:
     skill = Skill(name="testing", path=tmp_path / "testing.md", content="", description="Test")
     no_read_tool = AgentTool(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3066,6 +3066,32 @@ async def test_tui_sidebar_resource_sections_expand_independently() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_sidebar_refreshes_skill_tokens_when_model_invocation_changes() -> None:
+    session = FakeSession()
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 40)):
+        sidebar = app.query_one("#sidebar", SessionSidebar)
+        skills = app.query_one("#sidebar-skills", Collapsible)
+        initial_title = Content.from_markup(skills.title).plain
+        assert initial_title != "skills (1 · ~0 tokens)"
+
+        skill = session.skills[0]
+        session.skills = (
+            Skill(
+                name=skill.name,
+                path=skill.path,
+                content=skill.content,
+                description=skill.description,
+                disable_model_invocation=True,
+            ),
+        )
+        sidebar.update_from_session(session)
+
+        assert Content.from_markup(skills.title).plain == "skills (1 · ~0 tokens)"
+
+
+@pytest.mark.anyio
 async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
     session = FakeSession()
     session.skills = tuple(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -546,6 +546,31 @@ def test_session_sidebar_shows_all_skills() -> None:
     assert "more)" not in output
 
 
+def test_session_sidebar_marks_user_only_skills_with_hollow_bullets() -> None:
+    session = FakeSession()
+    session.skills = (
+        Skill(
+            name="model-visible",
+            path=session.cwd / ".tau/skills/model-visible/SKILL.md",
+            content="Model-visible skill",
+        ),
+        Skill(
+            name="user-only",
+            path=session.cwd / ".tau/skills/user-only/SKILL.md",
+            content="User-only skill",
+            disable_model_invocation=True,
+        ),
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "• model-visible" in output
+    assert "◦ user-only" in output
+    assert "• user-only" not in output
+
+
 def test_session_sidebar_groups_skills_by_origin(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -99,6 +99,25 @@ Pay special attention to authentication boundaries.
 `/skill:<name>` is a *prompt-expansion* path — Tau expands the skill and any
 inline or multiline request into your prompt, then runs it as a normal turn.
 
+### Hiding a skill from the model
+
+Set `disable-model-invocation: true` in the frontmatter to keep a skill out of
+the system prompt. The model will not see it or invoke it on its own, but you
+can still run it explicitly with `/skill:<name>` (and it still appears in the
+`/skills` picker and autocomplete):
+
+```md
+---
+description: Generate the weekly status report.
+disable-model-invocation: true
+---
+
+Steps to build the report...
+```
+
+This is useful for user-triggered workflows that would otherwise add noise to
+the skill list or tempt the model to fire them at the wrong time.
+
 ## Prompt templates
 
 A prompt template is a saved prompt you trigger by its filename. For example,

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -200,7 +200,8 @@ the loaded skill index in the system prompt; full skill instructions enter conte
 only when that skill is invoked. Click either heading (or focus it and press
 **Enter**) to expand or collapse that section independently, so both lists can
 remain open when needed. Every loaded skill or prompt is shown while its section
-is expanded. If
+is expanded. Model-visible skills use a solid bullet (`•`), while user-only skills
+with `disable-model-invocation: true` use a hollow bullet (`◦`). If
 the sidebar content is
 taller than the available space, scroll it to see the remaining resource groups;
 the Tau version mark stays pinned at the bottom. Context files


### PR DESCRIPTION
## Summary

Add support for `disable-model-invocation: true` in `SKILL.md` frontmatter. This behavior matches Pi's `disableModelInvocation` option.

Tau excludes a skill with this flag from the system prompt. The model cannot see the skill or invoke it by itself. The skill stays loaded, and the user can still access it through:

- explicit `/skill:<name>` invocation
- the `/skills` picker
- TUI autocomplete

This option is useful for workflows that the user must start. Examples include report generators and release checklists.

```md
---
description: Generate the weekly status report.
disable-model-invocation: true
---
```

## Implementation

- Add `disable_model_invocation: bool = False` to `Skill`.
- Parse the flag when Tau loads `SKILL.md`.
- Accept `true` without regard to letter case. Treat all other values as false. This behavior matches Pi's strict boolean check without a YAML dependency.
- Exclude user-only skills in `format_skills_for_prompt` and `build_skill_index`.
- Keep user-only skills available to explicit invocation, resource lists, autocomplete, and reload diagnostics.
- Include the flag in reload signatures. A flag change now rebuilds the system prompt.
- Include the flag in the TUI sidebar fingerprint. A flag change now refreshes the skill token estimate.
- Show a solid bullet (`•`) for model-visible skills and a hollow bullet (`◦`) for user-only skills in the sidebar.

## Testing

- `uv run pytest tests/test_tui_app.py` — 368 passed.
- `uv run pytest tests/test_skills.py tests/test_system_prompt.py` — 29 passed.
- `uv run ruff check src/tau_coding/tui/widgets.py tests/test_tui_app.py` — passed.
- `uv run ruff format --check src/tau_coding/tui/widgets.py tests/test_tui_app.py` — passed.

Tests cover:

- flag parsing for set, unset, false, invalid, and mixed-case values
- prompt filtering with mixed skill visibility
- explicit invocation of a user-only skill
- reload detection after a flag change
- sidebar token refresh after a flag change
- solid and hollow sidebar bullet indicators

## Documentation

- Update `website/content/guides/skills-and-prompts.md` with user-only skill instructions.
- Update `src/tau_coding/data/docs/skills.md` with the frontmatter option.
- Update `website/content/guides/tui.md` with the sidebar bullet meanings.

## Relationship to #309

PR #309 by @pedrobruning proposed the same core feature first and deserves credit for the initial implementation. It appears stale, with no review since July. This PR also adds the reload signature fix, packaged documentation, parser edge-case tests, sidebar token refresh, and sidebar visibility indicators.
