### PR TITLE
Make sidebar skills and prompts collapsible

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2983,6 +2983,36 @@ class TauTuiApp(App[None]):
         height: auto;
     }
 
+    #sidebar .sidebar-separator {
+        height: auto;
+    }
+
+    #sidebar .sidebar-resource-section {
+        width: 1fr;
+        height: auto;
+        padding: 0;
+        background: transparent;
+        border: none;
+    }
+
+    #sidebar .sidebar-resource-section CollapsibleTitle {
+        width: 1fr;
+        padding: 0 0 0 1;
+        color: $tau-prompt-text;
+        text-style: bold;
+        background: transparent;
+    }
+
+    #sidebar .sidebar-resource-section CollapsibleTitle:hover,
+    #sidebar .sidebar-resource-section CollapsibleTitle:focus {
+        color: $tau-highlight-text;
+        background: $tau-highlight-background;
+    }
+
+    #sidebar .sidebar-resource-section Contents {
+        padding: 1 0 0 1;
+    }
+
     #sidebar-brand {
         height: auto;
         color: $tau-prompt-text;

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -28,8 +28,8 @@ from textual.css.query import NoMatches
 from textual.geometry import Offset
 from textual.selection import Selection
 from textual.widget import Widget
+from textual.widgets import Collapsible, Static
 from textual.widgets import Markdown as TextualMarkdown
-from textual.widgets import Static
 from textual.widgets.markdown import MarkdownBlock, MarkdownStream
 
 from tau_agent.tools import AgentTool, ToolCall
@@ -111,11 +111,29 @@ class SessionSummarySource(Protocol):
 
 
 class SessionSidebar(Vertical):
-    """Compact sidebar with session metadata and bottom-aligned branding."""
+    """Compact sidebar with collapsible resource lists and pinned branding."""
 
     def compose(self) -> Any:
         with VerticalScroll(id="sidebar-scroll"):
             yield Static("", id="sidebar-content")
+            yield Static(_sidebar_separator(theme=TAU_DARK_THEME), classes="sidebar-separator")
+            yield Collapsible(
+                Static("", id="sidebar-skills-content"),
+                title="skills (0)",
+                collapsed=True,
+                id="sidebar-skills",
+                classes="sidebar-resource-section",
+            )
+            yield Static(_sidebar_separator(theme=TAU_DARK_THEME), classes="sidebar-separator")
+            yield Collapsible(
+                Static("", id="sidebar-prompts-content"),
+                title="prompts (0)",
+                collapsed=True,
+                id="sidebar-prompts",
+                classes="sidebar-resource-section",
+            )
+            yield Static(_sidebar_separator(theme=TAU_DARK_THEME), classes="sidebar-separator")
+            yield Static("", id="sidebar-extensions-content")
         yield Static("", id="sidebar-brand")
 
     _summary_fingerprint: tuple[object, ...] | None = None
@@ -131,13 +149,32 @@ class SessionSidebar(Vertical):
         if fingerprint == self._summary_fingerprint:
             return
         self._summary_fingerprint = fingerprint
+        content = _build_sidebar_content(session, theme=theme)
         self.query_one("#sidebar-content", Static).update(
-            render_session_sidebar(session, theme=theme),
+            Group(*_separate_sidebar_sections(content.summary_sections, theme=theme)),
         )
+        skills = self.query_one("#sidebar-skills", Collapsible)
+        skills.title = f"skills ({len(session.skills)})"
+        self.query_one("#sidebar-skills-content", Static).update(content.skills)
+        prompts = self.query_one("#sidebar-prompts", Collapsible)
+        prompts.title = f"prompts ({len(session.prompt_templates)})"
+        self.query_one("#sidebar-prompts-content", Static).update(content.prompts)
+        self.query_one("#sidebar-extensions-content", Static).update(
+            _sidebar_section("extensions", content.extensions, theme=theme),
+        )
+        for separator in self.query(Static).filter(".sidebar-separator"):
+            separator.update(_sidebar_separator(theme=theme))
         self.query_one("#sidebar-brand", Static).update(
             _sidebar_brand(theme=theme),
             layout=False,
         )
+
+    def on_collapsible_expanded(self, event: Collapsible.Expanded) -> None:
+        """Keep skills and prompts mutually exclusive like an accordion."""
+        other_id = (
+            "#sidebar-prompts" if event.collapsible.id == "sidebar-skills" else "#sidebar-skills"
+        )
+        self.query_one(other_id, Collapsible).collapsed = True
 
 
 class CompactSessionInfo(Static):
@@ -1512,12 +1549,36 @@ def _clip_selection_offset(offset: Offset | None, lines: list[str]) -> Offset | 
     return Offset(column, line_index)
 
 
+@dataclass(frozen=True, slots=True)
+class _SidebarContent:
+    summary_sections: tuple[RenderableType, ...]
+    skills: RenderableType
+    prompts: RenderableType
+    extensions: RenderableType
+
+
 def render_session_sidebar(
     session: SessionSummarySource,
     *,
     theme: TuiTheme = TAU_DARK_THEME,
 ) -> RenderableType:
-    """Render a dark, minimalist summary of the active coding session."""
+    """Render a static summary of the active coding session."""
+    content = _build_sidebar_content(session, theme=theme)
+    sections = (
+        *content.summary_sections,
+        _sidebar_section("skills", content.skills, theme=theme),
+        _sidebar_section("prompts", content.prompts, theme=theme),
+        _sidebar_section("extensions", content.extensions, theme=theme),
+    )
+    return Group(*_separate_sidebar_sections(sections, theme=theme))
+
+
+def _build_sidebar_content(
+    session: SessionSummarySource,
+    *,
+    theme: TuiTheme,
+) -> _SidebarContent:
+    """Build shared sidebar renderables for static and interactive views."""
     title = Text(session.session_title or "Untitled session", style=f"bold {theme.accent}")
     stats = session.session_stats
     activity = Text(
@@ -1547,37 +1608,42 @@ def render_session_sidebar(
         "off" if threshold is None else f"auto at {_compact_token_count(threshold)}",
         style=theme.completion_description,
     )
-    tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
-    skills = _grouped_skill_list(session.skills, cwd=session.cwd, theme=theme)
-    prompts = _grouped_prompt_list(session.prompt_templates, cwd=session.cwd, theme=theme)
-    extensions = _comma_list(
-        list(session.extension_names),
-        empty="No extensions",
-        theme=theme,
-    )
     context = _limited_bullet_list(
         _context_file_labels(session.context_files, cwd=session.cwd),
         empty="No context files",
         theme=theme,
     )
-    sections = (
-        Padding(title, (0, 0, 0, 1)),
-        _sidebar_section("activity", activity, theme=theme),
-        _sidebar_section("usage", usage, theme=theme),
-        _sidebar_section("compaction", compaction, theme=theme),
-        _sidebar_section("context", context, theme=theme),
-        _sidebar_section("tools", tools, theme=theme),
-        _sidebar_section("skills", skills, theme=theme),
-        _sidebar_section("prompts", prompts, theme=theme),
-        _sidebar_section("extensions", extensions, theme=theme),
+    tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
+    return _SidebarContent(
+        summary_sections=(
+            Padding(title, (0, 0, 0, 1)),
+            _sidebar_section("activity", activity, theme=theme),
+            _sidebar_section("usage", usage, theme=theme),
+            _sidebar_section("compaction", compaction, theme=theme),
+            _sidebar_section("context", context, theme=theme),
+            _sidebar_section("tools", tools, theme=theme),
+        ),
+        skills=_grouped_skill_list(session.skills, cwd=session.cwd, theme=theme),
+        prompts=_grouped_prompt_list(session.prompt_templates, cwd=session.cwd, theme=theme),
+        extensions=_comma_list(
+            list(session.extension_names),
+            empty="No extensions",
+            theme=theme,
+        ),
     )
-    separated_sections: list[RenderableType] = []
+
+
+def _separate_sidebar_sections(
+    sections: Sequence[RenderableType],
+    *,
+    theme: TuiTheme,
+) -> list[RenderableType]:
+    separated: list[RenderableType] = []
     for index, section in enumerate(sections):
         if index:
-            separated_sections.append(_sidebar_separator(theme=theme))
-        separated_sections.append(section)
-
-    return Group(*separated_sections)
+            separated.append(_sidebar_separator(theme=theme))
+        separated.append(section)
+    return separated
 
 
 def _sidebar_section(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -169,13 +169,6 @@ class SessionSidebar(Vertical):
             layout=False,
         )
 
-    def on_collapsible_expanded(self, event: Collapsible.Expanded) -> None:
-        """Keep skills and prompts mutually exclusive like an accordion."""
-        other_id = (
-            "#sidebar-prompts" if event.collapsible.id == "sidebar-skills" else "#sidebar-skills"
-        )
-        self.query_one(other_id, Collapsible).collapsed = True
-
 
 class CompactSessionInfo(Static):
     """Single-line session metadata for narrow TUI layouts."""

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -33,10 +33,11 @@ from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets.markdown import MarkdownBlock, MarkdownStream
 
 from tau_agent.tools import AgentTool, ToolCall
+from tau_coding.context_window import estimate_text_tokens
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.session_stats import SessionStats
 from tau_coding.skills import Skill
-from tau_coding.system_prompt import ProjectContextFile
+from tau_coding.system_prompt import ProjectContextFile, format_skills_for_prompt
 from tau_coding.tui.autocomplete import CompletionState
 from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import (
@@ -154,7 +155,7 @@ class SessionSidebar(Vertical):
             Group(*_separate_sidebar_sections(content.summary_sections, theme=theme)),
         )
         skills = self.query_one("#sidebar-skills", Collapsible)
-        skills.title = f"skills ({len(session.skills)})"
+        skills.title = _skill_section_title(session)
         self.query_one("#sidebar-skills-content", Static).update(content.skills)
         prompts = self.query_one("#sidebar-prompts", Collapsible)
         prompts.title = f"prompts ({len(session.prompt_templates)})"
@@ -189,6 +190,17 @@ class CompactSessionInfo(Static):
         self.update(render_compact_session_info(session, theme=theme))
 
 
+def _skill_section_title(session: SessionSummarySource) -> str:
+    """Summarize skill count and estimated system-prompt footprint."""
+    skill_prompt = (
+        format_skills_for_prompt(session.skills)
+        if any(tool.name == "read" for tool in session.tools)
+        else ""
+    )
+    estimated_tokens = estimate_text_tokens(skill_prompt)
+    return f"skills ({len(session.skills)} · ~{_compact_usage_count(estimated_tokens)} tokens)"
+
+
 def _session_summary_fingerprint(
     session: SessionSummarySource,
     *,
@@ -208,7 +220,7 @@ def _session_summary_fingerprint(
         session.session_stats,
         tuple(session.extension_names),
         tuple(tool.name for tool in session.tools),
-        tuple((skill.name, skill.path) for skill in session.skills),
+        tuple((skill.name, skill.path, skill.description) for skill in session.skills),
         tuple((template.name, template.path) for template in session.prompt_templates),
         tuple(context.path for context in session.context_files),
     )

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -16,7 +16,7 @@ from textual.containers import Container, VerticalScroll
 from textual.content import Style as TextualStyle
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
-from textual.widgets import Input, Label, ListItem, ListView, Static, TextArea
+from textual.widgets import Collapsible, Input, Label, ListItem, ListView, Static, TextArea
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets.markdown import MarkdownStream
 
@@ -3019,6 +3019,33 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_sidebar_resource_sections_are_a_collapsed_accordion() -> None:
+    session = FakeSession()
+    session.prompt_templates = (
+        PromptTemplate("explain", session.cwd / ".tau/prompts/explain.md", "Explain"),
+        PromptTemplate("fix", session.cwd / ".tau/prompts/fix.md", "Fix"),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        skills = app.query_one("#sidebar-skills", Collapsible)
+        prompts = app.query_one("#sidebar-prompts", Collapsible)
+
+        assert skills.title == "skills (1)"
+        assert prompts.title == "prompts (2)"
+        assert skills.collapsed is True
+        assert prompts.collapsed is True
+
+        await pilot.click("#sidebar-skills CollapsibleTitle")
+        assert skills.collapsed is False
+        assert prompts.collapsed is True
+
+        await pilot.click("#sidebar-prompts CollapsibleTitle")
+        assert skills.collapsed is True
+        assert prompts.collapsed is False
+
+
+@pytest.mark.anyio
 async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
     session = FakeSession()
     session.skills = tuple(
@@ -3034,6 +3061,7 @@ async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
     async with app.run_test(size=(120, 40)) as pilot:
         scroll = app.query_one("#sidebar-scroll", VerticalScroll)
         brand = app.query_one("#sidebar-brand", Static)
+        app.query_one("#sidebar-skills", Collapsible).collapsed = False
         await pilot.pause()
 
         assert scroll.max_scroll_y > 0
@@ -3064,9 +3092,11 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
             for index in range(1, 31)
         )
         sidebar.update_from_session(session)
+        app.query_one("#sidebar-skills", Collapsible).collapsed = False
         await pilot.pause()
 
         expanded_virtual_height = scroll.virtual_size.height
+        assert app.query_one("#sidebar-skills", Collapsible).title == "skills (30)"
         assert expanded_virtual_height > initial_virtual_height
         assert scroll.max_scroll_y > 0
 
@@ -3074,6 +3104,9 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
         sidebar.update_from_session(session)
         await pilot.pause()
 
+        skills = app.query_one("#sidebar-skills", Collapsible)
+        assert skills.title == "skills (1)"
+        assert skills.collapsed is False
         assert scroll.virtual_size.height < expanded_virtual_height
         assert scroll.max_scroll_y == 0
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3019,7 +3019,7 @@ async def test_tui_sidebar_is_visible_on_medium_windows() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_sidebar_resource_sections_are_a_collapsed_accordion() -> None:
+async def test_tui_sidebar_resource_sections_expand_independently() -> None:
     session = FakeSession()
     session.prompt_templates = (
         PromptTemplate("explain", session.cwd / ".tau/prompts/explain.md", "Explain"),
@@ -3041,6 +3041,10 @@ async def test_tui_sidebar_resource_sections_are_a_collapsed_accordion() -> None
         assert prompts.collapsed is True
 
         await pilot.click("#sidebar-prompts CollapsibleTitle")
+        assert skills.collapsed is False
+        assert prompts.collapsed is False
+
+        await pilot.click("#sidebar-skills CollapsibleTitle")
         assert skills.collapsed is True
         assert prompts.collapsed is False
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3072,7 +3072,7 @@ async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
         assert brand.region.bottom == app.query_one("#sidebar").content_region.bottom
         scroll.scroll_end(animate=False, immediate=True)
         await pilot.pause()
-        assert scroll.scroll_y == scroll.max_scroll_y
+        assert 0 < scroll.scroll_y <= scroll.max_scroll_y
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3031,7 +3031,7 @@ async def test_tui_sidebar_resource_sections_expand_independently() -> None:
         skills = app.query_one("#sidebar-skills", Collapsible)
         prompts = app.query_one("#sidebar-prompts", Collapsible)
 
-        assert skills.title == "skills (1)"
+        assert re.fullmatch(r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)", skills.title)
         assert prompts.title == "prompts (2)"
         assert skills.collapsed is True
         assert prompts.collapsed is True
@@ -3066,7 +3066,7 @@ async def test_tui_sidebar_scrolls_when_all_skills_overflow() -> None:
         scroll = app.query_one("#sidebar-scroll", VerticalScroll)
         brand = app.query_one("#sidebar-brand", Static)
         app.query_one("#sidebar-skills", Collapsible).collapsed = False
-        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
 
         assert scroll.max_scroll_y > 0
         assert brand.region.bottom == app.query_one("#sidebar").content_region.bottom
@@ -3100,7 +3100,10 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
         await pilot.pause()
 
         expanded_virtual_height = scroll.virtual_size.height
-        assert app.query_one("#sidebar-skills", Collapsible).title == "skills (30)"
+        assert re.fullmatch(
+            r"skills \(30 · ~\d+(?:\.\d+)?k? tokens\)",
+            app.query_one("#sidebar-skills", Collapsible).title,
+        )
         assert expanded_virtual_height > initial_virtual_height
         assert scroll.max_scroll_y > 0
 
@@ -3109,7 +3112,7 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
         await pilot.pause()
 
         skills = app.query_one("#sidebar-skills", Collapsible)
-        assert skills.title == "skills (1)"
+        assert re.fullmatch(r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)", skills.title)
         assert skills.collapsed is False
         assert scroll.virtual_size.height < expanded_virtual_height
         assert scroll.max_scroll_y == 0

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -194,9 +194,12 @@ and loaded tools, skills, prompt templates, extensions, and context files such a
 `AGENTS.md`. Tool and extension names use compact comma-separated lists limited
 to three rendered lines. Skills and prompt templates are grouped under their
 resource origins (for example, `./.tau/skills`, `~/.agents/skills`, or
-`./.tau/prompts`), and every loaded skill and prompt is shown. If the sidebar
-content is taller than the available space, scroll it to see the remaining
-resource groups; the Tau version mark stays pinned at the bottom. Context files
+`./.tau/prompts`). These two sections start collapsed and show their loaded-item
+counts in the headings. Click a heading (or focus it and press **Enter**) to
+expand it; opening one collapses the other like an accordion. Every loaded skill
+or prompt is shown while its section is expanded. If the sidebar content is
+taller than the available space, scroll it to see the remaining resource groups;
+the Tau version mark stays pinned at the bottom. Context files
 use a bullet list with one path per line, limited to five entries. Truncated sections
 end with `...(X more)` showing how many context entries are hidden. Project
 context paths are relative to the working directory; context

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -195,9 +195,10 @@ and loaded tools, skills, prompt templates, extensions, and context files such a
 to three rendered lines. Skills and prompt templates are grouped under their
 resource origins (for example, `./.tau/skills`, `~/.agents/skills`, or
 `./.tau/prompts`). These two sections start collapsed and show their loaded-item
-counts in the headings. Click a heading (or focus it and press **Enter**) to
-expand it; opening one collapses the other like an accordion. Every loaded skill
-or prompt is shown while its section is expanded. If the sidebar content is
+counts in the headings. Click either heading (or focus it and press **Enter**) to
+expand or collapse that section independently, so both lists can remain open when
+needed. Every loaded skill or prompt is shown while its section is expanded. If
+the sidebar content is
 taller than the available space, scroll it to see the remaining resource groups;
 the Tau version mark stays pinned at the bottom. Context files
 use a bullet list with one path per line, limited to five entries. Truncated sections

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -195,9 +195,12 @@ and loaded tools, skills, prompt templates, extensions, and context files such a
 to three rendered lines. Skills and prompt templates are grouped under their
 resource origins (for example, `./.tau/skills`, `~/.agents/skills`, or
 `./.tau/prompts`). These two sections start collapsed and show their loaded-item
-counts in the headings. Click either heading (or focus it and press **Enter**) to
-expand or collapse that section independently, so both lists can remain open when
-needed. Every loaded skill or prompt is shown while its section is expanded. If
+counts in the headings. The skills heading also shows the estimated token cost of
+the loaded skill index in the system prompt; full skill instructions enter context
+only when that skill is invoked. Click either heading (or focus it and press
+**Enter**) to expand or collapse that section independently, so both lists can
+remain open when needed. Every loaded skill or prompt is shown while its section
+is expanded. If
 the sidebar content is
 taller than the available space, scroll it to see the remaining resource groups;
 the Tau version mark stays pinned at the bottom. Context files


### PR DESCRIPTION
## Summary

- make the sidebar skills and prompts sections independently collapsible
- start both sections collapsed and show loaded resource counts
- show the estimated system-prompt token footprint for the loaded skill index
- preserve expanded state while resources reload
- document the updated sidebar behavior

## User experience

Skills and prompts no longer consume most of the sidebar by default. Users can expand either or both sections when needed, while collapsed headings retain useful count and token information.

## Validation

- `uv run pytest` (1521 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify` (passes with the existing taxonomy layout warning)

## Manual validation

1. Start Tau in a terminal wide enough to show the sidebar.
2. Confirm skills and prompts start collapsed with item counts.
3. Confirm the skills heading includes an estimated token count.
4. Expand skills and prompts and confirm both can remain open.
5. Collapse either section independently.
