### PR TITLE
Prepare Tau 0.3.11 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.10"
+version = "0.3.11"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.3.11",
+    "date": "2026-08-17",
+    "sections": {
+      "New": [
+        "Resume existing sessions in print mode with --session, restoring saved conversation history, working directory, provider, model, and Hugging Face route while allowing explicit provider and model overrides.",
+        "Show a startup transcript alert when a loaded skill or prompt template shadows a same-named resource from another location."
+      ],
+      "Changed": [
+        "Compact adjacent TUI tool activity into selectable batches, group related reads, edits, and writes with their file paths, and keep exact commands and results available through Ctrl+O.",
+        "Group sidebar skills and prompts by resource origin and make both sections independently collapsible with loaded counts and an estimated skill-index token footprint.",
+        "Toggle inline tool-result visibility without showing a redundant notification."
+      ],
+      "Fixed": [
+        "Preserve blank-line boundaries between streamed OpenAI reasoning-summary parts."
+      ]
+    }
+  },
+  {
     "version": "0.3.10",
     "date": "2026-08-15",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -755,7 +755,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.10" in console.export_text()
+    assert "τ = 2π  0.3.11" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.10"
+version = "0.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump Tau from `0.3.10` to `0.3.11`
- add structured release notes for changes merged since `v0.3.10`
- update the lockfile and version-sensitive sidebar test

## Validation

- `uv run pytest` — 1521 passed, 2 Windows-only skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `uv run tau --version` — `tau 0.3.11`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
