### PR TITLE
Refine sidebar resource heading styles

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2995,18 +2995,23 @@ class TauTuiApp(App[None]):
         border: none;
     }
 
+    #sidebar .sidebar-resource-section:focus-within {
+        background-tint: transparent;
+    }
+
     #sidebar .sidebar-resource-section CollapsibleTitle {
         width: 1fr;
         padding: 0 0 0 1;
         color: $tau-prompt-text;
-        text-style: bold;
+        text-style: none;
         background: transparent;
     }
 
     #sidebar .sidebar-resource-section CollapsibleTitle:hover,
     #sidebar .sidebar-resource-section CollapsibleTitle:focus {
-        color: $tau-highlight-text;
-        background: $tau-highlight-background;
+        color: $tau-prompt-text;
+        text-style: none;
+        background: transparent;
     }
 
     #sidebar .sidebar-resource-section Contents {

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -120,7 +120,11 @@ class SessionSidebar(Vertical):
             yield Static(_sidebar_separator(theme=TAU_DARK_THEME), classes="sidebar-separator")
             yield Collapsible(
                 Static("", id="sidebar-skills-content"),
-                title="skills (0)",
+                title=_sidebar_resource_title(
+                    "skills",
+                    "0 · ~0 tokens",
+                    theme=TAU_DARK_THEME,
+                ),
                 collapsed=True,
                 id="sidebar-skills",
                 classes="sidebar-resource-section",
@@ -128,7 +132,7 @@ class SessionSidebar(Vertical):
             yield Static(_sidebar_separator(theme=TAU_DARK_THEME), classes="sidebar-separator")
             yield Collapsible(
                 Static("", id="sidebar-prompts-content"),
-                title="prompts (0)",
+                title=_sidebar_resource_title("prompts", "0", theme=TAU_DARK_THEME),
                 collapsed=True,
                 id="sidebar-prompts",
                 classes="sidebar-resource-section",
@@ -155,10 +159,14 @@ class SessionSidebar(Vertical):
             Group(*_separate_sidebar_sections(content.summary_sections, theme=theme)),
         )
         skills = self.query_one("#sidebar-skills", Collapsible)
-        skills.title = _skill_section_title(session)
+        skills.title = _skill_section_title(session, theme=theme)
         self.query_one("#sidebar-skills-content", Static).update(content.skills)
         prompts = self.query_one("#sidebar-prompts", Collapsible)
-        prompts.title = f"prompts ({len(session.prompt_templates)})"
+        prompts.title = _sidebar_resource_title(
+            "prompts",
+            str(len(session.prompt_templates)),
+            theme=theme,
+        )
         self.query_one("#sidebar-prompts-content", Static).update(content.prompts)
         self.query_one("#sidebar-extensions-content", Static).update(
             _sidebar_section("extensions", content.extensions, theme=theme),
@@ -190,7 +198,12 @@ class CompactSessionInfo(Static):
         self.update(render_compact_session_info(session, theme=theme))
 
 
-def _skill_section_title(session: SessionSummarySource) -> str:
+def _sidebar_resource_title(label: str, detail: str, *, theme: TuiTheme) -> str:
+    """Style a resource label separately from its quieter summary."""
+    return f"[bold {theme.prompt_text}]{label}[/] [{theme.completion_description}]({detail})[/]"
+
+
+def _skill_section_title(session: SessionSummarySource, *, theme: TuiTheme) -> str:
     """Summarize skill count and estimated system-prompt footprint."""
     skill_prompt = (
         format_skills_for_prompt(session.skills)
@@ -198,7 +211,11 @@ def _skill_section_title(session: SessionSummarySource) -> str:
         else ""
     )
     estimated_tokens = estimate_text_tokens(skill_prompt)
-    return f"skills ({len(session.skills)} · ~{_compact_usage_count(estimated_tokens)} tokens)"
+    return _sidebar_resource_title(
+        "skills",
+        f"{len(session.skills)} · ~{_compact_usage_count(estimated_tokens)} tokens",
+        theme=theme,
+    )
 
 
 def _session_summary_fingerprint(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -13,6 +13,7 @@ from rich.text import Text
 from textual import events
 from textual.color import Color
 from textual.containers import Container, VerticalScroll
+from textual.content import Content
 from textual.content import Style as TextualStyle
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
@@ -3031,10 +3032,25 @@ async def test_tui_sidebar_resource_sections_expand_independently() -> None:
         skills = app.query_one("#sidebar-skills", Collapsible)
         prompts = app.query_one("#sidebar-prompts", Collapsible)
 
-        assert re.fullmatch(r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)", skills.title)
-        assert prompts.title == "prompts (2)"
+        skills_heading = Content.from_markup(skills.title)
+        prompts_heading = Content.from_markup(prompts.title)
+        assert re.fullmatch(r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)", skills_heading.plain)
+        assert prompts_heading.plain == "prompts (2)"
+        assert str(skills_heading.spans[0].style) == f"bold {TAU_DARK_THEME.prompt_text}"
+        assert str(skills_heading.spans[1].style) == TAU_DARK_THEME.completion_description
+        assert str(prompts_heading.spans[0].style) == f"bold {TAU_DARK_THEME.prompt_text}"
+        assert str(prompts_heading.spans[1].style) == TAU_DARK_THEME.completion_description
         assert skills.collapsed is True
         assert prompts.collapsed is True
+
+        skill_title = app.query_one("#sidebar-skills CollapsibleTitle")
+        await pilot.hover("#sidebar-skills CollapsibleTitle")
+        assert skill_title.styles.background == Color.parse("transparent")
+
+        skill_title.focus()
+        await pilot.pause()
+        assert skill_title.styles.background == Color.parse("transparent")
+        assert skills.styles.background_tint == Color.parse("transparent")
 
         await pilot.click("#sidebar-skills CollapsibleTitle")
         assert skills.collapsed is False
@@ -3102,7 +3118,7 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
         expanded_virtual_height = scroll.virtual_size.height
         assert re.fullmatch(
             r"skills \(30 · ~\d+(?:\.\d+)?k? tokens\)",
-            app.query_one("#sidebar-skills", Collapsible).title,
+            Content.from_markup(app.query_one("#sidebar-skills", Collapsible).title).plain,
         )
         assert expanded_virtual_height > initial_virtual_height
         assert scroll.max_scroll_y > 0
@@ -3112,7 +3128,10 @@ async def test_tui_sidebar_relayouts_when_reload_changes_resource_count() -> Non
         await pilot.pause()
 
         skills = app.query_one("#sidebar-skills", Collapsible)
-        assert re.fullmatch(r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)", skills.title)
+        assert re.fullmatch(
+            r"skills \(1 · ~\d+(?:\.\d+)?k? tokens\)",
+            Content.from_markup(skills.title).plain,
+        )
         assert skills.collapsed is False
         assert scroll.virtual_size.height < expanded_virtual_height
         assert scroll.max_scroll_y == 0


### PR DESCRIPTION
## Summary

- keep the skills and prompts labels bold while rendering counts and token estimates in muted sidebar text
- remove hover and focus background highlights from collapsible resource headings
- suppress the parent collapsible focus tint
- test heading spans and hover/focus states

## User experience

Resource metadata now matches the sidebar's quieter secondary text, and interacting with the collapsible headings no longer adds a background block.

## Validation

- `uv run pytest` (1521 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify` (passes with the existing taxonomy layout warning)

## Manual validation

1. Open Tau with the sidebar visible.
2. Confirm `skills` and `prompts` remain bold while counts/token metadata are muted gray.
3. Hover and focus each heading and confirm no background highlight appears.
4. Confirm each section still expands and collapses normally.
