### PR TITLE
Prepare Tau 0.3.12 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.11"
+version = "0.3.12"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.3.12",
+    "date": "2026-08-17",
+    "sections": {
+      "New": [
+        "Keep user-triggered skills out of the model-facing system prompt with disable-model-invocation frontmatter while retaining explicit invocation, picker, autocomplete, reload, and sidebar support."
+      ],
+      "Changed": [
+        "Refine sidebar skill and prompt headings with bold labels, muted metadata, and no hover or focus background highlights."
+      ]
+    }
+  },
+  {
     "version": "0.3.11",
     "date": "2026-08-17",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -781,7 +781,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.11" in console.export_text()
+    assert "τ = 2π  0.3.12" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.11"
+version = "0.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the Tau 0.3.12 patch release.

- bump `tau-ai` from 0.3.11 to 0.3.12
- update `uv.lock` and the version-sensitive sidebar test
- add structured release notes for changes since v0.3.11

## Release highlights

- support `disable-model-invocation: true` for user-triggered skills
- refine skill and prompt sidebar heading styles

## Validation

- `uv run pytest` — 1529 passed, 2 Windows-only tests skipped
- `uv run mypy` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv build` — built 0.3.12 wheel and source distribution
- `cd website && hugo --minify` — passed with the existing taxonomy warning
- `cd website && npx --yes pagefind@latest --site public` — passed
- `uv run tau --version` — `tau 0.3.12`

## Publishing

After merge, publish GitHub Release `v0.3.12` from `main`. The release event triggers the trusted PyPI publishing workflow.
