### PR TITLE
Add Pi-compatible RPC mode

### DIFF
--- a/dev-notes/architecture/phase-28-rpc.md
+++ b/dev-notes/architecture/phase-28-rpc.md
@@ -1,0 +1,35 @@
+---
+title: "Phase 28: Pi-compatible RPC mode"
+---
+
+Phase 28 adds a headless frontend at `tau_coding.rpc`. It consumes the same `CodingSession`
+events as print mode and Textual, preserving `tau_coding → tau_agent → tau_ai`.
+
+The process uses strict JSONL on stdin/stdout. A serialized writer prevents response and event
+bytes from interleaving; prompt work runs in an AnyIO task group so cancellation and queued input
+remain available while events stream. EOF cancels active work, waits for owned tasks, and closes
+the session.
+
+## Pi compatibility
+
+| Area | Status |
+| --- | --- |
+| prompt, steer, follow-up, abort | supported |
+| state/messages | supported |
+| models and thinking | supported |
+| manual compaction | supported |
+| new/switch session, stats, tree, fork | supported with Tau IDs/tree shape |
+| command discovery | supported |
+| direct bash and abort_bash | deferred; needs a cancellable public session API |
+| extension UI RPC | deferred; Tau currently uses frontend bridge callbacks |
+| set auto-compaction, clone, export, session naming | deferred |
+| get_entries cursor | deferred |
+
+The protocol intentionally maps only public `CodingSession` behavior. It does not read raw session
+JSONL, depend on Textual, or duplicate the agent loop.
+
+## Verification
+
+`tests/test_rpc.py` drives a real `CodingSession` with `FakeProvider` through in-memory JSONL
+streams. It covers correlated acceptance, event streaming, malformed records, CRLF, and Unicode
+line separators. CLI tests cover `--mode rpc` routing separately.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -41,6 +41,7 @@ from tau_coding.provider_config import (
 from tau_coding.provider_runtime import create_model_provider
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.resources import TauResourcePaths
+from tau_coding.rpc import RpcServer
 from tau_coding.session import (
     CodingSession,
     CodingSessionConfig,
@@ -202,8 +203,7 @@ def main(
         PrintOutputMode | None,
         typer.Option(
             "--mode",
-            help="Run in non-interactive print mode with this output format "
-            "(text, json, or transcript).",
+            help="Run headlessly with this output format (text, json, transcript, or rpc).",
         ),
     ] = None,
     output: Annotated[
@@ -350,7 +350,8 @@ def main(
     if extension_legacy is not None:
         raise typer.BadParameter("-x was renamed to -e/--extension.")
 
-    print_requested = print_mode or mode is not None
+    rpc_requested = mode is PrintOutputMode.rpc
+    print_requested = print_mode or (mode is not None and not rpc_requested)
     effective_output = mode or PrintOutputMode.text
 
     if session_id is not None:
@@ -407,6 +408,29 @@ def main(
         else None
     )
     resolved_append_system_prompt = _resolve_append_system_prompts(append_system_prompt or ())
+
+    if rpc_requested:
+        if initial_prompt is not None:
+            raise typer.BadParameter(
+                "RPC mode reads commands from stdin and does not accept a prompt"
+            )
+        try:
+            anyio.run(
+                run_openai_rpc_mode,
+                model,
+                cwd or Path.cwd(),
+                provider,
+                session,
+                extension_paths,
+                not no_extensions,
+                project_extensions,
+                custom_system_prompt,
+                resolved_append_system_prompt,
+                trust_override,
+            )
+        except (RuntimeError, ValueError) as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        raise typer.Exit()
 
     if not print_requested:
         notice = _startup_update_notice()
@@ -755,6 +779,73 @@ def _provider_credential_status(
     if environ.get(provider.api_key_env):
         return f"env:{provider.api_key_env}"
     return "missing"
+
+
+async def run_openai_rpc_mode(
+    model: str | None,
+    cwd: Path,
+    provider_name: str | None = None,
+    resume_session_id: str | None = None,
+    extension_paths: tuple[Path, ...] = (),
+    extensions_enabled: bool = True,
+    project_extensions_enabled: bool = False,
+    custom_system_prompt: str | None = None,
+    append_system_prompt: str | None = None,
+    trust_override: TrustOverride | None = None,
+) -> None:
+    """Run a persistent Pi-compatible JSONL RPC session."""
+    settings = load_provider_settings()
+    shell_settings = load_shell_settings()
+    manager = SessionManager()
+    record = _print_session_record(
+        manager,
+        resume_session_id=resume_session_id,
+        cwd=cwd,
+        settings=settings,
+        provider_name=provider_name,
+        model=model,
+        session_id=None,
+    )
+    explicit_selection = provider_name is not None or model is not None
+    selection = resolve_provider_selection(
+        settings,
+        provider_name=provider_name if explicit_selection else record.provider_name,
+        model=model if explicit_selection else record.model,
+    )
+    inference_provider = record.inference_provider if resume_session_id is not None else None
+    provider = create_model_provider(
+        selection.provider,
+        model=selection.model,
+        inference_provider=inference_provider,
+        thinking_level=resolve_startup_thinking_level(selection.provider, selection.model),
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model=selection.model,
+            cwd=record.cwd,
+            storage=jsonl_session_storage(record.path),
+            session_id=record.id,
+            session_manager=manager,
+            provider_name=selection.provider.name,
+            inference_provider=inference_provider,
+            provider_settings=settings,
+            runtime_provider_config=selection.provider,
+            shell_command_prefix=shell_settings.shell_command_prefix,
+            extension_paths=extension_paths,
+            extensions_enabled=extensions_enabled,
+            project_extensions_enabled=project_extensions_enabled,
+            custom_system_prompt=custom_system_prompt,
+            append_system_prompt=append_system_prompt,
+            trust_override=trust_override,
+            trust_default=shell_settings.default_project_trust,
+        )
+    )
+    session.extension_runtime.set_ui_bridge(StderrUiBridge())
+    try:
+        await RpcServer(session).run()
+    finally:
+        await provider.aclose()
 
 
 async def run_openai_print_mode(

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -366,29 +366,48 @@ def main(
     command = positional_args[0] if positional_args else None
     initial_prompt = " ".join(positional_args) if positional_args else None
 
-    if not print_requested and not export and command == "update":
+    if rpc_requested and export:
+        raise typer.BadParameter("--export cannot be combined with --mode rpc")
+
+    if not rpc_requested and not print_requested and not export and command == "update":
         if len(positional_args) != 1:
             raise typer.BadParameter("Usage: tau update")
         update_command()
         raise typer.Exit()
 
-    if not print_requested and not export and command == "sessions" and len(positional_args) == 1:
+    if (
+        not rpc_requested
+        and not print_requested
+        and not export
+        and command == "sessions"
+        and len(positional_args) == 1
+    ):
         render_session_list(SessionManager().list_sessions())
         raise typer.Exit()
 
-    if not print_requested and not export and command == "export":
+    if not rpc_requested and not print_requested and not export and command == "export":
         _run_export_cli(positional_args[1:])
 
-    if export:
+    if export and not rpc_requested:
         if print_requested:
             raise typer.BadParameter("--export cannot be combined with --print/--mode.")
         _run_export_cli(positional_args)
 
-    if not print_requested and command == "providers" and len(positional_args) == 1:
+    if (
+        not rpc_requested
+        and not print_requested
+        and command == "providers"
+        and len(positional_args) == 1
+    ):
         providers_command()
         raise typer.Exit()
 
-    if not print_requested and command == "setup" and len(positional_args) == 1:
+    if (
+        not rpc_requested
+        and not print_requested
+        and command == "setup"
+        and len(positional_args) == 1
+    ):
         setup_command(
             provider_name=provider or DEFAULT_PROVIDER_NAME,
             base_url=setup_base_url,
@@ -812,7 +831,17 @@ async def run_openai_rpc_mode(
         provider_name=provider_name if explicit_selection else record.provider_name,
         model=model if explicit_selection else record.model,
     )
-    inference_provider = record.inference_provider if resume_session_id is not None else None
+    inference_provider = (
+        record.inference_provider
+        if resume_session_id is not None
+        and record.provider_name == "huggingface"
+        and selection.provider.name == "huggingface"
+        and record.model == selection.model
+        else selection.provider.inference_providers.get(selection.model)
+        if isinstance(selection.provider, OpenAICompatibleProviderConfig)
+        and selection.provider.name == "huggingface"
+        else None
+    )
     provider = create_model_provider(
         selection.provider,
         model=selection.model,

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -1,6 +1,6 @@
 # Tau CLI and commands
 
-Tau supports print mode and a Textual interactive TUI. The CLI entry point is `tau_coding.cli:app`.
+Tau supports print mode, Pi-compatible JSONL RPC mode, and a Textual interactive TUI. The CLI entry point is `tau_coding.cli:app`.
 
 For current user-facing behavior in a Tau checkout, read:
 

--- a/src/tau_coding/rendering/base.py
+++ b/src/tau_coding/rendering/base.py
@@ -14,6 +14,7 @@ class PrintOutputMode(StrEnum):
     text = "text"
     json = "json"
     transcript = "transcript"
+    rpc = "rpc"
 
 
 class EventRenderer(Protocol):

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -1,0 +1,356 @@
+"""Pi-compatible JSONL RPC frontend for a Tau coding session."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import asdict, is_dataclass
+from typing import IO, Literal, Protocol, cast
+
+import anyio
+from pydantic import BaseModel
+
+from tau_agent.types import JSONValue
+from tau_coding.commands import CommandRegistry
+from tau_coding.events import CodingSessionEvent
+from tau_coding.session import CodingSession
+
+_MAX_RECORD_BYTES = 16 * 1024 * 1024
+
+
+class RpcSession(Protocol):
+    """Public CodingSession surface consumed by RPC mode."""
+
+    @property
+    def model(self) -> str: ...
+
+    @property
+    def provider_name(self) -> str: ...
+
+    @property
+    def thinking_level(self) -> str: ...
+
+    @property
+    def available_thinking_levels(self) -> tuple[str, ...]: ...
+
+    @property
+    def available_model_choices(self) -> tuple[object, ...]: ...
+
+    @property
+    def messages(self) -> tuple[object, ...]: ...
+
+    @property
+    def session_id(self) -> str | None: ...
+
+    @property
+    def auto_compact_token_threshold(self) -> int | None: ...
+
+    @property
+    def session_stats(self) -> object: ...
+
+    @property
+    def command_registry(self) -> CommandRegistry: ...
+
+    @property
+    def state(self) -> object: ...
+
+    def prompt(
+        self,
+        content: str,
+        *,
+        streaming_behavior: Literal["steer", "follow_up"] | None = None,
+    ) -> AsyncIterator[CodingSessionEvent]: ...
+
+    def cancel(self) -> None: ...
+
+    def set_provider(self, provider_name: str, *, persist_default: bool = True) -> None: ...
+
+    def set_model(self, model: str) -> None: ...
+
+    async def set_thinking_level(self, level: str) -> str: ...
+
+    async def compact(self, instructions: str | None = None) -> str: ...
+
+    async def new_session(self) -> str: ...
+
+    async def resume(self, session_id: str) -> str: ...
+
+    async def tree_choices(self) -> tuple[object, ...]: ...
+
+    async def branch_to_entry(self, entry_id: str) -> object: ...
+
+    async def emit_pending_session_start(self) -> None: ...
+
+    async def aclose(self) -> None: ...
+
+
+class RpcServer:
+    """Read Pi-style commands and stream responses/events as strict JSONL."""
+
+    def __init__(
+        self,
+        session: RpcSession,
+        *,
+        stdin: IO[str] | None = None,
+        stdout: IO[str] | None = None,
+    ) -> None:
+        self._session = session
+        self._stdin = stdin or sys.stdin
+        self._stdout = stdout or sys.stdout
+        self._write_lock = anyio.Lock()
+        self._active_prompt_tasks = 0
+
+    async def run(self) -> None:
+        """Serve commands until stdin reaches EOF."""
+        await self._session.emit_pending_session_start()
+        async with anyio.create_task_group() as tasks:
+            while True:
+                line = await anyio.to_thread.run_sync(self._stdin.readline)
+                if line == "":
+                    break
+                if line.endswith("\n"):
+                    line = line[:-1]
+                if line.endswith("\r"):
+                    line = line[:-1]
+                if not line:
+                    continue
+                if len(line.encode("utf-8")) > _MAX_RECORD_BYTES:
+                    await self._error(None, "parse", "RPC record exceeds 16 MiB")
+                    continue
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    await self._error(None, "parse", f"Failed to parse command: {exc.msg}")
+                    continue
+                if not isinstance(value, dict):
+                    await self._error(None, "parse", "Command must be a JSON object")
+                    continue
+                await self._dispatch(cast(dict[str, object], value), tasks)
+            if self._active_prompt_tasks:
+                self._session.cancel()
+        await self._session.aclose()
+
+    async def _dispatch(self, command: dict[str, object], tasks: anyio.abc.TaskGroup) -> None:
+        request_id = command.get("id")
+        command_type = command.get("type")
+        if not isinstance(command_type, str):
+            await self._error(request_id, "parse", "Command requires a string 'type'")
+            return
+        try:
+            if command_type in {"prompt", "steer", "follow_up"}:
+                message = _required_string(command, "message")
+                behavior: Literal["steer", "follow_up"] | None = None
+                if command_type == "steer":
+                    behavior = "steer"
+                elif command_type == "follow_up":
+                    behavior = "follow_up"
+                explicit = command.get("streamingBehavior")
+                if explicit is not None:
+                    if explicit not in {"steer", "followUp"}:
+                        raise ValueError("streamingBehavior must be 'steer' or 'followUp'")
+                    behavior = "follow_up" if explicit == "followUp" else "steer"
+                if self._active_prompt_tasks and behavior is None:
+                    raise ValueError(
+                        "Agent is already streaming; set streamingBehavior to steer or followUp"
+                    )
+                self._active_prompt_tasks += 1
+                await self._response(request_id, command_type)
+                tasks.start_soon(self._run_prompt, message, behavior)
+                return
+            if command_type == "abort":
+                self._session.cancel()
+                await self._response(request_id, command_type)
+                return
+            if command_type == "get_state":
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "model": self._session.model,
+                        "provider": self._session.provider_name,
+                        "thinkingLevel": self._session.thinking_level,
+                        "isStreaming": self._active_prompt_tasks > 0,
+                        "sessionId": self._session.session_id,
+                        "autoCompactionEnabled": (
+                            self._session.auto_compact_token_threshold is not None
+                        ),
+                        "messageCount": len(self._session.messages),
+                    },
+                )
+                return
+            if command_type == "get_messages":
+                await self._response(
+                    request_id, command_type, {"messages": list(self._session.messages)}
+                )
+                return
+            if command_type == "get_available_models":
+                await self._response(
+                    request_id,
+                    command_type,
+                    {"models": list(self._session.available_model_choices)},
+                )
+                return
+            if command_type == "set_model":
+                provider = command.get("provider")
+                if provider is not None:
+                    if not isinstance(provider, str):
+                        raise ValueError("provider must be a string")
+                    self._session.set_provider(provider, persist_default=False)
+                self._session.set_model(_required_string(command, "modelId"))
+                await self._response(
+                    request_id,
+                    command_type,
+                    {"provider": self._session.provider_name, "id": self._session.model},
+                )
+                return
+            if command_type == "get_available_thinking_levels":
+                await self._response(
+                    request_id,
+                    command_type,
+                    {"levels": list(self._session.available_thinking_levels)},
+                )
+                return
+            if command_type == "set_thinking_level":
+                level = await self._session.set_thinking_level(_required_string(command, "level"))
+                await self._response(request_id, command_type, {"level": level})
+                return
+            if command_type == "compact":
+                instructions = _optional_string(command, "customInstructions")
+                result = await self._session.compact(instructions)
+                await self._response(request_id, command_type, {"summary": result})
+                return
+            if command_type == "new_session":
+                message = await self._session.new_session()
+                await self._response(request_id, command_type, {"message": message})
+                return
+            if command_type == "switch_session":
+                session_id = command.get("sessionId", command.get("sessionPath"))
+                if not isinstance(session_id, str):
+                    raise ValueError("switch_session requires sessionId")
+                message = await self._session.resume(session_id)
+                await self._response(request_id, command_type, {"message": message})
+                return
+            if command_type == "get_session_stats":
+                await self._response(request_id, command_type, self._session.session_stats)
+                return
+            if command_type == "get_tree":
+                choices = await self._session.tree_choices()
+                await self._response(
+                    request_id,
+                    command_type,
+                    {"entries": list(choices), "leafId": _leaf_id(self._session.state)},
+                )
+                return
+            if command_type == "fork":
+                fork_result = await self._session.branch_to_entry(
+                    _required_string(command, "entryId")
+                )
+                await self._response(request_id, command_type, fork_result)
+                return
+            if command_type == "get_commands":
+                commands = self._session.command_registry.list_commands()
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "commands": [
+                            {"name": item.name, "description": item.description}
+                            for item in commands
+                        ]
+                    },
+                )
+                return
+            raise ValueError(f"Unknown command: {command_type}")
+        except (RuntimeError, ValueError) as exc:
+            await self._error(request_id, command_type, str(exc))
+
+    async def _run_prompt(
+        self, message: str, behavior: Literal["steer", "follow_up"] | None
+    ) -> None:
+        try:
+            stream = self._session.prompt(message, streaming_behavior=behavior)
+            async for event in stream:
+                await self._write(event)
+        except (RuntimeError, ValueError) as exc:
+            await self._write({"type": "rpc_error", "error": str(exc)})
+        finally:
+            self._active_prompt_tasks -= 1
+
+    async def _response(
+        self,
+        request_id: object,
+        command: str,
+        data: object | None = None,
+    ) -> None:
+        response: dict[str, object] = {
+            "type": "response",
+            "command": command,
+            "success": True,
+        }
+        if request_id is not None:
+            response["id"] = request_id
+        if data is not None:
+            response["data"] = data
+        await self._write(response)
+
+    async def _error(self, request_id: object, command: str, error: str) -> None:
+        response: dict[str, object] = {
+            "type": "response",
+            "command": command,
+            "success": False,
+            "error": error,
+        }
+        if request_id is not None:
+            response["id"] = request_id
+        await self._write(response)
+
+    async def _write(self, value: object) -> None:
+        payload = json.dumps(_jsonable(value), ensure_ascii=False, separators=(",", ":"))
+        async with self._write_lock:
+            self._stdout.write(payload + "\n")
+            self._stdout.flush()
+
+
+def _required_string(command: Mapping[str, object], key: str) -> str:
+    value = command.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(command: Mapping[str, object], key: str) -> str | None:
+    value = command.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def _leaf_id(state: object) -> object:
+    return getattr(state, "active_leaf_id", None)
+
+
+def _jsonable(value: object) -> JSONValue:
+    if isinstance(value, BaseModel):
+        return cast(JSONValue, value.model_dump(mode="json", by_alias=True))
+    if is_dataclass(value) and not isinstance(value, type):
+        return cast(JSONValue, asdict(value))
+    if isinstance(value, Mapping):
+        return cast(
+            JSONValue,
+            {str(key): _jsonable(item) for key, item in value.items()},
+        )
+    if isinstance(value, (list, tuple)):
+        return cast(JSONValue, [_jsonable(item) for item in value])
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        return cast(JSONValue, value.model_dump(mode="json", by_alias=True))
+    return str(value)
+
+
+async def run_rpc_session(session: CodingSession) -> None:
+    """Run RPC mode for an already configured CodingSession."""
+    await RpcServer(session).run()

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from tau_agent.types import JSONValue
 from tau_coding.commands import CommandRegistry
 from tau_coding.events import CodingSessionEvent
-from tau_coding.session import CodingSession
+from tau_coding.session import CodingSession, ModelChoice
 
 _MAX_RECORD_BYTES = 16 * 1024 * 1024
 
@@ -64,9 +64,7 @@ class RpcSession(Protocol):
 
     def cancel(self) -> None: ...
 
-    def set_provider(self, provider_name: str, *, persist_default: bool = True) -> None: ...
-
-    def set_model(self, model: str) -> None: ...
+    def set_model_choice(self, choice: ModelChoice) -> None: ...
 
     async def set_thinking_level(self, level: str) -> str: ...
 
@@ -154,9 +152,15 @@ class RpcServer:
                     raise ValueError(
                         "Agent is already streaming; set streamingBehavior to steer or followUp"
                     )
+                stream = self._session.prompt(message, streaming_behavior=behavior)
+                try:
+                    first_event = await anext(stream)
+                except StopAsyncIteration:
+                    await self._response(request_id, command_type)
+                    return
                 self._active_prompt_tasks += 1
                 await self._response(request_id, command_type)
-                tasks.start_soon(self._run_prompt, message, behavior)
+                tasks.start_soon(self._run_prompt, stream, first_event)
                 return
             if command_type == "abort":
                 self._session.cancel()
@@ -192,12 +196,15 @@ class RpcServer:
                 )
                 return
             if command_type == "set_model":
-                provider = command.get("provider")
-                if provider is not None:
-                    if not isinstance(provider, str):
-                        raise ValueError("provider must be a string")
-                    self._session.set_provider(provider, persist_default=False)
-                self._session.set_model(_required_string(command, "modelId"))
+                provider = command.get("provider", self._session.provider_name)
+                if not isinstance(provider, str):
+                    raise ValueError("provider must be a string")
+                self._session.set_model_choice(
+                    ModelChoice(
+                        provider_name=provider,
+                        model=_required_string(command, "modelId"),
+                    )
+                )
                 await self._response(
                     request_id,
                     command_type,
@@ -262,14 +269,16 @@ class RpcServer:
                 )
                 return
             raise ValueError(f"Unknown command: {command_type}")
-        except (RuntimeError, ValueError) as exc:
+        except Exception as exc:
             await self._error(request_id, command_type, str(exc))
 
     async def _run_prompt(
-        self, message: str, behavior: Literal["steer", "follow_up"] | None
+        self,
+        stream: AsyncIterator[CodingSessionEvent],
+        first_event: CodingSessionEvent,
     ) -> None:
         try:
-            stream = self._session.prompt(message, streaming_behavior=behavior)
+            await self._write(first_event)
             async for event in stream:
                 await self._write(event)
         except (RuntimeError, ValueError) as exc:

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,6 +1,8 @@
 import json
+from collections.abc import AsyncIterator
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -9,7 +11,7 @@ from pi_event_helpers import assistant_done, assistant_start, text_delta
 from tau_agent import AssistantMessage
 from tau_agent.session import JsonlSessionStorage
 from tau_ai import FakeProvider
-from tau_coding import CodingSession, CodingSessionConfig
+from tau_coding import CodingSession, CodingSessionConfig, ModelChoice
 from tau_coding import cli as cli_module
 from tau_coding.rpc import RpcServer
 
@@ -71,6 +73,25 @@ async def test_rpc_reports_bad_records_and_continues(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("command", ["providers", "sessions", "setup", "export", "update"])
+def test_rpc_mode_never_dispatches_utility_commands(
+    monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    called: list[str] = []
+    monkeypatch.setattr(cli_module, "providers_command", lambda: called.append("providers"))
+    monkeypatch.setattr(
+        cli_module, "render_session_list", lambda records: called.append("sessions")
+    )
+    monkeypatch.setattr(cli_module, "setup_command", lambda **kwargs: called.append("setup"))
+    monkeypatch.setattr(cli_module, "_run_export_cli", lambda args: called.append("export"))
+    monkeypatch.setattr(cli_module, "update_command", lambda: called.append("update"))
+
+    result = CliRunner().invoke(cli_module.app, ["--mode", "rpc", command])
+
+    assert result.exit_code == 2
+    assert called == []
+
+
 def test_cli_routes_rpc_mode_without_a_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     called = False
 
@@ -84,6 +105,77 @@ def test_cli_routes_rpc_mode_without_a_prompt(monkeypatch: pytest.MonkeyPatch) -
 
     assert result.exit_code == 0
     assert called is True
+
+
+class _PreflightFailureSession:
+    model = "before"
+    provider_name = "provider-before"
+    thinking_level = "off"
+    available_thinking_levels = ("off",)
+    available_model_choices: tuple[object, ...] = ()
+    messages: tuple[object, ...] = ()
+    session_id = None
+    auto_compact_token_threshold = None
+    session_stats = SimpleNamespace()
+    command_registry = SimpleNamespace(list_commands=lambda: ())
+    state = SimpleNamespace(active_leaf_id=None)
+
+    async def emit_pending_session_start(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+    def cancel(self) -> None:
+        return None
+
+    def prompt(
+        self, content: str, *, streaming_behavior: str | None = None
+    ) -> AsyncIterator[object]:
+        del content, streaming_behavior
+
+        async def fail() -> AsyncIterator[object]:
+            raise ValueError("preflight rejected")
+            yield
+
+        return fail()
+
+    def set_model_choice(self, choice: ModelChoice) -> None:
+        raise ValueError(f"Model is not available: {choice.provider_name}:{choice.model}")
+
+
+@pytest.mark.anyio
+async def test_rpc_preflight_failure_returns_one_correlated_failure() -> None:
+    session = _PreflightFailureSession()
+    stdin = StringIO('{"id":"bad","type":"prompt","message":"hi"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()  # type: ignore[arg-type]
+
+    records = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert records == [
+        {
+            "type": "response",
+            "command": "prompt",
+            "success": False,
+            "error": "preflight rejected",
+            "id": "bad",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_rpc_failed_model_change_does_not_mutate_session() -> None:
+    session = _PreflightFailureSession()
+    stdin = StringIO('{"id":"model","type":"set_model","provider":"other","modelId":"missing"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()  # type: ignore[arg-type]
+
+    record = json.loads(stdout.getvalue())
+    assert record["success"] is False
+    assert session.provider_name == "provider-before"
+    assert session.model == "before"
 
 
 @pytest.mark.anyio

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,0 +1,100 @@
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pi_event_helpers import assistant_done, assistant_start, text_delta
+from tau_agent import AssistantMessage
+from tau_agent.session import JsonlSessionStorage
+from tau_ai import FakeProvider
+from tau_coding import CodingSession, CodingSessionConfig
+from tau_coding import cli as cli_module
+from tau_coding.rpc import RpcServer
+
+
+async def _session(tmp_path: Path, provider: FakeProvider) -> CodingSession:
+    return await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_rpc_streams_correlated_response_and_events(tmp_path: Path) -> None:
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                text_delta("hello"),
+                assistant_done(AssistantMessage(content="hello", model="fake")),
+            ]
+        ]
+    )
+    session = await _session(tmp_path, provider)
+    stdin = StringIO('{"id":"one","type":"prompt","message":"hi"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    records = [json.loads(line) for line in stdout.getvalue().split("\n") if line]
+    assert records[0] == {
+        "type": "response",
+        "command": "prompt",
+        "success": True,
+        "id": "one",
+    }
+    assert any(record["type"] == "agent_start" for record in records)
+    assert records[-1]["type"] == "agent_settled"
+
+
+@pytest.mark.anyio
+async def test_rpc_reports_bad_records_and_continues(tmp_path: Path) -> None:
+    session = await _session(tmp_path, FakeProvider([]))
+    stdin = StringIO('not-json\n{"id":2,"type":"get_state"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    records = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert records[0]["success"] is False
+    assert records[0]["command"] == "parse"
+    assert records[1]["id"] == 2
+    assert records[1]["success"] is True
+    assert records[1]["data"]["model"] == "fake"
+
+
+@pytest.mark.anyio
+def test_cli_routes_rpc_mode_without_a_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    async def fake_run(*args: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli_module, "run_openai_rpc_mode", fake_run)
+
+    result = CliRunner().invoke(cli_module.app, ["--mode", "rpc"])
+
+    assert result.exit_code == 0
+    assert called is True
+
+
+@pytest.mark.anyio
+async def test_rpc_splits_only_on_lf_and_accepts_crlf(tmp_path: Path) -> None:
+    session = await _session(tmp_path, FakeProvider([]))
+    separator = chr(0x2028)
+    stdin = StringIO(f'{{"id":"a{separator}b","type":"get_state"}}\r\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    record = json.loads(stdout.getvalue())
+    assert record["success"] is True
+    assert record["id"] == "a\u2028b"

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -44,7 +44,7 @@ features and fixes.
 | `-m, --model TEXT` | Model to request from the provider |
 | `--provider TEXT` | Configured provider name to use |
 | `--cwd PATH` | Working directory for the built-in tools |
-| `--mode [text\|json\|transcript]` | Output mode for print mode (default `text`); also triggers print mode on its own |
+| `--mode [text\|json\|transcript\|rpc]` | Select headless output; `rpc` starts the JSONL subprocess protocol |
 | `--session TEXT` | Resume a session id in the TUI or print mode |
 | `--new-session` | Start a new session instead of resuming the default |
 | `--session-id TEXT` | Set the exact id for a newly created print-mode session; errors if it already exists |
@@ -140,5 +140,5 @@ tau --provider local \
   setup
 ```
 
-See also: [Slash commands]({{< relref "./slash-commands.md" >}}) (in-session) and
+See also: [RPC protocol]({{< relref "./rpc.md" >}}), [Slash commands]({{< relref "./slash-commands.md" >}}) (in-session), and
 [Keyboard shortcuts]({{< relref "./keybindings.md" >}}).

--- a/website/content/reference/rpc.md
+++ b/website/content/reference/rpc.md
@@ -1,0 +1,60 @@
+---
+title: RPC protocol
+description: Control Tau as a subprocess with Pi-compatible JSONL commands and events.
+---
+
+Run Tau as a headless subprocess:
+
+```bash
+tau --mode rpc [--provider NAME] [--model MODEL] [--cwd PATH] [--session ID]
+```
+
+RPC mode reads one JSON object per LF-terminated line from stdin and writes responses and
+session events as compact JSON lines to stdout. Diagnostics use stderr. Clients may include an
+`id`; the corresponding response echoes it. Event records are asynchronous and do not normally
+carry request IDs.
+
+```json
+{"id":"1","type":"prompt","message":"Inspect this project"}
+{"id":"1","type":"response","command":"prompt","success":true}
+{"type":"agent_start"}
+```
+
+The initial protocol supports Pi-compatible prompting (`prompt`, `steer`, `follow_up`, `abort`),
+state and message inspection, model and thinking controls, compaction, new/resumed sessions,
+session statistics and trees, forking, and command discovery. Unknown commands and invalid
+arguments return `success: false` without stopping the process.
+
+Use `agent_settled`, not `agent_end`, to decide that a run is fully idle: retries, overflow
+compaction, or queued continuations can follow `agent_end`.
+
+## Framing
+
+Split records only on LF (`\n`). A trailing CR is accepted for CRLF input. Unicode line
+separators such as U+2028 and U+2029 are ordinary characters inside JSON strings. Records are
+limited to 16 MiB.
+
+## Minimal Node/Electron client
+
+```js
+import { spawn } from "node:child_process";
+
+const tau = spawn("tau", ["--mode", "rpc"], { stdio: ["pipe", "pipe", "inherit"] });
+tau.stdout.setEncoding("utf8");
+let buffer = "";
+tau.stdout.on("data", chunk => {
+  buffer += chunk;
+  for (;;) {
+    const index = buffer.indexOf("\n");
+    if (index < 0) break;
+    const line = buffer.slice(0, index);
+    buffer = buffer.slice(index + 1);
+    console.log(JSON.parse(line));
+  }
+});
+tau.stdin.write(JSON.stringify({ id: "1", type: "prompt", message: "Hello" }) + "\n");
+```
+
+Tau mirrors Pi where its public `CodingSession` has equivalent behavior. This first version does
+not yet implement Pi's direct `bash`/`abort_bash`, extension UI request/response protocol,
+session naming, auto-compaction toggling, entry cursors, cloning, or export commands.


### PR DESCRIPTION
## Summary

- add `tau --mode rpc` as a headless, strict JSONL subprocess frontend
- mirror Pi command/response names for prompting, state, models, thinking, compaction, sessions, trees, forking, and command discovery
- stream canonical `CodingSessionEvent` values without coupling `tau_agent` to the CLI
- document compatibility boundaries and deferred protocol commands

## User experience

Editors, Electron applications, and other processes can now drive Tau through stdin/stdout without launching Textual or parsing human-readable output. Request IDs correlate responses while provider-neutral agent and tool events continue asynchronously.

## Validation

- `uv run pytest` — 1533 passed, 2 skipped
- `uv run pytest tests/test_rpc.py tests/test_cli.py` — 88 passed after the final lifecycle adjustment
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`

## Follow-ups

The compatibility matrix records deferred Pi surfaces: direct bash cancellation, extension UI RPC, cloning, exports, session naming, entry cursors, and auto-compaction toggling.

Addresses #612.
