### PR TITLE
Align RPC contract for interchangeable Tau/Pi frontends

### DIFF
--- a/dev-notes/architecture/phase-28-rpc.md
+++ b/dev-notes/architecture/phase-28-rpc.md
@@ -16,14 +16,16 @@ the session.
 | --- | --- |
 | prompt, steer, follow-up, abort | supported |
 | state/messages | supported |
-| models and thinking | supported |
-| manual compaction | supported |
-| new/switch session, stats, tree, fork | supported with Tau IDs/tree shape |
-| command discovery | supported |
-| direct bash and abort_bash | deferred; needs a cancellable public session API |
+| models and thinking | Pi-shaped models plus set/cycle/list supported |
+| manual compaction | supported; detailed usage remains approximate |
+| new/switch session, stats, tree, fork | Pi-shaped wire responses; Tau ID or indexed path accepted |
+| command discovery | supported with synthetic Tau source metadata |
+| direct bash | supported |
+| abort_bash | deferred; needs a cancellable public session API |
+| HTML export, session naming, entry cursor | supported |
+| auto-compaction toggle | supported |
 | extension UI RPC | deferred; Tau currently uses frontend bridge callbacks |
-| set auto-compaction, clone, export, session naming | deferred |
-| get_entries cursor | deferred |
+| queue/retry controls, clone, image prompts | deferred |
 
 The protocol intentionally maps only public `CodingSession` behavior. It does not read raw session
 JSONL, depend on Textual, or duplicate the agent loop.

--- a/dev-notes/design/rpc-runtime-interchangeability-plan.md
+++ b/dev-notes/design/rpc-runtime-interchangeability-plan.md
@@ -1,0 +1,113 @@
+# Tau/Pi RPC runtime interchangeability plan
+
+## Objective
+
+An Electron host should be able to select either subprocess with one product setting:
+
+```json
+{"agent_runtime": "tau"}
+```
+
+Runtime-specific startup configuration (binary path, provider/model, cwd, and session location)
+may differ. After startup, the host must use one command/event contract without branching on the
+runtime for ordinary coding-agent behavior.
+
+The compatibility target is Pi's documented JSONL RPC protocol in
+`packages/coding-agent/docs/rpc.md`, because Pi already publishes a typed TypeScript client. Tau
+must match command names, request fields, response envelopes, response data shapes, event names,
+and lifecycle semantics for the shared surface. Persisted session files do not need to be mutually
+readable; interchangeability is at the process boundary.
+
+## Definition of done
+
+1. The same black-box contract suite can launch Pi or Tau and exercise prompting, streaming,
+   cancellation, model selection, thinking controls, direct shell commands, compaction, session
+   inspection, and command discovery.
+2. Shared commands have the same required request fields and success response shapes.
+3. Shared events use the same camel-case wire vocabulary and lifecycle meaning.
+4. Unsupported optional behavior returns a deterministic failed response; it never silently
+   changes semantics.
+5. Runtime-specific capabilities are isolated to optional features rather than ordinary chat/tool
+   operation.
+6. Electron consumes generated/shared protocol types or its own normalized domain model, never
+   provider-specific chunks or either runtime's persisted JSONL.
+
+## Gap inventory
+
+### Wire shapes
+
+Tau's first RPC version used model references where Pi returns complete model objects, omitted
+state fields, returned a flat tree, exposed Tau session-stat names, and returned a display string
+from compaction. These are wire compatibility issues even when the underlying behavior exists.
+
+### Missing commands
+
+Pi additionally supports model/thinking cycling, queue delivery modes, auto-compaction/retry
+controls, direct bash cancellation, HTML export, cloning, fork-message discovery, entry cursors,
+last-assistant lookup, and session naming.
+
+### Input and extension UI
+
+Pi accepts image blocks and implements an extension dialog request/response subprotocol. Tau's
+provider-neutral messages support images, but `CodingSession.prompt()` currently accepts text and
+Tau's extension bridge is callback-oriented. Both require dedicated session seams before they can
+be made protocol-compatible.
+
+### Session identity
+
+Pi exposes session file paths; Tau primarily exposes indexed IDs. Tau should accept either an ID
+or an indexed Tau session path at the RPC boundary while keeping `SessionManager` authoritative.
+The two runtimes' persisted files remain intentionally different.
+
+## Delivery phases
+
+### Phase A — frontend-critical parity (this change)
+
+- Normalize state and model responses to Pi field names.
+- Add model/thinking cycling.
+- Add direct bash, HTML export, entry cursors, tree projection, fork-message discovery,
+  last-assistant lookup, and session naming.
+- Add auto-compaction control through a public `CodingSession` method.
+- Keep session restoration behind `SessionManager` while accepting Pi's `sessionPath` field.
+- Add fixture-style response tests and update the published compatibility matrix.
+
+This phase enables one Electron adapter for text chat, streaming tools, cancellation, model and
+thinking selection, direct commands, transcript restoration, and session browsing.
+
+### Phase B — execution controls
+
+- Add a cancellable direct-bash task owned by `CodingSession`; emit Pi-compatible
+  `bash_execution_update` records and implement `abort_bash`.
+- Add runtime auto-retry enable/disable and retry-delay cancellation seams.
+- Add queue delivery modes (`all` and `one-at-a-time`) to the portable harness rather than faking
+  them in the RPC frontend.
+- Return structured compaction data (summary, replaced boundary, token estimates, usage) from a
+  session API while preserving current TUI messages.
+
+### Phase C — multimodal and extension UI
+
+- Extend session prompt/queue APIs with provider-neutral image content.
+- Implement an RPC extension UI bridge for select, confirm, input, editor, notifications, status,
+  widgets, titles, and editor text.
+- Correlate dialog responses and handle cancellation/timeouts without blocking stdin dispatch.
+
+### Phase D — conformance and client validation
+
+- Vendor protocol fixtures derived from Pi's public documentation (not Pi runtime code).
+- Run the same subprocess scenarios against both installed binaries in an optional integration
+  job.
+- Add a small TypeScript smoke fixture using Pi's RPC client against Tau; pin the tested Pi
+  protocol version in documentation.
+- Classify future Pi protocol additions as supported, intentionally different, or pending before
+  claiming a newer compatibility level.
+
+## Electron integration guidance
+
+Use subprocess RPC for both runtimes, even though Pi can also be imported directly in Node. Keep
+process launch in the Electron main process and expose a narrow IPC API to the renderer. Store
+runtime-specific launch configuration separately from the shared session state. The renderer
+should key running state off `agent_settled`, not `agent_end`.
+
+A production host should still maintain a capability table for optional Phase B/C behavior.
+Choosing `agent_runtime` alone is sufficient for the Phase A common surface; optional controls
+should be hidden or disabled when the selected runtime does not advertise/support them.

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -44,6 +44,7 @@ class ModelChangeEntry(BaseSessionEntry):
 
     type: Literal["model_change"] = "model_change"
     model: str
+    provider: str | None = None
 
 
 class ThinkingLevelChangeEntry(BaseSessionEntry):

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -59,6 +59,8 @@ class CompactionEntry(BaseSessionEntry):
     type: Literal["compaction"] = "compaction"
     summary: str
     replaces_entry_ids: list[str] = Field(default_factory=list)
+    first_kept_entry_id: str | None = None
+    tokens_before: int | None = None
 
 
 class BranchSummaryEntry(BaseSessionEntry):

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -699,7 +699,11 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
             }
         return {**base, "message": _jsonable(entry.message)}
     if entry.type == "model_change":
-        return {**base, "provider": provider_name, "modelId": entry.model}
+        return {
+            **base,
+            "provider": entry.provider or provider_name,
+            "modelId": entry.model,
+        }
     if entry.type == "thinking_level_change":
         return {**base, "thinkingLevel": entry.thinking_level or "off"}
     if entry.type == "compaction":

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -6,15 +6,22 @@ import json
 import sys
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import asdict, is_dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import IO, Literal, Protocol, cast
 
 import anyio
 from pydantic import BaseModel
 
+from tau_agent.messages import AssistantMessage, UserMessage
+from tau_agent.session import JsonlSessionStorage
+from tau_agent.session.entries import SessionEntry
 from tau_agent.types import JSONValue
 from tau_coding.commands import CommandRegistry
 from tau_coding.events import CodingSessionEvent
-from tau_coding.session import CodingSession, ModelChoice
+from tau_coding.session import CodingSession, ModelChoice, TerminalCommandResult
+from tau_coding.session_manager import SessionManager
+from tau_coding.session_stats import SessionStats
 
 _MAX_RECORD_BYTES = 16 * 1024 * 1024
 
@@ -35,7 +42,7 @@ class RpcSession(Protocol):
     def available_thinking_levels(self) -> tuple[str, ...]: ...
 
     @property
-    def available_model_choices(self) -> tuple[object, ...]: ...
+    def available_model_choices(self) -> tuple[ModelChoice, ...]: ...
 
     @property
     def messages(self) -> tuple[object, ...]: ...
@@ -44,10 +51,31 @@ class RpcSession(Protocol):
     def session_id(self) -> str | None: ...
 
     @property
+    def session_title(self) -> str | None: ...
+
+    @property
+    def session_manager(self) -> SessionManager | None: ...
+
+    @property
+    def storage(self) -> object: ...
+
+    @property
     def auto_compact_token_threshold(self) -> int | None: ...
 
     @property
-    def session_stats(self) -> object: ...
+    def auto_compaction_enabled(self) -> bool: ...
+
+    @property
+    def context_window_tokens(self) -> int: ...
+
+    @property
+    def context_token_estimate(self) -> int: ...
+
+    @property
+    def queued_message_count(self) -> int: ...
+
+    @property
+    def session_stats(self) -> SessionStats: ...
 
     @property
     def command_registry(self) -> CommandRegistry: ...
@@ -66,7 +94,11 @@ class RpcSession(Protocol):
 
     def set_model_choice(self, choice: ModelChoice) -> None: ...
 
+    async def cycle_thinking_level(self) -> str: ...
+
     async def set_thinking_level(self, level: str) -> str: ...
+
+    def set_auto_compaction_enabled(self, enabled: bool) -> None: ...
 
     async def compact(self, instructions: str | None = None) -> str: ...
 
@@ -74,9 +106,21 @@ class RpcSession(Protocol):
 
     async def resume(self, session_id: str) -> str: ...
 
+    async def session_entries(self) -> tuple[SessionEntry, ...]: ...
+
     async def tree_choices(self) -> tuple[object, ...]: ...
 
     async def branch_to_entry(self, entry_id: str) -> object: ...
+
+    async def export(
+        self, destination: Path | None = None, *, format: str | None = None
+    ) -> Path: ...
+
+    async def run_terminal_command(
+        self, command: str, *, add_to_context: bool
+    ) -> TerminalCommandResult: ...
+
+    def set_session_name(self, name: str) -> None: ...
 
     async def emit_pending_session_start(self) -> None: ...
 
@@ -171,15 +215,18 @@ class RpcServer:
                     request_id,
                     command_type,
                     {
-                        "model": self._session.model,
-                        "provider": self._session.provider_name,
+                        "model": _model_wire(self._session),
                         "thinkingLevel": self._session.thinking_level,
                         "isStreaming": self._active_prompt_tasks > 0,
-                        "sessionId": self._session.session_id,
-                        "autoCompactionEnabled": (
-                            self._session.auto_compact_token_threshold is not None
-                        ),
+                        "isCompacting": False,
+                        "steeringMode": "one-at-a-time",
+                        "followUpMode": "one-at-a-time",
+                        "sessionFile": _session_file(self._session),
+                        "sessionId": self._session.session_id or "",
+                        "sessionName": self._session.session_title,
+                        "autoCompactionEnabled": self._session.auto_compaction_enabled,
                         "messageCount": len(self._session.messages),
+                        "pendingMessageCount": self._session.queued_message_count,
                     },
                 )
                 return
@@ -192,7 +239,12 @@ class RpcServer:
                 await self._response(
                     request_id,
                     command_type,
-                    {"models": list(self._session.available_model_choices)},
+                    {
+                        "models": [
+                            _model_wire(self._session, choice=choice)
+                            for choice in self._session.available_model_choices
+                        ]
+                    },
                 )
                 return
             if command_type == "set_model":
@@ -205,11 +257,40 @@ class RpcServer:
                         model=_required_string(command, "modelId"),
                     )
                 )
+                await self._response(request_id, command_type, _model_wire(self._session))
+                return
+            if command_type == "cycle_model":
+                choices = self._session.available_model_choices
+                if len(choices) <= 1:
+                    await self._response(request_id, command_type, None, include_data=True)
+                    return
+                current = ModelChoice(
+                    provider_name=self._session.provider_name,
+                    model=self._session.model,
+                )
+                try:
+                    index = choices.index(current)
+                except ValueError:
+                    index = -1
+                choice = choices[(index + 1) % len(choices)]
+                self._session.set_model_choice(choice)
                 await self._response(
                     request_id,
                     command_type,
-                    {"provider": self._session.provider_name, "id": self._session.model},
+                    {
+                        "model": _model_wire(self._session),
+                        "thinkingLevel": self._session.thinking_level,
+                        "isScoped": False,
+                    },
                 )
+                return
+            if command_type == "cycle_thinking_level":
+                levels = self._session.available_thinking_levels
+                if len(levels) <= 1:
+                    await self._response(request_id, command_type, None, include_data=True)
+                    return
+                level = await self._session.cycle_thinking_level()
+                await self._response(request_id, command_type, {"level": level})
                 return
             if command_type == "get_available_thinking_levels":
                 await self._response(
@@ -224,36 +305,148 @@ class RpcServer:
                 return
             if command_type == "compact":
                 instructions = _optional_string(command, "customInstructions")
-                result = await self._session.compact(instructions)
-                await self._response(request_id, command_type, {"summary": result})
-                return
-            if command_type == "new_session":
-                message = await self._session.new_session()
-                await self._response(request_id, command_type, {"message": message})
-                return
-            if command_type == "switch_session":
-                session_id = command.get("sessionId", command.get("sessionPath"))
-                if not isinstance(session_id, str):
-                    raise ValueError("switch_session requires sessionId")
-                message = await self._session.resume(session_id)
-                await self._response(request_id, command_type, {"message": message})
-                return
-            if command_type == "get_session_stats":
-                await self._response(request_id, command_type, self._session.session_stats)
-                return
-            if command_type == "get_tree":
-                choices = await self._session.tree_choices()
+                tokens_before = self._session.context_token_estimate
+                message = await self._session.compact(instructions)
                 await self._response(
                     request_id,
                     command_type,
-                    {"entries": list(choices), "leafId": _leaf_id(self._session.state)},
+                    {
+                        "summary": message,
+                        "firstKeptEntryId": _leaf_id(self._session.state),
+                        "tokensBefore": tokens_before,
+                        "estimatedTokensAfter": self._session.context_token_estimate,
+                        "details": {},
+                    },
                 )
                 return
-            if command_type == "fork":
-                fork_result = await self._session.branch_to_entry(
-                    _required_string(command, "entryId")
+            if command_type == "set_auto_compaction":
+                self._session.set_auto_compaction_enabled(_required_bool(command, "enabled"))
+                await self._response(request_id, command_type)
+                return
+            if command_type == "bash":
+                result = await self._session.run_terminal_command(
+                    _required_string(command, "command"),
+                    add_to_context=not bool(command.get("excludeFromContext", False)),
                 )
-                await self._response(request_id, command_type, fork_result)
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "output": result.output,
+                        "exitCode": result.exit_code,
+                        "cancelled": False,
+                        "truncated": False,
+                    },
+                )
+                return
+            if command_type == "abort_bash":
+                raise ValueError("abort_bash is not supported by Tau yet")
+            if command_type == "new_session":
+                await self._session.new_session()
+                await self._response(request_id, command_type, {"cancelled": False})
+                return
+            if command_type == "switch_session":
+                session_ref = command.get("sessionId", command.get("sessionPath"))
+                if not isinstance(session_ref, str):
+                    raise ValueError("switch_session requires sessionPath")
+                session_id = _resolve_session_id(self._session, session_ref)
+                await self._session.resume(session_id)
+                await self._response(request_id, command_type, {"cancelled": False})
+                return
+            if command_type == "get_session_stats":
+                await self._response(
+                    request_id,
+                    command_type,
+                    _session_stats_wire(self._session),
+                )
+                return
+            if command_type == "export_html":
+                output_path = _optional_string(command, "outputPath")
+                path = await self._session.export(
+                    Path(output_path).expanduser() if output_path is not None else None,
+                    format="html",
+                )
+                await self._response(request_id, command_type, {"path": str(path)})
+                return
+            if command_type == "get_fork_messages":
+                entries = await self._session.session_entries()
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "messages": [
+                            {"entryId": entry.id, "text": entry.message.text}
+                            for entry in entries
+                            if entry.type == "message" and isinstance(entry.message, UserMessage)
+                        ]
+                    },
+                )
+                return
+            if command_type == "get_entries":
+                cursor_entries = list(await self._session.session_entries())
+                since = _optional_string(command, "since")
+                if since is not None:
+                    try:
+                        index = next(
+                            i for i, entry in enumerate(cursor_entries) if entry.id == since
+                        )
+                    except StopIteration as exc:
+                        raise ValueError(f"Entry not found: {since}") from exc
+                    cursor_entries = cursor_entries[index + 1 :]
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "entries": [_entry_wire(entry) for entry in cursor_entries],
+                        "leafId": _leaf_id(self._session.state),
+                    },
+                )
+                return
+            if command_type == "get_tree":
+                entries = await self._session.session_entries()
+                await self._response(
+                    request_id,
+                    command_type,
+                    {
+                        "tree": _tree_wire(entries),
+                        "leafId": _leaf_id(self._session.state),
+                    },
+                )
+                return
+            if command_type == "get_last_assistant_text":
+                text = next(
+                    (
+                        message.text
+                        for message in reversed(self._session.messages)
+                        if isinstance(message, AssistantMessage)
+                    ),
+                    None,
+                )
+                await self._response(request_id, command_type, {"text": text})
+                return
+            if command_type == "set_session_name":
+                self._session.set_session_name(_required_string(command, "name"))
+                await self._response(request_id, command_type)
+                return
+            if command_type == "fork":
+                entry_id = _required_string(command, "entryId")
+                entries = await self._session.session_entries()
+                selected_text = next(
+                    (
+                        entry.message.text
+                        for entry in entries
+                        if entry.id == entry_id
+                        and entry.type == "message"
+                        and isinstance(entry.message, UserMessage)
+                    ),
+                    "",
+                )
+                await self._session.branch_to_entry(entry_id)
+                await self._response(
+                    request_id,
+                    command_type,
+                    {"text": selected_text, "cancelled": False},
+                )
                 return
             if command_type == "get_commands":
                 commands = self._session.command_registry.list_commands()
@@ -262,7 +455,17 @@ class RpcServer:
                     command_type,
                     {
                         "commands": [
-                            {"name": item.name, "description": item.description}
+                            {
+                                "name": item.name,
+                                "description": item.description,
+                                "source": "extension",
+                                "sourceInfo": {
+                                    "path": "tau://command/" + item.name,
+                                    "source": "tau",
+                                    "scope": "temporary",
+                                    "origin": "top-level",
+                                },
+                            }
                             for item in commands
                         ]
                     },
@@ -291,6 +494,8 @@ class RpcServer:
         request_id: object,
         command: str,
         data: object | None = None,
+        *,
+        include_data: bool = False,
     ) -> None:
         response: dict[str, object] = {
             "type": "response",
@@ -299,7 +504,7 @@ class RpcServer:
         }
         if request_id is not None:
             response["id"] = request_id
-        if data is not None:
+        if data is not None or include_data:
             response["data"] = data
         await self._write(response)
 
@@ -328,6 +533,13 @@ def _required_string(command: Mapping[str, object], key: str) -> str:
     return value
 
 
+def _required_bool(command: Mapping[str, object], key: str) -> bool:
+    value = command.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
 def _optional_string(command: Mapping[str, object], key: str) -> str | None:
     value = command.get(key)
     if value is None:
@@ -339,6 +551,118 @@ def _optional_string(command: Mapping[str, object], key: str) -> str | None:
 
 def _leaf_id(state: object) -> object:
     return getattr(state, "active_leaf_id", None)
+
+
+def _model_wire(session: RpcSession, *, choice: ModelChoice | None = None) -> dict[str, JSONValue]:
+    selected = choice or ModelChoice(provider_name=session.provider_name, model=session.model)
+    reasoning = (
+        bool(session.available_thinking_levels)
+        if selected.provider_name == session.provider_name and selected.model == session.model
+        else False
+    )
+    return {
+        "id": selected.model,
+        "name": selected.model,
+        "api": "anthropic-messages"
+        if selected.provider_name == "anthropic"
+        else "openai-completions",
+        "provider": selected.provider_name,
+        "baseUrl": "",
+        "reasoning": reasoning,
+        "input": ["text"],
+        "contextWindow": session.context_window_tokens,
+        "maxTokens": 16_384,
+        "cost": {
+            "input": 0.0,
+            "output": 0.0,
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+        },
+    }
+
+
+def _session_file(session: RpcSession) -> str | None:
+    storage = session.storage
+    return str(storage.path) if isinstance(storage, JsonlSessionStorage) else None
+
+
+def _session_stats_wire(session: RpcSession) -> dict[str, JSONValue]:
+    stats = session.session_stats
+    user_messages = sum(isinstance(message, UserMessage) for message in session.messages)
+    assistant_messages = sum(isinstance(message, AssistantMessage) for message in session.messages)
+    return {
+        "sessionFile": _session_file(session),
+        "sessionId": session.session_id or "",
+        "userMessages": user_messages,
+        "assistantMessages": assistant_messages,
+        "toolCalls": stats.tool_call_count,
+        "toolResults": stats.tool_call_count,
+        "totalMessages": len(session.messages),
+        "tokens": {
+            "input": stats.input_tokens,
+            "output": stats.output_tokens,
+            "cacheRead": stats.cached_input_tokens,
+            "cacheWrite": stats.cache_write_tokens,
+            "total": stats.input_tokens + stats.output_tokens,
+        },
+        "cost": stats.estimated_cost or 0.0,
+        "contextUsage": {
+            "tokens": session.context_token_estimate,
+            "contextWindow": session.context_window_tokens,
+            "percent": round(
+                session.context_token_estimate / session.context_window_tokens * 100,
+                2,
+            ),
+        },
+    }
+
+
+def _entry_wire(entry: SessionEntry) -> dict[str, JSONValue]:
+    data = cast(dict[str, JSONValue], entry.model_dump(mode="json"))
+    data["parentId"] = data.pop("parent_id", None)
+    timestamp = datetime.fromtimestamp(entry.timestamp, tz=UTC)
+    data["timestamp"] = timestamp.isoformat().replace("+00:00", "Z")
+    if "thinking_level" in data:
+        data["thinkingLevel"] = data.pop("thinking_level")
+    if "replaces_entry_ids" in data:
+        data["replacesEntryIds"] = data.pop("replaces_entry_ids")
+    if "branch_root_id" in data:
+        data["branchRootId"] = data.pop("branch_root_id")
+    if "entry_id" in data:
+        data["entryId"] = data.pop("entry_id")
+    if "created_at" in data:
+        data["createdAt"] = data.pop("created_at")
+    return data
+
+
+def _tree_wire(entries: tuple[SessionEntry, ...]) -> list[JSONValue]:
+    children: dict[str | None, list[SessionEntry]] = {}
+    ids = {entry.id for entry in entries}
+    for entry in entries:
+        parent = entry.parent_id if entry.parent_id in ids else None
+        children.setdefault(parent, []).append(entry)
+
+    def build(entry: SessionEntry) -> dict[str, JSONValue]:
+        return {
+            "entry": _entry_wire(entry),
+            "children": [build(child) for child in children.get(entry.id, [])],
+        }
+
+    return [build(entry) for entry in children.get(None, [])]
+
+
+def _resolve_session_id(session: RpcSession, reference: str) -> str:
+    manager = session.session_manager
+    if manager is None:
+        raise ValueError("Session manager is not available")
+    direct = manager.get_session(reference)
+    if direct is not None:
+        return direct.id
+    candidate = Path(reference).expanduser().resolve(strict=False)
+    for record in manager.list_sessions():
+        if record.path.resolve(strict=False) == candidate:
+            return record.id
+    raise ValueError(f"Unknown session: {reference}")
 
 
 def _jsonable(value: object) -> JSONValue:

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -13,13 +13,24 @@ from typing import IO, Literal, Protocol, cast
 import anyio
 from pydantic import BaseModel
 
-from tau_agent.messages import AssistantMessage, UserMessage
+from tau_agent.messages import AssistantMessage, CustomMessage, UserMessage
 from tau_agent.session import JsonlSessionStorage
 from tau_agent.session.entries import SessionEntry
 from tau_agent.types import JSONValue
 from tau_coding.commands import CommandRegistry
 from tau_coding.events import CodingSessionEvent
-from tau_coding.session import CodingSession, ModelChoice, TerminalCommandResult
+from tau_coding.provider_config import (
+    AnthropicProviderConfig,
+    OpenAICompatibleProviderConfig,
+    ProviderConfig,
+    provider_thinking_levels,
+)
+from tau_coding.session import (
+    CodingSession,
+    ManualCompactionResult,
+    ModelChoice,
+    TerminalCommandResult,
+)
 from tau_coding.session_manager import SessionManager
 from tau_coding.session_stats import SessionStats
 
@@ -43,6 +54,8 @@ class RpcSession(Protocol):
 
     @property
     def available_model_choices(self) -> tuple[ModelChoice, ...]: ...
+
+    def provider_config(self, provider_name: str) -> ProviderConfig | None: ...
 
     @property
     def messages(self) -> tuple[object, ...]: ...
@@ -100,7 +113,7 @@ class RpcSession(Protocol):
 
     def set_auto_compaction_enabled(self, enabled: bool) -> None: ...
 
-    async def compact(self, instructions: str | None = None) -> str: ...
+    async def compact_detailed(self, instructions: str | None = None) -> ManualCompactionResult: ...
 
     async def new_session(self) -> str: ...
 
@@ -300,21 +313,20 @@ class RpcServer:
                 )
                 return
             if command_type == "set_thinking_level":
-                level = await self._session.set_thinking_level(_required_string(command, "level"))
-                await self._response(request_id, command_type, {"level": level})
+                await self._session.set_thinking_level(_required_string(command, "level"))
+                await self._response(request_id, command_type)
                 return
             if command_type == "compact":
                 instructions = _optional_string(command, "customInstructions")
-                tokens_before = self._session.context_token_estimate
-                message = await self._session.compact(instructions)
+                result = await self._session.compact_detailed(instructions)
                 await self._response(
                     request_id,
                     command_type,
                     {
-                        "summary": message,
-                        "firstKeptEntryId": _leaf_id(self._session.state),
-                        "tokensBefore": tokens_before,
-                        "estimatedTokensAfter": self._session.context_token_estimate,
+                        "summary": result.summary,
+                        "firstKeptEntryId": result.first_kept_entry_id,
+                        "tokensBefore": result.tokens_before,
+                        "estimatedTokensAfter": result.estimated_tokens_after,
                         "details": {},
                     },
                 )
@@ -324,7 +336,7 @@ class RpcServer:
                 await self._response(request_id, command_type)
                 return
             if command_type == "bash":
-                result = await self._session.run_terminal_command(
+                bash_result = await self._session.run_terminal_command(
                     _required_string(command, "command"),
                     add_to_context=not bool(command.get("excludeFromContext", False)),
                 )
@@ -332,8 +344,8 @@ class RpcServer:
                     request_id,
                     command_type,
                     {
-                        "output": result.output,
-                        "exitCode": result.exit_code,
+                        "output": bash_result.output,
+                        "exitCode": bash_result.exit_code,
                         "cancelled": False,
                         "truncated": False,
                     },
@@ -397,7 +409,12 @@ class RpcServer:
                     request_id,
                     command_type,
                     {
-                        "entries": [_entry_wire(entry) for entry in cursor_entries],
+                        "entries": [
+                            projected
+                            for entry in cursor_entries
+                            if (projected := _entry_wire(entry, self._session.provider_name))
+                            is not None
+                        ],
                         "leafId": _leaf_id(self._session.state),
                     },
                 )
@@ -408,7 +425,7 @@ class RpcServer:
                     request_id,
                     command_type,
                     {
-                        "tree": _tree_wire(entries),
+                        "tree": _tree_wire(entries, self._session.provider_name),
                         "leafId": _leaf_id(self._session.state),
                     },
                 )
@@ -555,28 +572,62 @@ def _leaf_id(state: object) -> object:
 
 def _model_wire(session: RpcSession, *, choice: ModelChoice | None = None) -> dict[str, JSONValue]:
     selected = choice or ModelChoice(provider_name=session.provider_name, model=session.model)
-    reasoning = (
-        bool(session.available_thinking_levels)
-        if selected.provider_name == session.provider_name and selected.model == session.model
-        else False
+    provider = session.provider_config(selected.provider_name)
+    metadata = provider.model_metadata.get(selected.model) if provider is not None else None
+    configured_api = (
+        provider.api
+        if isinstance(provider, OpenAICompatibleProviderConfig | AnthropicProviderConfig)
+        else None
     )
+    api = (
+        metadata.api
+        if metadata is not None and metadata.api is not None
+        else configured_api
+        if isinstance(configured_api, str)
+        else "openai-responses"
+        if selected.provider_name == "openai-codex"
+        else "openai-completions"
+    )
+    reasoning = (
+        metadata.reasoning
+        if metadata is not None and metadata.reasoning is not None
+        else bool(provider_thinking_levels(provider, model=selected.model))
+        if provider is not None
+        else bool(session.available_thinking_levels)
+    )
+    context_window = (
+        metadata.context_window
+        if metadata is not None and metadata.context_window is not None
+        else provider.context_windows.get(selected.model)
+        if provider is not None
+        else None
+    )
+    cost = metadata.cost if metadata is not None else {}
     return {
         "id": selected.model,
-        "name": selected.model,
-        "api": "anthropic-messages"
-        if selected.provider_name == "anthropic"
-        else "openai-completions",
+        "name": metadata.name if metadata is not None and metadata.name else selected.model,
+        "api": api,
         "provider": selected.provider_name,
-        "baseUrl": "",
+        "baseUrl": (
+            metadata.base_url
+            if metadata is not None and metadata.base_url is not None
+            else provider.base_url
+            if provider is not None
+            else ""
+        ),
         "reasoning": reasoning,
-        "input": ["text"],
-        "contextWindow": session.context_window_tokens,
-        "maxTokens": 16_384,
+        "input": list(metadata.input) if metadata is not None and metadata.input else ["text"],
+        "contextWindow": context_window or session.context_window_tokens,
+        "maxTokens": (
+            metadata.max_tokens
+            if metadata is not None and metadata.max_tokens is not None
+            else 16_384
+        ),
         "cost": {
-            "input": 0.0,
-            "output": 0.0,
-            "cacheRead": 0.0,
-            "cacheWrite": 0.0,
+            "input": cost.get("input", 0.0),
+            "output": cost.get("output", 0.0),
+            "cacheRead": cost.get("cacheRead", 0.0),
+            "cacheWrite": cost.get("cacheWrite", 0.0),
         },
     }
 
@@ -590,6 +641,10 @@ def _session_stats_wire(session: RpcSession) -> dict[str, JSONValue]:
     stats = session.session_stats
     user_messages = sum(isinstance(message, UserMessage) for message in session.messages)
     assistant_messages = sum(isinstance(message, AssistantMessage) for message in session.messages)
+    uncached_input = max(
+        0,
+        stats.input_tokens - stats.cached_input_tokens - stats.cache_write_tokens,
+    )
     return {
         "sessionFile": _session_file(session),
         "sessionId": session.session_id or "",
@@ -599,13 +654,18 @@ def _session_stats_wire(session: RpcSession) -> dict[str, JSONValue]:
         "toolResults": stats.tool_call_count,
         "totalMessages": len(session.messages),
         "tokens": {
-            "input": stats.input_tokens,
+            "input": uncached_input,
             "output": stats.output_tokens,
             "cacheRead": stats.cached_input_tokens,
             "cacheWrite": stats.cache_write_tokens,
-            "total": stats.input_tokens + stats.output_tokens,
+            "total": (
+                uncached_input
+                + stats.output_tokens
+                + stats.cached_input_tokens
+                + stats.cache_write_tokens
+            ),
         },
-        "cost": stats.estimated_cost or 0.0,
+        "cost": stats.estimated_cost,
         "contextUsage": {
             "tokens": session.context_token_estimate,
             "contextWindow": session.context_window_tokens,
@@ -617,34 +677,69 @@ def _session_stats_wire(session: RpcSession) -> dict[str, JSONValue]:
     }
 
 
-def _entry_wire(entry: SessionEntry) -> dict[str, JSONValue]:
-    data = cast(dict[str, JSONValue], entry.model_dump(mode="json"))
-    data["parentId"] = data.pop("parent_id", None)
+def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue] | None:
+    if entry.type == "leaf":
+        return None
     timestamp = datetime.fromtimestamp(entry.timestamp, tz=UTC)
-    data["timestamp"] = timestamp.isoformat().replace("+00:00", "Z")
-    if "thinking_level" in data:
-        data["thinkingLevel"] = data.pop("thinking_level")
-    if "replaces_entry_ids" in data:
-        data["replacesEntryIds"] = data.pop("replaces_entry_ids")
-    if "branch_root_id" in data:
-        data["branchRootId"] = data.pop("branch_root_id")
-    if "entry_id" in data:
-        data["entryId"] = data.pop("entry_id")
-    if "created_at" in data:
-        data["createdAt"] = data.pop("created_at")
-    return data
+    base: dict[str, JSONValue] = {
+        "type": entry.type,
+        "id": entry.id,
+        "parentId": entry.parent_id,
+        "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+    }
+    if entry.type == "message":
+        if isinstance(entry.message, CustomMessage):
+            return {
+                **base,
+                "type": "custom_message",
+                "customType": entry.message.custom_type,
+                "content": _jsonable(entry.message.content),
+                "details": entry.message.details,
+                "display": entry.message.display,
+            }
+        return {**base, "message": _jsonable(entry.message)}
+    if entry.type == "model_change":
+        return {**base, "provider": provider_name, "modelId": entry.model}
+    if entry.type == "thinking_level_change":
+        return {**base, "thinkingLevel": entry.thinking_level or "off"}
+    if entry.type == "compaction":
+        return {
+            **base,
+            "summary": entry.summary,
+            "firstKeptEntryId": entry.id,
+            "tokensBefore": 0,
+            "details": {"tauReplacedEntryIds": list(entry.replaces_entry_ids)},
+        }
+    if entry.type == "branch_summary":
+        return {
+            **base,
+            "fromId": entry.branch_root_id or entry.parent_id or entry.id,
+            "summary": entry.summary,
+            "details": {},
+        }
+    if entry.type == "custom":
+        return {**base, "customType": entry.namespace, "data": entry.data}
+    if entry.type == "label":
+        return {**base, "targetId": entry.parent_id or entry.id, "label": entry.label}
+    if entry.type == "session_info":
+        return {**base, "name": entry.title}
+    raise AssertionError(f"Unhandled Tau session entry: {entry.type}")
 
 
-def _tree_wire(entries: tuple[SessionEntry, ...]) -> list[JSONValue]:
+def _tree_wire(entries: tuple[SessionEntry, ...], provider_name: str) -> list[JSONValue]:
+    visible = tuple(entry for entry in entries if entry.type != "leaf")
     children: dict[str | None, list[SessionEntry]] = {}
-    ids = {entry.id for entry in entries}
-    for entry in entries:
+    ids = {entry.id for entry in visible}
+    for entry in visible:
         parent = entry.parent_id if entry.parent_id in ids else None
         children.setdefault(parent, []).append(entry)
 
     def build(entry: SessionEntry) -> dict[str, JSONValue]:
+        projected = _entry_wire(entry, provider_name)
+        if projected is None:
+            raise AssertionError("Leaf entries must be filtered before tree projection")
         return {
-            "entry": _entry_wire(entry),
+            "entry": projected,
             "children": [build(child) for child in children.get(entry.id, [])],
         }
 

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -665,7 +665,7 @@ def _session_stats_wire(session: RpcSession) -> dict[str, JSONValue]:
                 + stats.cache_write_tokens
             ),
         },
-        "cost": stats.estimated_cost,
+        "cost": stats.estimated_cost if stats.estimated_cost is not None else 0.0,
         "contextUsage": {
             "tokens": session.context_token_estimate,
             "contextWindow": session.context_window_tokens,
@@ -703,11 +703,21 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
     if entry.type == "thinking_level_change":
         return {**base, "thinkingLevel": entry.thinking_level or "off"}
     if entry.type == "compaction":
+        if entry.first_kept_entry_id is None or entry.tokens_before is None:
+            return {
+                **base,
+                "type": "custom",
+                "customType": "tau.compaction",
+                "data": {
+                    "summary": entry.summary,
+                    "replacesEntryIds": list(entry.replaces_entry_ids),
+                },
+            }
         return {
             **base,
             "summary": entry.summary,
-            "firstKeptEntryId": entry.id,
-            "tokensBefore": 0,
+            "firstKeptEntryId": entry.first_kept_entry_id,
+            "tokensBefore": entry.tokens_before,
             "details": {"tauReplacedEntryIds": list(entry.replaces_entry_ids)},
         }
     if entry.type == "branch_summary":

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1877,9 +1877,35 @@ class CodingSession:
         self._extension_runtime.attach_harness_listener(self._harness.subscribe)
 
     async def compact_detailed(self, instructions: str | None = None) -> ManualCompactionResult:
-        """Generate a manual compaction and return its canonical result."""
+        """Compact older context while preserving a real recent-entry boundary."""
         await self._flush_pending_message_writes(context=self._diagnostic_context())
+        rows = self._active_context_rows()
+        plan = self._recent_preserving_compaction_plan()
+        if plan is None:
+            raise ValueError("Not enough context to compact while preserving recent entries")
+        first_kept_entry_id = rows[len(plan.replace_entry_ids)][0]
         tokens_before = self.context_token_estimate
+        summary = await self._generate_compaction_summary(
+            plan.messages_to_summarize,
+            custom_instructions=instructions,
+        )
+        compaction = await self._append_compaction(
+            summary,
+            replace_entry_ids=plan.replace_entry_ids,
+            first_kept_entry_id=first_kept_entry_id,
+            tokens_before=tokens_before,
+        )
+        return ManualCompactionResult(
+            summary=summary,
+            first_kept_entry_id=first_kept_entry_id,
+            tokens_before=tokens_before,
+            estimated_tokens_after=self.context_token_estimate,
+            replaced_entry_count=len(compaction.replaces_entry_ids),
+        )
+
+    async def compact(self, instructions: str | None = None) -> str:
+        """Generate a manual compaction summary and rebuild active context."""
+        await self._flush_pending_message_writes(context=self._diagnostic_context())
         plan = self._manual_compaction_plan()
         summary = await self._generate_compaction_summary(
             plan.messages_to_summarize,
@@ -1888,19 +1914,9 @@ class CodingSession:
         compaction = await self._append_compaction(
             summary,
             replace_entry_ids=plan.replace_entry_ids,
+            tokens_before=self.context_token_estimate,
         )
-        return ManualCompactionResult(
-            summary=summary,
-            first_kept_entry_id=compaction.id,
-            tokens_before=tokens_before,
-            estimated_tokens_after=self.context_token_estimate,
-            replaced_entry_count=len(compaction.replaces_entry_ids),
-        )
-
-    async def compact(self, instructions: str | None = None) -> str:
-        """Generate a manual compaction summary and rebuild active context."""
-        result = await self.compact_detailed(instructions)
-        return f"Compacted {result.replaced_entry_count} context entries."
+        return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
 
     async def aclose(self) -> None:
         """Close runtime providers created by this coding session."""
@@ -2670,6 +2686,8 @@ class CodingSession:
         summary: str,
         *,
         replace_entry_ids: tuple[str, ...],
+        first_kept_entry_id: str | None = None,
+        tokens_before: int | None = None,
     ) -> CompactionEntry:
         if not replace_entry_ids:
             raise ValueError("No active context messages to compact")
@@ -2678,6 +2696,8 @@ class CodingSession:
             parent_id=self._last_parent_id,
             summary=summary,
             replaces_entry_ids=list(replace_entry_ids),
+            first_kept_entry_id=first_kept_entry_id,
+            tokens_before=tokens_before,
         )
         await self._append_session_entry(compaction)
         leaf = LeafEntry(parent_id=compaction.id, entry_id=compaction.id)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -614,6 +614,10 @@ class CodingSession:
         """Return the last replayed durable session state."""
         return self._state
 
+    async def session_entries(self) -> tuple[SessionEntry, ...]:
+        """Return append-only entries for frontend session inspection."""
+        return tuple(await self._read_session_entries())
+
     async def tree_choices(self) -> tuple[SessionTreeChoice, ...]:
         """Return branchable session entries for a tree picker."""
         entries = await self._read_session_entries()
@@ -811,6 +815,16 @@ class CodingSession:
                 return limits.effective_auto_compact_token_limit
         return auto_compaction_threshold_for_context_window(self.context_window_tokens)
 
+    def set_auto_compaction_enabled(self, enabled: bool) -> None:
+        """Enable or disable automatic compaction for future turns."""
+        self._auto_compact_enabled = enabled
+        self._config = replace(self._config, auto_compact_enabled=enabled)
+
+    @property
+    def auto_compaction_enabled(self) -> bool:
+        """Return whether automatic compaction is enabled."""
+        return self._auto_compact_enabled
+
     @property
     def context_window_tokens(self) -> int:
         """Return the active model's discovered or configured context window."""
@@ -995,6 +1009,11 @@ class CodingSession:
     def is_running(self) -> bool:
         """Return whether this session currently has an active agent run."""
         return self._harness.is_running
+
+    @property
+    def queued_message_count(self) -> int:
+        """Return the number of queued steering and follow-up messages."""
+        return self._harness.pending_message_count
 
     @property
     def queued_messages(self) -> QueuedMessages:
@@ -1699,6 +1718,18 @@ class CodingSession:
             replacement._sync_image_support()
         await self._adopt_replacement(replacement, reason="resume")
         return f"Resumed session: {record.id}"
+
+    def set_session_name(self, name: str) -> None:
+        """Set the indexed session's human-friendly name."""
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("Session name cannot be empty")
+        manager = self._config.session_manager
+        session_id = self._config.session_id
+        if manager is None or session_id is None:
+            raise ValueError("Session manager is not available")
+        if manager.touch_session(session_id, title=normalized) is None:
+            raise ValueError(f"Unknown session: {session_id}")
 
     async def new_session(self) -> str:
         """Replace this session's active state with a pending unindexed session."""

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -214,6 +214,17 @@ class CompactionPlan:
 
 
 @dataclass(frozen=True, slots=True)
+class ManualCompactionResult:
+    """Structured result from one manual compaction."""
+
+    summary: str
+    first_kept_entry_id: str
+    tokens_before: int
+    estimated_tokens_after: int
+    replaced_entry_count: int
+
+
+@dataclass(frozen=True, slots=True)
 class _PendingMessageWrite:
     """Stable entries retained while a message persistence attempt is retried."""
 
@@ -554,6 +565,15 @@ class CodingSession:
         if self._provider_settings is None:
             return (self._provider_name,)
         return tuple(provider.name for provider in self._usable_provider_configs())
+
+    def provider_config(self, provider_name: str) -> ProviderConfig | None:
+        """Return configured metadata for a provider available to this session."""
+        if self._provider_settings is None:
+            return self._runtime_provider_config if provider_name == self.provider_name else None
+        try:
+            return self._provider_settings.get_provider(provider_name)
+        except ProviderConfigError:
+            return None
 
     @property
     def available_models(self) -> tuple[str, ...]:
@@ -1856,9 +1876,10 @@ class CodingSession:
         self._extension_runtime.bind(self)
         self._extension_runtime.attach_harness_listener(self._harness.subscribe)
 
-    async def compact(self, instructions: str | None = None) -> str:
-        """Generate a manual compaction summary and rebuild active context."""
+    async def compact_detailed(self, instructions: str | None = None) -> ManualCompactionResult:
+        """Generate a manual compaction and return its canonical result."""
         await self._flush_pending_message_writes(context=self._diagnostic_context())
+        tokens_before = self.context_token_estimate
         plan = self._manual_compaction_plan()
         summary = await self._generate_compaction_summary(
             plan.messages_to_summarize,
@@ -1868,7 +1889,18 @@ class CodingSession:
             summary,
             replace_entry_ids=plan.replace_entry_ids,
         )
-        return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
+        return ManualCompactionResult(
+            summary=summary,
+            first_kept_entry_id=compaction.id,
+            tokens_before=tokens_before,
+            estimated_tokens_after=self.context_token_estimate,
+            replaced_entry_count=len(compaction.replaces_entry_ids),
+        )
+
+    async def compact(self, instructions: str | None = None) -> str:
+        """Generate a manual compaction summary and rebuild active context."""
+        result = await self.compact_detailed(instructions)
+        return f"Compacted {result.replaced_entry_count} context entries."
 
     async def aclose(self) -> None:
         """Close runtime providers created by this coding session."""

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -369,6 +369,7 @@ class CodingSession:
             model = ModelChangeEntry(
                 parent_id=info.id,
                 model=initial_model,
+                provider=config.provider_name,
             )
             thinking = ThinkingLevelChangeEntry(
                 parent_id=model.id,
@@ -1121,7 +1122,11 @@ class CodingSession:
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         self._sync_image_support()
-        entry = ModelChangeEntry(parent_id=self._last_parent_id, model=model)
+        entry = ModelChangeEntry(
+            parent_id=self._last_parent_id,
+            model=model,
+            provider=self.provider_name,
+        )
         await self._append_session_entry(entry)
         leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
         await self._append_session_entry(leaf)
@@ -2263,7 +2268,11 @@ class CodingSession:
             await self._append_session_entry(entry)
             parent_id = entry.id
         if active_model is not None:
-            model_entry = ModelChangeEntry(parent_id=parent_id, model=active_model)
+            model_entry = ModelChangeEntry(
+                parent_id=parent_id,
+                model=active_model,
+                provider=self.provider_name,
+            )
             await self._append_session_entry(model_entry)
             parent_id = model_entry.id
         thinking_entry = ThinkingLevelChangeEntry(

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -901,7 +901,11 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
     assert isinstance(entries[0], SessionInfoEntry)
     assert entries[0].cwd == str(tmp_path)
     assert entries[1] == ModelChangeEntry(
-        id=entries[1].id, parent_id=entries[0].id, model="fake", timestamp=entries[1].timestamp
+        id=entries[1].id,
+        parent_id=entries[0].id,
+        model="fake",
+        provider="openai",
+        timestamp=entries[1].timestamp,
     )
     assert entries[2] == ThinkingLevelChangeEntry(
         id=entries[2].id,

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -8,8 +8,8 @@ import pytest
 from typer.testing import CliRunner
 
 from pi_event_helpers import assistant_done, assistant_start, text_delta
-from tau_agent import AssistantMessage
-from tau_agent.session import JsonlSessionStorage
+from tau_agent import AssistantMessage, UserMessage
+from tau_agent.session import JsonlSessionStorage, MessageEntry
 from tau_ai import FakeProvider
 from tau_coding import CodingSession, CodingSessionConfig, ModelChoice
 from tau_coding import cli as cli_module
@@ -57,6 +57,107 @@ async def test_rpc_streams_correlated_response_and_events(tmp_path: Path) -> Non
 
 
 @pytest.mark.anyio
+async def test_rpc_state_matches_pi_frontend_contract(tmp_path: Path) -> None:
+    session = await _session(tmp_path, FakeProvider([]))
+    stdin = StringIO(
+        '{"id":"state","type":"get_state"}\n'
+        '{"id":"models","type":"get_available_models"}\n'
+        '{"id":"cycle","type":"cycle_model"}\n'
+    )
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    state, models, cycle = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert set(state["data"]) == {
+        "model",
+        "thinkingLevel",
+        "isStreaming",
+        "isCompacting",
+        "steeringMode",
+        "followUpMode",
+        "sessionFile",
+        "sessionId",
+        "sessionName",
+        "autoCompactionEnabled",
+        "messageCount",
+        "pendingMessageCount",
+    }
+    assert state["data"]["model"]["id"] == "fake"
+    assert models["data"]["models"][0]["provider"] == "openai"
+    assert cycle["data"] is None
+
+
+@pytest.mark.anyio
+async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    user = MessageEntry(message=UserMessage(content="question"))
+    assistant = MessageEntry(
+        parent_id=user.id,
+        message=AssistantMessage(content="answer", model="fake"),
+    )
+    await storage.append(user)
+    await storage.append(assistant)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
+    stdin = StringIO(
+        '{"id":"entries","type":"get_entries"}\n'
+        '{"id":"tree","type":"get_tree"}\n'
+        '{"id":"last","type":"get_last_assistant_text"}\n'
+        '{"id":"forks","type":"get_fork_messages"}\n'
+    )
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    entries, tree, last, forks = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert entries["data"]["entries"][1]["parentId"] == user.id
+    assert tree["data"]["tree"][0]["children"][0]["entry"]["id"] == assistant.id
+    assert last["data"] == {"text": "answer"}
+    assert forks["data"] == {"messages": [{"entryId": user.id, "text": "question"}]}
+
+
+@pytest.mark.anyio
+async def test_rpc_auto_compaction_control_updates_pi_state(tmp_path: Path) -> None:
+    session = await _session(tmp_path, FakeProvider([]))
+    stdin = StringIO(
+        '{"id":"set","type":"set_auto_compaction","enabled":false}\n'
+        '{"id":"state","type":"get_state"}\n'
+    )
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    changed, state = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert changed["success"] is True
+    assert state["data"]["autoCompactionEnabled"] is False
+
+
+@pytest.mark.anyio
+async def test_rpc_direct_bash_matches_pi_result_shape(tmp_path: Path) -> None:
+    session = await _session(tmp_path, FakeProvider([]))
+    stdin = StringIO('{"id":"bash","type":"bash","command":"printf ok"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    response = json.loads(stdout.getvalue())
+    assert response["data"] == {
+        "output": "ok",
+        "exitCode": 0,
+        "cancelled": False,
+        "truncated": False,
+    }
+
+
+@pytest.mark.anyio
 async def test_rpc_reports_bad_records_and_continues(tmp_path: Path) -> None:
     session = await _session(tmp_path, FakeProvider([]))
     stdin = StringIO('not-json\n{"id":2,"type":"get_state"}\n')
@@ -69,7 +170,8 @@ async def test_rpc_reports_bad_records_and_continues(tmp_path: Path) -> None:
     assert records[0]["command"] == "parse"
     assert records[1]["id"] == 2
     assert records[1]["success"] is True
-    assert records[1]["data"]["model"] == "fake"
+    assert records[1]["data"]["model"]["id"] == "fake"
+    assert records[1]["data"]["model"]["provider"] == "openai"
 
 
 @pytest.mark.anyio

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -8,11 +8,18 @@ import pytest
 from typer.testing import CliRunner
 
 from pi_event_helpers import assistant_done, assistant_start, text_delta
-from tau_agent import AssistantMessage, UserMessage
-from tau_agent.session import JsonlSessionStorage, MessageEntry
+from tau_agent import AssistantMessage, Usage, UserMessage
+from tau_agent.session import JsonlSessionStorage, LeafEntry, MessageEntry, ModelChangeEntry
 from tau_ai import FakeProvider
-from tau_coding import CodingSession, CodingSessionConfig, ModelChoice
+from tau_coding import (
+    CodingSession,
+    CodingSessionConfig,
+    ModelChoice,
+    OpenAICompatibleProviderConfig,
+    ProviderSettings,
+)
 from tau_coding import cli as cli_module
+from tau_coding.provider_config import ProviderModelMetadata
 from tau_coding.rpc import RpcServer
 
 
@@ -63,12 +70,13 @@ async def test_rpc_state_matches_pi_frontend_contract(tmp_path: Path) -> None:
         '{"id":"state","type":"get_state"}\n'
         '{"id":"models","type":"get_available_models"}\n'
         '{"id":"cycle","type":"cycle_model"}\n'
+        '{"id":"thinking","type":"set_thinking_level","level":"off"}\n'
     )
     stdout = StringIO()
 
     await RpcServer(session, stdin=stdin, stdout=stdout).run()
 
-    state, models, cycle = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    state, models, cycle, thinking = [json.loads(line) for line in stdout.getvalue().splitlines()]
     assert set(state["data"]) == {
         "model",
         "thinkingLevel",
@@ -86,6 +94,68 @@ async def test_rpc_state_matches_pi_frontend_contract(tmp_path: Path) -> None:
     assert state["data"]["model"]["id"] == "fake"
     assert models["data"]["models"][0]["provider"] == "openai"
     assert cycle["data"] is None
+    assert thinking == {
+        "type": "response",
+        "command": "set_thinking_level",
+        "success": True,
+        "id": "thinking",
+    }
+
+
+@pytest.mark.anyio
+async def test_rpc_model_shape_uses_catalog_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider_config = OpenAICompatibleProviderConfig(
+        name="local",
+        base_url="http://localhost:1234/v1",
+        models=("vision",),
+        default_model="vision",
+        model_metadata={
+            "vision": ProviderModelMetadata(
+                name="Vision Model",
+                api="openai-responses",
+                reasoning=True,
+                input=("text", "image"),
+                context_window=131_072,
+                max_tokens=32_768,
+                cost={"input": 1.0, "output": 2.0},
+            )
+        },
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="vision",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="local",
+            provider_settings=ProviderSettings(
+                default_provider="local", providers=(provider_config,)
+            ),
+            runtime_provider_config=provider_config,
+        )
+    )
+    stdin = StringIO('{"id":"state","type":"get_state"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    model = json.loads(stdout.getvalue())["data"]["model"]
+    assert model == {
+        "id": "vision",
+        "name": "Vision Model",
+        "api": "openai-responses",
+        "provider": "local",
+        "baseUrl": "http://localhost:1234/v1",
+        "reasoning": True,
+        "input": ["text", "image"],
+        "contextWindow": 131072,
+        "maxTokens": 32768,
+        "cost": {"input": 1.0, "output": 2.0, "cacheRead": 0.0, "cacheWrite": 0.0},
+    }
 
 
 @pytest.mark.anyio
@@ -94,10 +164,18 @@ async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
     user = MessageEntry(message=UserMessage(content="question"))
     assistant = MessageEntry(
         parent_id=user.id,
-        message=AssistantMessage(content="answer", model="fake"),
+        message=AssistantMessage(
+            content="answer",
+            model="fake",
+            usage=Usage(input=10, output=3, cache_read=20, cache_write=5),
+        ),
     )
+    model_change = ModelChangeEntry(parent_id=assistant.id, model="fake-next")
+    leaf = LeafEntry(parent_id=model_change.id, entry_id=model_change.id)
     await storage.append(user)
     await storage.append(assistant)
+    await storage.append(model_change)
+    await storage.append(leaf)
     session = await CodingSession.load(
         CodingSessionConfig(
             provider=FakeProvider([]),
@@ -112,16 +190,64 @@ async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
         '{"id":"tree","type":"get_tree"}\n'
         '{"id":"last","type":"get_last_assistant_text"}\n'
         '{"id":"forks","type":"get_fork_messages"}\n'
+        '{"id":"stats","type":"get_session_stats"}\n'
     )
     stdout = StringIO()
 
     await RpcServer(session, stdin=stdin, stdout=stdout).run()
 
-    entries, tree, last, forks = [json.loads(line) for line in stdout.getvalue().splitlines()]
-    assert entries["data"]["entries"][1]["parentId"] == user.id
-    assert tree["data"]["tree"][0]["children"][0]["entry"]["id"] == assistant.id
+    entries, tree, last, forks, stats = [
+        json.loads(line) for line in stdout.getvalue().splitlines()
+    ]
+    projected_entries = entries["data"]["entries"]
+    assert projected_entries[1]["parentId"] == user.id
+    assert projected_entries[2]["type"] == "model_change"
+    assert projected_entries[2]["provider"] == "openai"
+    assert projected_entries[2]["modelId"] == "fake-next"
+    assert all(entry["type"] != "leaf" for entry in projected_entries)
+    tree_root = tree["data"]["tree"][0]
+    assert tree_root["children"][0]["entry"]["id"] == assistant.id
+    assert tree_root["children"][0]["children"][0]["entry"]["type"] == "model_change"
     assert last["data"] == {"text": "answer"}
     assert forks["data"] == {"messages": [{"entryId": user.id, "text": "question"}]}
+    assert stats["data"]["tokens"] == {
+        "input": 10,
+        "output": 3,
+        "cacheRead": 20,
+        "cacheWrite": 5,
+        "total": 38,
+    }
+    assert stats["data"]["cost"] is None
+
+
+@pytest.mark.anyio
+async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: Path) -> None:
+    provider = FakeProvider(
+        [
+            [
+                assistant_start(model="fake"),
+                assistant_done(AssistantMessage(content="answer", model="fake")),
+            ],
+            [
+                assistant_start(model="fake"),
+                assistant_done(AssistantMessage(content="real summary", model="fake")),
+            ],
+        ]
+    )
+    session = await _session(tmp_path, provider)
+    _events = [event async for event in session.prompt("question")]
+    stdin = StringIO('{"id":"compact","type":"compact"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    response = json.loads(stdout.getvalue())
+    compactions = [
+        entry for entry in await session.storage.read_all() if entry.type == "compaction"
+    ]
+    assert response["data"]["summary"] == "real summary"
+    assert response["data"]["firstKeptEntryId"] == compactions[0].id
+    assert response["data"]["summary"] != "Compacted 2 context entries."
 
 
 @pytest.mark.anyio

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -170,11 +170,20 @@ async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
             usage=Usage(input=10, output=3, cache_read=20, cache_write=5),
         ),
     )
-    model_change = ModelChangeEntry(parent_id=assistant.id, model="fake-next")
-    leaf = LeafEntry(parent_id=model_change.id, entry_id=model_change.id)
+    model_change = ModelChangeEntry(
+        parent_id=assistant.id,
+        model="fake-next",
+        provider="historical-openai",
+    )
+    legacy_model_change = ModelChangeEntry(
+        parent_id=model_change.id,
+        model="legacy-model",
+    )
+    leaf = LeafEntry(parent_id=legacy_model_change.id, entry_id=legacy_model_change.id)
     await storage.append(user)
     await storage.append(assistant)
     await storage.append(model_change)
+    await storage.append(legacy_model_change)
     await storage.append(leaf)
     session = await CodingSession.load(
         CodingSessionConfig(
@@ -202,8 +211,10 @@ async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
     projected_entries = entries["data"]["entries"]
     assert projected_entries[1]["parentId"] == user.id
     assert projected_entries[2]["type"] == "model_change"
-    assert projected_entries[2]["provider"] == "openai"
+    assert projected_entries[2]["provider"] == "historical-openai"
     assert projected_entries[2]["modelId"] == "fake-next"
+    assert projected_entries[3]["provider"] == "openai"
+    assert projected_entries[3]["modelId"] == "legacy-model"
     assert all(entry["type"] != "leaf" for entry in projected_entries)
     tree_root = tree["data"]["tree"][0]
     assert tree_root["children"][0]["entry"]["id"] == assistant.id

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -217,37 +217,59 @@ async def test_rpc_session_inspection_matches_pi_shapes(tmp_path: Path) -> None:
         "cacheWrite": 5,
         "total": 38,
     }
-    assert stats["data"]["cost"] is None
+    assert stats["data"]["cost"] == 0.0
+    assert isinstance(stats["data"]["cost"], float)
 
 
 @pytest.mark.anyio
 async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    parent_id: str | None = None
+    original_ids: list[str] = []
+    for index in range(6):
+        user = MessageEntry(
+            parent_id=parent_id,
+            message=UserMessage(content=f"question-{index}-" + "x" * 8_000),
+        )
+        assistant = MessageEntry(
+            parent_id=user.id,
+            message=AssistantMessage(content="y" * 8_000, model="fake"),
+        )
+        await storage.append(user)
+        await storage.append(assistant)
+        original_ids.extend((user.id, assistant.id))
+        parent_id = assistant.id
     provider = FakeProvider(
         [
             [
                 assistant_start(model="fake"),
-                assistant_done(AssistantMessage(content="answer", model="fake")),
-            ],
-            [
-                assistant_start(model="fake"),
                 assistant_done(AssistantMessage(content="real summary", model="fake")),
-            ],
+            ]
         ]
     )
-    session = await _session(tmp_path, provider)
-    _events = [event async for event in session.prompt("question")]
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+        )
+    )
     stdin = StringIO('{"id":"compact","type":"compact"}\n')
     stdout = StringIO()
 
     await RpcServer(session, stdin=stdin, stdout=stdout).run()
 
     response = json.loads(stdout.getvalue())
-    compactions = [
-        entry for entry in await session.storage.read_all() if entry.type == "compaction"
-    ]
+    compaction = next(entry for entry in await storage.read_all() if entry.type == "compaction")
+    boundary = response["data"]["firstKeptEntryId"]
     assert response["data"]["summary"] == "real summary"
-    assert response["data"]["firstKeptEntryId"] == compactions[0].id
-    assert response["data"]["summary"] != "Compacted 2 context entries."
+    assert boundary in original_ids
+    assert boundary not in compaction.replaces_entry_ids
+    assert boundary != compaction.id
+    assert compaction.first_kept_entry_id == boundary
+    assert compaction.tokens_before == response["data"]["tokensBefore"]
 
 
 @pytest.mark.anyio

--- a/website/content/reference/rpc.md
+++ b/website/content/reference/rpc.md
@@ -57,6 +57,11 @@ tau.stdout.on("data", chunk => {
 tau.stdin.write(JSON.stringify({ id: "1", type: "prompt", message: "Hello" }) + "\n");
 ```
 
+RPC compaction preserves recent entries and returns the first pre-existing retained entry as
+`firstKeptEntryId`, matching Pi. Older Tau compaction records and TUI compactions that replaced
+all active context have no such boundary; session inspection exposes those honestly as
+`customType: "tau.compaction"` entries instead of fabricating Pi compaction metadata.
+
 Tau mirrors Pi where its public `CodingSession` has equivalent behavior. Direct `bash` is
 supported, but `abort_bash` requires a future cancellable session API. Queue delivery modes,
 retry controls, cloning, image prompts, and the extension UI request/response subprotocol remain

--- a/website/content/reference/rpc.md
+++ b/website/content/reference/rpc.md
@@ -20,10 +20,12 @@ carry request IDs.
 {"type":"agent_start"}
 ```
 
-The initial protocol supports Pi-compatible prompting (`prompt`, `steer`, `follow_up`, `abort`),
-state and message inspection, model and thinking controls, compaction, new/resumed sessions,
-session statistics and trees, forking, and command discovery. Unknown commands and invalid
-arguments return `success: false` without stopping the process.
+The protocol supports Pi-compatible prompting (`prompt`, `steer`, `follow_up`, `abort`), state
+and message inspection, complete Pi-shaped model references, model and thinking cycling,
+auto-compaction control, direct shell commands, HTML export, new/resumed sessions, entry cursors,
+session statistics and trees, forking, last-assistant lookup, session naming, and command
+discovery. Unknown commands and invalid arguments return `success: false` without stopping the
+process.
 
 Use `agent_settled`, not `agent_end`, to decide that a run is fully idle: retries, overflow
 compaction, or queued continuations can follow `agent_end`.
@@ -55,6 +57,8 @@ tau.stdout.on("data", chunk => {
 tau.stdin.write(JSON.stringify({ id: "1", type: "prompt", message: "Hello" }) + "\n");
 ```
 
-Tau mirrors Pi where its public `CodingSession` has equivalent behavior. This first version does
-not yet implement Pi's direct `bash`/`abort_bash`, extension UI request/response protocol,
-session naming, auto-compaction toggling, entry cursors, cloning, or export commands.
+Tau mirrors Pi where its public `CodingSession` has equivalent behavior. Direct `bash` is
+supported, but `abort_bash` requires a future cancellable session API. Queue delivery modes,
+retry controls, cloning, image prompts, and the extension UI request/response subprotocol remain
+staged compatibility work. See `dev-notes/design/rpc-runtime-interchangeability-plan.md` for the
+contract, completed frontend-critical phase, and remaining production phases.


### PR DESCRIPTION
## Summary

- document the production plan and definition of done for Tau/Pi RPC interchangeability
- normalize frontend-critical Tau responses to Pi's model, state, session, tree, entry, and statistics shapes
- add model/thinking cycling, direct bash, auto-compaction control, HTML export, entry cursors, fork-message discovery, last-assistant lookup, and session naming
- accept either Tau session IDs or indexed session paths at Pi's `switch_session` boundary
- add Pi-shape contract regressions for state, models, session inspection, direct bash, and compaction controls

## User experience

An Electron host can use one Pi-shaped command/response adapter for the common text coding-agent surface and select Tau or Pi at process launch. Runtime-specific persisted session formats remain isolated behind each subprocess.

This PR implements Phase A of the included production plan. It deliberately documents rather than fakes the remaining optional surfaces: cancellable bash streaming, queue/retry controls, cloning, image prompts, and extension UI RPC.

## Validation

- `uv run pytest` — 1543 passed, 2 skipped
- final focused suite — 135 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`

## Manual validation

Start `tau --mode rpc`, then send `get_state`, `get_available_models`, `bash`, `get_entries`, and `get_tree` JSONL commands. Their response envelopes and data fields follow Pi's documented RPC vocabulary.
