### PR TITLE
Phase 2: trusted hidden built-in extensions

### DIFF
--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -58,6 +58,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Queued Steering and Follow-ups](./queued-steering-follow-ups.md)
 - [Pre-extension Hardening Summary](./pre-extension-hardening.md)
 - [Phase 21: Extensions](./phase-21-extensions.md)
+- [Trusted hidden built-in extensions](./trusted-built-in-extensions.md)
 - [Phase 22: Compaction Replay Foundation](./phase-22-compaction-foundation.md)
 - [Phase 23: Advanced TUI and Product Polish](./phase-23-tui-polish.md)
 - [Bounded TUI Transcript Rendering](./tui-long-transcript-performance.md)

--- a/dev-notes/architecture/trusted-built-in-extensions.md
+++ b/dev-notes/architecture/trusted-built-in-extensions.md
@@ -1,0 +1,163 @@
+# Trusted hidden built-in extensions
+
+## What Phase 2 adds
+
+Issue #606 adds a generic way for Tau to run extension code bundled in the
+installed package. It does not add llama.cpp, startup provider preparation,
+`/local`, a local-backend API, or network work.
+
+The declaration is intentionally small:
+
+```python
+BuiltInExtension(name="capability", setup=setup, hidden=True)
+```
+
+Declarations live in `tau_coding.built_in_extensions.BUILT_IN_EXTENSIONS`.
+Later phases can add product capabilities to that tuple without teaching the
+loader their names. The Phase 2 production tuple is empty; deterministic tests
+inject a minimal fake declaration.
+
+## Why built-ins use extensions
+
+A bundled capability still needs normal lifecycle and failure boundaries. If it
+registered a tool, command, or provider through private host branches, reload and
+source cleanup would differ from user extensions and each capability would make
+core more provider-specific.
+
+Instead, a built-in receives the ordinary `ExtensionAPI`. The Phase 2 fake proves
+that one setup function can register:
+
+- an `AgentTool`;
+- a slash command;
+- a Phase 1 `DynamicProvider` layer.
+
+The real `ExtensionRuntime` composes all three. No test-only loader bypass is
+used.
+
+## Load order
+
+`ExtensionRuntime.load()` first calls its once-per-generation built-in loader,
+then performs normal filesystem discovery:
+
+```text
+trusted built-in declarations
+→ user extension directory
+→ explicit -e paths
+→ trusted, opted-in project extension directory (later staged call)
+```
+
+`include_resource_dirs=False`, which implements `--no-extensions`, skips user
+and project directory discovery but not built-ins or explicit paths. A session
+now always calls `ExtensionRuntime.load()`, even when discovery is disabled, so
+built-ins cannot accidentally disappear in that mode.
+
+Project extensions remain a separate post-trust load. Built-ins are direct
+installed-package callables, not filesystem candidates, so they neither add a
+protected-input category nor cause a trust prompt. They may use the existing
+pre-trust hook only when a project already has protected inputs; this phase's
+fake does not.
+
+## Provenance and hidden metadata
+
+Filesystem discovery now labels every source as `user`, `explicit`, or
+`project`. Built-ins use:
+
+```text
+source      = built-in
+source_id   = built-in:<declaration name>
+path        = None
+hidden      = declaration.hidden
+```
+
+The runtime retains this in immutable `ExtensionSourceMetadata`. The host-owned
+source ID, rather than the display name, owns tools, commands, handlers, and
+provider layers.
+
+`extension_names` remains the ordinary visible listing and omits hidden
+built-ins. `extension_metadata` is the detailed diagnostic view and includes
+both visible and hidden sources. Hidden therefore means “not advertised as an
+installed/discovered extension,” never “not loaded.”
+
+## Failure isolation
+
+Built-in setup runs through the same `_setup_extension()` boundary as imported
+extensions. The runtime creates one source-scoped API, records the source, and
+then calls setup synchronously. If setup raises:
+
+1. the failed source is removed from active extension metadata;
+2. its tools, commands, guidelines, renderers, and handlers are removed;
+3. all of its dynamic provider layers and refresh work are unregistered;
+4. a `built-in setup failed` extension diagnostic is retained;
+5. the next declaration and normal startup continue.
+
+This keeps built-in failures visible without turning them into host startup
+failures.
+
+## Generation and cleanup lifecycle
+
+Every staged `ExtensionRuntime` snapshots the declaration tuple and creates a
+fresh `ExtensionGeneration` plus Phase 1 provider registry. Repeated `load()`
+calls on one runtime do not rerun built-in setup; this matters because project
+extensions load in a second post-trust call.
+
+Reload, resume, new-session, and cwd replacement already stage fresh runtimes.
+Each therefore reruns built-in setup with a fresh API and provider generation.
+When the old runtime retires, it:
+
+- retires and detaches every dynamic provider layer;
+- requests cancellation of owned provider refresh/discovery work;
+- invalidates every captured API/context/UI facade;
+- unsubscribes the harness listener;
+- removes extension handlers, tools, commands, guidelines, and renderers;
+- drops bound-session and turn-request callbacks.
+
+Replacement code clears old host UI before the successor mounts UI on the shared
+bridge. Retirement deliberately does not clear that bridge again: doing so after
+the successor's `session_start` would erase fresh widgets. Final session close has
+no successor, so it clears extension components before retiring the runtime.
+
+Async close then drains cooperative provider work or reports Phase 1's bounded
+containment result. Tests start a fake built-in provider refresh, retire the
+runtime, and assert cancellation, stale API rejection, empty source metadata,
+and removal of the tool, command, and provider.
+
+## Security boundary
+
+“Trusted” means the code is reviewed and shipped inside Tau. It does not mean a
+sandbox. Like every extension, a built-in executes Python in the Tau process.
+Hidden status is display metadata only. Project trust remains an ambient
+project-input guard and does not sandbox built-ins, providers, tools, network,
+filesystem, credentials, or subprocesses.
+
+## Pi alignment and intentional Tau choices
+
+This follows Pi's hidden bundled-extension pattern and source invalidation on
+reload. Tau deliberately keeps its own cwd/trust-bound fresh-runtime staging,
+source/generation-aware Phase 1 provider registry, and detailed metadata view.
+There is no process-global built-in runtime and no capability-name branch in the
+loader.
+
+## How to verify
+
+Focused deterministic coverage:
+
+```bash
+uv run pytest tests/test_extensions.py tests/test_extension_providers.py \
+  tests/test_project_trust.py
+```
+
+The tests cover declaration validation, real runtime registration, hidden/source
+metadata, load order, `--no-extensions`, setup-once behavior, setup rollback,
+no trust prompt, fresh reload/new/resume generations, stale API invalidation,
+and provider-task retirement.
+
+Full repository gates remain:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+hugo --source website --minify
+uv build
+```

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from tau_coding.built_in_extensions import BuiltInExtension, BuiltInExtensionSetup
 from tau_coding.commands import (
     CommandRegistry,
     CommandResult,
@@ -176,6 +177,8 @@ __all__ = [
     "CodingSession",
     "CodingSessionConfig",
     "CodingSessionRecord",
+    "BuiltInExtension",
+    "BuiltInExtensionSetup",
     "CommandRegistry",
     "CommandResult",
     "DEFAULT_MODEL",

--- a/src/tau_coding/built_in_extensions.py
+++ b/src/tau_coding/built_in_extensions.py
@@ -1,0 +1,53 @@
+"""Trusted extension declarations bundled with Tau."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tau_coding.extensions.api import ExtensionAPI
+
+BuiltInExtensionSetup = Callable[["ExtensionAPI"], None]
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltInExtension:
+    """One trusted extension setup function shipped as part of Tau.
+
+    Built-ins use the normal extension API and runtime lifecycle. They differ
+    only in provenance: Tau declares their callable directly, loads them before
+    filesystem extensions, and may hide them from ordinary extension listings.
+    """
+
+    name: str
+    setup: BuiltInExtensionSetup
+    hidden: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("Built-in extension name must be a non-empty string")
+        if self.name != self.name.strip():
+            raise ValueError("Built-in extension name must not have surrounding whitespace")
+        if not callable(self.setup):
+            raise ValueError("Built-in extension setup must be callable")
+        setup_call = type(self.setup).__call__
+        if iscoroutinefunction(self.setup) or iscoroutinefunction(setup_call):
+            raise ValueError("Built-in extension setup must be a sync function")
+        if not isinstance(self.hidden, bool):
+            raise ValueError("Built-in extension hidden flag must be a boolean")
+
+    @property
+    def source_id(self) -> str:
+        """Return the stable host-owned source identity for this declaration."""
+        return f"built-in:{self.name}"
+
+
+# Product capabilities are added here by later phases. Keeping this registry
+# explicit makes built-in code reviewable and prevents filesystem discovery or
+# project inputs from changing what Tau treats as trusted.
+BUILT_IN_EXTENSIONS: tuple[BuiltInExtension, ...] = ()
+
+__all__ = ["BUILT_IN_EXTENSIONS", "BuiltInExtension", "BuiltInExtensionSetup"]

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -17,6 +17,29 @@ Installed examples are under `examples/extensions/` next to these docs. Read the
 - `<project>/.tau/extensions/`: requires project approval and `--project-extensions`.
 - `tau -e PATH`: explicitly load a file or directory.
 
+## Trusted built-in sources
+
+Tau can declare product capabilities as `BuiltInExtension` values in
+`tau_coding.built_in_extensions`. These call the same synchronous `setup(tau)`
+and use the same tool, command, provider, hook, and lifecycle APIs as filesystem
+extensions. Generic loading never branches on a capability's name.
+
+Built-ins are trusted because their code ships inside the installed Tau package;
+they are not discovered from the cwd. They load before user, explicit, and
+trusted project extensions, including when `--no-extensions` disables directory
+discovery. Hidden declarations stay active but are omitted from ordinary
+extension-name counts; detailed runtime metadata retains `source="built-in"`,
+the stable `built-in:<name>` source ID, and the hidden flag. A setup failure is a
+normal extension diagnostic and rolls back that source's registrations without
+blocking later extensions or startup.
+
+Every staged runtime loads each declaration once. Reload, resume, new-session,
+and cwd replacement create a fresh generation; retiring the old generation
+invalidates captured APIs, removes source registrations, and cancels its dynamic
+provider work. Built-ins do not create protected project inputs or a trust prompt.
+They can only observe or decide an already-required trust flow through the same
+explicit `project_trust` hook available to eligible pre-trust extensions.
+
 An extension defines `setup(tau)`. Built-in, user, and explicit extensions may
 handle `project_trust` before protected loading; first decisive result wins.
 Project extensions cannot approve themselves. They execute arbitrary Python and

--- a/src/tau_coding/data/docs/security.md
+++ b/src/tau_coding/data/docs/security.md
@@ -4,7 +4,11 @@ Tau resolves trust for the canonical destination cwd before reading ambient
 project Markdown/JSON or importing project extensions. Protected inputs include
 project skills, prompts, themes, system-prompt files, AGENTS.md context,
 extension candidates, and reserved future project settings/package metadata.
-User/global and explicit CLI resources remain eligible.
+User/global and explicit CLI resources remain eligible. Trusted built-in
+extensions are installed Tau package code, load before this decision even with
+`--no-extensions`, and are not ambient project candidates. Their presence alone
+never creates a project trust prompt. Hidden status affects ordinary listings,
+not execution or trust.
 
 Interactive users can save exact or displayed-parent decisions or choose a
 run-only result. `~/.tau/trust.json` is a locked, atomically replaced version-1

--- a/src/tau_coding/extensions/__init__.py
+++ b/src/tau_coding/extensions/__init__.py
@@ -39,6 +39,8 @@ from tau_coding.extensions.api import (
 from tau_coding.extensions.loader import (
     DiscoveredExtension,
     ExtensionLoadResult,
+    ExtensionSource,
+    ExtensionSourceMetadata,
     LoadedExtension,
     discover_extensions,
     extension_dirs,
@@ -107,6 +109,8 @@ __all__ = [
     "ExtensionHandler",
     "ExtensionLoadResult",
     "ExtensionRuntime",
+    "ExtensionSource",
+    "ExtensionSourceMetadata",
     "ExtensionUi",
     "InputEvent",
     "InputHookOutcome",

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -1016,6 +1016,8 @@ class RegisteredExtension:
 
     name: str
     source_id: str
-    path: Path
+    path: Path | None
     api: ExtensionAPI
+    source: Literal["built-in", "user", "explicit", "project"] = "explicit"
+    hidden: bool = False
     handlers: dict[str, list[ExtensionHandler]] = field(default_factory=dict)

--- a/src/tau_coding/extensions/loader.py
+++ b/src/tau_coding/extensions/loader.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 from importlib.util import module_from_spec, spec_from_file_location
 from inspect import iscoroutinefunction
 from pathlib import Path
+from typing import Literal
 
 from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
 
@@ -16,6 +17,9 @@ EXTENSION_ENTRY_ATTRIBUTE = "setup"
 _MODULE_NAME_PREFIX = "tau_extension"
 
 _load_counter = 0
+
+
+ExtensionSource = Literal["built-in", "user", "explicit", "project"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +30,7 @@ class DiscoveredExtension:
     path: Path
     package_dir: Path | None = None
     source_id: str | None = None
+    source: ExtensionSource = "explicit"
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,9 +38,22 @@ class LoadedExtension:
     """A successfully imported extension module and its entry point."""
 
     name: str
-    path: Path
+    path: Path | None
     source_id: str
     setup: Callable[..., object]
+    source: ExtensionSource = "explicit"
+    hidden: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionSourceMetadata:
+    """Non-executable provenance retained for one active extension source."""
+
+    name: str
+    source_id: str
+    source: ExtensionSource
+    hidden: bool
+    path: Path | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,12 +123,18 @@ def discover_extensions(
         discovered.append(replace(entry, source_id=f"extension:{resolved.as_uri()}"))
 
     if include_resource_dirs:
-        for directory in extension_dirs(
-            paths,
-            include_project_dir=include_project_dir,
-            include_user_dir=include_user_dir,
-        ):
-            for entry in _discover_in_dir(directory, diagnostics):
+        directories: list[tuple[Path, ExtensionSource]] = []
+        if include_project_dir and paths.cwd is not None and paths.project_resources_enabled:
+            directories.append((paths.cwd / ".tau" / "extensions", "project"))
+        if include_user_dir:
+            directories.append((paths.root / "extensions", "user"))
+        seen_directories: set[Path] = set()
+        for directory, source in directories:
+            resolved_directory = directory.expanduser().resolve()
+            if resolved_directory in seen_directories:
+                continue
+            seen_directories.add(resolved_directory)
+            for entry in _discover_in_dir(directory, diagnostics, source=source):
                 add(entry)
 
     for path in extra_paths:
@@ -123,10 +147,17 @@ def discover_extensions(
                 continue
             entry_file = expanded / "extension.py"
             if entry_file.is_file():
-                add(DiscoveredExtension(name=expanded.name, path=entry_file, package_dir=expanded))
+                add(
+                    DiscoveredExtension(
+                        name=expanded.name,
+                        path=entry_file,
+                        package_dir=expanded,
+                        source="explicit",
+                    )
+                )
                 continue
             found_any = False
-            for entry in _discover_in_dir(expanded, diagnostics):
+            for entry in _discover_in_dir(expanded, diagnostics, source="explicit"):
                 found_any = True
                 add(entry)
             if not found_any:
@@ -138,7 +169,7 @@ def discover_extensions(
                     )
                 )
         elif expanded.is_file():
-            add(DiscoveredExtension(name=expanded.stem, path=expanded))
+            add(DiscoveredExtension(name=expanded.stem, path=expanded, source="explicit"))
         else:
             diagnostics.append(
                 ResourceDiagnostic(
@@ -188,7 +219,10 @@ def load_extensions(
 
 
 def _discover_in_dir(
-    directory: Path, diagnostics: list[ResourceDiagnostic]
+    directory: Path,
+    diagnostics: list[ResourceDiagnostic],
+    *,
+    source: ExtensionSource,
 ) -> Iterator[DiscoveredExtension]:
     if not directory.is_dir():
         return
@@ -196,15 +230,20 @@ def _discover_in_dir(
         if path.name.startswith(("_", ".")):
             continue
         if path.is_file() and path.suffix == ".py":
-            yield DiscoveredExtension(name=path.stem, path=path)
+            yield DiscoveredExtension(name=path.stem, path=path, source=source)
         elif path.is_dir():
             manifest_entries = _manifest_entries(path, diagnostics)
             if manifest_entries:
-                yield from manifest_entries
+                yield from (replace(entry, source=source) for entry in manifest_entries)
                 continue
             entry_file = path / "extension.py"
             if entry_file.is_file():
-                yield DiscoveredExtension(name=path.name, path=entry_file, package_dir=path)
+                yield DiscoveredExtension(
+                    name=path.name,
+                    path=entry_file,
+                    package_dir=path,
+                    source=source,
+                )
 
 
 def _manifest_entries(
@@ -324,6 +363,7 @@ def _load_extension(
         path=entry.path,
         source_id=source_id,
         setup=setup,
+        source=entry.source,
     ), []
 
 

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from time import time_ns
 from typing import Literal, Protocol
 
+import tau_coding.built_in_extensions as built_in_extension_registry
 from tau_agent.events import AgentEvent, AgentStartEvent
 from tau_agent.events import TurnEndEvent as AgentTurnEndEvent
 from tau_agent.events import TurnStartEvent as AgentTurnStartEvent
@@ -21,6 +22,7 @@ from tau_agent.tools import (
     ToolUpdateCallback,
 )
 from tau_agent.types import JSONValue
+from tau_coding.built_in_extensions import BuiltInExtension
 from tau_coding.commands import (
     CommandContext,
     CommandRegistry,
@@ -58,6 +60,7 @@ from tau_coding.extensions.api import (
     UiBridge,
 )
 from tau_coding.extensions.loader import (
+    ExtensionSourceMetadata,
     LoadedExtension,
     load_extensions,
     unload_extension_modules,
@@ -173,8 +176,15 @@ class ExtensionRuntime:
         durable_providers: Sequence[ProviderConfig] = (),
         credentials: CredentialReader | None = None,
         environment: Mapping[str, str] | None = None,
+        built_in_extensions: Sequence[BuiltInExtension] | None = None,
     ) -> None:
         self._generation = ExtensionGeneration()
+        self._built_in_extensions = tuple(
+            built_in_extension_registry.BUILT_IN_EXTENSIONS
+            if built_in_extensions is None
+            else built_in_extensions
+        )
+        self._built_ins_loaded = False
         self._durable_providers = tuple(durable_providers)
         self._provider_credentials = credentials
         self._provider_environment = environment
@@ -210,7 +220,8 @@ class ExtensionRuntime:
         include_project_dir: bool = False,
         include_user_dir: bool = True,
     ) -> None:
-        """Discover extensions and run each `setup` with an isolated API."""
+        """Load built-ins, then discover extensions and run isolated setup."""
+        self._load_built_ins()
         result = load_extensions(
             paths,
             extra_paths=extra_paths,
@@ -222,23 +233,53 @@ class ExtensionRuntime:
         for extension in result.extensions:
             self._setup_extension(extension)
 
+    def _load_built_ins(self) -> None:
+        """Load each trusted declaration once, before filesystem sources."""
+        if self._built_ins_loaded:
+            return
+        self._built_ins_loaded = True
+        for declaration in self._built_in_extensions:
+            self._setup_extension(
+                LoadedExtension(
+                    name=declaration.name,
+                    path=None,
+                    source_id=declaration.source_id,
+                    setup=declaration.setup,
+                    source="built-in",
+                    hidden=declaration.hidden,
+                )
+            )
+
     @property
     def active(self) -> bool:
         """Return whether this runtime generation still owns live registrations."""
         return self._generation.active
 
     def retire(self) -> None:
-        """Invalidate a successfully replaced runtime without touching its successor."""
+        """Invalidate this generation and release all source-owned work."""
         if not self._generation.active:
             return
+        # Replacement callers clear host UI before a successor uses the shared
+        # bridge; clearing here could erase that successor's freshly mounted UI.
+        # Provider retirement synchronously detaches every layer and requests
+        # cancellation of generation-owned refresh work.
         self._provider_registry.retire()
         self._generation.invalidate()
         if self._harness_unsubscribe is not None:
             self._harness_unsubscribe()
             self._harness_unsubscribe = None
+        self._extensions.clear()
+        self._tools.clear()
+        self._commands.clear()
+        self._prompt_guidelines.clear()
+        self._message_renderers.clear()
+        self._renderer_failures_reported.clear()
+        self._turn_requested = None
+        self._session = None
 
     async def aclose(self) -> ProviderRegistryCloseResult:
         """Retire this generation and report drain or bounded containment."""
+        self.retire()
         registries = (*self._retired_provider_registries, self._provider_registry)
         try:
             results = await asyncio.gather(*(registry.aclose() for registry in registries))
@@ -277,6 +318,7 @@ class ExtensionRuntime:
         self._retired_provider_registries.append(self._provider_registry)
         self._generation.invalidate()
         self._generation = ExtensionGeneration()
+        self._built_ins_loaded = False
         self._provider_registry = DynamicProviderRegistry(
             self._durable_providers,
             generation_id=self._generation.id,
@@ -319,6 +361,8 @@ class ExtensionRuntime:
             source_id=source_id,
             path=extension.path,
             api=api,
+            source=extension.source,
+            hidden=extension.hidden,
         )
         self._extensions.append(registered)
         try:
@@ -331,7 +375,11 @@ class ExtensionRuntime:
                     kind="extension",
                     name=extension.name,
                     path=extension.path,
-                    message=f"setup failed: {exc!r}",
+                    message=(
+                        f"built-in setup failed: {exc!r}"
+                        if extension.source == "built-in"
+                        else f"setup failed: {exc!r}"
+                    ),
                     severity="error",
                 )
             )
@@ -653,8 +701,22 @@ class ExtensionRuntime:
 
     @property
     def extension_names(self) -> tuple[str, ...]:
-        """Return loaded extension names in load order."""
-        return tuple(extension.name for extension in self._extensions)
+        """Return visible extension names in load order."""
+        return tuple(extension.name for extension in self._extensions if not extension.hidden)
+
+    @property
+    def extension_metadata(self) -> tuple[ExtensionSourceMetadata, ...]:
+        """Return active visible and hidden source metadata in load order."""
+        return tuple(
+            ExtensionSourceMetadata(
+                name=extension.name,
+                source_id=extension.source_id,
+                source=extension.source,
+                hidden=extension.hidden,
+                path=extension.path,
+            )
+            for extension in self._extensions
+        )
 
     @property
     def diagnostics(self) -> tuple[ResourceDiagnostic, ...]:

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -432,13 +432,12 @@ class CodingSession:
         # never reuse source-project code across replacement trust boundaries.
         previous_runtime = config.extension_runtime
         extension_runtime = ExtensionRuntime()
-        if config.extensions_enabled or config.extension_paths:
-            extension_runtime.load(
-                unfiltered_resource_paths,
-                extra_paths=config.extension_paths,
-                include_resource_dirs=config.extensions_enabled,
-                include_project_dir=False,
-            )
+        extension_runtime.load(
+            unfiltered_resource_paths,
+            extra_paths=config.extension_paths,
+            include_resource_dirs=config.extensions_enabled,
+            include_project_dir=False,
+        )
 
         coordinator = config.project_trust_coordinator or ProjectTrustCoordinator(
             ProjectTrustStore(
@@ -1498,13 +1497,12 @@ class CodingSession:
         unfiltered_paths = resource_paths_with_cwd(self._config.resource_paths, self.cwd)
         previous_ui = self._extension_runtime.ui
         staged_runtime = ExtensionRuntime()
-        if self._config.extensions_enabled or self._config.extension_paths:
-            staged_runtime.load(
-                unfiltered_paths,
-                extra_paths=self._config.extension_paths,
-                include_resource_dirs=self._config.extensions_enabled,
-                include_project_dir=False,
-            )
+        staged_runtime.load(
+            unfiltered_paths,
+            extra_paths=self._config.extension_paths,
+            include_resource_dirs=self._config.extensions_enabled,
+            include_project_dir=False,
+        )
 
         staged_resolution = self._project_trust_resolution
         staged_paths = self._resource_paths
@@ -1953,6 +1951,14 @@ class CodingSession:
                 await self._extension_runtime.emit_session_shutdown("quit")
         except BaseException as exc:
             error = exc
+
+        # Final close has no successor sharing the UI bridge. Remove any
+        # source-owned widgets/interceptors before invalidating the API.
+        try:
+            self._extension_runtime.clear_ui_components()
+        except BaseException as exc:
+            if error is None:
+                error = exc
 
         # A runtime may already be synchronously retired by replacement. Close
         # still owns the async drain/containment step and must never skip it.

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -15,7 +15,13 @@ from tau_agent.session import CustomEntry, JsonlSessionStorage, LeafEntry, Messa
 from tau_agent.tools import AgentTool, AgentToolResult
 from tau_agent.types import JSONValue
 from tau_ai import FakeProvider
-from tau_coding import CodingSession, CodingSessionConfig, ResourceError, TauResourcePaths
+from tau_coding import (
+    BuiltInExtension,
+    CodingSession,
+    CodingSessionConfig,
+    ResourceError,
+    TauResourcePaths,
+)
 from tau_coding.extensions import (
     CustomMessageView,
     DynamicProvider,
@@ -27,11 +33,15 @@ from tau_coding.extensions import (
     MessageRenderOptions,
     NoAuth,
     OpenAICompatibleTransport,
+    ProviderModelSnapshot,
+    ProviderRefreshContext,
+    RefreshModels,
     ToolCallHookResult,
     ToolResultHookResult,
     discover_extensions,
     load_extensions,
 )
+from tau_coding.project_trust import ProjectTrustRequest, TrustChoice
 
 pytestmark = pytest.mark.anyio
 
@@ -488,6 +498,246 @@ def test_underscore_files_are_skipped(tmp_path: Path) -> None:
     discovered, _ = discover_extensions(paths)
 
     assert discovered == ()
+
+
+def _fake_built_in(
+    setup_apis: list[ExtensionAPI],
+    *,
+    refresh_models: RefreshModels | None = None,
+) -> BuiltInExtension:
+    def command(args: str, context: object) -> str:
+        del context
+        return f"built-in: {args}"
+
+    async def execute(
+        tool_call_id: str,
+        arguments: object,
+        signal: object = None,
+        on_update: object = None,
+    ) -> AgentToolResult:
+        del tool_call_id, arguments, signal, on_update
+        return AgentToolResult(content="built-in tool")
+
+    def setup(tau: ExtensionAPI) -> None:
+        setup_apis.append(tau)
+        tau.register_tool(
+            AgentTool(
+                name="fake-built-in-tool",
+                label="Fake built-in",
+                description="Exercise built-in extension loading.",
+                parameters={},
+                execute_fn=execute,
+            )
+        )
+        tau.register_command("fake-built-in", command)
+        tau.register_provider(
+            DynamicProvider(
+                id="fake-built-in-provider",
+                display_name="Fake built-in provider",
+                transport=OpenAICompatibleTransport(
+                    base_url="http://example.test/v1",
+                    auth=NoAuth(),
+                ),
+                refresh_models=refresh_models,
+            )
+        )
+
+    return BuiltInExtension(name="fake-built-in", setup=setup)
+
+
+def test_built_in_declaration_validates_name_setup_and_hidden_flag() -> None:
+    def setup(tau: ExtensionAPI) -> None:
+        del tau
+
+    async def async_setup(tau: ExtensionAPI) -> None:
+        del tau
+
+    with pytest.raises(ValueError, match="non-empty"):
+        BuiltInExtension(name="", setup=setup)
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        BuiltInExtension(name=" spaced ", setup=setup)
+    with pytest.raises(ValueError, match="sync function"):
+        BuiltInExtension(name="async", setup=async_setup)
+    with pytest.raises(ValueError, match="hidden flag"):
+        BuiltInExtension(name="visible", setup=setup, hidden=cast(bool, "yes"))
+
+
+async def test_hidden_built_in_registers_real_runtime_surfaces_despite_no_extensions(
+    tmp_path: Path,
+) -> None:
+    setup_apis: list[ExtensionAPI] = []
+    runtime = ExtensionRuntime(built_in_extensions=(_fake_built_in(setup_apis),))
+
+    runtime.load(_paths(tmp_path), include_resource_dirs=False)
+
+    assert len(setup_apis) == 1
+    assert runtime.extension_names == ()
+    assert len(runtime.extension_metadata) == 1
+    metadata = runtime.extension_metadata[0]
+    assert metadata.name == "fake-built-in"
+    assert metadata.source_id == "built-in:fake-built-in"
+    assert metadata.source == "built-in"
+    assert metadata.hidden is True
+    assert metadata.path is None
+    tool = runtime.compose_tools([])[0]
+    assert tool.name == "fake-built-in-tool"
+    assert (await tool.execute("call-1", {})).text == "built-in tool"
+    registry = runtime.build_command_registry()
+    command = registry.get("fake-built-in")
+    assert command is not None
+    result = command.handler(_command_context(registry, "/fake-built-in ok", "fake-built-in", "ok"))
+    assert result.message == "built-in: ok"
+    provider = runtime.provider_registry.effective("fake-built-in-provider")
+    assert provider is not None
+    assert provider.source_id == "built-in:fake-built-in"
+
+
+def test_built_ins_load_once_before_user_explicit_and_project_sources(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    setup_apis: list[ExtensionAPI] = []
+    _write_extension(_user_extensions_dir(paths), "user_ext", "def setup(tau):\n    pass\n")
+    explicit = _write_extension(
+        tmp_path / "explicit", "explicit_ext", "def setup(tau):\n    pass\n"
+    )
+    _write_extension(_project_extensions_dir(paths), "project_ext", "def setup(tau):\n    pass\n")
+    runtime = ExtensionRuntime(built_in_extensions=(_fake_built_in(setup_apis),))
+
+    runtime.load(paths, extra_paths=(explicit,), include_project_dir=False)
+    runtime.load(paths, include_project_dir=True, include_user_dir=False)
+
+    assert len(setup_apis) == 1
+    assert [metadata.name for metadata in runtime.extension_metadata] == [
+        "fake-built-in",
+        "user_ext",
+        "explicit_ext",
+        "project_ext",
+    ]
+    assert [metadata.source for metadata in runtime.extension_metadata] == [
+        "built-in",
+        "user",
+        "explicit",
+        "project",
+    ]
+    assert runtime.extension_names == ("user_ext", "explicit_ext", "project_ext")
+
+
+async def test_built_in_order_preserves_tool_command_and_provider_precedence(
+    tmp_path: Path,
+) -> None:
+    paths = _paths(tmp_path)
+    setup_apis: list[ExtensionAPI] = []
+    _write_extension(
+        _user_extensions_dir(paths),
+        "shadow",
+        """
+from tau_agent.tools import AgentTool, AgentToolResult
+from tau_coding.extensions import DynamicProvider, NoAuth, OpenAICompatibleTransport
+
+
+async def execute(tool_call_id, arguments, signal=None, on_update=None):
+    return AgentToolResult(content="user tool")
+
+
+def command(args, context):
+    return "user command"
+
+
+def setup(tau):
+    tau.register_tool(AgentTool(
+        name="fake-built-in-tool",
+        label="User",
+        description="User",
+        parameters={},
+        execute_fn=execute,
+    ))
+    tau.register_command("fake-built-in", command)
+    tau.register_provider(DynamicProvider(
+        id="fake-built-in-provider",
+        display_name="User provider",
+        transport=OpenAICompatibleTransport(
+            base_url="http://user.example.test/v1",
+            auth=NoAuth(),
+        ),
+    ))
+""",
+    )
+    runtime = ExtensionRuntime(built_in_extensions=(_fake_built_in(setup_apis),))
+
+    runtime.load(paths)
+
+    tool = runtime.compose_tools([])[0]
+    assert (await tool.execute("call-1", {})).text == "built-in tool"
+    registry = runtime.build_command_registry()
+    command = registry.get("fake-built-in")
+    assert command is not None
+    result = command.handler(_command_context(registry, "/fake-built-in", "fake-built-in", ""))
+    assert result.message == "built-in: "
+    provider = runtime.provider_registry.effective("fake-built-in-provider")
+    assert provider is not None
+    assert provider.source_id.startswith("extension:file:")
+    assert provider.definition.display_name == "User provider"
+
+
+def test_built_in_setup_failure_is_isolated_and_rolls_back_every_registration(
+    tmp_path: Path,
+) -> None:
+    setup_apis: list[ExtensionAPI] = []
+    working = BuiltInExtension(name="working", setup=lambda tau: None)
+    fake = _fake_built_in(setup_apis)
+
+    def broken_setup(tau: ExtensionAPI) -> None:
+        fake.setup(tau)
+        raise RuntimeError("broken declaration")
+
+    runtime = ExtensionRuntime(
+        built_in_extensions=(BuiltInExtension(name="broken", setup=broken_setup), working)
+    )
+
+    runtime.load(_paths(tmp_path), include_resource_dirs=False)
+
+    assert [metadata.name for metadata in runtime.extension_metadata] == ["working"]
+    assert runtime.extension_tools == ()
+    assert runtime.build_command_registry().get("fake-built-in") is None
+    assert runtime.provider_registry.effective("fake-built-in-provider") is None
+    assert any(
+        diagnostic.name == "broken"
+        and diagnostic.severity == "error"
+        and "built-in setup failed" in diagnostic.message
+        for diagnostic in runtime.diagnostics
+    )
+
+
+async def test_retiring_built_in_generation_cancels_provider_work_and_drops_registrations(
+    tmp_path: Path,
+) -> None:
+    setup_apis: list[ExtensionAPI] = []
+    entered = asyncio.Event()
+
+    async def refresh(context: ProviderRefreshContext) -> ProviderModelSnapshot:
+        del context
+        entered.set()
+        await asyncio.sleep(10)
+        return ProviderModelSnapshot()
+
+    runtime = ExtensionRuntime(
+        built_in_extensions=(_fake_built_in(setup_apis, refresh_models=refresh),)
+    )
+    runtime.load(_paths(tmp_path), include_resource_dirs=False)
+    registry = runtime.provider_registry
+    pending = asyncio.create_task(registry.refresh("fake-built-in-provider"))
+    await entered.wait()
+
+    runtime.retire()
+    close_result = await runtime.aclose()
+
+    assert close_result.drained is True
+    assert (await pending).status == "cancelled"
+    assert registry.effective("fake-built-in-provider") is None
+    assert runtime.extension_metadata == ()
+    assert runtime.extension_tools == ()
+    assert runtime.build_command_registry().get("fake-built-in") is None
+    with pytest.raises(ExtensionError, match="stale after reload"):
+        _ = setup_apis[0].name
 
 
 # -- runtime registration ------------------------------------------------------
@@ -1598,6 +1848,104 @@ def _session_config(
         cwd=paths.cwd,
         resource_paths=paths,
     )
+
+
+async def test_session_loads_built_in_without_extension_discovery_or_project_trust_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dataclasses import replace as dataclass_replace
+
+    import tau_coding.built_in_extensions as declarations
+
+    setup_apis: list[ExtensionAPI] = []
+    monkeypatch.setattr(
+        declarations,
+        "BUILT_IN_EXTENSIONS",
+        (_fake_built_in(setup_apis),),
+    )
+    prompt_calls = 0
+
+    async def prompt(request: ProjectTrustRequest) -> TrustChoice:
+        nonlocal prompt_calls
+        del request
+        prompt_calls += 1
+        return "decline_once"
+
+    config = dataclass_replace(
+        _session_config(
+            tmp_path,
+            FakeProvider([]),
+            extension_body=(
+                "def setup(tau):\n    tau.add_prompt_guideline('user should not load')\n"
+            ),
+        ),
+        extensions_enabled=False,
+        trust_interactive=True,
+        trust_prompt=prompt,
+    )
+
+    session = await CodingSession.load(config)
+
+    assert prompt_calls == 0
+    assert session.project_trust_resolution is not None
+    assert session.project_trust_resolution.source == "empty"
+    assert "fake-built-in-tool" in [tool.name for tool in session.tools]
+    assert "user should not load" not in session.extension_runtime.prompt_guidelines
+    assert session.extension_names == ()
+    assert session.extension_runtime.extension_metadata[0].source == "built-in"
+    await session.aclose()
+
+
+@pytest.mark.parametrize("operation", ["reload", "new", "resume"])
+async def test_session_lifecycle_recreates_built_in_in_a_fresh_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    from dataclasses import replace as dataclass_replace
+
+    import tau_coding.built_in_extensions as declarations
+    from tau_coding import SessionManager, TauPaths
+
+    setup_apis: list[ExtensionAPI] = []
+    monkeypatch.setattr(
+        declarations,
+        "BUILT_IN_EXTENSIONS",
+        (_fake_built_in(setup_apis),),
+    )
+    manager = SessionManager(
+        TauPaths(home=tmp_path / "home-tau", agents_home=tmp_path / "home-agents")
+    )
+    config = _session_config(tmp_path, FakeProvider([]))
+    initial = manager.create_session(cwd=config.cwd, model="fake")
+    destination = manager.create_session(cwd=config.cwd, model="fake")
+    config = dataclass_replace(
+        config,
+        extensions_enabled=False,
+        session_manager=manager,
+        session_id=initial.id,
+    )
+    session = await CodingSession.load(config)
+    old_runtime = session.extension_runtime
+    old_generation = old_runtime.provider_registry.generation_id
+    old_api = setup_apis[0]
+
+    if operation == "reload":
+        await session.reload()
+    elif operation == "resume":
+        await session.resume(destination.id)
+    else:
+        await session.new_session()
+
+    assert len(setup_apis) == 2
+    assert session.extension_runtime is not old_runtime
+    assert session.extension_runtime.provider_registry.generation_id != old_generation
+    assert old_runtime.active is False
+    assert session.extension_runtime.extension_metadata[0].source_id == "built-in:fake-built-in"
+    with pytest.raises(ExtensionError, match="stale after reload"):
+        _ = old_api.name
+    await session.aclose()
 
 
 async def test_session_exposes_extension_tools_and_commands(tmp_path: Path) -> None:

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -50,6 +50,29 @@ defining `setup(tau)`, which runs once at startup with the extension API.
 | `<project>/.tau/extensions/` | only after project approval **and** `--project-extensions` |
 | any file or directory | with `tau -e PATH` (repeatable) |
 
+### Trusted built-in extensions
+
+Tau may bundle product capabilities as `BuiltInExtension` declarations. A
+built-in is not a special provider or command branch: its synchronous
+`setup(tau)` receives the normal extension API and registers tools, commands,
+process-local providers, hooks, or later extension capabilities through the
+same runtime.
+
+Built-ins load once per staged runtime, before user, explicit, and trusted
+project sources. They still load with `--no-extensions`, because that flag turns
+off filesystem discovery rather than capabilities shipped in Tau itself. Their
+code is trusted as installed package code and never counts as ambient project
+input, so a built-in alone cannot trigger project trust.
+
+Declarations are hidden by default. Hidden means omitted from ordinary
+extension-name counts, not inactive: detailed runtime metadata retains the
+`built-in` source, stable `built-in:<name>` source ID, and hidden flag. Setup
+exceptions are isolated diagnostics and all partial registrations from that
+source are removed. Reload, resume, new-session, and cwd replacement use fresh
+generations; retiring an old generation invalidates captured APIs, removes its
+registrations, and cancels generation-owned provider refresh work. Generic core
+loading never checks a built-in capability's name.
+
 Within a directory, `*.py` files are extensions, and a subdirectory
 containing `extension.py` is a package-style extension — its sibling
 modules are imported with relative imports (`from . import helper`).
@@ -83,9 +106,10 @@ first decisive result wins, errors safely defer, and remembered results save
 only the exact cwd before project loading. Project extensions cannot approve
 themselves.
 
-Extensions load project-first after approval; on name conflicts (extension names, tool
-names, command names) the first registration wins. `--no-extensions`
-disables directory discovery entirely (explicit `-e` paths still load).
+After built-ins, filesystem extensions keep their existing precedence; on name
+conflicts (extension names, tool names, command names) the first registration
+wins. `--no-extensions` disables directory discovery (explicit `-e` paths and
+trusted built-ins still load).
 `/reload` awaits `session_shutdown(reason="reload")` on the outgoing
 extension generation, clears its UI, re-imports every extension and re-runs
 `setup`, then awaits `session_start(reason="reload")` on the new generation.

--- a/website/content/guides/project-trust.md
+++ b/website/content/guides/project-trust.md
@@ -17,8 +17,10 @@ Detection checks names and metadata only; Tau does not read, parse, or import a
 candidate before deciding.
 
 User resources under `~/.tau` and `~/.agents`, built-ins, and paths explicitly
-passed on the CLI remain eligible. Trusted project extensions still require the
-additional `--project-extensions` opt-in.
+passed on the CLI remain eligible. Trusted built-in extensions are installed Tau
+package code rather than cwd discovery: they load before the decision, even with
+`--no-extensions`, and their presence alone never creates a trust prompt. Trusted
+project extensions still require the additional `--project-extensions` opt-in.
 
 ## Decisions
 


### PR DESCRIPTION
## Summary

- add trusted `BuiltInExtension` declarations with hidden metadata and stable source IDs
- load built-ins once per runtime generation before filesystem extensions, including `--no-extensions`
- isolate setup failures, retire source registrations, invalidate stale APIs, and cancel provider work
- document the Phase 2 architecture and trust boundary

## Verification

- `uv run pytest tests/test_extensions.py tests/test_extension_providers.py tests/test_project_trust.py` — 253 passed
- `uv run pytest` — 1636 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --source website --minify`
- `uv build`
- `git diff --check`

Base commit: `5216df60a7d2cb2f67438815549121230871e00a`
Head commit: `8e6a912ab98b5beaaf7cdfd2c3bbf6c5d5ddcd79`
