### PR TITLE
Add Pi-style extension install command

### DIFF
--- a/dev-notes/architecture/extension-installer.md
+++ b/dev-notes/architecture/extension-installer.md
@@ -48,7 +48,7 @@ source argument
       ↓
 resolve local path or normalize Git source/ref
       ↓
-copy or clone to a sibling staging path
+copy or clone into a temporary root/extensions/<name> layout
       ↓
 validate that normal user-directory discovery can see it
       ↓
@@ -62,10 +62,14 @@ end in `.py`. A directory must contain `extension.py` or declare entries in
 `[tool.tau].extensions`; a loose directory of Python files is rejected because
 `-e` could discover it but user-directory discovery would not.
 
-Staging happens inside the destination directory so publication is a same-filesystem
-rename. Failed copies, clones, checkouts, and validation remove their staging
-artifacts. Forced replacement keeps the previous destination as a temporary
-backup and restores it if publication fails.
+Staging happens inside the destination directory so publication is a
+same-filesystem rename. The temporary tree reproduces the exact
+`root/extensions/<name>` discovery layout, preventing nested-only packages from
+passing explicit-path validation and then disappearing after installation.
+Failed copies, clones, checkouts, validation, and filesystem operations remove
+their staging artifacts and surface as `ExtensionInstallError`. Forced
+replacement keeps the previous destination as a temporary backup and restores
+it if publication fails.
 
 ## Security boundary
 

--- a/dev-notes/architecture/extension-installer.md
+++ b/dev-notes/architecture/extension-installer.md
@@ -1,0 +1,96 @@
+---
+title: "Extension installer"
+---
+
+# Extension installer
+
+Tau now has a small `tau install <source>` command for making an extension
+available on future runs. It intentionally implements the useful first slice of
+Pi's package installer without introducing a settings/package-management system.
+
+## What was added
+
+The command accepts:
+
+```text
+tau install ./extension.py
+tau install ./extension-directory
+tau install git:github.com/owner/repository
+tau install git:github.com/owner/repository@ref
+tau install https://github.com/owner/repository.git
+```
+
+Local sources are copied and Git sources are cloned into
+`~/.tau/extensions/`. Existing destinations are preserved unless the caller
+passes `--force`.
+
+## Why this shape
+
+Before this change, users had to know Tau's resource directory and manually
+copy or clone into it, or repeat `tau -e PATH` on every run. Pi solves that
+problem with `pi install`. Tau now mirrors that command's source-oriented UX and
+Pi-style `git:` spelling while reusing Tau's existing extension discovery.
+
+The first version is deliberately narrower than Pi's package manager:
+
+- it installs extensions only, not skills, prompts, or themes;
+- it supports local paths and Git, not npm/PyPI packages;
+- it does not install Python dependencies;
+- it has no package registry, remove command, or update command.
+
+This keeps package policy in `tau_coding` and avoids changing the portable
+`tau_agent` harness.
+
+## Installation flow
+
+```text
+source argument
+      ↓
+resolve local path or normalize Git source/ref
+      ↓
+copy or clone to a sibling staging path
+      ↓
+validate that normal user-directory discovery can see it
+      ↓
+atomically rename into ~/.tau/extensions
+      ↓
+load through the existing runtime on the next Tau startup
+```
+
+Validation does not import or execute extension code. A single local file must
+end in `.py`. A directory must contain `extension.py` or declare entries in
+`[tool.tau].extensions`; a loose directory of Python files is rejected because
+`-e` could discover it but user-directory discovery would not.
+
+Staging happens inside the destination directory so publication is a same-filesystem
+rename. Failed copies, clones, checkouts, and validation remove their staging
+artifacts. Forced replacement keeps the previous destination as a temporary
+backup and restores it if publication fails.
+
+## Security boundary
+
+Installation is not sandboxing. The command prints a warning, but the user is
+responsible for reviewing the source. Installed modules execute in the Tau
+process with the user's filesystem, network, credentials, and process access.
+
+## Main files
+
+| File | Responsibility |
+| --- | --- |
+| `src/tau_coding/extension_installer.py` | Source parsing, staging, validation, and publication |
+| `src/tau_coding/cli.py` | `tau install` command dispatch and user-facing output |
+| `src/tau_coding/paths.py` | Canonical user extension directory |
+| `tests/test_extension_installer.py` | Local/Git installs, validation, replacement, cleanup |
+| `tests/test_cli.py` | CLI dispatch and errors |
+
+## Verification
+
+Run:
+
+```bash
+uv run pytest tests/test_extension_installer.py tests/test_cli.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -58,6 +58,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Queued Steering and Follow-ups](./queued-steering-follow-ups.md)
 - [Pre-extension Hardening Summary](./pre-extension-hardening.md)
 - [Phase 21: Extensions](./phase-21-extensions.md)
+- [Extension Installer](./extension-installer.md)
 - [Phase 22: Compaction Replay Foundation](./phase-22-compaction-foundation.md)
 - [Phase 23: Advanced TUI and Product Polish](./phase-23-tui-polish.md)
 - [Bounded TUI Transcript Rendering](./tui-long-transcript-performance.md)

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -22,6 +22,7 @@ from tau_ai.env import (
 from tau_coding.catalog_loader import user_catalog_path
 from tau_coding.commands import format_reload_summary
 from tau_coding.credentials import FileCredentialStore
+from tau_coding.extension_installer import ExtensionInstallError, install_extension
 from tau_coding.extensions import StderrUiBridge
 from tau_coding.project_trust import TrustDefault, TrustOverride
 from tau_coding.provider_config import (
@@ -100,6 +101,35 @@ app = typer.Typer(
 def providers_command() -> None:
     """List configured model providers."""
     render_provider_settings(load_provider_settings(), credential_reader=FileCredentialStore())
+
+
+def install_command(args: list[str]) -> None:
+    """Install an extension into Tau's user extension directory."""
+    source: str | None = None
+    force = False
+    for arg in args:
+        if arg == "--force":
+            force = True
+        elif arg.startswith("-"):
+            raise typer.BadParameter(f"Unknown option for `tau install`: {arg}")
+        elif source is None:
+            source = arg
+        else:
+            raise typer.BadParameter("Usage: tau install <source> [--force]")
+    if source is None:
+        raise typer.BadParameter("Usage: tau install <source> [--force]")
+
+    typer.echo(
+        "Warning: extensions execute arbitrary Python with your user permissions. "
+        "Only install sources you trust.",
+        err=True,
+    )
+    try:
+        destination = install_extension(source, force=force)
+    except ExtensionInstallError as exc:
+        typer.echo(f"Could not install extension: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    typer.echo(f"Installed {source} to {destination}")
 
 
 def setup_command(
@@ -373,6 +403,10 @@ def main(
         if len(positional_args) != 1:
             raise typer.BadParameter("Usage: tau update")
         update_command()
+        raise typer.Exit()
+
+    if not rpc_requested and not print_requested and not export and command == "install":
+        install_command(positional_args[1:])
         raise typer.Exit()
 
     if (

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -17,6 +17,20 @@ Installed examples are under `examples/extensions/` next to these docs. Read the
 - `<project>/.tau/extensions/`: requires project approval and `--project-extensions`.
 - `tau -e PATH`: explicitly load a file or directory.
 
+Install a trusted local or Git extension for future runs with:
+
+```bash
+tau install git:github.com/owner/repository
+tau install git:github.com/owner/repository@v1.2.0
+tau install ./path/to/extension.py
+tau install ./path/to/extension-directory
+```
+
+Git repositories and local directories install under `~/.tau/extensions/` and
+must contain `extension.py` or a `[tool.tau].extensions` manifest. Use `--force`
+to replace an existing install. The installer does not install Python
+dependencies or provide package remove/update commands yet.
+
 An extension defines `setup(tau)`. Built-in, user, and explicit extensions may
 handle `project_trust` before protected loading; first decisive result wins.
 Project extensions cannot approve themselves. They execute arbitrary Python and

--- a/src/tau_coding/extension_installer.py
+++ b/src/tau_coding/extension_installer.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import os
+import contextlib
 import re
 import shutil
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import mkdtemp, mkstemp
+from tempfile import mkdtemp
 
 from tau_coding.extensions import discover_extensions
 from tau_coding.paths import TauPaths
@@ -45,45 +45,44 @@ def install_extension(
     the normal user-directory discovery path can load them on the next run.
     """
     destination_root = extensions_dir or TauPaths().user_extensions_dir
-    destination_root.mkdir(parents=True, exist_ok=True)
-
-    staging: Path | None = None
+    staging_root: Path | None = None
     try:
+        destination_root.mkdir(parents=True, exist_ok=True)
         local_source = Path(source).expanduser()
+        resolved_source: Path | None = None
+        git_source: GitExtensionSource | None = None
         if local_source.exists():
             resolved_source = local_source.resolve()
             name = _local_install_name(resolved_source)
-            destination = destination_root / name
-            if resolved_source.is_file():
-                descriptor, staging_name = mkstemp(
-                    prefix=f".{resolved_source.stem}.install-",
-                    suffix=".py",
-                    dir=destination_root,
-                )
-                os.close(descriptor)
-                staging = Path(staging_name)
-                shutil.copy2(resolved_source, staging)
-            elif resolved_source.is_dir():
-                staging = Path(mkdtemp(prefix=f".{name}.install-", dir=destination_root))
-                staging.rmdir()
-                shutil.copytree(resolved_source, staging, ignore=_local_copy_ignore)
-            else:
-                raise ExtensionInstallError(f"unsupported local extension source: {source}")
         else:
             git_source = parse_git_extension_source(source)
             name = git_source.name
-            destination = destination_root / name
-            staging = Path(mkdtemp(prefix=f".{name}.install-", dir=destination_root))
-            staging.rmdir()
-            _clone_git_source(git_source, staging, command_runner=command_runner)
+        destination = destination_root / name
 
-        _validate_staged_extension(staging)
+        # Reproduce the exact ~/.tau/extensions/<name> shape during validation.
+        # This catches layouts that explicit -e discovery accepts but normal
+        # user-directory discovery would skip, such as nested/extension.py.
+        staging_root = Path(mkdtemp(prefix=".extension-install-", dir=destination_root))
+        staging = staging_root / "extensions" / name
+        staging.parent.mkdir()
+        if resolved_source is not None and resolved_source.is_file():
+            shutil.copy2(resolved_source, staging)
+        elif resolved_source is not None and resolved_source.is_dir():
+            shutil.copytree(resolved_source, staging, ignore=_local_copy_ignore)
+        elif git_source is not None:
+            _clone_git_source(git_source, staging, command_runner=command_runner)
+        else:
+            raise ExtensionInstallError(f"unsupported local extension source: {source}")
+
+        _validate_staged_extension(staging_root)
         _publish_staged_extension(staging, destination, force=force)
         return destination
-    except BaseException:
-        if staging is not None:
-            _remove_path(staging)
-        raise
+    except OSError as exc:
+        raise ExtensionInstallError(f"extension installation failed: {exc}") from exc
+    finally:
+        if staging_root is not None:
+            with contextlib.suppress(OSError):
+                _remove_path(staging_root)
 
 
 def parse_git_extension_source(source: str) -> GitExtensionSource:
@@ -157,25 +156,13 @@ def _validate_install_name(name: str) -> None:
         raise ExtensionInstallError(f"extension source has an unsupported install name: {name!r}")
 
 
-def _validate_staged_extension(staging: Path) -> None:
-    if staging.is_file():
-        if staging.suffix != ".py":
-            raise ExtensionInstallError("an extension file must have a .py suffix")
-        return
-
-    paths = TauResourcePaths(root=staging.parent / ".validation-home", cwd=Path.cwd())
-    discovered, diagnostics = discover_extensions(
-        paths,
-        extra_paths=(staging,),
-        include_resource_dirs=False,
-    )
+def _validate_staged_extension(staging_root: Path) -> None:
+    paths = TauResourcePaths(root=staging_root, cwd=Path.cwd())
+    discovered, diagnostics = discover_extensions(paths)
     errors = [diagnostic.message for diagnostic in diagnostics if diagnostic.severity == "error"]
     if errors:
         raise ExtensionInstallError("invalid extension package: " + "; ".join(errors))
-    # A directory in ~/.tau/extensions is only auto-discovered when it is a
-    # package-style extension. A loose directory of standalone .py files works
-    # with -e but would silently disappear after installation.
-    if not discovered or any(entry.package_dir is None for entry in discovered):
+    if not discovered:
         raise ExtensionInstallError(
             "an extension directory must contain extension.py or declare "
             "[tool.tau].extensions in pyproject.toml"

--- a/src/tau_coding/extension_installer.py
+++ b/src/tau_coding/extension_installer.py
@@ -1,0 +1,213 @@
+"""Install Tau extensions from local paths or Git repositories."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import mkdtemp, mkstemp
+
+from tau_coding.extensions import discover_extensions
+from tau_coding.paths import TauPaths
+from tau_coding.resources import TauResourcePaths
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+class ExtensionInstallError(RuntimeError):
+    """Raised when an extension source cannot be installed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class GitExtensionSource:
+    """A normalized Git repository source and optional checkout ref."""
+
+    url: str
+    ref: str | None
+    name: str
+
+
+def install_extension(
+    source: str,
+    *,
+    force: bool = False,
+    extensions_dir: Path | None = None,
+    command_runner: CommandRunner = subprocess.run,
+) -> Path:
+    """Install one extension into Tau's user extension directory.
+
+    Local Python files are copied. Local package directories and Git
+    repositories must expose ``extension.py`` or ``[tool.tau].extensions`` so
+    the normal user-directory discovery path can load them on the next run.
+    """
+    destination_root = extensions_dir or TauPaths().user_extensions_dir
+    destination_root.mkdir(parents=True, exist_ok=True)
+
+    staging: Path | None = None
+    try:
+        local_source = Path(source).expanduser()
+        if local_source.exists():
+            resolved_source = local_source.resolve()
+            name = _local_install_name(resolved_source)
+            destination = destination_root / name
+            if resolved_source.is_file():
+                descriptor, staging_name = mkstemp(
+                    prefix=f".{resolved_source.stem}.install-",
+                    suffix=".py",
+                    dir=destination_root,
+                )
+                os.close(descriptor)
+                staging = Path(staging_name)
+                shutil.copy2(resolved_source, staging)
+            elif resolved_source.is_dir():
+                staging = Path(mkdtemp(prefix=f".{name}.install-", dir=destination_root))
+                staging.rmdir()
+                shutil.copytree(resolved_source, staging, ignore=_local_copy_ignore)
+            else:
+                raise ExtensionInstallError(f"unsupported local extension source: {source}")
+        else:
+            git_source = parse_git_extension_source(source)
+            name = git_source.name
+            destination = destination_root / name
+            staging = Path(mkdtemp(prefix=f".{name}.install-", dir=destination_root))
+            staging.rmdir()
+            _clone_git_source(git_source, staging, command_runner=command_runner)
+
+        _validate_staged_extension(staging)
+        _publish_staged_extension(staging, destination, force=force)
+        return destination
+    except BaseException:
+        if staging is not None:
+            _remove_path(staging)
+        raise
+
+
+def parse_git_extension_source(source: str) -> GitExtensionSource:
+    """Normalize a Pi-style Git source accepted by ``tau install``."""
+    raw = source[4:] if source.startswith("git:") else source
+    if not raw:
+        raise ExtensionInstallError("Git extension source is empty")
+
+    ref: str | None = None
+    last_at = raw.rfind("@")
+    last_separator = max(raw.rfind("/"), raw.rfind(":"))
+    if last_at > last_separator:
+        raw, ref = raw[:last_at], raw[last_at + 1 :]
+        if not ref:
+            raise ExtensionInstallError("Git extension ref is empty")
+
+    if raw.startswith("github.com/"):
+        url = f"https://{raw}"
+    elif raw.startswith(("https://", "http://", "ssh://", "git://", "file://", "git@")):
+        url = raw
+    else:
+        raise ExtensionInstallError(
+            "extension source does not exist locally and is not a supported Git source; "
+            "use a local path, git:github.com/owner/repo, or a Git URL"
+        )
+
+    repository_path = raw.rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+    name = repository_path.removesuffix(".git")
+    _validate_install_name(name)
+    return GitExtensionSource(url=url, ref=ref, name=name)
+
+
+def _clone_git_source(
+    source: GitExtensionSource,
+    destination: Path,
+    *,
+    command_runner: CommandRunner,
+) -> None:
+    result = command_runner(
+        ["git", "clone", "--", source.url, str(destination)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git clone failed").strip()
+        raise ExtensionInstallError(f"could not clone {source.url}: {detail}")
+    if source.ref is None:
+        return
+    result = command_runner(
+        ["git", "-C", str(destination), "checkout", "--detach", source.ref],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git checkout failed").strip()
+        raise ExtensionInstallError(f"could not check out ref {source.ref!r}: {detail}")
+
+
+def _local_install_name(source: Path) -> str:
+    if source.is_file() and source.suffix != ".py":
+        raise ExtensionInstallError("a local extension file must have a .py suffix")
+    name = source.name
+    _validate_install_name(name)
+    return name
+
+
+def _validate_install_name(name: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", name) or name in {".", ".."}:
+        raise ExtensionInstallError(f"extension source has an unsupported install name: {name!r}")
+
+
+def _validate_staged_extension(staging: Path) -> None:
+    if staging.is_file():
+        if staging.suffix != ".py":
+            raise ExtensionInstallError("an extension file must have a .py suffix")
+        return
+
+    paths = TauResourcePaths(root=staging.parent / ".validation-home", cwd=Path.cwd())
+    discovered, diagnostics = discover_extensions(
+        paths,
+        extra_paths=(staging,),
+        include_resource_dirs=False,
+    )
+    errors = [diagnostic.message for diagnostic in diagnostics if diagnostic.severity == "error"]
+    if errors:
+        raise ExtensionInstallError("invalid extension package: " + "; ".join(errors))
+    # A directory in ~/.tau/extensions is only auto-discovered when it is a
+    # package-style extension. A loose directory of standalone .py files works
+    # with -e but would silently disappear after installation.
+    if not discovered or any(entry.package_dir is None for entry in discovered):
+        raise ExtensionInstallError(
+            "an extension directory must contain extension.py or declare "
+            "[tool.tau].extensions in pyproject.toml"
+        )
+
+
+def _publish_staged_extension(staging: Path, destination: Path, *, force: bool) -> None:
+    if destination.exists() or destination.is_symlink():
+        if not force:
+            raise ExtensionInstallError(
+                f"extension is already installed at {destination}; pass --force to replace it"
+            )
+        backup = destination.with_name(f".{destination.name}.backup")
+        _remove_path(backup)
+        destination.replace(backup)
+        try:
+            staging.replace(destination)
+        except BaseException:
+            backup.replace(destination)
+            raise
+        _remove_path(backup)
+        return
+    staging.replace(destination)
+
+
+def _local_copy_ignore(_directory: str, names: Sequence[str]) -> set[str]:
+    ignored = {".git", ".hg", ".svn", ".venv", "__pycache__", ".pytest_cache", ".mypy_cache"}
+    return ignored.intersection(names)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path)

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -50,6 +50,11 @@ class TauPaths:
         return self.home / "themes"
 
     @property
+    def user_extensions_dir(self) -> Path:
+        """Return Tau's user-level extension directory."""
+        return self.home / "extensions"
+
+    @property
     def user_agents_skills_dir(self) -> Path:
         """Return the user-level `.agents/skills` directory."""
         return self.agents_home / "skills"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,49 @@ def test_help_lists_system_prompt_options() -> None:
     assert "--append-system-promptTEXT_OR_PATH" in output
 
 
+def test_install_command_installs_extension(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, bool]] = []
+    destination = tmp_path / ".tau" / "extensions" / "demo"
+
+    def fake_install(source: str, *, force: bool = False) -> Path:
+        calls.append((source, force))
+        return destination
+
+    monkeypatch.setattr(cli, "install_extension", fake_install)
+
+    result = CliRunner().invoke(
+        app,
+        ["install", "git:github.com/example/demo", "--force"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("git:github.com/example/demo", True)]
+    assert "execute arbitrary Python" in result.output
+    assert f"Installed git:github.com/example/demo to {destination}" in result.output
+
+
+def test_install_command_reports_install_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_install(source: str, *, force: bool = False) -> Path:
+        del source, force
+        raise cli.ExtensionInstallError("clone failed")
+
+    monkeypatch.setattr(cli, "install_extension", fail_install)
+
+    result = CliRunner().invoke(app, ["install", "git:github.com/example/demo"])
+
+    assert result.exit_code == 1
+    assert "Could not install extension: clone failed" in result.output
+
+
+def test_install_command_requires_exactly_one_source() -> None:
+    result = CliRunner().invoke(app, ["install"])
+
+    assert result.exit_code == 2
+    assert "Usage: tau install <source> [--force]" in _panel_text(result.output)
+
+
 def test_prompt_inputs_resolve_files_literals_and_append_order(tmp_path: Path) -> None:
     base_path = tmp_path / "base.md"
     append_path = tmp_path / "append.md"

--- a/tests/test_extension_installer.py
+++ b/tests/test_extension_installer.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tau_coding.extension_installer import (
+    ExtensionInstallError,
+    install_extension,
+    parse_git_extension_source,
+)
+from tau_coding.extensions import discover_extensions
+from tau_coding.resources import TauResourcePaths
+
+
+def test_install_local_extension_file_is_discovered(tmp_path: Path) -> None:
+    source = tmp_path / "hello.py"
+    source.write_text("def setup(tau):\n    pass\n", encoding="utf-8")
+    extensions_dir = tmp_path / "home" / "extensions"
+
+    destination = install_extension(str(source), extensions_dir=extensions_dir)
+
+    assert destination == extensions_dir / "hello.py"
+    paths = TauResourcePaths(root=tmp_path / "home", cwd=tmp_path)
+    discovered, diagnostics = discover_extensions(paths)
+    assert [entry.name for entry in discovered] == ["hello"]
+    assert diagnostics == ()
+
+
+def test_install_local_package_copies_manifest_layout(tmp_path: Path) -> None:
+    source = tmp_path / "my-extension"
+    entry = source / "src" / "my_extension" / "extension.py"
+    entry.parent.mkdir(parents=True)
+    entry.write_text("from . import helper\n\ndef setup(tau):\n    pass\n", encoding="utf-8")
+    (entry.parent / "helper.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (source / "pyproject.toml").write_text(
+        '[tool.tau]\nextensions = ["src/my_extension/extension.py"]\n',
+        encoding="utf-8",
+    )
+    extensions_dir = tmp_path / "home" / "extensions"
+
+    destination = install_extension(str(source), extensions_dir=extensions_dir)
+
+    assert (destination / "src" / "my_extension" / "helper.py").is_file()
+    paths = TauResourcePaths(root=tmp_path / "home", cwd=tmp_path)
+    discovered, diagnostics = discover_extensions(paths)
+    assert [item.name for item in discovered] == ["my_extension"]
+    assert diagnostics == ()
+
+
+def test_install_rejects_directory_that_would_not_be_auto_discovered(tmp_path: Path) -> None:
+    source = tmp_path / "loose-files"
+    source.mkdir()
+    (source / "one.py").write_text("def setup(tau):\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(ExtensionInstallError, match="extension.py"):
+        install_extension(str(source), extensions_dir=tmp_path / "extensions")
+
+
+def test_install_preserves_existing_extension_without_force(tmp_path: Path) -> None:
+    source = tmp_path / "hello.py"
+    source.write_text("new\n", encoding="utf-8")
+    extensions_dir = tmp_path / "extensions"
+    extensions_dir.mkdir()
+    installed = extensions_dir / "hello.py"
+    installed.write_text("old\n", encoding="utf-8")
+
+    with pytest.raises(ExtensionInstallError, match="already installed"):
+        install_extension(str(source), extensions_dir=extensions_dir)
+
+    assert installed.read_text(encoding="utf-8") == "old\n"
+
+
+def test_install_force_replaces_existing_extension(tmp_path: Path) -> None:
+    source = tmp_path / "hello.py"
+    source.write_text("new\n", encoding="utf-8")
+    extensions_dir = tmp_path / "extensions"
+    extensions_dir.mkdir()
+    installed = extensions_dir / "hello.py"
+    installed.write_text("old\n", encoding="utf-8")
+
+    destination = install_extension(str(source), extensions_dir=extensions_dir, force=True)
+
+    assert destination.read_text(encoding="utf-8") == "new\n"
+    assert not (extensions_dir / ".hello.py.backup").exists()
+
+
+@pytest.mark.parametrize(
+    ("source", "url", "ref", "name"),
+    [
+        (
+            "git:github.com/rian-dolphin/tau-subagents@v1.2.0",
+            "https://github.com/rian-dolphin/tau-subagents",
+            "v1.2.0",
+            "tau-subagents",
+        ),
+        (
+            "https://github.com/rian-dolphin/tau-subagents.git",
+            "https://github.com/rian-dolphin/tau-subagents.git",
+            None,
+            "tau-subagents",
+        ),
+        (
+            "git:git@github.com:rian-dolphin/tau-subagents.git@abc123",
+            "git@github.com:rian-dolphin/tau-subagents.git",
+            "abc123",
+            "tau-subagents",
+        ),
+    ],
+)
+def test_parse_git_extension_source(source: str, url: str, ref: str | None, name: str) -> None:
+    parsed = parse_git_extension_source(source)
+
+    assert (parsed.url, parsed.ref, parsed.name) == (url, ref, name)
+
+
+def test_failed_git_install_removes_partial_clone(tmp_path: Path) -> None:
+    extensions_dir = tmp_path / "extensions"
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check
+        Path(command[-1]).mkdir()
+        return subprocess.CompletedProcess(command, 1, "", "network failed")
+
+    with pytest.raises(ExtensionInstallError, match="network failed"):
+        install_extension(
+            "git:github.com/example/tau-demo",
+            extensions_dir=extensions_dir,
+            command_runner=fake_run,
+        )
+
+    assert list(extensions_dir.iterdir()) == []
+
+
+def test_install_git_source_clones_and_checks_out_ref(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check
+        calls.append(command)
+        if command[1] == "clone":
+            destination = Path(command[-1])
+            destination.mkdir()
+            (destination / "extension.py").write_text(
+                "def setup(tau):\n    pass\n", encoding="utf-8"
+            )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    destination = install_extension(
+        "git:github.com/example/tau-demo@v1",
+        extensions_dir=tmp_path / "extensions",
+        command_runner=fake_run,
+    )
+
+    assert destination == tmp_path / "extensions" / "tau-demo"
+    assert calls[0][:4] == ["git", "clone", "--", "https://github.com/example/tau-demo"]
+    assert calls[1][0:2] == ["git", "-C"]
+    assert Path(calls[1][2]).parent == destination.parent
+    assert calls[1][3:] == ["checkout", "--detach", "v1"]

--- a/tests/test_extension_installer.py
+++ b/tests/test_extension_installer.py
@@ -49,10 +49,14 @@ def test_install_local_package_copies_manifest_layout(tmp_path: Path) -> None:
     assert diagnostics == ()
 
 
-def test_install_rejects_directory_that_would_not_be_auto_discovered(tmp_path: Path) -> None:
-    source = tmp_path / "loose-files"
-    source.mkdir()
-    (source / "one.py").write_text("def setup(tau):\n    pass\n", encoding="utf-8")
+@pytest.mark.parametrize("nested_entry", ["one.py", "nested/extension.py"])
+def test_install_rejects_directory_that_would_not_be_auto_discovered(
+    tmp_path: Path, nested_entry: str
+) -> None:
+    source = tmp_path / "nested-only"
+    entry = source / nested_entry
+    entry.parent.mkdir(parents=True)
+    entry.write_text("def setup(tau):\n    pass\n", encoding="utf-8")
 
     with pytest.raises(ExtensionInstallError, match="extension.py"):
         install_extension(str(source), extensions_dir=tmp_path / "extensions")
@@ -115,6 +119,21 @@ def test_parse_git_extension_source(source: str, url: str, ref: str | None, name
     assert (parsed.url, parsed.ref, parsed.name) == (url, ref, name)
 
 
+def test_missing_git_is_reported_as_install_error(tmp_path: Path) -> None:
+    def missing_git(
+        command: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        del command, capture_output, text, check
+        raise FileNotFoundError("git executable not found")
+
+    with pytest.raises(ExtensionInstallError, match="git executable not found"):
+        install_extension(
+            "git:github.com/example/tau-demo",
+            extensions_dir=tmp_path / "extensions",
+            command_runner=missing_git,
+        )
+
+
 def test_failed_git_install_removes_partial_clone(tmp_path: Path) -> None:
     extensions_dir = tmp_path / "extensions"
 
@@ -160,5 +179,5 @@ def test_install_git_source_clones_and_checks_out_ref(tmp_path: Path) -> None:
     assert destination == tmp_path / "extensions" / "tau-demo"
     assert calls[0][:4] == ["git", "clone", "--", "https://github.com/example/tau-demo"]
     assert calls[1][0:2] == ["git", "-C"]
-    assert Path(calls[1][2]).parent == destination.parent
+    assert Path(calls[1][2]).name == destination.name
     assert calls[1][3:] == ["checkout", "--detach", "v1"]

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -42,6 +42,42 @@ def setup(tau):
 Start `tau` and the model can call `greet`. Every extension is a module
 defining `setup(tau)`, which runs once at startup with the extension API.
 
+## Install an extension
+
+Install a trusted extension from Git with the same command shape as Pi:
+
+```bash
+tau install git:github.com/owner/repository
+tau install git:github.com/owner/repository@v1.2.0
+tau install https://github.com/owner/repository.git
+```
+
+Tau clones the repository into `~/.tau/extensions/<repository>` and loads it on
+the next Tau startup. A pinned ref may be a tag, branch, or commit. Replacing an
+existing install requires an explicit opt-in:
+
+```bash
+tau install git:github.com/owner/repository@v1.3.0 --force
+```
+
+Local files and package directories work too:
+
+```bash
+tau install ./my_extension.py
+tau install ./my-extension
+```
+
+A local file is copied into `~/.tau/extensions/`. A directory is copied and must
+contain `extension.py` or declare `[tool.tau].extensions` in `pyproject.toml`, so
+it remains discoverable without `-e`. Local virtual environments, VCS metadata,
+and Python cache directories are not copied.
+
+The installer validates discovery metadata without importing the extension.
+It does not install Python dependencies, maintain a package registry, or provide
+remove/update commands yet. Install dependencies into Tau's Python environment
+separately when an extension requires them. Extensions execute arbitrary Python
+with your user permissions, so review the source before installation.
+
 ## Where extensions live
 
 | Location | Loaded |
@@ -519,12 +555,9 @@ tau -e ./tau-subagents
 
 ## Not yet supported
 
-Compared to Pi's extension system, v1 does not yet include: package
-management (`pi install`-style), custom providers, extension-authored TUI
-widgets (custom *message* rendering via `register_message_renderer` *is*
-supported; the host-provided `context.ui` dialogs *are* supported), custom
-entry renderers (non-context cards), keyboard shortcuts, CLI flag
-registration, system-prompt replacement, context rewriting, or a project trust
-store. The
-architecture document
-(`dev-notes/architecture/phase-21-extensions.md`) tracks these.
+Compared to Pi's extension system, Tau does not yet include a complete package
+manager (the installer has no registry, dependency installation, remove, or
+package-update commands), custom providers, custom entry renderers (non-context
+cards), declarative keyboard-shortcut registration, CLI flag registration,
+system-prompt replacement, or context rewriting. The architecture document
+(`dev-notes/architecture/phase-21-extensions.md`) tracks the extension design.

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -30,6 +30,7 @@ features and fixes.
 | `tau` | Open the interactive TUI |
 | `tau "<prompt>"` | Open the TUI with an initial prompt |
 | `tau update` | Upgrade Tau with the installer that owns its environment. Windows uv-tool updates are handed off and begin after Tau exits; follow the printed log path for the final result. |
+| `tau install <source> [--force]` | Install a trusted local or Git extension under `~/.tau/extensions/`; `--force` replaces an existing install. |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |
 | `tau --export <ref> [dest]` | Same as `tau export`, as a top-level flag |
@@ -57,6 +58,11 @@ features and fixes.
 | `-a, --approve` | Trust protected project inputs for this invocation only |
 | `-na, --no-approve` | Decline protected project inputs for this invocation only |
 | `-v, --version` | Print the version and exit |
+
+`tau install` accepts local Python files, local package directories, Pi-style
+`git:github.com/owner/repository[@ref]` sources, and normal HTTP/SSH Git URLs.
+See [Extensions]({{< relref "../guides/extensions.md#install-an-extension" >}})
+for package-layout, dependency, and security details.
 
 `--approve` and `--no-approve` are mutually exclusive and never write the
 trust store. See [Project trust]({{< relref "../guides/project-trust.md" >}})


### PR DESCRIPTION
## Summary

- add `tau install <source>` for trusted local and Git-hosted extensions
- support Pi-style `git:github.com/owner/repo[@ref]` sources plus normal Git URLs
- stage and validate installs before publishing them under `~/.tau/extensions/`
- preserve existing installs unless `--force` is supplied
- document the command, security boundary, and current package-manager limitations

## User experience

Users no longer need to manually clone/copy extensions into Tau's resource directory or pass `-e` on every run:

```bash
tau install git:github.com/rian-dolphin/tau-subagents
tau install ./my-extension.py
```

The command prints an arbitrary-code warning, rejects directory layouts that would not be auto-discovered, cleans failed staging installs, and accepts pinned Git refs.

## Scope

This is the extension-install slice of Pi's package workflow. It does not yet add a package registry, dependency installation, remove/update commands, or non-extension package resources.

## Validation

- `uv run pytest` — 1564 passed, 2 skipped (Windows-only)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- manually installed `examples/extensions/hello_tool.py` with an isolated home
- manually cloned and installed `https://github.com/rian-dolphin/tau-subagents.git` with an isolated home
