### PR TITLE
Phase 3: add trust-aware session preparation

### DIFF
--- a/src/tau_agent/session/__init__.py
+++ b/src/tau_agent/session/__init__.py
@@ -22,7 +22,7 @@ from tau_agent.session.jsonl import (
     entry_to_json_line,
 )
 from tau_agent.session.memory import SessionState
-from tau_agent.session.storage import JsonlSessionStorage, SessionStorage
+from tau_agent.session.storage import InMemorySessionStorage, JsonlSessionStorage, SessionStorage
 from tau_agent.session.tree import SessionTreeError, entries_by_id, path_to_entry
 
 __all__ = [
@@ -30,6 +30,7 @@ __all__ = [
     "BranchSummaryEntry",
     "CompactionEntry",
     "CustomEntry",
+    "InMemorySessionStorage",
     "JsonlSessionStorage",
     "LabelEntry",
     "LeafEntry",

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -40,10 +40,16 @@ class MessageEntry(BaseSessionEntry):
 
 
 class ModelChangeEntry(BaseSessionEntry):
-    """A model selection change entry."""
+    """A model selection change entry.
+
+    ``provider`` was added after Tau's first session format.  It remains
+    optional so older transcripts continue to load; new entries always carry
+    the provider selected by the host.
+    """
 
     type: Literal["model_change"] = "model_change"
     model: str
+    provider: str | None = None
 
 
 class ThinkingLevelChangeEntry(BaseSessionEntry):

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -24,6 +24,7 @@ class SessionState:
 
     messages: tuple[AgentMessage, ...]
     model: str | None
+    provider: str | None
     thinking_level: str | None
     label: str | None
     active_leaf_id: str | None
@@ -58,6 +59,7 @@ class SessionState:
 
         message_rows: list[tuple[str, AgentMessage]] = []
         model: str | None = None
+        provider: str | None = None
         thinking_level: str | None = None
         label: str | None = None
         active_leaf_id: str | None = resolved_leaf_id
@@ -71,6 +73,8 @@ class SessionState:
                     message_rows.append((entry.id, entry.message))
                 case "model_change":
                     model = entry.model
+                    if entry.provider is not None:
+                        provider = entry.provider
                 case "thinking_level_change":
                     thinking_level = entry.thinking_level
                 case "label":
@@ -92,6 +96,7 @@ class SessionState:
         return cls(
             messages=tuple(message for _entry_id, message in message_rows),
             model=model,
+            provider=provider,
             thinking_level=thinking_level,
             label=label,
             active_leaf_id=active_leaf_id,

--- a/src/tau_agent/session/storage.py
+++ b/src/tau_agent/session/storage.py
@@ -1,19 +1,33 @@
-"""Session storage protocols and JSONL implementation."""
+"""Locked, append-only session storage implementations."""
 
 from __future__ import annotations
 
+import asyncio
+import os
+import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Protocol
+from typing import BinaryIO, Protocol
 
 from tau_agent.session.entries import SessionEntry
 from tau_agent.session.jsonl import entries_from_json_lines, entry_to_json_line
 
 
 class SessionStorage(Protocol):
-    """Append-only session storage interface."""
+    """Append-only session storage interface.
+
+    ``append_batch`` is the durable transaction boundary used by startup,
+    replacement, and model selection. Implementations must make the complete
+    batch visible or leave the previous transcript untouched.
+    """
 
     async def append(self, entry: SessionEntry) -> None:
         """Append one entry to storage."""
+        ...
+
+    async def append_batch(self, entries: Sequence[SessionEntry]) -> None:
+        """Atomically append a complete batch of entries."""
         ...
 
     async def read_all(self) -> list[SessionEntry]:
@@ -22,21 +36,168 @@ class SessionStorage(Protocol):
 
 
 class JsonlSessionStorage:
-    """Local append-only JSONL session storage."""
+    """Local JSONL storage with a per-session cross-process lock.
+
+    The lock is deliberately separate from the transcript. Readers use a
+    shared lock when the platform provides one; every write uses an exclusive
+    lock and re-reads the current file before changing it. Batch writes use a
+    same-directory temporary file, fsync, replace, and directory fsync.
+    """
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
+        self.lock_path = self.path.with_name(f".{self.path.name}.lock")
+        self.temp_path = self.path.with_name(f".{self.path.name}.tmp")
 
     async def append(self, entry: SessionEntry) -> None:
-        """Append one entry, creating parent directories if needed."""
+        """Append one entry under the session's exclusive cross-process lock."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open("a", encoding="utf-8") as file:
-            file.write(entry_to_json_line(entry))
+        with self._locked(exclusive=True):
+            self._remove_incomplete_temp()
+            with self.path.open("ab") as file:
+                file.write(entry_to_json_line(entry).encode("utf-8"))
+                file.flush()
+                os.fsync(file.fileno())
+
+    async def append_batch(self, entries: Sequence[SessionEntry]) -> None:
+        """Atomically append all entries, preserving the old file on failure."""
+        batch = tuple(entries)
+        if not batch:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = b"".join(entry_to_json_line(entry).encode("utf-8") for entry in batch)
+        with self._locked(exclusive=True):
+            self._remove_incomplete_temp()
+            previous = self.path.read_bytes() if self.path.exists() else b""
+            data = previous + encoded
+            self._atomic_replace(data)
 
     async def read_all(self) -> list[SessionEntry]:
-        """Read all entries in file order. Missing files are empty sessions."""
+        """Read all entries in file order; missing files are empty sessions."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # A fixed temp name makes crash recovery deterministic. If it exists,
+        # take an exclusive lock and discard it; it was never the commit file.
+        if self.temp_path.exists():
+            with self._locked(exclusive=True):
+                self._remove_incomplete_temp()
+                return self._read_unlocked()
+        with self._locked(exclusive=False):
+            return self._read_unlocked()
+
+    def _read_unlocked(self) -> list[SessionEntry]:
         if not self.path.exists():
             return []
-        # Split on newlines only: str.splitlines() would also split on characters
-        # like U+2028 that appear unescaped inside JSON string values.
         return entries_from_json_lines(self.path.read_text(encoding="utf-8").split("\n"))
+
+    def _atomic_replace(self, data: bytes) -> None:
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=self.path.parent,
+        )
+        # Keep the stable recovery marker in addition to the unique temp. A
+        # crash between writes leaves a safely removable artifact.
+        try:
+            os.close(descriptor)
+            temporary_path = Path(temporary)
+            with temporary_path.open("wb") as file:
+                file.write(data)
+                file.flush()
+                os.fsync(file.fileno())
+            os.replace(temporary_path, self.path)
+            _fsync_directory(self.path.parent)
+        except BaseException:
+            with _suppress_os_error():
+                Path(temporary).unlink()
+            raise
+
+    def _remove_incomplete_temp(self) -> None:
+        with _suppress_os_error():
+            self.temp_path.unlink()
+        # Also clean unique temp files left by a process killed during a
+        # replacement. They are never authoritative because replace is atomic.
+        prefix = f".{self.path.name}."
+        for candidate in self.path.parent.glob(f"{prefix}*.tmp"):
+            with _suppress_os_error():
+                candidate.unlink()
+
+    @contextmanager
+    def _locked(self, *, exclusive: bool) -> Iterator[None]:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+b") as lock_file:
+            os.chmod(self.lock_path, 0o600)
+            _lock_file(lock_file, exclusive=exclusive)
+            try:
+                yield
+            finally:
+                _unlock_file(lock_file)
+
+
+class InMemorySessionStorage:
+    """Deterministic storage useful for tests and embedded frontends."""
+
+    def __init__(self, entries: Sequence[SessionEntry] = ()) -> None:
+        self.entries = list(entries)
+        self._lock = asyncio.Lock()
+
+    async def append(self, entry: SessionEntry) -> None:
+        async with self._lock:
+            self.entries.append(entry)
+
+    async def append_batch(self, entries: Sequence[SessionEntry]) -> None:
+        async with self._lock:
+            self.entries.extend(entries)
+
+    async def read_all(self) -> list[SessionEntry]:
+        async with self._lock:
+            return list(self.entries)
+
+
+@contextmanager
+def _suppress_os_error() -> Iterator[None]:
+    with suppress(OSError):
+        yield
+
+
+def _lock_file(file: BinaryIO, *, exclusive: bool) -> None:
+    """Apply an advisory lock, with a clear unsupported-platform fallback."""
+    if os.name == "nt":
+        import msvcrt
+
+        # msvcrt has no shared lock; an exclusive lock is the safe behavior for
+        # reads on Windows and still provides cross-process serialization.
+        del exclusive
+        msvcrt.locking(file.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+        return
+    import fcntl
+
+    mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    fcntl.flock(file.fileno(), mode)
+
+
+def _unlock_file(file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        return
+    import fcntl
+
+    fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist the directory entry where the OS supports directory fsync."""
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        with suppress(OSError):
+            os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = ["InMemorySessionStorage", "JsonlSessionStorage", "SessionStorage"]

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import sys
+from collections.abc import Sequence
 from os import environ
 from pathlib import Path
 from typing import Annotated
@@ -30,6 +31,7 @@ from tau_coding.provider_config import (
     CredentialReader,
     OpenAICompatibleProviderConfig,
     ProviderConfig,
+    ProviderConfigError,
     ProviderSettings,
     load_provider_settings,
     provider_kind,
@@ -38,7 +40,7 @@ from tau_coding.provider_config import (
     save_provider_settings,
     upsert_openai_compatible_provider,
 )
-from tau_coding.provider_runtime import create_model_provider
+from tau_coding.provider_runtime import ClosableModelProvider, create_model_provider
 from tau_coding.rendering import PrintOutputMode, create_event_renderer
 from tau_coding.resources import TauResourcePaths
 from tau_coding.session import (
@@ -54,6 +56,7 @@ from tau_coding.session_export import (
     normalize_export_format,
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager, validate_session_id
+from tau_coding.session_preparation import prepare_coding_session
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.tui import run_tui_app
 from tau_coding.update_check import (
@@ -787,42 +790,86 @@ async def run_openai_print_mode(
         session_id=session_id,
     )
     explicit_selection = provider_name is not None or model is not None
-    selection = resolve_provider_selection(
-        settings,
-        provider_name=provider_name if explicit_selection else record.provider_name,
-        model=model if explicit_selection else record.model,
+    selection = None
+    if not explicit_selection and record.provider_name is None:
+        selection = resolve_provider_selection(settings)
+    elif not explicit_selection and record.provider_name is not None:
+        try:
+            selection = resolve_provider_selection(
+                settings,
+                provider_name=record.provider_name,
+                model=record.model,
+            )
+        except ProviderConfigError:
+            selection = None
+    selected_model = model or record.model or (selection.model if selection is not None else "")
+    selected_provider: str = (
+        provider_name
+        if provider_name is not None
+        else record.provider_name
+        or (selection.provider.name if selection is not None else DEFAULT_PROVIDER_NAME)
     )
-    inference_provider = (
-        record.inference_provider
-        if resume_session_id is not None
-        and record.provider_name == "huggingface"
-        and selection.provider.name == "huggingface"
-        and record.model == selection.model
-        else selection.provider.inference_providers.get(selection.model)
-        if isinstance(selection.provider, OpenAICompatibleProviderConfig)
-        and selection.provider.name == "huggingface"
-        else None
-    )
-    provider = create_model_provider(
-        selection.provider,
-        model=selection.model,
-        inference_provider=inference_provider,
-        thinking_level=resolve_startup_thinking_level(selection.provider, selection.model),
-    )
+    # Durable providers retain the established print-mode construction seam.
+    # Dynamic providers are absent from ProviderSettings and therefore remain
+    # None until CodingSession's trusted staged environment resolves them.
+    static_selection = selection
+    if static_selection is None:
+        try:
+            static_selection = resolve_provider_selection(
+                settings,
+                provider_name=selected_provider,
+                model=selected_model or None,
+            )
+        except ProviderConfigError:
+            static_selection = None
+    initial_provider: ClosableModelProvider | None = None
+    runtime_config: ProviderConfig | None = None
+    runtime_inference = record.inference_provider
+    if static_selection is not None:
+        runtime_inference = (
+            record.inference_provider
+            if (
+                resume_session_id is not None
+                and record.provider_name == "huggingface"
+                and static_selection.provider.name == "huggingface"
+                and record.model == static_selection.model
+            )
+            else (
+                static_selection.provider.inference_providers.get(static_selection.model)
+                if isinstance(static_selection.provider, OpenAICompatibleProviderConfig)
+                and static_selection.provider.name == "huggingface"
+                else None
+            )
+        )
+        initial_provider = create_model_provider(
+            static_selection.provider,
+            model=static_selection.model,
+            inference_provider=runtime_inference,
+            thinking_level=resolve_startup_thinking_level(
+                static_selection.provider,
+                static_selection.model,
+            ),
+        )
+        selected_provider = static_selection.provider.name
+        selected_model = static_selection.model
+        runtime_config = static_selection.provider
     try:
         return await run_print_mode(
             prompt=prompt,
-            model=selection.model,
+            model=selected_model,
             cwd=record.cwd,
-            provider=provider,
+            provider=initial_provider,
             output=output,
             storage=jsonl_session_storage(record.path),
             session_id=record.id,
             session_manager=manager,
-            provider_name=selection.provider.name,
-            inference_provider=inference_provider,
+            provider_name=selected_provider,
+            inference_provider=runtime_inference,
             provider_settings=settings,
-            runtime_provider_config=selection.provider,
+            runtime_provider_config=runtime_config,
+            requested_provider=provider_name if explicit_selection else None,
+            requested_model=model if explicit_selection else None,
+            session_provider_name=record.provider_name,
             shell_command_prefix=shell_settings.shell_command_prefix,
             extension_paths=extension_paths,
             extensions_enabled=extensions_enabled,
@@ -831,10 +878,14 @@ async def run_openai_print_mode(
             append_system_prompt=append_system_prompt,
             trust_override=trust_override,
             trust_default=shell_settings.default_project_trust,
-            startup_model_override=provider_name is not None or model is not None,
+            startup_model_override=False,
         )
     finally:
-        await provider.aclose()
+        # This remains the ownership path for the compatibility provider
+        # constructed by this legacy wrapper. Dynamic candidates are created
+        # and owned inside the staged CodingSession instead.
+        if initial_provider is not None:
+            await initial_provider.aclose()
 
 
 def _print_session_record(
@@ -854,7 +905,18 @@ def _print_session_record(
             raise ValueError(f"Unknown session: {resume_session_id}")
         return record
 
-    selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
+    try:
+        selection = resolve_provider_selection(settings, provider_name=provider_name, model=model)
+    except ProviderConfigError:
+        if provider_name is None or model is None:
+            raise
+        return _create_print_session(
+            manager,
+            cwd=cwd,
+            model=model,
+            provider_name=provider_name,
+            session_id=session_id,
+        )
     inference_provider = (
         selection.provider.inference_providers.get(selection.model)
         if isinstance(selection.provider, OpenAICompatibleProviderConfig)
@@ -895,7 +957,7 @@ async def run_print_mode(
     prompt: str,
     model: str,
     cwd: Path,
-    provider: ModelProvider,
+    provider: ModelProvider | None,
     output: PrintOutputMode = PrintOutputMode.text,
     resource_paths: TauResourcePaths | None = None,
     storage: SessionStorage | None = None,
@@ -905,6 +967,9 @@ async def run_print_mode(
     inference_provider: str | None = None,
     provider_settings: ProviderSettings | None = None,
     runtime_provider_config: ProviderConfig | None = None,
+    requested_provider: str | None = None,
+    requested_model: str | None = None,
+    session_provider_name: str | None = None,
     shell_command_prefix: str | None = None,
     extension_paths: tuple[Path, ...] = (),
     extensions_enabled: bool = True,
@@ -920,7 +985,7 @@ async def run_print_mode(
     Returns False when the agent emits a non-recoverable error so CLI callers
     can fail non-interactive runs while still rendering the error message.
     """
-    session = await CodingSession.load(
+    prepared = await prepare_coding_session(
         CodingSessionConfig(
             provider=provider,
             model=model,
@@ -933,6 +998,9 @@ async def run_print_mode(
             inference_provider=inference_provider,
             provider_settings=provider_settings,
             runtime_provider_config=runtime_provider_config,
+            requested_provider=requested_provider,
+            requested_model=requested_model,
+            session_provider_name=session_provider_name,
             shell_command_prefix=shell_command_prefix,
             extension_paths=extension_paths,
             extensions_enabled=extensions_enabled,
@@ -941,8 +1009,18 @@ async def run_print_mode(
             append_system_prompt=append_system_prompt,
             trust_override=trust_override,
             trust_default=trust_default,
-        )
+        ),
+        session_loader=CodingSession,
     )
+    # Informational print commands must not publish the staged initial
+    # transcript; /system explicitly promises not to save anything.
+    if (stripped_prompt := prompt.strip()) == "/system" or stripped_prompt.startswith("/system "):
+        command = prepared.session.handle_command(prompt)
+        await prepared.abort()
+        if command.message:
+            typer.echo(command.message)
+        return True
+    session = await prepared.adopt()
     if startup_model_override:
         await session.apply_startup_model_override(model)
     session.extension_runtime.set_ui_bridge(StderrUiBridge())
@@ -991,6 +1069,9 @@ class _MemorySessionStorage:
 
     async def append(self, entry: SessionEntry) -> None:
         self.entries.append(entry)
+
+    async def append_batch(self, entries: Sequence[SessionEntry]) -> None:
+        self.entries.extend(entries)
 
     async def read_all(self) -> list[SessionEntry]:
         return list(self.entries)

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -114,6 +114,8 @@ class CommandResult:
     logout_picker_requested: bool = False
     logout_provider: str | None = None
     model_picker_requested: bool = False
+    model_selection_provider: str | None = None
+    model_selection_model: str | None = None
     tools_picker_requested: bool = False
     scoped_models_picker_requested: bool = False
     skills_picker_requested: bool = False
@@ -637,6 +639,12 @@ def _model_command(context: CommandContext) -> CommandResult:
                 handled=True,
                 message=f"Unknown model for provider {context.session.provider_name}: {model}\n"
                 f"Available models: {models}",
+            )
+        if callable(getattr(context.session, "select_provider_model", None)):
+            return CommandResult(
+                handled=True,
+                model_selection_provider=context.session.provider_name,
+                model_selection_model=model,
             )
         context.session.set_model(model)
         return CommandResult(handled=True, message=f"Current model: {model}")

--- a/src/tau_coding/project_trust.py
+++ b/src/tau_coding/project_trust.py
@@ -97,6 +97,8 @@ class ProjectTrustResolution:
     diagnostics: tuple[str, ...] = ()
     had_candidates: bool = True
     cancelled: bool = False
+    # True when staged preparation deferred the durable trust-store write.
+    needs_persistence: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -500,6 +502,7 @@ class ProjectTrustCoordinator:
         extension_deciders: Sequence[ExtensionDecider] = (),
         refresh: bool = False,
         cache_result: bool = True,
+        persist: bool = True,
     ) -> tuple[ProtectedResourceSummary, ProjectTrustResolution]:
         canonical = canonicalize_project_path(cwd, base=Path.cwd())
         summary = self.detector.detect(canonical)
@@ -543,19 +546,24 @@ class ProjectTrustCoordinator:
                 continue
             trusted = extension_result.decision == "approve"
             saved_path: CanonicalProjectPath | None = None
+            needs_persistence = False
             if extension_result.remember:
-                try:
-                    self.store.set(canonical, "trusted" if trusted else "untrusted")
-                except ProjectTrustError as exc:
-                    diagnostics.append(str(exc))
-                    trusted = False
+                saved_path = canonical
+                if persist:
+                    try:
+                        self.store.set(canonical, "trusted" if trusted else "untrusted")
+                    except ProjectTrustError as exc:
+                        diagnostics.append(str(exc))
+                        trusted = False
+                        saved_path = None
                 else:
-                    saved_path = canonical
+                    needs_persistence = True
             result = ProjectTrustResolution(
                 trusted=trusted,
                 source="extension",
                 saved_path=saved_path,
                 diagnostics=tuple(diagnostics),
+                needs_persistence=needs_persistence,
             )
             return summary, finish(result)
 
@@ -590,15 +598,26 @@ class ProjectTrustCoordinator:
         choice = await prompt(ProjectTrustRequest(canonical, summary, inherited))
         trusted = choice in {"trust-exact", "trust-parent", "trust-run"}
         saved_path = None
+        needs_persistence = False
         try:
             if choice == "trust-exact":
-                self.store.set(canonical, "trusted")
                 saved_path = canonical
+                if persist:
+                    self.store.set(canonical, "trusted")
+                else:
+                    needs_persistence = True
             elif choice == "trust-parent":
-                saved_path = self.store.trust_parent(canonical)
+                saved_path = CanonicalProjectPath(canonical.value.parent)
+                if persist:
+                    saved_path = self.store.trust_parent(canonical)
+                else:
+                    needs_persistence = True
             elif choice == "decline-exact":
-                self.store.set(canonical, "untrusted")
                 saved_path = canonical
+                if persist:
+                    self.store.set(canonical, "untrusted")
+                else:
+                    needs_persistence = True
         except ProjectTrustError as exc:
             diagnostics.append(str(exc))
             trusted = False
@@ -609,11 +628,21 @@ class ProjectTrustCoordinator:
             saved_path=saved_path,
             diagnostics=tuple(diagnostics),
             cancelled=choice is None,
+            needs_persistence=needs_persistence,
         )
         return summary, finish(result)
 
     def commit(self, cwd: CanonicalProjectPath, result: ProjectTrustResolution) -> None:
-        """Publish a staged resolution after its resource snapshot succeeds."""
+        """Publish a staged resolution after its candidate is adopted."""
+        if result.needs_persistence and result.saved_path is not None:
+            # A store failure cannot undo an already adopted run.  The write is
+            # intentionally fail-closed: the next process asks again rather
+            # than accidentally treating an uncommitted grant as durable.
+            with suppress(ProjectTrustError):
+                self.store.set(
+                    result.saved_path,
+                    "trusted" if result.trusted else "untrusted",
+                )
         self._cache[cwd.value] = result
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import string
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -72,6 +72,8 @@ from tau_coding.events import (
     QueueUpdateEvent,
     SessionAgentEndEvent,
 )
+from tau_coding.extensions.provider_registry import DynamicProviderRegistry
+from tau_coding.extensions.providers import DynamicProvider
 from tau_coding.extensions.runtime import ExtensionRuntime
 from tau_coding.paths import TauPaths
 from tau_coding.project_trust import (
@@ -101,13 +103,18 @@ from tau_coding.provider_config import (
     provider_thinking_levels,
     provider_thinking_unavailable_reason,
     resolve_provider_selection,
+    resolve_startup_thinking_level,
     save_default_provider_model,
     save_provider_thinking_level,
     toggle_saved_scoped_model,
     validate_huggingface_inference_provider,
     validate_provider_model,
 )
-from tau_coding.provider_runtime import ClosableModelProvider, create_model_provider
+from tau_coding.provider_runtime import (
+    ClosableModelProvider,
+    create_dynamic_model_provider,
+    create_model_provider,
+)
 from tau_coding.reload import CodingReloadSummary, ReloadCategorySummary
 from tau_coding.resources import (
     ResourceDiagnostic,
@@ -204,6 +211,14 @@ class ModelChoice:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelSelectionResult:
+    """Result of a candidate-first provider/model selection."""
+
+    choice: ModelChoice
+    changed: bool
+
+
+@dataclass(frozen=True, slots=True)
 class TerminalCommandResult:
     """Result of an input-bar terminal command."""
 
@@ -275,7 +290,7 @@ class _PendingMessageWrite:
 class CodingSessionConfig:
     """Configuration for a persistent coding session."""
 
-    provider: ModelProvider
+    provider: ModelProvider | None
     model: str
     storage: SessionStorage
     cwd: Path
@@ -290,8 +305,13 @@ class CodingSessionConfig:
     command_registry: CommandRegistry | None = None
     provider_name: str = "openai"
     inference_provider: str | None = None
+    requested_provider: str | None = None
+    requested_model: str | None = None
+    session_provider_name: str | None = None
     provider_settings: ProviderSettings | None = None
     runtime_provider_config: ProviderConfig | None = None
+    dynamic_provider: DynamicProvider | None = None
+    owns_initial_provider: bool = False
     auto_compact_token_threshold: int | None = None
     auto_compact_enabled: bool = True
     thinking_level: ThinkingLevel = DEFAULT_THINKING_LEVEL
@@ -319,6 +339,9 @@ class CodingSessionConfig:
     trust_default: TrustDefault = "ask"
     trust_interactive: bool = False
     trust_prompt: TrustPrompt | None = None
+    # Shared preparation keeps transcript/trust/index writes staged until
+    # PreparedCodingSession.adopt() reaches its durable commit point.
+    defer_authoritative_writes: bool = False
 
 
 class CodingSession:
@@ -354,10 +377,12 @@ class CodingSession:
         self._state = state
         self._harness = harness
         self._extension_runtime = extension_runtime or ExtensionRuntime()
+        self._provider_registry = self._extension_runtime.provider_registry
         self._image_support = image_support or ImageSupportState()
         self._session_start_pending = False
         self._last_parent_id = last_parent_id
         self._pending_initial_entries = pending_initial_entries
+        self._prepared_entries: list[SessionEntry] = list(pending_initial_entries)
         self._skills = skills
         self._prompt_templates = prompt_templates
         self._context_files = context_files
@@ -408,6 +433,11 @@ class CodingSession:
             model = ModelChangeEntry(
                 parent_id=info.id,
                 model=initial_model,
+                provider=(
+                    config.requested_provider or config.provider_name
+                    if config.defer_authoritative_writes
+                    else None
+                ),
             )
             thinking = ThinkingLevelChangeEntry(
                 parent_id=model.id,
@@ -431,7 +461,17 @@ class CodingSession:
         # Always stage a fresh eligible-only runtime for a destination snapshot;
         # never reuse source-project code across replacement trust boundaries.
         previous_runtime = config.extension_runtime
-        extension_runtime = ExtensionRuntime()
+        credential_store = FileCredentialStore(
+            credentials_path(unfiltered_resource_paths.paths)
+            if unfiltered_resource_paths.paths is not None
+            else None
+        )
+        extension_runtime = ExtensionRuntime(
+            durable_providers=(
+                config.provider_settings.providers if config.provider_settings else ()
+            ),
+            credentials=credential_store,
+        )
         extension_runtime.load(
             unfiltered_resource_paths,
             extra_paths=config.extension_paths,
@@ -452,6 +492,7 @@ class CodingSession:
             prompt=config.trust_prompt,
             extension_deciders=(extension_runtime.decide_project_trust,),
             cache_result=False,
+            persist=not config.defer_authoritative_writes,
         )
         canonical_cwd = summary.cwd.value
         resource_paths = resource_paths_with_project_trust(
@@ -494,6 +535,33 @@ class CodingSession:
                 include_user_dir=False,
             )
 
+        if config.provider is None:
+            prepared = await _prepare_provider_selection(
+                config,
+                state=state,
+                provider_registry=extension_runtime.provider_registry,
+                credential_store=credential_store,
+            )
+            config = replace(
+                config,
+                provider=prepared.provider,
+                model=prepared.model,
+                provider_name=prepared.provider_name,
+                inference_provider=prepared.inference_provider,
+                runtime_provider_config=prepared.runtime_provider_config,
+                dynamic_provider=prepared.dynamic_provider,
+                owns_initial_provider=True,
+            )
+            if pending_initial_entries:
+                pending_initial_entries = tuple(
+                    entry.model_copy(
+                        update={"model": config.model, "provider": config.provider_name}
+                    )
+                    if isinstance(entry, ModelChangeEntry)
+                    else entry
+                    for entry in pending_initial_entries
+                )
+        assert config.provider is not None
         active_model = _runtime_model_for_state(config, state)
         image_support = ImageSupportState(
             supported=_configured_model_supports_images(config, active_model)
@@ -562,10 +630,15 @@ class CodingSession:
             image_support=image_support,
             project_trust_resolution=trust_resolution,
         )
+        if config.owns_initial_provider:
+            # Ownership starts before any repair/discovery work so every
+            # failure path has exactly one closer for the candidate.
+            session._owned_providers.append(config.provider)  # type: ignore[arg-type]
         await session._persist_active_tool_history_repairs()
         session._sync_thinking_level_to_active_model()
         try:
-            session._refresh_runtime_provider()
+            if not config.owns_initial_provider and config.provider is not None:
+                session._refresh_runtime_provider()
             await session._refresh_runtime_model_limits()
             extension_runtime.bind(session)
             # Attach to session._harness, not the local `harness`:
@@ -599,20 +672,43 @@ class CodingSession:
         return self._provider_name
 
     @property
+    def provider(self) -> ModelProvider:
+        """Return the currently active runtime provider."""
+        return self._harness.config.provider
+
+    @property
     def inference_provider(self) -> str | None:
         """Return the pinned Hugging Face backing provider, if any."""
         return self._inference_provider
 
     @property
+    def _active_dynamic_provider(self) -> DynamicProvider | None:
+        effective = self._provider_registry.effective(self._provider_name)
+        if effective is None or not isinstance(effective.definition, DynamicProvider):
+            return None
+        return effective.definition
+
+    @property
     def available_providers(self) -> tuple[str, ...]:
         """Return provider names Tau can call with available credentials."""
-        if self._provider_settings is None:
-            return (self._provider_name,)
-        return tuple(provider.name for provider in self._usable_provider_configs())
+        names: list[str] = []
+        if self._provider_settings is not None:
+            names.extend(provider.name for provider in self._usable_provider_configs())
+        for effective in self._provider_registry.effective_providers():
+            if (
+                isinstance(effective.definition, DynamicProvider)
+                and (effective.definition.models or effective.definition.id == self._provider_name)
+                and effective.definition.id not in names
+            ):
+                names.append(effective.definition.id)
+        return tuple(names) or (self._provider_name,)
 
     @property
     def available_models(self) -> tuple[str, ...]:
         """Return model names for the active provider when it is usable."""
+        dynamic = self._active_dynamic_provider
+        if dynamic is not None:
+            return tuple(model.id for model in dynamic.models)
         if self._provider_settings is None:
             return (self.model,)
         try:
@@ -625,14 +721,24 @@ class CodingSession:
 
     @property
     def available_model_choices(self) -> tuple[ModelChoice, ...]:
-        """Return provider/model choices Tau can call with available credentials."""
-        if self._provider_settings is None:
+        """Return provider/model choices from the effective runtime view."""
+        choices: list[ModelChoice] = []
+        dynamic_ids: set[str] = set()
+        for effective in self._provider_registry.effective_providers():
+            if isinstance(effective.definition, DynamicProvider):
+                dynamic = effective.definition
+                dynamic_ids.add(dynamic.id)
+                choices.extend(ModelChoice(dynamic.id, model.id) for model in dynamic.models)
+        if self._provider_settings is not None:
+            choices.extend(
+                ModelChoice(provider.name, model)
+                for provider in self._usable_provider_configs()
+                if provider.name not in dynamic_ids
+                for model in provider.models
+            )
+        if not choices and self._provider_settings is None:
             return (ModelChoice(provider_name=self._provider_name, model=self.model),)
-        return tuple(
-            ModelChoice(provider_name=provider.name, model=model)
-            for provider in self._usable_provider_configs()
-            for model in provider.models
-        )
+        return tuple(choices)
 
     @property
     def scoped_model_choices(self) -> tuple[ModelChoice, ...]:
@@ -1051,6 +1157,14 @@ class CodingSession:
         """Return whether this session currently has an active agent run."""
         return self._harness.is_running
 
+    def _require_idle(self, operation: str) -> None:
+        """Reject replacement-like operations until an active turn is drained."""
+        if self._harness.is_running:
+            raise RuntimeError(
+                f"Cannot {operation} while Tau is working. "
+                "Press Escape to interrupt and wait for it to finish."
+            )
+
     @property
     def queued_messages(self) -> QueuedMessages:
         """Return queued steering and follow-up messages."""
@@ -1137,12 +1251,146 @@ class CodingSession:
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         self._sync_image_support()
-        entry = ModelChangeEntry(parent_id=self._last_parent_id, model=model)
-        await self._append_session_entry(entry)
+        entry = ModelChangeEntry(
+            parent_id=self._last_parent_id,
+            model=model,
+            provider=self.provider_name,
+        )
         leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-        await self._append_session_entry(leaf)
+        await self._append_session_batch((entry, leaf))
         self._last_parent_id = entry.id
         await self._refresh_persisted_state(leaf_id=entry.id)
+
+    async def select_provider_model(self, choice: ModelChoice) -> ModelSelectionResult:
+        """Switch provider/model with candidate-first durable publication.
+
+        No active state changes until the candidate runtime exists and the
+        provider-aware model entry plus leaf are committed as one batch.
+        """
+        if self._harness.is_running:
+            raise RuntimeError(
+                "Tau is still working. Press Escape to interrupt before switching models."
+            )
+        if choice.provider_name == self.provider_name and choice.model == self.model:
+            return ModelSelectionResult(choice, changed=False)
+
+        candidate: ClosableModelProvider | None = None
+        selected_dynamic: DynamicProvider | None = None
+        selected_config: ProviderConfig | None = None
+        selected_inference: str | None = None
+        selected_thinking = self._thinking_level
+        selected_image_support: bool | None = None
+        try:
+            effective = self._provider_registry.effective(choice.provider_name)
+            if effective is not None and isinstance(effective.definition, DynamicProvider):
+                selected_dynamic = effective.definition
+                selected_model = next(
+                    (item for item in selected_dynamic.models if item.id == choice.model), None
+                )
+                if selected_model is None:
+                    raise ProviderConfigError(
+                        "Model is not available for provider "
+                        f"{choice.provider_name}: {choice.model}"
+                    )
+                candidate = await create_dynamic_model_provider(
+                    selected_dynamic,
+                    model=choice.model,
+                    credential_store=self._credential_store,
+                )
+                if (
+                    selected_model.thinking_levels is not None
+                    and selected_thinking not in selected_model.thinking_levels
+                ):
+                    selected_thinking = (
+                        selected_model.thinking_levels[0]
+                        if selected_model.thinking_levels
+                        else DEFAULT_THINKING_LEVEL
+                    )
+                selected_image_support = (
+                    "image" in selected_model.input_modalities
+                    if selected_model.input_modalities is not None
+                    else None
+                )
+            else:
+                if self._provider_settings is None:
+                    raise ProviderConfigError(f"Provider is not available: {choice.provider_name}")
+                selected_config = self._provider_settings.get_provider(choice.provider_name)
+                validate_provider_model(selected_config, choice.model)
+                selected_inference = _configured_inference_provider(selected_config, choice.model)
+                selected_thinking = _coerced_thinking_level(
+                    selected_config,
+                    model=choice.model,
+                    current=self._thinking_level,
+                )
+                candidate = _create_runtime_provider(
+                    selected_config,
+                    credential_store=self._credential_store,
+                    model=choice.model,
+                    thinking_level=selected_thinking,
+                    inference_provider=selected_inference,
+                    response_headers_observer=(
+                        self._observe_response_headers
+                        if selected_config.name == "huggingface"
+                        else None
+                    ),
+                )
+                selected_image_support = provider_model_supports_images(
+                    selected_config, choice.model
+                )
+
+            entry = ModelChangeEntry(
+                parent_id=self._last_parent_id,
+                model=choice.model,
+                provider=choice.provider_name,
+            )
+            leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
+            await self._append_session_batch((entry, leaf))
+        except BaseException:
+            if candidate is not None:
+                await candidate.aclose()
+            raise
+
+        # From this point the transcript is authoritative. Only synchronous
+        # assignments happen before control returns to the frontend.
+        old_provider = self._harness.config.provider
+        assert candidate is not None
+        self._owned_providers.append(candidate)
+        self._harness.config.provider = candidate
+        self._harness.config.model = choice.model
+        self._provider_name = choice.provider_name
+        self._inference_provider = selected_inference
+        self._runtime_provider_config = selected_config
+        self._config = replace(
+            self._config,
+            provider=candidate,
+            model=choice.model,
+            provider_name=choice.provider_name,
+            inference_provider=selected_inference,
+            runtime_provider_config=selected_config,
+            dynamic_provider=selected_dynamic,
+        )
+        self._thinking_level = selected_thinking
+        self._image_support.supported = selected_image_support
+        self._last_parent_id = entry.id
+        self._invalidate_runtime_model_limits()
+        self._invalidate_context_usage_cache()
+        try:
+            await self._refresh_persisted_state(leaf_id=entry.id)
+        except Exception as exc:  # committed history wins over repairable index failure
+            self._resource_diagnostics = (
+                *self._resource_diagnostics,
+                ResourceDiagnostic(
+                    kind="session-index",
+                    message=f"Committed model switch requires index repair: {type(exc).__name__}",
+                    severity="warning",
+                ),
+            )
+        if old_provider is not candidate:
+            with suppress(Exception):
+                await self._close_replaced_provider(old_provider)
+        if selected_config is not None:
+            self._persist_default_model_choice()
+        return ModelSelectionResult(choice, changed=True)
 
     def set_inference_provider(self, route: str | None) -> str:
         """Select or reset the active Hugging Face session route."""
@@ -1181,6 +1429,11 @@ class CodingSession:
 
     def toggle_scoped_model(self, choice: ModelChoice) -> tuple[ModelChoice, ...]:
         """Add or remove a model from the persisted scoped model list."""
+        effective = self._provider_registry.effective(choice.provider_name)
+        if effective is not None and isinstance(effective.definition, DynamicProvider):
+            raise ProviderConfigError(
+                "Dynamic providers do not support persisted scoped models yet"
+            )
         if self._provider_settings is None:
             raise ProviderConfigError("Provider settings are not available for this session")
         available = set(self.available_model_choices)
@@ -1476,6 +1729,7 @@ class CodingSession:
 
     async def reload(self) -> CodingReloadSummary:
         """Stage and atomically publish a complete replacement snapshot."""
+        self._require_idle("reload")
         before_skills = _skill_signatures(self._skills)
         before_prompt_templates = _prompt_template_signatures(self._prompt_templates)
         before_context_files = _context_file_signatures(self._context_files)
@@ -1496,7 +1750,12 @@ class CodingSession:
         # first so project code cannot import before the destination decision.
         unfiltered_paths = resource_paths_with_cwd(self._config.resource_paths, self.cwd)
         previous_ui = self._extension_runtime.ui
-        staged_runtime = ExtensionRuntime()
+        staged_runtime = ExtensionRuntime(
+            durable_providers=(
+                self._provider_settings.providers if self._provider_settings else ()
+            ),
+            credentials=self._credential_store,
+        )
         staged_runtime.load(
             unfiltered_paths,
             extra_paths=self._config.extension_paths,
@@ -1640,6 +1899,7 @@ class CodingSession:
         self._resource_diagnostics = resources.diagnostics
         self._command_registry = staged_commands
         self._extension_runtime = staged_runtime
+        self._provider_registry = staged_runtime.provider_registry
         self._harness.config.tools = staged_tools
         self._harness.config.system = staged_system
         if system_prompt_rebuilt:
@@ -1685,6 +1945,7 @@ class CodingSession:
 
     async def resume(self, session_id: str) -> str:
         """Replace this session's active state with another indexed session."""
+        self._require_idle("resume")
         await self._flush_pending_message_writes(context=self._diagnostic_context())
         manager = self._config.session_manager
         if manager is None:
@@ -1697,26 +1958,44 @@ class CodingSession:
         runtime_provider_config = self._runtime_provider_config
         model = self.model
         restore_record_model = False
+        dynamic_resume = False
         if record.provider_name:
-            if self._provider_settings is None:
-                raise ProviderConfigError(
-                    "Cannot resume session provider without provider settings: "
-                    f"{record.provider_name}"
-                )
-            try:
-                runtime_provider_config = self._provider_settings.get_provider(record.provider_name)
-            except ProviderConfigError as exc:
-                raise ProviderConfigError(
-                    f"Session provider is not configured: {record.provider_name}"
-                ) from exc
-            provider_name = runtime_provider_config.name
-            model = record.model
-            restore_record_model = True
-            validate_provider_model(runtime_provider_config, model)
+            effective = self._provider_registry.effective(record.provider_name)
+            if effective is not None and isinstance(effective.definition, DynamicProvider):
+                # Dynamic definitions are generation-local. Re-resolve the
+                # reference in the fresh destination runtime instead of
+                # carrying this runtime's provider object across cwd/trust
+                # boundaries.
+                provider_name = record.provider_name
+                model = record.model
+                runtime_provider_config = None
+                dynamic_resume = True
+                restore_record_model = True
+            else:
+                provider_name = record.provider_name
+                model = record.model
+                restore_record_model = True
+                if self._provider_settings is None:
+                    # The destination runtime may provide a process-local
+                    # definition even when the source session did not.
+                    dynamic_resume = True
+                    runtime_provider_config = None
+                else:
+                    try:
+                        runtime_provider_config = self._provider_settings.get_provider(
+                            record.provider_name
+                        )
+                    except ProviderConfigError:
+                        # Do not reject a dynamic overlay merely because the
+                        # current cwd has not loaded its destination extension.
+                        dynamic_resume = True
+                        runtime_provider_config = None
+                    else:
+                        validate_provider_model(runtime_provider_config, model)
 
         replacement = await type(self).load(
             CodingSessionConfig(
-                provider=self._harness.config.provider,
+                provider=None if dynamic_resume else self._harness.config.provider,
                 model=model,
                 cwd=record.cwd,
                 storage=jsonl_session_storage(record.path),
@@ -1729,7 +2008,10 @@ class CodingSession:
                 session_manager=manager,
                 command_registry=self._config.command_registry,
                 provider_name=provider_name,
-                inference_provider=record.inference_provider,
+                inference_provider=None if dynamic_resume else record.inference_provider,
+                requested_provider=provider_name if dynamic_resume else None,
+                requested_model=model if dynamic_resume else None,
+                session_provider_name=record.provider_name,
                 provider_settings=self._provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=self._auto_compact_token_threshold,
@@ -1746,14 +2028,12 @@ class CodingSession:
                 trust_default=self._config.trust_default,
                 trust_interactive=self._config.trust_interactive,
                 trust_prompt=self._config.trust_prompt,
+                defer_authoritative_writes=dynamic_resume,
+                owns_initial_provider=dynamic_resume,
             )
         )
         try:
-            if restore_record_model:
-                if runtime_provider_config is None:
-                    raise ProviderConfigError(
-                        f"Session provider is not configured: {provider_name}"
-                    )
+            if restore_record_model and runtime_provider_config is not None:
                 validate_provider_model(runtime_provider_config, replacement.model)
             else:
                 replacement._harness.config.model = self.model
@@ -1769,6 +2049,7 @@ class CodingSession:
 
     async def new_session(self) -> str:
         """Replace this session's active state with a pending unindexed session."""
+        self._require_idle("start a new session")
         await self._flush_pending_message_writes(context=self._diagnostic_context())
         manager = self._config.session_manager
         if manager is None:
@@ -1789,7 +2070,24 @@ class CodingSession:
                 current=self._thinking_level,
             )
 
-        inference_provider = _configured_inference_provider(runtime_provider_config, model)
+        effective = self._provider_registry.effective(provider_name)
+        dynamic_provider = (
+            effective.definition
+            if effective is not None and isinstance(effective.definition, DynamicProvider)
+            else None
+        )
+        if dynamic_provider is not None:
+            model = next(
+                (item.id for item in dynamic_provider.models if item.id == model),
+                dynamic_provider.default_model
+                or (dynamic_provider.models[0].id if dynamic_provider.models else model),
+            )
+            runtime_provider_config = None
+        inference_provider = (
+            None
+            if dynamic_provider is not None
+            else _configured_inference_provider(runtime_provider_config, model)
+        )
         record = (
             manager.prepare_session(
                 cwd=self.cwd,
@@ -1807,15 +2105,21 @@ class CodingSession:
         replacement = await type(self).load(
             replace(
                 self._config,
-                provider=self._harness.config.provider,
+                provider=(None if dynamic_provider is not None else self._harness.config.provider),
                 model=record.model or model,
                 cwd=record.cwd,
                 storage=jsonl_session_storage(record.path),
                 session_id=record.id,
                 provider_name=provider_name,
                 inference_provider=inference_provider,
+                requested_provider=provider_name if dynamic_provider is not None else None,
+                requested_model=model if dynamic_provider is not None else None,
+                session_provider_name=provider_name,
                 provider_settings=self._provider_settings,
                 runtime_provider_config=runtime_provider_config,
+                dynamic_provider=dynamic_provider,
+                owns_initial_provider=dynamic_provider is not None,
+                defer_authoritative_writes=dynamic_provider is not None,
                 thinking_level=thinking_level,
                 index_on_first_persist=True,
                 extension_runtime=self._extension_runtime,
@@ -1844,6 +2148,11 @@ class CodingSession:
                 and replacement.project_trust_resolution.cancelled
             ):
                 raise ValueError("Project trust decision cancelled; current session unchanged")
+
+            # Destination transcript initialization/repair is the durable
+            # commit point. It must succeed before the outgoing runtime enters
+            # its shutdown path.
+            await replacement._commit_prepared_entries()
 
             # The replacement remains the explicit owner of its providers
             # through every cancellable/erroring pre-publication seam.
@@ -1890,6 +2199,13 @@ class CodingSession:
         self._pending_initial_entries = replacement._pending_initial_entries
         self._pending_message_writes = replacement._pending_message_writes
         self._extension_runtime = replacement._extension_runtime
+        self._provider_registry = replacement._provider_registry
+        self._credential_store = replacement._credential_store
+        self._diagnostic_logger = replacement._diagnostic_logger
+        self._runtime_model_limits = replacement._runtime_model_limits
+        self._runtime_model_limits_key = replacement._runtime_model_limits_key
+        self._model_limits_discovery_error = replacement._model_limits_discovery_error
+        self._prepared_entries = replacement._prepared_entries
         self._owned_providers.extend(replacement._owned_providers)
         replacement._owned_providers.clear()
         self._image_support = replacement._image_support
@@ -2285,7 +2601,7 @@ class CodingSession:
         )
 
     async def _persist_active_tool_history_repairs(self) -> ToolHistoryRepair | None:
-        """Rewrite malformed active tool history as a valid append-only branch."""
+        """Stage or append one complete repair branch for malformed history."""
         plan = _tool_history_repair_plan(
             self._state.messages,
             context_entry_ids=self._state.context_entry_ids,
@@ -2308,30 +2624,35 @@ class CodingSession:
             for entry in active_entries[parent_index + 1 :]
             if isinstance(entry, CustomEntry) and entry.namespace != "tau.session-history-repair"
         ]
-        diagnostic = CustomEntry(
-            parent_id=parent_id,
-            namespace="tau.session-history-repair",
-            data={"version": 1, **repair.diagnostic_data()},
-        )
-        await self._append_session_entry(diagnostic)
-        parent_id = diagnostic.id
+        staged: list[SessionEntry] = [
+            CustomEntry(
+                parent_id=parent_id,
+                namespace="tau.session-history-repair",
+                data={"version": 1, **repair.diagnostic_data()},
+            )
+        ]
+        parent_id = staged[-1].id
         for message in suffix:
             entry = MessageEntry(parent_id=parent_id, message=message)
-            await self._append_session_entry(entry)
+            staged.append(entry)
             parent_id = entry.id
         if active_model is not None:
-            model_entry = ModelChangeEntry(parent_id=parent_id, model=active_model)
-            await self._append_session_entry(model_entry)
+            model_entry = ModelChangeEntry(
+                parent_id=parent_id,
+                model=active_model,
+                provider=self.provider_name,
+            )
+            staged.append(model_entry)
             parent_id = model_entry.id
         thinking_entry = ThinkingLevelChangeEntry(
             parent_id=parent_id,
             thinking_level=active_thinking_level,
         )
-        await self._append_session_entry(thinking_entry)
+        staged.append(thinking_entry)
         parent_id = thinking_entry.id
         if active_label is not None:
             label_entry = LabelEntry(parent_id=parent_id, label=active_label)
-            await self._append_session_entry(label_entry)
+            staged.append(label_entry)
             parent_id = label_entry.id
         for custom_entry in custom_entries:
             copied_entry = CustomEntry(
@@ -2339,12 +2660,19 @@ class CodingSession:
                 namespace=custom_entry.namespace,
                 data=custom_entry.data,
             )
-            await self._append_session_entry(copied_entry)
+            staged.append(copied_entry)
             parent_id = copied_entry.id
-        leaf = LeafEntry(parent_id=parent_id, entry_id=parent_id)
-        await self._append_session_entry(leaf)
-        self._last_parent_id = parent_id
-        await self._refresh_persisted_state(leaf_id=parent_id)
+        staged.append(LeafEntry(parent_id=parent_id, entry_id=parent_id))
+
+        if self._config.defer_authoritative_writes:
+            self._prepared_entries.extend(staged)
+            self._last_parent_id = parent_id
+            replay_entries = [*self._state.entries, *staged]
+            self._state = SessionState.from_entries(replay_entries, leaf_id=parent_id)
+        else:
+            await self._append_session_batch(staged)
+            self._last_parent_id = parent_id
+            await self._refresh_persisted_state(leaf_id=parent_id)
         self._harness.replace_messages(self._state.messages)
         self._invalidate_context_usage_cache()
         return repair
@@ -2480,23 +2808,79 @@ class CodingSession:
         """Read stored entries, detaching roots imported from external history."""
         return _detach_missing_parents(await self._config.storage.read_all())
 
+    async def _commit_prepared_entries(self) -> None:
+        """Durably commit the staged startup/repair batch exactly once."""
+        if not self._config.defer_authoritative_writes:
+            return
+        durable_ids = {entry.id for entry in await self._config.storage.read_all()}
+        missing = tuple(entry for entry in self._prepared_entries if entry.id not in durable_ids)
+        if missing:
+            append_batch = getattr(self._config.storage, "append_batch", None)
+            if append_batch is None:
+                # Compatibility storage implementations predate the atomic
+                # batch contract.  Production storage always takes this path.
+                for entry in missing:
+                    await self._config.storage.append(entry)
+            else:
+                await append_batch(missing)
+        self._pending_initial_entries = ()
+        self._prepared_entries.clear()
+        self._config = replace(self._config, defer_authoritative_writes=False)
+        try:
+            if self._config.index_on_first_persist:
+                self._index_current_session()
+        except Exception as exc:  # index is a rebuildable cache, not authority
+            self._record_session_index_diagnostic(exc)
+
     async def _append_session_entry(self, entry: SessionEntry) -> None:
         """Append one durable entry after flushing deferred session metadata."""
         await self._ensure_session_initialized()
         await self._config.storage.append(entry)
 
+    async def _append_session_batch(self, entries: Sequence[SessionEntry]) -> None:
+        """Append entries as one storage transaction, with legacy fallback."""
+        await self._ensure_session_initialized()
+        append_batch = getattr(self._config.storage, "append_batch", None)
+        if append_batch is None:
+            for entry in entries:
+                await self._config.storage.append(entry)
+            return
+        await append_batch(tuple(entries))
+
+    async def _close_replaced_provider(self, provider: ModelProvider) -> None:
+        """Close a Tau-owned provider once after a committed publication."""
+        if provider not in self._owned_providers:
+            return
+        self._owned_providers.remove(provider)
+        close = getattr(provider, "aclose", None)
+        if close is not None:
+            await close()
+
     async def _ensure_session_initialized(self) -> None:
+        if self._config.defer_authoritative_writes and self._prepared_entries:
+            await self._commit_prepared_entries()
+            return
         if not self._pending_initial_entries:
             return
         await self._write_pending_initial_entries()
         if self._config.index_on_first_persist:
-            self._index_current_session()
+            try:
+                self._index_current_session()
+            except Exception as exc:
+                self._record_session_index_diagnostic(exc)
 
     async def _write_pending_initial_entries(self) -> None:
         durable_ids = {entry.id for entry in await self._config.storage.read_all()}
-        for entry in self._pending_initial_entries:
-            if entry.id not in durable_ids:
-                await self._config.storage.append(entry)
+        missing = tuple(
+            entry for entry in self._pending_initial_entries if entry.id not in durable_ids
+        )
+        if missing:
+            append_batch = getattr(self._config.storage, "append_batch", None)
+            if append_batch is not None:
+                await append_batch(missing)
+            else:
+                for entry in missing:
+                    await self._config.storage.append(entry)
         self._pending_initial_entries = ()
 
     def _ensure_session_file_initialized(self) -> None:
@@ -2505,6 +2889,16 @@ class CodingSession:
         for entry in self._pending_initial_entries:
             _append_session_entry_sync(self._config.storage, entry)
         self._pending_initial_entries = ()
+
+    def _record_session_index_diagnostic(self, exc: BaseException) -> None:
+        self._resource_diagnostics = (
+            *self._resource_diagnostics,
+            ResourceDiagnostic(
+                kind="session-index",
+                message=f"Session index needs repair: {type(exc).__name__}",
+                severity="warning",
+            ),
+        )
 
     def _index_current_session(self) -> None:
         if self._config.session_id is None or self._config.session_manager is None:
@@ -3035,7 +3429,149 @@ def _session_export_title(session: CodingSession) -> str:
     return f"Tau session {session_id}" if session_id is not None else "Tau Session Export"
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedProvider:
+    """A runtime candidate built after the destination environment is trusted."""
+
+    provider: ClosableModelProvider
+    provider_name: str
+    model: str
+    inference_provider: str | None
+    runtime_provider_config: ProviderConfig | None
+    dynamic_provider: DynamicProvider | None
+
+
+async def _prepare_provider_selection(
+    config: CodingSessionConfig,
+    *,
+    state: SessionState,
+    provider_registry: DynamicProviderRegistry,
+    credential_store: FileCredentialStore | None = None,
+) -> _PreparedProvider:
+    """Resolve and construct the provider after extension/project staging."""
+    requested_provider = config.requested_provider
+    requested_model = config.requested_model
+    provider_name = requested_provider or state.provider or config.session_provider_name
+    explicit = requested_provider is not None or requested_model is not None
+
+    if provider_name is not None:
+        effective = provider_registry.effective(provider_name)
+        if effective is not None and isinstance(effective.definition, DynamicProvider):
+            dynamic = effective.definition
+            model = requested_model
+            if model is None and state.provider == provider_name:
+                model = state.model
+            if model is None:
+                model = dynamic.default_model
+            if model is None and len(dynamic.models) == 1:
+                model = dynamic.models[0].id
+            if (
+                (model is None or not any(item.id == model for item in dynamic.models))
+                and dynamic.refresh_models is not None
+                and (explicit or state.provider == provider_name)
+            ):
+                refreshed = await provider_registry.refresh(
+                    provider_name,
+                    allow_network=True,
+                    timeout_seconds=5.0,
+                )
+                if refreshed.provider is not None:
+                    dynamic = refreshed.provider
+                if model is None:
+                    model = dynamic.default_model
+                    if model is None and len(dynamic.models) == 1:
+                        model = dynamic.models[0].id
+            if model is None:
+                raise ProviderConfigError(
+                    f"Provider {provider_name} has no selectable models; refresh it explicitly."
+                )
+            selected = next((item for item in dynamic.models if item.id == model), None)
+            if selected is None:
+                raise ProviderConfigError(
+                    f"Model is not available for provider {provider_name}: {model}"
+                )
+            try:
+                runtime = await create_dynamic_model_provider(
+                    dynamic,
+                    model=model,
+                    credential_store=credential_store or FileCredentialStore(),
+                )
+            except (ProviderConfigError, RuntimeError) as exc:
+                raise ProviderConfigError(str(exc)) from exc
+            return _PreparedProvider(
+                provider=runtime,
+                provider_name=provider_name,
+                model=model,
+                inference_provider=None,
+                runtime_provider_config=None,
+                dynamic_provider=dynamic,
+            )
+
+    settings = config.provider_settings
+    if settings is None:
+        raise ProviderConfigError(
+            f"Provider is not available after trusted extension loading: "
+            f"{provider_name or config.model}"
+        )
+    selection = resolve_provider_selection(
+        settings,
+        provider_name=provider_name,
+        model=(requested_model or (state.model if state.provider == provider_name else None)),
+    )
+    inference_provider = _session_inference_provider(
+        config,
+        state,
+        selection.provider.name,
+        selection.model,
+    )
+    try:
+        runtime = create_model_provider(
+            selection.provider,
+            credential_store=credential_store,
+            model=selection.model,
+            inference_provider=inference_provider,
+            thinking_level=resolve_startup_thinking_level(
+                selection.provider,
+                selection.model,
+            ),
+        )
+    except RuntimeError as exc:
+        raise ProviderConfigError(str(exc)) from exc
+    return _PreparedProvider(
+        provider=runtime,
+        provider_name=selection.provider.name,
+        model=selection.model,
+        inference_provider=inference_provider,
+        runtime_provider_config=selection.provider,
+        dynamic_provider=None,
+    )
+
+
+def _session_inference_provider(
+    config: CodingSessionConfig,
+    state: SessionState,
+    provider_name: str,
+    model: str,
+) -> str | None:
+    """Preserve HF routing only for the same logical provider/model."""
+    if provider_name != "huggingface":
+        return None
+    if state.provider == provider_name and state.model == model:
+        return config.inference_provider
+    provider = (
+        config.provider_settings.get_provider(provider_name) if config.provider_settings else None
+    )
+    if isinstance(provider, OpenAICompatibleProviderConfig):
+        return provider.inference_providers.get(model)
+    return None
+
+
 def _configured_model_supports_images(config: CodingSessionConfig, model: str) -> bool | None:
+    if config.dynamic_provider is not None:
+        selected = next((item for item in config.dynamic_provider.models if item.id == model), None)
+        if selected is None or selected.input_modalities is None:
+            return None
+        return "image" in selected.input_modalities
     provider = config.runtime_provider_config
     if provider is None and config.provider_settings is not None:
         try:
@@ -3060,6 +3596,8 @@ def _initial_model_for_config(config: CodingSessionConfig) -> str:
 
 def _runtime_model_for_state(config: CodingSessionConfig, state: SessionState) -> str:
     state_model = state.model or config.model
+    if config.dynamic_provider is not None:
+        return config.model
     if config.provider_settings is None or config.runtime_provider_config is None:
         return state_model
     provider = _provider_config_for_name(config, config.provider_name)

--- a/src/tau_coding/session_preparation.py
+++ b/src/tau_coding/session_preparation.py
@@ -1,0 +1,88 @@
+"""Shared trust-aware staging for coding-session startup and replacement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from tau_agent.provider import ModelProvider
+from tau_coding.session import CodingSession, CodingSessionConfig
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPreparationRequest:
+    """Frontend-neutral request for a staged coding session."""
+
+    storage: object
+    destination_cwd: Path
+    model: str
+    provider: str | None = None
+    session_provider: str | None = None
+    session_id: str | None = None
+
+
+@dataclass(slots=True)
+class PreparedCodingSession:
+    """A candidate session whose resources are not authoritative until adopted."""
+
+    session: CodingSession
+    _state: str = "prepared"
+
+    @property
+    def provider(self) -> ModelProvider:
+        return self.session.provider
+
+    async def adopt(self) -> CodingSession:
+        """Commit staged entries, then transfer the candidate's ownership."""
+        if self._state != "prepared":
+            raise RuntimeError(f"Prepared session is already {self._state}")
+        trust_resolution = getattr(self.session, "project_trust_resolution", None)
+        if trust_resolution is not None and trust_resolution.cancelled:
+            await self.abort()
+            raise ValueError("Project trust decision cancelled; session was not adopted")
+        try:
+            commit = getattr(self.session, "_commit_prepared_entries", None)
+            if commit is not None:
+                await commit()
+        except BaseException:
+            await self.abort()
+            raise
+        self._state = "adopted"
+        return self.session
+
+    async def abort(self) -> None:
+        """Close an unpublished candidate exactly once."""
+        if self._state != "prepared":
+            return
+        self._state = "aborted"
+        close = getattr(self.session, "aclose", None)
+        if close is not None:
+            await close()
+
+
+async def prepare_coding_session(
+    config: CodingSessionConfig,
+    *,
+    session_loader: type[CodingSession] | None = None,
+) -> PreparedCodingSession:
+    """Prepare a session through the shared trust/provider lifecycle.
+
+    Application frontends use this entry point with authoritative writes
+    deferred. Adoption appends the complete staged batch before exposing the
+    candidate. Supplying a provider remains the compatibility seam for static
+    embedded callers, which retain the historical lazy initial write.
+    """
+    # Every frontend gets the same candidate-first durability boundary, even
+    # when it supplies a compatibility provider object. Provider ownership is
+    # controlled independently by CodingSessionConfig.owns_initial_provider.
+    staged_config = replace(config, defer_authoritative_writes=True)
+    loader = session_loader or CodingSession
+    session = await loader.load(staged_config)
+    return PreparedCodingSession(session)
+
+
+__all__ = [
+    "PreparedCodingSession",
+    "SessionPreparationRequest",
+    "prepare_coding_session",
+]

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -105,8 +105,11 @@ from tau_coding.provider_catalog import (
     builtin_provider_entry,
 )
 from tau_coding.provider_config import (
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER_NAME,
     OpenAICompatibleProviderConfig,
     ProviderConfig,
+    ProviderConfigError,
     ProviderSelection,
     load_provider_settings,
     provider_config_from_catalog_entry,
@@ -117,7 +120,7 @@ from tau_coding.provider_config import (
     upsert_openai_compatible_provider,
     upsert_saved_provider,
 )
-from tau_coding.provider_runtime import create_model_provider
+from tau_coding.provider_runtime import ClosableModelProvider, create_model_provider
 from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
 from tau_coding.session import (
     TREE_RUNNING_MESSAGE,
@@ -131,6 +134,7 @@ from tau_coding.session import (
     parse_terminal_command,
 )
 from tau_coding.session_manager import CodingSessionRecord, SessionManager
+from tau_coding.session_preparation import prepare_coding_session
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.skills import Skill
 from tau_coding.tui.adapter import TuiEventAdapter
@@ -4037,6 +4041,17 @@ class TauTuiApp(App[None]):
                 self._open_logout_picker()
             if command.logout_provider is not None:
                 self._logout(command.logout_provider)
+            if command.model_selection_model is not None:
+                self.run_worker(
+                    self._switch_model(
+                        ModelChoice(
+                            provider_name=command.model_selection_provider
+                            or self.session.provider_name,
+                            model=command.model_selection_model,
+                        )
+                    ),
+                    exclusive=False,
+                )
             if command.model_picker_requested:
                 self._open_model_picker()
             if command.tools_picker_requested:
@@ -5811,14 +5826,23 @@ class TauTuiApp(App[None]):
     def _handle_model_picker_result(self, choice: ModelChoice | None) -> None:
         if choice is None:
             return
+        self.run_worker(self._switch_model(choice), exclusive=False)
+
+    async def _switch_model(self, choice: ModelChoice) -> None:
         try:
-            set_model_choice = getattr(self.session, "set_model_choice", None)
-            if set_model_choice is None:
-                if choice.provider_name != self.session.provider_name:
-                    self.session.set_provider(choice.provider_name)
-                self.session.set_model(choice.model)
+            select = getattr(self.session, "select_provider_model", None)
+            if select is not None:
+                result = select(choice)
+                if isawaitable(result):
+                    await result
             else:
-                set_model_choice(choice)
+                set_model_choice = getattr(self.session, "set_model_choice", None)
+                if set_model_choice is None:
+                    if choice.provider_name != self.session.provider_name:
+                        self.session.set_provider(choice.provider_name)
+                    self.session.set_model(choice.model)
+                else:
+                    set_model_choice(choice)
         except Exception as exc:  # noqa: BLE001 - surface model switch failures in the TUI
             self._notify(f"Could not switch model: {exc}", severity="error")
             return
@@ -7006,63 +7030,115 @@ async def run_tui_app(
         manager,
         session_id=session_id,
     )
-    selection = _resolve_tui_startup_selection(
-        provider_settings,
-        record=record,
-        provider_name=provider_name,
-        model=model,
-        explicit_resume=session_id is not None,
-    )
+    selection: ProviderSelection | None = None
+    try:
+        selection = _resolve_tui_startup_selection(
+            provider_settings,
+            record=record,
+            provider_name=provider_name,
+            model=model,
+            explicit_resume=session_id is not None,
+        )
+    except ProviderConfigError:
+        # A resumed record may point at a process-local provider that is not in
+        # durable settings. Let the staged loader resolve it after trusted
+        # built-in/project extensions are loaded.
+        dynamic_resume = (
+            session_id is not None
+            and record is not None
+            and record.provider_name is not None
+            and provider_name is None
+            and model is None
+        )
+        if (provider_name is None or model is None) and not dynamic_resume:
+            raise
     startup_message: str | None = None
     startup_error_notice: str | None = None
-    runtime_provider_config: ProviderConfig | None = selection.provider
-    inference_provider = _startup_inference_provider(selection, record)
-    try:
-        provider = create_model_provider(
-            selection.provider,
-            model=selection.model,
-            inference_provider=inference_provider,
-            thinking_level=resolve_startup_thinking_level(
+    explicit_selection = provider_name is not None or model is not None
+    selected_provider_name: str = (
+        provider_name
+        if provider_name is not None
+        else (record.provider_name if record is not None else None)
+        or (selection.provider.name if selection is not None else DEFAULT_PROVIDER_NAME)
+    )
+    selected_model = (
+        model
+        if explicit_selection and model is not None
+        else (record.model if record is not None else None)
+        or (selection.model if selection is not None else DEFAULT_MODEL)
+    )
+    # Keep static-provider construction compatible with embedded TUI callers,
+    # while dynamic providers are deliberately left for CodingSession.load()
+    # after trusted extension setup. The provider passed below is owned by the
+    # prepared session when the real loader is used.
+    initial_provider: ClosableModelProvider | None = None
+    runtime_provider_config: ProviderConfig | None = selection.provider if selection else None
+    inference_provider = _startup_inference_provider(selection, record) if selection else None
+    if selection is not None:
+        try:
+            initial_provider = create_model_provider(
                 selection.provider,
-                selection.model,
-            ),
-        )
-    except RuntimeError as exc:
-        # Most startup RuntimeErrors are missing credentials, but surface the real
-        # cause so a non-auth failure is not silently misreported as "Login required".
-        login_required_message = (
+                model=selection.model,
+                inference_provider=inference_provider,
+                thinking_level=resolve_startup_thinking_level(
+                    selection.provider,
+                    selection.model,
+                ),
+            )
+        except RuntimeError as exc:
+            login_required_message = (
+                "Login required. Run /login to choose a provider, "
+                f"or /login {selected_provider_name} to continue with the current provider."
+            )
+            startup_message = f"{login_required_message}\n\nStartup error: {exc}"
+            startup_error_notice = (
+                f"Startup provider creation failed for "
+                f"{selection.provider.name}:{selection.model}: {exc}"
+            )
+            initial_provider = LoginRequiredProvider(startup_message)
+            runtime_provider_config = None
+    elif not explicit_selection:
+        startup_message = (
             "Login required. Run /login to choose a provider, "
-            f"or /login {selection.provider.name} to continue with the current provider."
+            f"or /login {selected_provider_name} to continue with the current provider."
         )
-        startup_message = f"{login_required_message}\n\nStartup error: {exc}"
-        startup_error_notice = (
-            f"Startup provider creation failed for "
-            f"{selection.provider.name}:{selection.model}: {exc}"
-        )
-        provider = LoginRequiredProvider(startup_message)
-        runtime_provider_config = None
+        initial_provider = LoginRequiredProvider(startup_message)
     session: CodingSession | None = None
     try:
         index_on_first_persist = False
         if record is None:
-            record = _create_startup_session_record(
-                manager,
-                cwd=cwd,
-                selection=selection,
-                inference_provider=inference_provider,
-            )
+            if selection is not None:
+                record = _create_startup_session_record(
+                    manager,
+                    cwd=cwd,
+                    selection=selection,
+                    inference_provider=inference_provider,
+                )
+            else:
+                if provider_name is None or model is None:
+                    raise ProviderConfigError(
+                        "An explicit provider and model are required for this startup."
+                    )
+                record = manager.prepare_session(
+                    cwd=cwd,
+                    model=model,
+                    provider_name=provider_name,
+                )
             index_on_first_persist = manager.get_session(record.id) is None
 
-        session = await CodingSession.load(
+        prepared = await prepare_coding_session(
             CodingSessionConfig(
-                provider=provider,
-                model=record.model or selection.model,
+                provider=initial_provider,
+                model=record.model or selected_model,
                 cwd=record.cwd,
                 storage=jsonl_session_storage(record.path),
                 session_id=record.id,
                 session_manager=manager,
-                provider_name=selection.provider.name,
+                provider_name=selected_provider_name,
                 inference_provider=inference_provider,
+                requested_provider=provider_name if explicit_selection else None,
+                requested_model=model if explicit_selection else None,
+                session_provider_name=record.provider_name,
                 provider_settings=provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=auto_compact_token_threshold,
@@ -7077,8 +7153,22 @@ async def run_tui_app(
                 trust_default=shell_settings.default_project_trust,
                 trust_interactive=True,
                 trust_prompt=prompt_project_trust,
-            )
+                defer_authoritative_writes=True,
+                owns_initial_provider=initial_provider is not None,
+            ),
+            session_loader=CodingSession,
         )
+        try:
+            session = await prepared.adopt()
+        except ValueError:
+            candidate = prepared.session
+            trust_resolution = getattr(candidate, "project_trust_resolution", None)
+            if trust_resolution is None or not trust_resolution.cancelled:
+                raise
+            # The preparation object already closed the unpublished candidate.
+            # Do not close that candidate again from the outer finally block.
+            del candidate
+            return None
         trust_resolution = getattr(session, "project_trust_resolution", None)
         if trust_resolution is not None and trust_resolution.cancelled:
             return None
@@ -7113,14 +7203,24 @@ async def run_tui_app(
         )
         set_trust_prompt = getattr(session, "set_project_trust_prompt", None)
         if set_trust_prompt is not None:
-            set_trust_prompt(app.prompt_project_trust)
+            prompt_trust = getattr(app, "prompt_project_trust", None)
+            if prompt_trust is not None:
+                set_trust_prompt(prompt_trust)
         await app.run_async()
     finally:
         if session is not None:
             close_session = getattr(session, "aclose", None)
             if close_session is not None:
                 await close_session()
-        await provider.aclose()
+        # Compatibility for lightweight test/embedded session loaders that do
+        # not expose ownership. A real CodingSession owns the exact candidate,
+        # so this branch does not double-close it.
+        if (
+            initial_provider is not None
+            and getattr(session, "provider", None) is not initial_provider
+        ):
+            with suppress(Exception):
+                await initial_provider.aclose()
 
     active_session_id: str | None = getattr(session, "session_id", None)
     if active_session_id is None or manager.get_session(active_session_id) is None:


### PR DESCRIPTION
## Summary

- add shared trust-aware `PreparedCodingSession` staging for CLI and TUI startup
- make transcript initialization, model/provider changes, and leaf publication atomic and provider-aware
- stage fresh extension/provider runtimes across reload, resume, and new-session replacement with idle guards and single-owner cleanup
- preserve `/system` print-mode behavior without publishing a session transcript

## Verification

- focused lifecycle suites: 766 passed
- `uv run pytest`: 1636 passed, 2 skipped (Windows-only)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Hugo build passed (existing taxonomy-layout warning)
- `uv build`
- `git diff --check`

This Phase 3 branch is based on umbrella commit `e2aa06dbbf5e54a4174d705187365911fd266933` (`feat/602-built-in-local-inference`).