### PR TITLE
Document utility commands in Tau CLI help

### DIFF
--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -93,6 +93,20 @@ _force_utf8_streams()
 app = typer.Typer(
     name="tau",
     help="Tau coding-agent harness.",
+    epilog="""Commands:
+
+  tau install SOURCE [--force] - Install a trusted local or Git extension.
+
+  tau update - Upgrade Tau.
+
+  tau sessions - List indexed sessions.
+
+  tau export REF [DEST] - Export a session as HTML or JSONL.
+
+  tau providers - List configured model providers.
+
+  tau setup - Configure an OpenAI-compatible provider.
+""",
     add_completion=False,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,6 +119,7 @@ def test_help_lists_system_prompt_options() -> None:
     assert result.exit_code == 0
     assert "--system-promptTEXT_OR_PATH" in output
     assert "--append-system-promptTEXT_OR_PATH" in output
+    assert "tauinstallSOURCE[--force]" in output
 
 
 def test_install_command_installs_extension(


### PR DESCRIPTION
## Summary

- list Tau's positional utility commands in `tau --help`
- include the newly added `tau install SOURCE [--force]` command
- add regression coverage so the installer stays visible in CLI help

## User experience

`tau --help` now includes a readable command summary for install, update, sessions, export, providers, and setup instead of exposing only callback options.

## Validation

- `uv run pytest` — 1566 passed, 2 skipped (Windows-only)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- manually inspected `uv run tau --help`
