### PR TITLE
Phase 5: add built-in llama.cpp inference

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -26,5 +26,7 @@ User-facing documentation lives in `website/content/` and is published at
 - `catalog-model-safety.md` — checklist for adding providers and models to the built-in catalog safely.
 - `startup-thinking-level-fallback.md` — why startup resolves a valid thinking
   level per model instead of assuming the global `medium` default.
+- `llama-cpp-phase-5.md` — built-in llama.cpp connection, safe state, `/local`,
+  failure handling, and Phase 5 validation.
 
 The roadmap is tracked in [GitHub issue #1](https://github.com/huggingface/tau/issues/1).

--- a/dev-notes/llama-cpp-phase-5.md
+++ b/dev-notes/llama-cpp-phase-5.md
@@ -1,0 +1,86 @@
+# Phase 5: built-in llama.cpp connection and inference
+
+Phase 5 adds a useful first local-inference path without adding llama.cpp
+branches to the agent harness or implementing router mutations.
+
+## What changed
+
+- `llama.cpp` is declared as a trusted, hidden built-in extension.
+- The extension registers a dormant dynamic provider and a generic `/local`
+  backend through the normal extension contracts.
+- `/local` configures a normalized server endpoint, optional API key, status,
+  refresh, Doctor, and safe reset.
+- `/v1/models` discovery publishes exact server model IDs and only allowlisted
+  metadata. Unknown context, output, reasoning, modality, pricing, and tool
+  compatibility remain unknown.
+- The existing OpenAI-compatible streaming provider is reused with an explicit
+  local API choice, so IDs resembling `gpt-*` or `codex-*` do not select a
+  first-party endpoint.
+- Print and TUI explicit startup use the shared staged preparation path. A
+  cached snapshot can keep an explicit local startup usable while the server is
+  down; local inference is never an implicit ordinary-provider fallback.
+- State is stored in the locked, private,
+  `~/.tau/state/extensions/llama.cpp.json` integration file. Keys remain in the
+  credential store or `LLAMA_API_KEY`, and no fake key is synthesized.
+- Existing user `llama-cpp` catalog providers remain separate from built-in
+  `llama.cpp`.
+
+## Why this maps to Pi
+
+Pi treats built-in integrations as product extensions that register provider
+objects and own protocol-specific behavior. Tau follows that separation while
+keeping its reusable layers independent:
+
+```text
+tau_ai       OpenAI-compatible transport and streaming
+tau_agent    portable harness, tools, events, sessions
+tau_coding   trusted extension, provider overlays, /local, state, TUI/CLI
+```
+
+The extension owns URL parsing, `/health`, `/v1/models`, authentication
+precedence, safe snapshot conversion, diagnostics, Doctor probes, and reset.
+The generic registry owns source/generation lifetime and snapshot publication.
+The TUI owns field rendering, confirmation, cancellation, and idle checks.
+
+The accepted plan's later router phase is intentionally not included here:
+there are no load, unload, Hugging Face search/download, or implicit model-file
+mutations in this implementation.
+
+## Failure safety
+
+Configuration writes a generation-specific credential before committing the safe
+state reference. If state commit fails, the old configuration stays active and
+the new credential is deleted or reported as an integration-owned orphan. After
+a successful commit, failure to delete the old credential reports cleanup while
+leaving the new configuration usable. Reset removes safe state first and treats
+credential deletion as a separate confirmation.
+
+Refresh publishes a complete snapshot only after defensive parsing. Timeout,
+HTTP failure, cancellation, malformed data, and endpoint downtime retain the
+last safe snapshot and produce bounded diagnostics. If a refreshed catalog loses
+the active model, the current runtime remains usable and the local status is
+stale; Tau does not silently select the remaining model.
+
+## How to test
+
+The deterministic suite uses `httpx.MockTransport` and fake credential/state
+stores. It covers endpoint safety, auth headers, cache/offline behavior,
+malformed discovery, metadata allowlisting, stale model handling, atomic state
+writes, orphan cleanup, reset, Doctor, real runtime registration, generation
+retirement, and explicit print/TUI startup:
+
+```bash
+uv run pytest tests/test_llama_cpp_extension.py -q
+uv run pytest tests/test_local_backends.py tests/test_tui_local_backends.py -q
+```
+
+For a manual smoke test, start a tool-capable llama.cpp server, configure
+`/local`, choose the discovered ID in `/model`, run Doctor, and then try:
+
+```bash
+tau --provider llama.cpp --model <model-id> --print "summarize this project"
+```
+
+Stop the server after setup and repeat the explicit startup to verify the safe
+snapshot path. Never put real API keys or private model endpoints in tests,
+session exports, or documentation.

--- a/src/tau_coding/built_in_extensions.py
+++ b/src/tau_coding/built_in_extensions.py
@@ -2,15 +2,38 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING
 
+import httpx
+
+from tau_coding.credentials import CredentialStore
+from tau_coding.paths import TauPaths
+
 if TYPE_CHECKING:
     from tau_coding.extensions.api import ExtensionAPI
 
+
+@dataclass(frozen=True, slots=True)
+class BuiltInExtensionContext:
+    """Trusted runtime dependencies supplied only to bundled extensions.
+
+    Filesystem extensions receive the ordinary :class:`ExtensionAPI` only. The
+    context exists so a bundled integration uses the session's Tau home,
+    credential store, environment snapshot, and deterministic HTTP client
+    rather than silently reaching process-global defaults.
+    """
+
+    paths: TauPaths
+    credential_store: CredentialStore
+    environment: Mapping[str, str]
+    http_client: httpx.AsyncClient | None = None
+
+
 BuiltInExtensionSetup = Callable[["ExtensionAPI"], None]
+BuiltInExtensionContextSetup = Callable[["ExtensionAPI", BuiltInExtensionContext], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +48,7 @@ class BuiltInExtension:
     name: str
     setup: BuiltInExtensionSetup
     hidden: bool = True
+    setup_with_context: BuiltInExtensionContextSetup | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.name, str) or not self.name.strip():
@@ -38,6 +62,14 @@ class BuiltInExtension:
             raise ValueError("Built-in extension setup must be a sync function")
         if not isinstance(self.hidden, bool):
             raise ValueError("Built-in extension hidden flag must be a boolean")
+        if self.setup_with_context is not None:
+            if not callable(self.setup_with_context):
+                raise ValueError("Built-in contextual setup must be callable")
+            context_setup_call = type(self.setup_with_context).__call__
+            if iscoroutinefunction(self.setup_with_context) or iscoroutinefunction(
+                context_setup_call
+            ):
+                raise ValueError("Built-in contextual setup must be a sync function")
 
     @property
     def source_id(self) -> str:
@@ -45,9 +77,38 @@ class BuiltInExtension:
         return f"built-in:{self.name}"
 
 
-# Product capabilities are added here by later phases. Keeping this registry
-# explicit makes built-in code reviewable and prevents filesystem discovery or
-# project inputs from changing what Tau treats as trusted.
-BUILT_IN_EXTENSIONS: tuple[BuiltInExtension, ...] = ()
+def _llama_cpp_setup(api: ExtensionAPI) -> None:
+    """Load the product extension with its normal process dependencies."""
+    from tau_coding.extensions.builtins.llama_cpp import setup
 
-__all__ = ["BUILT_IN_EXTENSIONS", "BuiltInExtension", "BuiltInExtensionSetup"]
+    setup(api)
+
+
+def _llama_cpp_setup_with_context(
+    api: ExtensionAPI,
+    context: BuiltInExtensionContext,
+) -> None:
+    """Load the product extension lazily with trusted runtime dependencies."""
+    from tau_coding.extensions.builtins.llama_cpp import setup
+
+    setup(api, context)
+
+
+# Product capabilities are declared explicitly so filesystem discovery or
+# project inputs cannot change what Tau treats as trusted.
+BUILT_IN_EXTENSIONS: tuple[BuiltInExtension, ...] = (
+    BuiltInExtension(
+        name="llama.cpp",
+        setup=_llama_cpp_setup,
+        hidden=True,
+        setup_with_context=_llama_cpp_setup_with_context,
+    ),
+)
+
+__all__ = [
+    "BUILT_IN_EXTENSIONS",
+    "BuiltInExtension",
+    "BuiltInExtensionContext",
+    "BuiltInExtensionContextSetup",
+    "BuiltInExtensionSetup",
+]

--- a/src/tau_coding/credentials.py
+++ b/src/tau_coding/credentials.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from json import dumps, loads
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from tau_agent.types import JSONValue
 from tau_coding.paths import TauPaths
@@ -61,6 +61,18 @@ type StoredCredential = str | ApiKeyCredential | OAuthCredential
 type StoredCredentialKind = Literal["api_key", "oauth"]
 
 
+class CredentialStore(Protocol):
+    """Mutable credential-store operations used by setup integrations."""
+
+    def get(self, name: str) -> str | None: ...
+
+    def set(self, name: str, value: str) -> None: ...
+
+    def delete(self, name: str) -> None: ...
+
+    def names(self, *, prefix: str | None = None) -> tuple[str, ...]: ...
+
+
 class FileCredentialStore:
     """Small JSON-backed provider credential store under Tau home."""
 
@@ -110,6 +122,13 @@ class FileCredentialStore:
         data = self._load()
         data.pop(name, None)
         self._save(data)
+
+    def names(self, *, prefix: str | None = None) -> tuple[str, ...]:
+        """Return credential names without exposing their values."""
+        names = tuple(sorted(self._load()))
+        if prefix is None:
+            return names
+        return tuple(name for name in names if name.startswith(prefix))
 
     def _load(self) -> dict[str, StoredCredential]:
         if not self.path.exists():

--- a/src/tau_coding/data/docs/README.md
+++ b/src/tau_coding/data/docs/README.md
@@ -4,10 +4,11 @@ Tau is a minimalist Python coding-agent harness inspired by Pi. Use these instal
 
 - [Extensions](extensions.md): build Python extensions, custom tools, commands, hooks, dialogs, and renderers.
 - [Skills](skills.md): install reusable task knowledge and prompt templates.
-- [Models](models.md): configure providers and models or change Tau's built-in catalog.
+- [Models](models.md): configure providers and models, including local inference.
+- [Local inference](local-inference.md): configure the built-in llama.cpp backend through `/local`.
 - [CLI](cli.md): command-line and slash-command entry points.
-- [Security](security.md): project-input trust behavior and its non-sandbox boundary.
-- [TUI](tui.md): interactive interface behavior.
+- [Security](security.md): project-input trust behavior and local-backend boundaries.
+- [TUI](tui.md): interactive interface behavior, including `/local`.
 - [Architecture](architecture.md): package boundaries and contributor design rules.
 
 Read only the references relevant to the task, then follow their links and the active project's instructions.

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -1,61 +1,54 @@
 # Tau CLI and commands
 
-`/local` is an interactive TUI command. Print mode does not execute its
-configuration flow; configure a backend in the TUI, then use explicit
-`--provider` and `--model` flags for headless requests. This avoids probing a
-local endpoint or selecting a model implicitly during non-interactive startup.
+`tau` opens the interactive TUI by default. Print mode is selected with
+`-p/--print` or `--mode` and uses the same staged session/provider preparation
+as the TUI.
 
-Tau supports print mode and a Textual interactive TUI. The CLI entry point is `tau_coding.cli:app`.
+## Local inference
 
-For current user-facing behavior in a Tau checkout, read:
+`/local` is interactive-only. It opens the provider-neutral local-backend host
+in the TUI; print mode never runs setup, probes endpoints, or picks a model
+implicitly. Configure llama.cpp through `/local`, then use its exact provider
+and model explicitly in headless mode:
 
-- `website/content/reference/cli.md`
-- `website/content/reference/slash-commands.md`
-- `src/tau_coding/commands.py`
+```bash
+tau --provider llama.cpp --model <server-reported-id> --print "summarize this project"
+```
 
-Keep command parsing and application-specific resource loading in `tau_coding`, not the reusable `tau_agent` harness. When changing behavior, test both command results and the relevant print/TUI integration, then update published reference documentation.
+The built-in provider is loaded before explicit provider/model validation, so
+both print and TUI startup work after setup. A saved safe snapshot can allow
+startup while the server is temporarily unavailable. A first-time explicit
+model still requires a successful discovery; an unavailable built-in backend
+never blocks unrelated ordinary-provider startup.
 
-## Project trust startup controls
+See `local-inference.md` for endpoint precedence, optional/no authentication,
+state and credential storage, Doctor, reset, and troubleshooting.
 
-`--approve`/`-a` and `--no-approve`/`-na` are mutually exclusive run-only
-overrides. They are parsed before protected resource loading and never persist.
-Headless modes never prompt; user-global `defaultProjectTrust` controls unresolved
-projects. Keep diagnostics on stderr for structured stdout modes. See
-`security.md` and `website/content/guides/project-trust.md`.
+## Common flags
 
-## System prompt startup controls
+```text
+tau [OPTIONS] [PROMPT]
+```
 
-`--system-prompt TEXT_OR_PATH` replaces the default base prompt.
-`--append-system-prompt TEXT_OR_PATH` is repeatable; values retain command-line
-order and are separated by exactly one blank line. Put recognized flags before
-the positional prompt.
+- `-p, --print`: run one prompt without the TUI.
+- `--mode text|json|transcript`: choose print output and imply print mode.
+- `--provider NAME`: select an explicit provider.
+- `-m, --model ID`: select an explicit model.
+- `--session ID`: resume a session in the TUI or print mode.
+- `--cwd PATH`: set the coding-session working directory.
+- `-e, --extension PATH`: load an explicit extension.
+- `--no-extensions`: disable discovered extension directories; trusted built-ins
+  remain available.
+- `--project-extensions`: opt in to trusted project extensions after approval.
+- `-a, --approve` / `-na, --no-approve`: run-only project-trust decisions.
 
-Each value is read as UTF-8 when it names an existing path (with `~` expanded),
-or used verbatim when the path does not exist. An existing directory, unreadable
-file, or invalid UTF-8 file stops startup with a diagnostic naming the option
-and path.
+Explicit `--provider` and `--model` overrides take precedence over a resumed
+provider-aware transcript entry. Print mode reports actionable errors instead of
+opening an interactive login or local setup flow.
 
-Both flags apply to print and interactive TUI startup, including the next request
-of a session resumed with `--session`. They are not persisted, so pass them on
-each later resume that needs them. A custom base still goes through
-`build_system_prompt`: configured append text, project context, eligible skills,
-the current date, and cwd remain included. Do not route this CLI option through
-the lower-level exact `CodingSessionConfig.system` override.
+## Safety boundary
 
-## System prompt files
-
-Tau discovers replacement `SYSTEM.md` and append-only `APPEND_SYSTEM.md` files
-from `<cwd>/.tau/` and `~/.tau/`. Explicit CLI prompt input wins over a project
-file, which wins over a user file. Project and user append files are alternatives,
-not cumulative layers. `.agents/SYSTEM.md` and `.agents/APPEND_SYSTEM.md` are not
-supported because these are Tau-specific configuration resources.
-
-The selected replacement still receives append text, project context, eligible
-skills, date, and cwd. Run `/reload` after changing files; the next-turn prompt is
-rebuilt without adding prompt contents to session history. Selected, shadowed,
-and CLI-overridden sources appear in resource diagnostics. Unreadable or invalid
-UTF-8 selected files stop startup/reload with an actionable error.
-
-Project files load only after the canonical cwd trust decision. Users should
-still inspect trusted `.tau/SYSTEM.md` and `.tau/APPEND_SYSTEM.md`: project trust
-is an input-loading guard, not a sandbox or prompt-safety guarantee.
+Project trust controls ambient project-resource loading; it is not a sandbox.
+Built-in local backends are trusted package code and do not create a project
+trust prompt. They probe only configured endpoints and never stop external
+servers or delete model files. See `security.md`.

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -90,9 +90,10 @@ retirement. Failures retain the current snapshot and emit one bounded, secret-fr
 diagnostic. Nested compatibility data is deeply immutable while registered.
 Callbacks receive structured data, not Rich or Textual objects.
 
-This Phase 1 API is provisional pending second-backend validation. Registration and
-registry mechanics exist now; startup selection, built-in providers, `/local`, and
-llama.cpp behavior land in later #602 phases.
+This API remains provisional pending second-backend validation. The trusted
+built-in `llama.cpp` provider now uses these contracts; its connection, cache,
+and troubleshooting behavior are covered in `local-inference.md`. Router
+management and Hugging Face model mutations remain outside this phase.
 
 ## Local-backend registrations
 

--- a/src/tau_coding/data/docs/local-inference.md
+++ b/src/tau_coding/data/docs/local-inference.md
@@ -1,0 +1,133 @@
+# Local inference with llama.cpp
+
+Tau ships llama.cpp as a trusted, hidden built-in local backend. It is exposed
+through the provider-neutral `/local` command; there is no `/llama` or
+`/llama-cpp` command. The built-in provider ID is `llama.cpp`, which is distinct
+from an older user-created `llama-cpp` catalog provider.
+
+## Start a server
+
+Install llama.cpp separately and start its OpenAI-compatible server with a
+model that supports the work you want to do:
+
+```bash
+llama-server -hf <tool-capable-gguf>
+```
+
+The default endpoint is `http://127.0.0.1:8080`. Tau does not install, start,
+stop, scan for, or download llama.cpp models. Keep the server running while Tau
+uses it.
+
+## Configure `/local`
+
+Open Tau and run:
+
+```text
+/local
+```
+
+Choose the recommended `llama.cpp` backend and confirm the choice, even when it
+is the only backend. Enter the server URL, with or without `/v1`, and optionally
+enter an API key. Tau probes only the endpoint you provide. It never scans ports,
+processes, or the local network.
+
+Endpoint precedence is:
+
+1. the value currently entered in `/local`;
+2. the saved endpoint;
+3. `LLAMA_BASE_URL` for the current process;
+4. `http://127.0.0.1:8080` as the offered default.
+
+The default alone does not configure the backend or cause a network request. An
+explicitly saved endpoint or non-empty `LLAMA_BASE_URL` counts as configured.
+Successful setup discovers the exact IDs returned by `/v1/models`; it never
+requires a fake model ID.
+
+Use the optional key in one of these ways:
+
+- enter it in the secret `/local` field; Tau stores it in `~/.tau/credentials.json`;
+- set `LLAMA_API_KEY` for an environment-only setup;
+- leave both empty for an unauthenticated server.
+
+A stored key takes precedence over `LLAMA_API_KEY`. Without a key Tau sends no
+`Authorization` header. Keys are never written to the llama.cpp state file,
+sessions, exports, or diagnostics.
+
+## Select and use a model
+
+After setup:
+
+```text
+/model
+```
+
+The picker shows server-reported model IDs and display names. Use an explicit
+provider and exact model ID for startup, especially in scripts:
+
+```bash
+tau --provider llama.cpp --model <model-id>
+tau --provider llama.cpp --model <model-id> --print "summarize this project"
+```
+
+Both print mode and the TUI load the built-in provider before validating an
+explicit selection. A saved safe snapshot lets an explicit startup continue
+when the server is temporarily down. If there are several models, headless
+startup requires the exact `--model`; Tau never silently picks a different
+explicit model. Local inference is not an automatic global-provider fallback.
+
+The safe integration snapshot is stored at:
+
+```text
+~/.tau/state/extensions/llama.cpp.json
+```
+
+It contains only the endpoint, selected model reference, allowlisted model
+metadata, and a timestamp. The file is versioned, locked, atomically replaced,
+and private. Dynamic provider definitions are not copied into `catalog.toml` or
+`providers.json`.
+
+## Status, refresh, doctor, and reset
+
+`/local` provides status and refresh. Refresh updates the complete model
+snapshot atomically. Temporary downtime retains the last safe snapshot and marks
+it stale; it does not erase the active provider or block unrelated providers.
+If the server no longer reports the active model, Tau keeps the current runtime
+usable, marks the snapshot stale, and does not offer a replacement model without
+an explicit selection after the original model returns.
+
+`doctor` is an explicit action. It reports endpoint reachability, model discovery,
+streaming, tool-schema acceptance, and observed tool-call emission. A model that
+streams but does not emit the probe tool receives a compatibility warning, not a
+connectivity failure. Use a tool-capable instruct model and the server's required
+chat-template options when tool calls are unavailable.
+
+Reset removes only Tau's llama.cpp integration settings and safe snapshots. It
+never stops the external server or deletes model files. Settings reset and stored
+credential deletion are separate actions; a credential is retained until its
+separate deletion confirmation succeeds.
+
+## Troubleshooting
+
+- **Connection refused or timeout:** start `llama-server`, check the exact URL,
+  and run `/local` → Refresh. Tau does not discover a different port.
+- **HTTP 401/403:** enter the server's configured key in `/local`, or set
+  `LLAMA_API_KEY`. A stored key wins over the environment value.
+- **Loading:** wait for llama.cpp to finish loading, then refresh.
+- **Malformed or empty `/v1/models`:** inspect the server response and model
+  loading state. Tau does not invent an ID or metadata.
+- **Print mode says the model is unavailable:** configure `/local` first and
+  pass both `--provider llama.cpp` and the exact discovered `--model`. A cached
+  snapshot can work offline, but a first-time explicit model needs discovery.
+- **Tools are not called:** run Doctor. Streaming can work while a model's GGUF
+  chat template does not support tools. Use a tool-capable instruct GGUF and
+  check llama.cpp's template/server flags.
+- **An old `llama-cpp` provider still exists:** it is a separate manually
+  configured provider. Use `llama.cpp` for the built-in backend, or keep the old
+  provider for its existing catalog configuration.
+
+For project trust and the security boundary, see `security.md`. For command
+flags and print/TUI startup, see `cli.md`, `tui.md`, and `models.md`.
+
+Router model management, Hugging Face search/download, and implicit load/unload
+are not part of this phase. Use the standard OpenAI-compatible loaded-model API;
+those mutating workflows require a later router phase.

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -1,87 +1,70 @@
 # Tau providers and models
 
-Tau separates provider/model streaming (`tau_ai`), the portable harness (`tau_agent`), and application configuration (`tau_coding`).
+A provider hosts models; a model is the exact ID accepted by that provider. Use
+`/login` for durable built-in credentials and `/model` to choose an available
+model.
 
-## User configuration
+## Built-in llama.cpp
 
-Use `/login` and `/model` for built-in providers. The custom-provider flow supports OpenAI-compatible endpoints. Durable provider settings live under Tau's home directory; consult the published `website/content/guides/providers-and-models.md` in a Tau checkout for the current schema and authentication behavior.
+Tau includes a trusted, hidden `llama.cpp` provider layer for local inference.
+Configure it in the TUI with `/local`, not `/login custom`:
 
-## Durable versus dynamic providers
-
-Catalog providers are durable user/application configuration. Extension providers
-are source- and generation-owned overlays held only by an `ExtensionRuntime`.
-The host identifies each source by its canonical entry path, independently of the
-extension's display name. It freezes that identity before importing extension code,
-so later symlink mutation cannot change ownership or failed-setup cleanup; same-name
-files from different paths therefore cannot replace or remove each other's layers.
-Their definitions and refresh snapshots must never be copied into `catalog.toml`,
-`providers.json`, session metadata, or a generic
-disk cache. Removing the final dynamic layer restores the original complete durable
-provider object.
-
-Dynamic providers support required, optional, or absent authentication without
-fake keys. Secrets are resolved immediately before refresh/runtime creation;
-resolved keys, headers, and extension-provided auth provenance are excluded from
-representations and diagnostics. Custom runtime-auth exceptions become categorical
-host errors, while Tau's required-key strategy retains missing-credential guidance.
-Nested compatibility metadata is deeply frozen
-inside registered definitions and copied back to ordinary JSON containers only at
-the transport boundary. Phase 1 provides the provider contracts and registry
-mechanics. The Phase 4 local-backend host adds `/local` for registered backends;
-it does not turn a dynamic provider into a durable catalog entry or silently
-select one at startup. Use an explicit `--provider`/`--model` or the TUI's
-**Use** action after a backend has discovered a model.
-
-## `/local` and dynamic local backends
-
-In the TUI, `/local` first opens an explicit backend chooser. A single backend
-is preselected and may be marked recommended, but it still requires confirmation.
-The backend screen exposes configure, refresh, status, use, doctor, reset, and
-model-management actions only when the backend declares them. Configuration
-fields are host-rendered structured text, secret, or choice values; cancellation,
-validation failure, and failed backend commits leave the prior state untouched.
-
-Dynamic providers are process-local overlays. A backend may persist safe
-integration state through its own versioned store, but provider definitions,
-secrets, and arbitrary response data do not belong in `catalog.toml`,
-`providers.json`, sessions, or generic extension state. Stored credentials are
-referenced indirectly, and diagnostics identify only their source. The generic
-host never probes endpoints on its own and never invents an API key.
-
-## Changing the built-in catalog
-
-For changes to a first-party provider or model, use this workflow:
-
-1. Decide whether this is a model on an existing provider or a new provider.
-2. Verify the exact model ID, endpoint, transport, authentication, context window, modalities, output limit, reasoning values, pricing, and plan restrictions in official provider documentation. Never guess undocumented metadata.
-3. Confirm Tau supports the API transport before adding a provider.
-4. Update the catalog source of truth:
-
-   ```text
-   src/tau_coding/data/catalog.toml
-   ```
-
-5. Preserve the existing `default_model` unless changing it is intentional, and match nearby TOML compatibility metadata.
-6. Test provider membership, context and model metadata, thinking-level filtering and wire mappings, runtime construction when the transport changes, and intentionally preserved defaults. Relevant tests usually include:
-
-   ```text
-   tests/test_provider_catalog.py
-   tests/test_provider_config.py
-   tests/test_provider_runtime.py
-   ```
-
-Tau thinking levels are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Provider-level `thinking_levels` must include every level needed by its models. Use model metadata when the wire value differs or a model supports only a subset:
-
-```toml
-thinking_level_map = { xhigh = "max" }
-unsupported_thinking_levels = ["off", "minimal", "low", "medium", "high"]
+```text
+/local
 ```
 
-When withdrawing a model from one built-in provider, add it to that provider's
-`removed_models` list. Tombstones are applied after user overlays, preventing
-stale saved catalog definitions from restoring an unroutable provider/model
-combination while leaving the same model ID available on other providers.
+The backend is recommended and preselected, but the selection is explicit. It
+accepts a server URL with or without `/v1`, discovers real IDs from `/v1/models`,
+and supports optional, environment, or absent authentication. No fake key or
+fake model value is used. See `local-inference.md` for server setup, cache,
+troubleshooting, Doctor, and reset behavior.
 
-Test both the exposed levels and the actual API value produced by provider configuration. Update `website/content/guides/providers-and-models.md` and add a beginner-friendly development note for substantial user-facing changes. Inspect `src/tau_coding/data/release-notes/releases.json`, but update it only when appropriate.
+After setup, choose models in `/model` or start explicitly:
 
-Run focused provider tests followed by the repository's full pytest, Ruff, formatting, and mypy checks. Build the website when published provider documentation changes.
+```bash
+tau --provider llama.cpp --model <server-reported-id>
+tau --provider llama.cpp --model <server-reported-id> --print "summarize this project"
+```
+
+The built-in provider is dynamic and process-local. Its safe endpoint/model
+snapshot is stored under `~/.tau/state/extensions/llama.cpp.json`; its optional
+secret is stored separately in `~/.tau/credentials.json`. Dynamic definitions
+are never copied into `catalog.toml`, `providers.json`, or session files. A
+cached snapshot can keep an explicit startup usable during temporary server
+downtime. An unavailable local backend is never an implicit fallback for a new
+ordinary session.
+
+## Durable and dynamic providers
+
+Catalog providers are durable user/application configuration. Extension provider
+layers are source- and generation-owned overlays held only by an active
+`ExtensionRuntime`. Their definitions and refresh snapshots are not persisted as
+durable provider configuration. Removing a dynamic layer restores the complete
+preceding layer or the durable baseline.
+
+Dynamic providers support required, optional, or absent authentication without
+fake keys. Secrets resolve immediately before refresh or runtime creation and are
+excluded from representations, diagnostics, snapshots, sessions, and exports.
+
+## Existing custom providers
+
+Other OpenAI-compatible endpoints can still be configured with `/login custom`,
+`tau setup`, or a user-level `~/.tau/catalog.toml` entry. That path is useful for
+Ollama, gateways, and older manually configured local providers. An existing
+provider named `llama-cpp` remains distinct from the built-in `llama.cpp`; Tau
+does not migrate or overwrite it.
+
+## Metadata and selection rules
+
+Use exact provider/model IDs. Tau does not infer context windows, output limits,
+reasoning support, modalities, pricing, or tool compatibility when a server does
+not report them. Local Doctor can verify streaming and tool-call behavior only
+when explicitly requested. If a refreshed server no longer reports the active
+model, Tau keeps the current runtime usable and marks the model snapshot stale;
+it does not silently replace the model.
+
+Provider/model selection precedence is explicit CLI selection, the resumed
+transcript's provider-aware model entry, the session record for legacy sessions,
+a durable default, and then a usable durable provider. Dynamic local providers
+are selected only by explicit startup, a resumed local session, or an in-session
+`/model`/`/local` action.

--- a/src/tau_coding/data/docs/security.md
+++ b/src/tau_coding/data/docs/security.md
@@ -2,37 +2,56 @@
 
 Tau resolves trust for the canonical destination cwd before reading ambient
 project Markdown/JSON or importing project extensions. Protected inputs include
-project skills, prompts, themes, system-prompt files, AGENTS.md context,
-extension candidates, and reserved future project settings/package metadata.
-User/global and explicit CLI resources remain eligible. Trusted built-in
-extensions are installed Tau package code, load before this decision even with
-`--no-extensions`, and are not ambient project candidates. Their presence alone
-never creates a project trust prompt. Hidden status affects ordinary listings,
-not execution or trust.
+project skills, prompts, themes, system-prompt files, `AGENTS.md` context,
+extension candidates, and reserved project settings.
 
 Interactive users can save exact or displayed-parent decisions or choose a
-run-only result. `~/.tau/trust.json` is a locked, atomically replaced version-1
-store. `defaultProjectTrust` in user `~/.tau/settings.json` is `ask`, `always`,
-or `never`; headless `ask`/`never` decline. `--approve` and `--no-approve` are
-run-only. Cancelling the interactive startup decision exits Tau; continuing
-without project inputs requires selecting a decline option. Trusted project
-extensions additionally require `--project-extensions`.
-
-Project trust is only an input-loading guard. It is not a filesystem, process,
-shell, network, tool, credential, provider, model, package-install,
-prompt-injection, or exfiltration sandbox. Use OS/container/VM isolation and
-restricted credentials/network when isolation is required.
+run-only result. Headless `ask`/`never` decisions decline project inputs;
+`--approve` and `--no-approve` are run-only overrides. Cancelling an interactive
+trust decision exits startup or preserves the current session during reload and
+replacement. Trust is committed only after the staged session is adopted.
 
 ## Built-in local-backend boundary
 
-Built-in local backends are trusted Tau package code and do not create a project
-trust prompt. Their provider/backend definitions live only in the active,
-generation-owned runtime. Endpoint settings and safe model snapshots, when a
-backend supports them, are user-level integration state—not project inputs.
+The bundled llama.cpp backend is trusted Tau package code. It loads before the
+project-trust decision, remains available with `--no-extensions`, and never
+creates a project trust prompt. Its provider/backend definitions are owned by
+the active extension-runtime generation. Endpoint settings and allowlisted model
+snapshots are user-level integration state, not project inputs; they live under
+`~/.tau/state/extensions/llama.cpp.json`.
 
-Configuration secrets are collected by the host as secret fields, passed only to
-the backend transaction, and kept out of reprs, snapshots, session metadata, and
-diagnostics. No API key is synthesized when authentication is optional or absent.
-A local backend never stops a server or deletes model files as part of reset.
+`/local` probes only the endpoint the user entered, saved, or supplied through
+`LLAMA_BASE_URL`. It does not scan processes, ports, or the local network. Tau
+does not install, start, stop, download, or delete llama.cpp servers or model
+files. The default localhost endpoint is an offered value, not an automatic
+probe.
 
-Published details: `website/content/guides/project-trust.md`.
+## Credentials and safe state
+
+API keys are collected through secret fields. A stored key is kept in Tau's
+private credential store and referenced by an opaque integration-owned name.
+`LLAMA_API_KEY` is an environment fallback. If neither is present, Tau omits
+`Authorization`; it never synthesizes a fake local key. Stored credentials win
+over the environment value.
+
+The llama.cpp state file contains only the normalized endpoint, exact
+server-reported model IDs, allowlisted display/context/modality metadata, the
+selected reference, and a timestamp. It does not contain keys, arbitrary
+headers, server PIDs, project-local overrides, or raw server payloads. Secrets
+are excluded from provider representations, diagnostics, sessions, and exports.
+State and credential writes are separate transactions: a failed state commit
+leaves the prior configuration active and an unreferenced credential is cleaned
+up or reported for recovery; old-credential cleanup failure does not invalidate
+the committed new configuration. Reset removes safe settings first and deletes a
+stored credential only after separate confirmation.
+
+## General boundary
+
+Project trust is an input-loading guard, not a filesystem, process, shell,
+network, tool, credential, provider, model, package-install, prompt-injection,
+or exfiltration sandbox. Extensions execute arbitrary Python. Use an OS
+sandbox, container, VM, remote environment, and restricted credentials/network
+when isolation is required.
+
+For endpoint, auth, cached-downtime, Doctor, and model-selection troubleshooting,
+see `local-inference.md`.

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -1,25 +1,32 @@
 # Tau TUI
 
-Tau's full interactive interface uses Textual behind an adapter boundary. `tau_agent` emits provider-neutral events; `tau_coding.tui` consumes and renders them.
+Tau's interactive interface uses Textual behind an adapter boundary. The
+portable `tau_agent` harness emits provider-neutral events; the TUI renders
+them and owns interaction.
 
-For current behavior in a Tau checkout, read:
-
-- `website/content/guides/tui.md`
-- `website/content/reference/keybindings.md`
-- `src/tau_coding/tui/`
-
-## Local backends
+## `/local`
 
 Type `/local` to open the generic local-backend host. It explicitly chooses a
-registered backend, including when only one is available; a recommended backend
-is merely preselected. Configure screens render backend-declared text, secret,
-and choice fields without exposing backend UI objects to extension code.
+registered backend even when only one is available; the recommended backend is
+preselected but still requires confirmation. Tau's built-in `llama.cpp` backend
+provides endpoint/API-key fields, status, refresh, use, Doctor, and reset.
 
-The host supports asynchronous configure, refresh, status, use, doctor, reset,
-and optional model actions. It displays structured status and progress, refuses
-state-changing actions while the agent is busy, and cancels owned work when the
-screen closes. Results from a replaced or retired extension generation are
-ignored. Backends that do not declare an optional capability do not show its
-control.
+Configuration fields are structured text, secret, or choice values. Secret input
+is not echoed into diagnostics or session history. Backends perform async
+validation and return typed status, model, diagnostic, and progress data; they
+do not construct Textual widgets.
 
-Do not introduce Textual dependencies into `tau_agent`. Keep reusable behavior in the harness/session layers and UI behavior in the adapter. Use Textual pilot tests and fake providers for deterministic interaction tests.
+Refresh may show a cached/stale model snapshot when the server is down. Use an
+exact discovered model with `--provider llama.cpp --model ...` for print or TUI
+startup. A missing active model is marked stale rather than silently replaced.
+State-changing local actions require an idle agent. Closing the screen cancels
+its owned work, and results from a retired or replaced extension generation are
+ignored.
+
+Reset removes only Tau's llama.cpp settings and safe snapshot. Stored credential
+deletion is separately confirmed. Tau never stops the external server or
+deletes model files. See `local-inference.md` and `security.md`.
+
+Do not introduce Textual dependencies into `tau_agent`. Keep reusable behavior
+in the harness/session layers and UI behavior in this adapter. Use Textual pilot
+tests and deterministic fake providers/backends for interaction tests.

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -898,6 +898,11 @@ class ExtensionAPI:
         self._generation.assert_active()
         self._runtime.register_provider(self._source_id, provider)
 
+    def update_provider(self, provider: DynamicProvider) -> bool:
+        """Update this source's provider snapshot while preserving its layer token."""
+        self._generation.assert_active()
+        return self._runtime.update_provider(self._source_id, provider)
+
     def register_local_backend(self, backend: LocalBackend) -> None:
         """Register a backend paired with this source's provider layer."""
         self._generation.assert_active()

--- a/src/tau_coding/extensions/builtins/__init__.py
+++ b/src/tau_coding/extensions/builtins/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled extension implementations."""

--- a/src/tau_coding/extensions/builtins/llama_cpp/__init__.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/__init__.py
@@ -1,0 +1,84 @@
+"""Trusted built-in llama.cpp local backend."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from tau_coding.built_in_extensions import BuiltInExtensionContext
+from tau_coding.credentials import FileCredentialStore, credentials_path
+from tau_coding.paths import TauPaths
+
+from .service import (
+    DEFAULT_LLAMA_CPP_TIMEOUT_SECONDS,
+    LLAMA_CPP_API_KEY_ENV,
+    LLAMA_CPP_BACKEND_ID,
+    LLAMA_CPP_DEFAULT_ENDPOINT,
+    LLAMA_CPP_DISPLAY_NAME,
+    LLAMA_CPP_ENDPOINT_ENV,
+    LLAMA_CPP_PROVIDER_ID,
+    LlamaCppDiscovery,
+    LlamaCppEndpoint,
+    LlamaCppEndpointError,
+    LlamaCppError,
+    LlamaCppService,
+    normalize_llama_cpp_endpoint,
+)
+from .state import (
+    LLAMA_CPP_CREDENTIAL_PREFIX,
+    LLAMA_CPP_STATE_SCHEMA_VERSION,
+    LlamaCppIntegrationState,
+    LlamaCppStateError,
+    LlamaCppStateStore,
+    LlamaCppStoredModel,
+)
+
+if TYPE_CHECKING:
+    from tau_coding.extensions.api import ExtensionAPI
+
+
+def setup(
+    tau: ExtensionAPI,
+    context: BuiltInExtensionContext | None = None,
+) -> None:
+    """Register the trusted provider and provider-neutral local backend."""
+    dependencies = context or BuiltInExtensionContext(
+        paths=TauPaths(),
+        credential_store=FileCredentialStore(credentials_path(TauPaths())),
+        environment=dict(os.environ),
+    )
+    service = LlamaCppService(
+        state_store=LlamaCppStateStore(paths=dependencies.paths),
+        credential_store=dependencies.credential_store,
+        environment=dependencies.environment,
+        client=dependencies.http_client,
+        register_provider=tau.register_provider,
+        update_provider=tau.update_provider,
+        register_backend=tau.register_local_backend,
+    )
+    tau.register_provider(service.provider())
+    tau.register_local_backend(service.backend())
+
+
+__all__ = [
+    "DEFAULT_LLAMA_CPP_TIMEOUT_SECONDS",
+    "LLAMA_CPP_API_KEY_ENV",
+    "LLAMA_CPP_CREDENTIAL_PREFIX",
+    "LLAMA_CPP_BACKEND_ID",
+    "LLAMA_CPP_DEFAULT_ENDPOINT",
+    "LLAMA_CPP_DISPLAY_NAME",
+    "LLAMA_CPP_ENDPOINT_ENV",
+    "LLAMA_CPP_PROVIDER_ID",
+    "LLAMA_CPP_STATE_SCHEMA_VERSION",
+    "LlamaCppDiscovery",
+    "LlamaCppEndpoint",
+    "LlamaCppEndpointError",
+    "LlamaCppError",
+    "LlamaCppIntegrationState",
+    "LlamaCppService",
+    "LlamaCppStateError",
+    "LlamaCppStateStore",
+    "LlamaCppStoredModel",
+    "normalize_llama_cpp_endpoint",
+    "setup",
+]

--- a/src/tau_coding/extensions/builtins/llama_cpp/service.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/service.py
@@ -1,0 +1,1127 @@
+"""llama.cpp protocol adapter used by the built-in extension."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from types import MappingProxyType
+from typing import Literal, cast
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from tau_agent.harness import SimpleCancellationToken
+from tau_agent.messages import TextContent, UserMessage
+from tau_agent.provider import CancellationToken
+from tau_agent.provider_events import (
+    AssistantErrorEvent,
+    AssistantStartEvent,
+    ToolCallEndEvent,
+)
+from tau_agent.tools import AgentTool, AgentToolResult, ToolCancellationToken
+from tau_agent.types import JSONValue
+from tau_ai.env import OpenAICompatibleConfig
+from tau_ai.http import create_async_client
+from tau_ai.openai_compatible import OpenAICompatibleProvider
+from tau_coding.credentials import CredentialStore, FileCredentialStore, credentials_path
+from tau_coding.extensions.providers import (
+    DynamicProvider,
+    OpenAICompatibleTransport,
+    ProviderAuthContext,
+    ProviderAuthError,
+    ProviderModel,
+    ProviderModelSnapshot,
+    ProviderRefreshContext,
+    ResolvedProviderAuth,
+)
+from tau_coding.local_backends import (
+    LocalAction,
+    LocalBackend,
+    LocalBackendStatus,
+    LocalConfigField,
+    LocalConfigureResult,
+    LocalConfigureSpec,
+    LocalDiagnostic,
+    LocalModel,
+    LocalOperationContext,
+    LocalOperationResult,
+)
+from tau_coding.paths import TauPaths
+
+from .state import (
+    LLAMA_CPP_CREDENTIAL_PREFIX,
+    LlamaCppIntegrationState,
+    LlamaCppStateError,
+    LlamaCppStateStore,
+    LlamaCppStoredModel,
+)
+
+LLAMA_CPP_PROVIDER_ID = "llama.cpp"
+LLAMA_CPP_DISPLAY_NAME = "llama.cpp"
+LLAMA_CPP_BACKEND_ID = "llama.cpp"
+LLAMA_CPP_DEFAULT_ENDPOINT = "http://127.0.0.1:8080"
+LLAMA_CPP_ENDPOINT_ENV = "LLAMA_BASE_URL"
+LLAMA_CPP_API_KEY_ENV = "LLAMA_API_KEY"
+DEFAULT_LLAMA_CPP_TIMEOUT_SECONDS = 5.0
+
+
+class LlamaCppError(RuntimeError):
+    """Raised for a safe, user-actionable llama.cpp integration failure."""
+
+
+class LlamaCppEndpointError(ValueError):
+    """Raised when an endpoint is not a safe HTTP base URL."""
+
+
+@dataclass(frozen=True, slots=True)
+class LlamaCppEndpoint:
+    """The server root and OpenAI-compatible inference base for one endpoint."""
+
+    server_root: str
+    inference_base: str
+
+
+@dataclass(frozen=True, slots=True)
+class LlamaCppDiscovery:
+    """Defensive result from the standard health and model endpoints."""
+
+    endpoint: LlamaCppEndpoint
+    models: tuple[ProviderModel, ...]
+    health: str = "ok"
+
+
+@dataclass(frozen=True, slots=True)
+class _LlamaCppAuth:
+    """Generation-referenced optional auth; secrets never enter the provider."""
+
+    credential_ref: str | None = None
+    env_var: str = LLAMA_CPP_API_KEY_ENV
+
+    async def resolve(self, context: ProviderAuthContext) -> ResolvedProviderAuth:
+        if self.credential_ref:
+            stored = context.credentials.get(self.credential_ref)
+            if stored:
+                return ResolvedProviderAuth(
+                    api_key=stored,
+                    source="stored credential",
+                    omit_authorization_header=False,
+                )
+        environment_value = context.environment.get(self.env_var)
+        if environment_value:
+            return ResolvedProviderAuth(
+                api_key=environment_value,
+                source=f"environment variable {self.env_var}",
+                omit_authorization_header=False,
+            )
+        return ResolvedProviderAuth()
+
+
+class _HttpFailure(LlamaCppError):
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class LlamaCppService:
+    """Own endpoint state, discovery, diagnostics, and provider construction."""
+
+    def __init__(
+        self,
+        *,
+        state_store: LlamaCppStateStore | None = None,
+        credential_store: CredentialStore | None = None,
+        environment: Mapping[str, str] | None = None,
+        client: httpx.AsyncClient | None = None,
+        timeout_seconds: float = DEFAULT_LLAMA_CPP_TIMEOUT_SECONDS,
+        register_provider: Callable[[DynamicProvider], None] | None = None,
+        update_provider: Callable[[DynamicProvider], bool] | None = None,
+        register_backend: Callable[[LocalBackend], None] | None = None,
+    ) -> None:
+        self.state_store = state_store or LlamaCppStateStore()
+        self.credential_store: CredentialStore = (
+            credential_store
+            if credential_store is not None
+            else FileCredentialStore(credentials_path(TauPaths()))
+        )
+        self.environment = dict(environment or {})
+        if environment is None:
+            import os
+
+            self.environment = dict(os.environ)
+        self.client = client
+        self.timeout_seconds = timeout_seconds
+        self._register_provider = register_provider
+        self._update_provider = update_provider
+        self._register_backend = register_backend
+        self._last_discovery: LlamaCppDiscovery | None = None
+        self._last_error: LlamaCppError | None = None
+        self._state_error: str | None = None
+        self._orphaned_credentials: tuple[str, ...] = ()
+        self._stale_selected_model: str | None = None
+        try:
+            active = self.state_store.active()
+        except LlamaCppStateError as exc:
+            active = None
+            self._state_error = str(exc)
+        self._active_state = active
+        self._endpoint_error: str | None = None
+        endpoint = self._resolve_effective_endpoint(active)
+        self._endpoint = endpoint or normalize_llama_cpp_endpoint(LLAMA_CPP_DEFAULT_ENDPOINT)
+        self._cleanup_orphans()
+
+    @property
+    def configured(self) -> bool:
+        return self._active_state is not None or bool(self.environment.get(LLAMA_CPP_ENDPOINT_ENV))
+
+    @property
+    def endpoint(self) -> LlamaCppEndpoint:
+        return self._endpoint
+
+    @property
+    def endpoint_error(self) -> str | None:
+        return self._endpoint_error
+
+    @property
+    def last_discovery(self) -> LlamaCppDiscovery | None:
+        return self._last_discovery
+
+    @property
+    def state_error(self) -> str | None:
+        return self._state_error
+
+    @property
+    def orphaned_credentials(self) -> tuple[str, ...]:
+        return self._orphaned_credentials
+
+    def provider(self) -> DynamicProvider:
+        active = self._active_state
+        models = (
+            tuple(_provider_model(model) for model in active.models)
+            if active is not None and active.endpoint == self.endpoint.server_root
+            else ()
+        )
+        default = (
+            None if self._stale_selected_model is not None else _selected_model(active, models)
+        )
+        return DynamicProvider(
+            id=LLAMA_CPP_PROVIDER_ID,
+            display_name=LLAMA_CPP_DISPLAY_NAME,
+            models=models,
+            default_model=default,
+            transport=OpenAICompatibleTransport(
+                base_url=self.endpoint.inference_base,
+                auth=_LlamaCppAuth(active.credential_ref if active else None),
+                timeout_seconds=self.timeout_seconds,
+                max_retries=2,
+                max_retry_delay_seconds=1.0,
+                client=self.client,
+            ),
+            refresh_models=self.refresh_provider_models,
+        )
+
+    async def refresh_provider_models(
+        self,
+        context: ProviderRefreshContext,
+    ) -> ProviderModelSnapshot:
+        """Discovery callback used by the generic provider registry."""
+        if not context.allow_network:
+            return ProviderModelSnapshot(
+                models=tuple(context.cached_models),
+                default_model=_cached_default(context.cached_models),
+            )
+        discovery = await self.discover(context.auth, signal=context.signal)
+        self._last_discovery = discovery
+        self._last_error = None
+        self._save_discovery(discovery)
+        return ProviderModelSnapshot(
+            models=discovery.models,
+            default_model=_selected_model(self._active_state, discovery.models),
+        )
+
+    async def discover(
+        self,
+        auth: ResolvedProviderAuth,
+        *,
+        signal: CancellationToken | None = None,
+    ) -> LlamaCppDiscovery:
+        """Probe only the already-selected endpoint and parse standard models."""
+        headers = _auth_headers(auth)
+        owned_client = self.client is None
+        client = self.client or create_async_client(timeout=self.timeout_seconds)
+        try:
+            health = await self._get(client, self.endpoint.server_root + "/health", headers, signal)
+            health_state = _health_state(health)
+            if health_state == "loading":
+                raise LlamaCppError(
+                    "llama.cpp is still loading a model. Wait for it to become ready and retry."
+                )
+            if health_state == "unavailable":
+                raise LlamaCppError("llama.cpp reported that its server is unavailable.")
+            response = await self._get(
+                client, self.endpoint.inference_base + "/models", headers, signal
+            )
+            payload = _json_object(response, "/v1/models")
+            models = _parse_models(payload)
+            return LlamaCppDiscovery(self.endpoint, models, health=health_state)
+        except asyncio.CancelledError:
+            raise
+        except LlamaCppError as exc:
+            self._last_error = exc
+            raise
+        except httpx.TimeoutException as exc:
+            error = LlamaCppError(
+                f"Timed out connecting to llama.cpp at {self.endpoint.server_root}. "
+                "Check the server and retry."
+            )
+            self._last_error = error
+            raise error from exc
+        except httpx.HTTPError as exc:
+            error = LlamaCppError(
+                f"Could not connect to llama.cpp at {self.endpoint.server_root}. "
+                "Start llama-server and retry."
+            )
+            self._last_error = error
+            raise error from exc
+        finally:
+            if owned_client:
+                await client.aclose()
+
+    async def configure(
+        self,
+        values: Mapping[str, str],
+        context: LocalOperationContext,
+    ) -> LocalConfigureResult:
+        """Commit endpoint and optional credential as one safe-state transaction."""
+        del context
+        try:
+            endpoint = normalize_llama_cpp_endpoint(values.get("endpoint", ""))
+        except LlamaCppEndpointError as exc:
+            return LocalConfigureResult(
+                diagnostics=(LocalDiagnostic(str(exc), "error", "configuration"),)
+            )
+        key = values.get("api_key", "").strip() or None
+        old_active = self._active_state
+        try:
+            prior_for_endpoint = self.state_store.get(endpoint.server_root)
+        except Exception:
+            return LocalConfigureResult(
+                message="Could not save llama.cpp settings.",
+                diagnostics=(
+                    LocalDiagnostic(
+                        "The existing llama.cpp settings could not be read.",
+                        "error",
+                        "configuration",
+                    ),
+                ),
+            )
+
+        credential_ref = (
+            f"{LLAMA_CPP_CREDENTIAL_PREFIX}{secrets.token_urlsafe(18)}" if key else None
+        )
+        if credential_ref is not None:
+            assert key is not None
+            try:
+                self.credential_store.set(credential_ref, key)
+            except Exception:
+                return LocalConfigureResult(
+                    message="Could not save llama.cpp settings.",
+                    diagnostics=(
+                        LocalDiagnostic(
+                            "The API key could not be stored; no settings were changed.",
+                            "error",
+                            "credentials",
+                        ),
+                    ),
+                )
+
+        state = LlamaCppIntegrationState(
+            endpoint=endpoint.server_root,
+            selected_model=(prior_for_endpoint.selected_model if prior_for_endpoint else None),
+            credential_ref=credential_ref,
+            models=(prior_for_endpoint.models if prior_for_endpoint else ()),
+            checked_at=(prior_for_endpoint.checked_at if prior_for_endpoint else None),
+        )
+        try:
+            self.state_store.save(
+                state,
+                replace_endpoint=(
+                    old_active.endpoint
+                    if old_active is not None and old_active.endpoint != endpoint.server_root
+                    else None
+                ),
+            )
+        except Exception:
+            orphaned = False
+            if credential_ref is not None:
+                try:
+                    self.credential_store.delete(credential_ref)
+                except Exception:
+                    orphaned = True
+            return LocalConfigureResult(
+                message="llama.cpp settings were not saved.",
+                diagnostics=(
+                    LocalDiagnostic(
+                        "The previous llama.cpp configuration is still active.",
+                        "error",
+                        "configuration",
+                    ),
+                ),
+                credential_orphaned=orphaned,
+            )
+
+        self._active_state = state
+        self._endpoint = endpoint
+        self._endpoint_error = None
+        self._last_error = None
+        self._stale_selected_model = None
+        cleanup_error = self._delete_unreferenced_credentials(
+            old_active.credential_ref if old_active else None
+        )
+        self._publish_provider()
+        discovery = await self._try_discover_current()
+        status = (
+            self._status_from_discovery(discovery)
+            if discovery is not None
+            else self._cached_status(
+                diagnostics=(
+                    LocalDiagnostic(
+                        "Start llama-server at the configured endpoint and refresh.",
+                        "warning",
+                        "connection",
+                    ),
+                ),
+                stale=True,
+            )
+        )
+        diagnostics = list(status.diagnostics)
+        if cleanup_error:
+            diagnostics.append(LocalDiagnostic(cleanup_error, "warning", "credentials"))
+        return LocalConfigureResult(
+            committed=True,
+            backend_status=status,
+            message="llama.cpp settings saved.",
+            diagnostics=tuple(diagnostics),
+            credential_orphaned=bool(cleanup_error),
+        )
+
+    async def status(self, context: LocalOperationContext) -> LocalBackendStatus:
+        del context
+        if not self.configured:
+            if self._state_error or self._endpoint_error:
+                return self._cached_status()
+            return self._status(
+                "unconfigured",
+                diagnostics=(
+                    LocalDiagnostic(
+                        "Configure an endpoint to connect to llama.cpp.",
+                        "info",
+                        "configuration",
+                    ),
+                ),
+            )
+        if self._last_discovery is not None:
+            return self._status_from_discovery(self._last_discovery)
+        return self._cached_status()
+
+    async def refresh(self, context: LocalOperationContext) -> LocalOperationResult:
+        if not self.configured:
+            return LocalOperationResult(
+                backend_status=self._status(
+                    "unconfigured",
+                    diagnostics=(
+                        LocalDiagnostic(
+                            "No configured endpoint was probed. Enter an endpoint in Configure.",
+                            "info",
+                            "configuration",
+                        ),
+                    ),
+                )
+            )
+        try:
+            auth = await _resolve_auth_for_backend(self)
+            discovery = await self.discover(auth, signal=context.signal)
+            self._last_discovery = discovery
+            self._save_discovery(discovery)
+            self._publish_provider()
+            return LocalOperationResult(backend_status=self._status_from_discovery(discovery))
+        except asyncio.CancelledError:
+            return LocalOperationResult(cancelled=True)
+        except LlamaCppError as exc:
+            return LocalOperationResult(
+                backend_status=self._cached_status(
+                    diagnostics=(LocalDiagnostic(str(exc), "error", "connection"),),
+                    stale=True,
+                ),
+                diagnostics=(LocalDiagnostic(str(exc), "error", "connection"),),
+            )
+
+    async def doctor(self, context: LocalOperationContext) -> LocalOperationResult:
+        if not self.configured:
+            return LocalOperationResult(
+                backend_status=await self.status(context),
+                diagnostics=(
+                    LocalDiagnostic("Configure an endpoint before running doctor.", "warning"),
+                ),
+            )
+        try:
+            auth = await _resolve_auth_for_backend(self)
+            discovery = await self.discover(auth, signal=context.signal)
+        except asyncio.CancelledError:
+            return LocalOperationResult(cancelled=True)
+        except LlamaCppError as exc:
+            return LocalOperationResult(
+                backend_status=self._cached_status(
+                    diagnostics=(LocalDiagnostic(str(exc), "error", "connection"),),
+                    stale=True,
+                ),
+                diagnostics=(LocalDiagnostic(str(exc), "error", "connection"),),
+            )
+        selected = _selected_model(self._active_state, discovery.models)
+        if selected is None:
+            return LocalOperationResult(
+                backend_status=self._status_from_discovery(discovery),
+                diagnostics=(
+                    LocalDiagnostic(
+                        "The server is reachable but has no selectable model.",
+                        "warning",
+                        "models",
+                    ),
+                ),
+            )
+        diagnostics = [
+            LocalDiagnostic(
+                f"Found llama.cpp at {discovery.endpoint.inference_base}", "info", "server"
+            ),
+            LocalDiagnostic(f"Discovered model: {selected}", "info", "models"),
+        ]
+        stream_ok, stream_message = await self._probe_stream(auth, selected, context.signal)
+        diagnostics.append(
+            LocalDiagnostic(stream_message, "info" if stream_ok else "error", "streaming")
+        )
+        if stream_ok:
+            tools_ok, tools_message = await self._probe_tools(auth, selected, context.signal)
+            diagnostics.append(
+                LocalDiagnostic(tools_message, "info" if tools_ok else "warning", "tools")
+            )
+        return LocalOperationResult(
+            backend_status=self._status_from_discovery(discovery), diagnostics=tuple(diagnostics)
+        )
+
+    async def reset(self, context: LocalOperationContext) -> LocalOperationResult:
+        del context
+        try:
+            refs = self.state_store.clear()
+        except LlamaCppStateError as exc:
+            return LocalOperationResult(diagnostics=(LocalDiagnostic(str(exc), "error", "reset"),))
+        self._active_state = None
+        self._last_discovery = None
+        self._last_error = None
+        self._stale_selected_model = None
+        self._endpoint = self._endpoint_from_environment_or_default()
+        self._publish_provider()
+        diagnostics = (
+            (
+                LocalDiagnostic(
+                    "Saved settings were removed. Stored credentials were retained; "
+                    "confirm credential deletion separately.",
+                    "warning",
+                    "reset",
+                ),
+            )
+            if refs
+            else ()
+        )
+        return LocalOperationResult(
+            message="llama.cpp integration settings reset.",
+            backend_status=await self.status(_noop_context("reset")),
+            diagnostics=diagnostics,
+            committed=True,
+        )
+
+    def backend(self) -> LocalBackend:
+        return LocalBackend(
+            id=LLAMA_CPP_BACKEND_ID,
+            provider_id=LLAMA_CPP_PROVIDER_ID,
+            display_name=LLAMA_CPP_DISPLAY_NAME,
+            configure_spec=LocalConfigureSpec(
+                fields=(
+                    LocalConfigField(
+                        "endpoint",
+                        "llama.cpp endpoint",
+                        "text",
+                        required=True,
+                        placeholder=f"{LLAMA_CPP_DEFAULT_ENDPOINT} or .../v1",
+                    ),
+                    LocalConfigField(
+                        "api_key",
+                        "API key (optional)",
+                        "secret",
+                        required=False,
+                        placeholder="Leave empty for no authentication",
+                    ),
+                )
+            ),
+            configure=self.configure,
+            status=self.status,
+            refresh=self.refresh,
+            doctor=self.doctor,
+            reset=self.reset,
+            recommended=True,
+        )
+
+    def _resolve_effective_endpoint(
+        self,
+        active: LlamaCppIntegrationState | None,
+    ) -> LlamaCppEndpoint | None:
+        if active is not None:
+            try:
+                return normalize_llama_cpp_endpoint(active.endpoint)
+            except LlamaCppEndpointError as exc:
+                self._endpoint_error = str(exc)
+                return None
+        environment_endpoint = self.environment.get(LLAMA_CPP_ENDPOINT_ENV, "").strip()
+        if not environment_endpoint:
+            return None
+        try:
+            return normalize_llama_cpp_endpoint(environment_endpoint)
+        except LlamaCppEndpointError as exc:
+            self._endpoint_error = str(exc)
+            return None
+
+    def _endpoint_from_environment_or_default(self) -> LlamaCppEndpoint:
+        endpoint = self._resolve_effective_endpoint(None)
+        return endpoint or normalize_llama_cpp_endpoint(LLAMA_CPP_DEFAULT_ENDPOINT)
+
+    def _cleanup_orphans(self) -> None:
+        try:
+            referenced = self.state_store.referenced_credentials()
+            names = self.credential_store.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+            orphaned: list[str] = []
+            for name in names:
+                if name in referenced:
+                    continue
+                try:
+                    self.credential_store.delete(name)
+                except Exception:
+                    orphaned.append(name)
+            self._orphaned_credentials = tuple(orphaned)
+        except Exception:
+            self._orphaned_credentials = ()
+
+    def _delete_unreferenced_credentials(self, old_ref: str | None) -> str | None:
+        if not old_ref:
+            return None
+        try:
+            if old_ref not in self.state_store.referenced_credentials():
+                self.credential_store.delete(old_ref)
+        except Exception:
+            return "The new configuration is active, but the previous credential needs cleanup."
+        return None
+
+    async def _try_discover_current(self) -> LlamaCppDiscovery | None:
+        try:
+            auth = await _resolve_auth_for_backend(self)
+            discovery = await self.discover(auth)
+        except (LlamaCppError, ProviderAuthError):
+            return None
+        self._last_discovery = discovery
+        self._save_discovery(discovery)
+        self._publish_provider()
+        return discovery
+
+    def _save_discovery(self, discovery: LlamaCppDiscovery) -> None:
+        if (
+            self._active_state is None
+            or self._active_state.endpoint != discovery.endpoint.server_root
+        ):
+            # Environment endpoints are intentionally not copied to safe state.
+            return
+        previous_selected = self._active_state.selected_model
+        selected = _selected_model(self._active_state, discovery.models)
+        self._stale_selected_model = (
+            previous_selected
+            if previous_selected is not None
+            and selected is None
+            and previous_selected not in {model.id for model in discovery.models}
+            else None
+        )
+        state = LlamaCppIntegrationState(
+            endpoint=discovery.endpoint.server_root,
+            selected_model=selected,
+            credential_ref=self._active_state.credential_ref,
+            models=tuple(_stored_model(model) for model in discovery.models),
+            checked_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        )
+        try:
+            self.state_store.save(state)
+            self._active_state = state
+        except LlamaCppStateError as exc:
+            self._state_error = str(exc)
+
+    def _publish_provider(self) -> None:
+        provider = self.provider()
+        updated = self._update_provider(provider) if self._update_provider is not None else False
+        if not updated and self._register_provider is not None:
+            self._register_provider(provider)
+        if not updated and self._register_backend is not None:
+            # Initial setup and a source replacement need a paired backend
+            # registration. Snapshot updates use ``update_provider`` above so
+            # an in-flight local operation keeps its source-layer token.
+            self._register_backend(self.backend())
+
+    def _status_from_discovery(self, discovery: LlamaCppDiscovery) -> LocalBackendStatus:
+        self._last_error = None
+        stale_model = self._stale_selected_model
+        diagnostics: list[LocalDiagnostic] = []
+        if not discovery.models:
+            diagnostics.append(
+                LocalDiagnostic(
+                    "Server is ready but exposes no selectable models.", "warning", "models"
+                )
+            )
+        if stale_model is not None:
+            diagnostics.append(
+                LocalDiagnostic(
+                    f"The active model {stale_model!r} is no longer reported by the server; "
+                    "the current runtime remains usable, but select it again after it returns.",
+                    "warning",
+                    "models",
+                )
+            )
+        return self._status(
+            "stale"
+            if stale_model is not None
+            else ("ready" if discovery.models else "unavailable"),
+            models=discovery.models,
+            selected=(
+                None
+                if stale_model is not None
+                else _selected_model(self._active_state, discovery.models)
+            ),
+            diagnostics=tuple(diagnostics),
+            stale=stale_model is not None,
+        )
+
+    def _cached_status(
+        self,
+        *,
+        diagnostics: tuple[LocalDiagnostic, ...] = (),
+        stale: bool = False,
+    ) -> LocalBackendStatus:
+        active = self._active_state
+        models = tuple(_provider_model(model) for model in active.models) if active else ()
+        selected = _selected_model(active, models)
+        if self._state_error:
+            diagnostics = (*diagnostics, LocalDiagnostic(self._state_error, "warning", "state"))
+        if self._endpoint_error:
+            diagnostics = (*diagnostics, LocalDiagnostic(self._endpoint_error, "error", "endpoint"))
+        if self._stale_selected_model is not None:
+            diagnostics = (
+                *diagnostics,
+                LocalDiagnostic(
+                    f"The active model {self._stale_selected_model!r} is not in the cached "
+                    "snapshot; the current runtime remains usable.",
+                    "warning",
+                    "models",
+                ),
+            )
+        return self._status(
+            "stale"
+            if (stale or self._stale_selected_model is not None) and models
+            else "unavailable",
+            models=models,
+            selected=(None if self._stale_selected_model is not None else selected),
+            diagnostics=diagnostics,
+            cached=bool(models),
+            stale=stale,
+        )
+
+    def _status(
+        self,
+        state: str,
+        *,
+        models: tuple[ProviderModel, ...] = (),
+        selected: str | None = None,
+        diagnostics: tuple[LocalDiagnostic, ...] = (),
+        cached: bool = False,
+        stale: bool = False,
+    ) -> LocalBackendStatus:
+        actions: list[LocalAction] = ["configure", "refresh", "doctor", "reset"]
+        if selected is not None:
+            actions.append("use")
+        return LocalBackendStatus(
+            state=state,  # type: ignore[arg-type]
+            endpoint_display=self.endpoint.inference_base if self.configured else None,
+            authentication_source=_authentication_source(
+                self._active_state,
+                self.environment,
+                self.credential_store,
+            ),
+            models=tuple(_local_model(model) for model in models),
+            selected_model=selected,
+            actions=tuple(actions),
+            diagnostics=diagnostics,
+            cached=cached,
+            stale=stale,
+        )
+
+    async def _probe_stream(
+        self,
+        auth: ResolvedProviderAuth,
+        model: str,
+        signal: SimpleCancellationToken,
+    ) -> tuple[bool, str]:
+        owned_client = self.client is None
+        client = self.client or create_async_client(timeout=self.timeout_seconds)
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key=auth.api_key or "",
+                base_url=self.endpoint.inference_base,
+                provider_name=LLAMA_CPP_PROVIDER_ID,
+                timeout_seconds=self.timeout_seconds,
+                max_retries=0,
+                omit_authorization_header=auth.omit_authorization_header,
+                infer_api_from_model=False,
+            ),
+            client=client,
+        )
+        try:
+            async for event in provider.stream_response(
+                model=model,
+                system="Reply briefly.",
+                messages=[UserMessage(content="Reply with exactly: OK")],
+                tools=[],
+                signal=signal,
+            ):
+                if isinstance(event, AssistantStartEvent):
+                    return True, "Streaming chat completions accepted."
+                if isinstance(event, AssistantErrorEvent):
+                    return False, f"Streaming chat completions failed: {event.error.text}"
+        except httpx.HTTPError:
+            return False, "Streaming chat completions could not be reached."
+        finally:
+            if owned_client:
+                await provider.aclose()
+        return False, "The server did not accept a streaming completion."
+
+    async def _probe_tools(
+        self,
+        auth: ResolvedProviderAuth,
+        model: str,
+        signal: SimpleCancellationToken,
+    ) -> tuple[bool, str]:
+        async def executor(
+            tool_call_id: str,
+            arguments: Mapping[str, JSONValue],
+            signal: ToolCancellationToken | None = None,
+            on_update: Callable[[AgentToolResult], None] | None = None,
+        ) -> AgentToolResult:
+            del tool_call_id, arguments, signal, on_update
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        tool = AgentTool(
+            name="tau_probe",
+            label="tau_probe",
+            description="Call this tool to verify tool calling.",
+            parameters={"type": "object", "properties": {}},
+            execute_fn=executor,
+        )
+        owned_client = self.client is None
+        client = self.client or create_async_client(timeout=self.timeout_seconds)
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key=auth.api_key or "",
+                base_url=self.endpoint.inference_base,
+                provider_name=LLAMA_CPP_PROVIDER_ID,
+                timeout_seconds=self.timeout_seconds,
+                max_retries=0,
+                omit_authorization_header=auth.omit_authorization_header,
+                infer_api_from_model=False,
+            ),
+            client=client,
+        )
+        try:
+            async for event in provider.stream_response(
+                model=model,
+                system="Call the tau_probe tool.",
+                messages=[UserMessage(content="Call tau_probe now.")],
+                tools=[tool],
+                signal=signal,
+            ):
+                if isinstance(event, ToolCallEndEvent):
+                    return True, "Tool calls supported."
+                if isinstance(event, AssistantErrorEvent):
+                    return False, f"Tool-call probe failed: {event.error.text}"
+        except httpx.HTTPError:
+            return False, "Tool-call compatibility could not be checked."
+        finally:
+            if owned_client:
+                await provider.aclose()
+        return False, (
+            "Streaming works, but the model did not emit a tool call. Use a tool-capable "
+            "instruct GGUF and a compatible llama.cpp chat template."
+        )
+
+    async def _get(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: Mapping[str, str],
+        signal: CancellationToken | None,
+    ) -> httpx.Response:
+        if signal is not None and signal.is_cancelled():
+            raise asyncio.CancelledError
+        try:
+            response = await client.get(url, headers=dict(headers))
+        except asyncio.CancelledError:
+            raise
+        except httpx.TimeoutException:
+            raise
+        if response.status_code in {401, 403}:
+            raise _HttpFailure(
+                response.status_code,
+                "llama.cpp rejected the request. Check the optional API key or LLAMA_API_KEY.",
+            )
+        if response.status_code == 503 and url.endswith("/health"):
+            health = _safe_json(response)
+            if _health_state(health) == "loading":
+                raise LlamaCppError(
+                    "llama.cpp is still loading a model. Wait for it to become ready and retry."
+                )
+        if response.status_code == 404 and url.endswith("/health"):
+            return response
+        if response.status_code >= 400:
+            raise _HttpFailure(
+                response.status_code,
+                f"llama.cpp returned HTTP {response.status_code} while checking its server.",
+            )
+        return response
+
+
+def normalize_llama_cpp_endpoint(value: str) -> LlamaCppEndpoint:
+    """Normalize a server root or OpenAI-compatible ``/v1`` URL safely."""
+    if not isinstance(value, str) or not value.strip():
+        raise LlamaCppEndpointError("llama.cpp endpoint cannot be empty")
+    raw = value.strip()
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"}:
+        raise LlamaCppEndpointError("llama.cpp endpoint must use http or https")
+    if parsed.username is not None or parsed.password is not None:
+        raise LlamaCppEndpointError("llama.cpp endpoint must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise LlamaCppEndpointError("llama.cpp endpoint must not contain a query or fragment")
+    if not parsed.netloc or parsed.hostname is None:
+        raise LlamaCppEndpointError("llama.cpp endpoint must include a host")
+    path = parsed.path.rstrip("/")
+    if path == "/v1":
+        path = ""
+    elif path.endswith("/v1"):
+        path = path[: -len("/v1")].rstrip("/")
+    root = urlunsplit((parsed.scheme.lower(), parsed.netloc, path, "", ""))
+    root = root.rstrip("/")
+    if not root:
+        raise LlamaCppEndpointError("llama.cpp endpoint must include a host")
+    return LlamaCppEndpoint(server_root=root, inference_base=f"{root}/v1")
+
+
+def _auth_headers(auth: ResolvedProviderAuth) -> dict[str, str]:
+    headers = dict(auth.headers)
+    if auth.api_key is not None and not auth.omit_authorization_header:
+        headers.setdefault("Authorization", f"Bearer {auth.api_key}")
+    return headers
+
+
+async def _resolve_auth_for_backend(service: LlamaCppService) -> ResolvedProviderAuth:
+    active = service._active_state
+    return await _LlamaCppAuth(active.credential_ref if active else None).resolve(
+        ProviderAuthContext(
+            credentials=service.credential_store,
+            environment=service.environment,
+        )
+    )
+
+
+def _safe_json(response: httpx.Response) -> object:
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _json_object(response: httpx.Response, endpoint: str) -> Mapping[str, object]:
+    payload = _safe_json(response)
+    if not isinstance(payload, Mapping):
+        raise LlamaCppError(f"llama.cpp {endpoint} returned malformed JSON.")
+    return payload
+
+
+def _health_state(payload: object) -> str:
+    if not isinstance(payload, Mapping):
+        return "ok"
+    status = payload.get("status")
+    if isinstance(status, str):
+        normalized = status.casefold()
+        if any(word in normalized for word in ("loading", "starting", "initializing")):
+            return "loading"
+        if any(word in normalized for word in ("unavailable", "error", "failed")):
+            return "unavailable"
+    return "ok"
+
+
+def _parse_models(payload: Mapping[str, object]) -> tuple[ProviderModel, ...]:
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise LlamaCppError("llama.cpp /v1/models returned a malformed model list.")
+    models: list[ProviderModel] = []
+    ids: set[str] = set()
+    for item in data:
+        if not isinstance(item, Mapping):
+            raise LlamaCppError("llama.cpp /v1/models returned a malformed model.")
+        model_id = item.get("id")
+        if not isinstance(model_id, str) or not model_id or model_id != model_id.strip():
+            raise LlamaCppError("llama.cpp /v1/models returned a model without an exact id.")
+        if model_id in ids:
+            raise LlamaCppError("llama.cpp /v1/models returned duplicate model ids.")
+        ids.add(model_id)
+        display = item.get("name", item.get("display_name"))
+        display_name = display if isinstance(display, str) and display.strip() else model_id
+        modalities = _modalities(item)
+        context_window = _reported_context_window(item)
+        models.append(
+            ProviderModel(
+                id=model_id,
+                display_name=display_name,
+                api="openai-completions",
+                context_window=context_window,
+                input_modalities=modalities,
+                # No output-limit, reasoning, cost, or tool-support guesses.
+                compat=_safe_model_compat(item),
+            )
+        )
+    return tuple(models)
+
+
+def _modalities(item: Mapping[str, object]) -> tuple[Literal["text", "image"], ...] | None:
+    value = item.get("input_modalities", item.get("modalities"))
+    if not isinstance(value, list) or not value:
+        return None
+    if not all(isinstance(entry, str) and entry in {"text", "image"} for entry in value):
+        return None
+    result = tuple(dict.fromkeys(value))
+    return cast(tuple[Literal["text", "image"], ...], result) or None
+
+
+def _reported_context_window(item: Mapping[str, object]) -> int | None:
+    # These names are accepted only when directly reported by a server. Tau
+    # never derives one from a model family, max tokens, or a 128K convention.
+    for key in ("context_window", "context_length"):
+        value = item.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+    return None
+
+
+def _safe_model_compat(item: Mapping[str, object]) -> Mapping[str, JSONValue]:
+    # Keep a tiny, non-secret diagnostic subset in memory.  It is not copied to
+    # the disk snapshot and is never interpreted as capability metadata.
+    result: dict[str, JSONValue] = {}
+    for key in ("object", "owned_by"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            result[key] = value
+    return MappingProxyType(result)
+
+
+def _provider_model(model: LlamaCppStoredModel) -> ProviderModel:
+    return ProviderModel(
+        id=model.id,
+        display_name=model.display_name or model.id,
+        api="openai-completions",
+        context_window=model.context_window,
+        input_modalities=(
+            cast(tuple[Literal["text", "image"], ...], model.input_modalities)
+            if model.input_modalities is not None
+            else None
+        ),
+    )
+
+
+def _stored_model(model: ProviderModel) -> LlamaCppStoredModel:
+    return LlamaCppStoredModel(
+        id=model.id,
+        display_name=model.display_name,
+        context_window=model.context_window,
+        input_modalities=model.input_modalities,
+    )
+
+
+def _local_model(model: ProviderModel) -> LocalModel:
+    return LocalModel(model.id, model.display_name or model.id)
+
+
+def _selected_model(
+    state: LlamaCppIntegrationState | None,
+    models: tuple[ProviderModel, ...],
+) -> str | None:
+    ids = {model.id for model in models}
+    if state is not None and state.selected_model is not None:
+        # Never silently replace an explicitly selected model when the server
+        # no longer reports it. The active runtime may continue using it, but
+        # a new selection must wait for the model to return.
+        return state.selected_model if state.selected_model in ids else None
+    if len(models) == 1:
+        return models[0].id
+    return None
+
+
+def _cached_default(models: tuple[ProviderModel, ...]) -> str | None:
+    return models[0].id if len(models) == 1 else None
+
+
+def _authentication_source(
+    state: LlamaCppIntegrationState | None,
+    environment: Mapping[str, str],
+    credentials: CredentialStore | None = None,
+) -> Literal["none", "environment", "stored credential"]:
+    if state is not None and state.credential_ref:
+        try:
+            if credentials is None or credentials.get(state.credential_ref):
+                return "stored credential"
+        except Exception:
+            pass
+    if environment.get(LLAMA_CPP_API_KEY_ENV):
+        return "environment"
+    return "none"
+
+
+def _noop_context(action: str) -> LocalOperationContext:
+    signal = SimpleCancellationToken()
+    return LocalOperationContext(
+        signal=signal,
+        action=action,  # type: ignore[arg-type]
+        generation_id="reset",
+        backend_id=LLAMA_CPP_BACKEND_ID,
+        source_id="built-in:llama.cpp",
+        _is_current=lambda: True,
+        _progress=lambda _: None,
+    )
+
+
+__all__ = [
+    "DEFAULT_LLAMA_CPP_TIMEOUT_SECONDS",
+    "LLAMA_CPP_API_KEY_ENV",
+    "LLAMA_CPP_BACKEND_ID",
+    "LLAMA_CPP_DEFAULT_ENDPOINT",
+    "LLAMA_CPP_DISPLAY_NAME",
+    "LLAMA_CPP_ENDPOINT_ENV",
+    "LLAMA_CPP_PROVIDER_ID",
+    "LlamaCppDiscovery",
+    "LlamaCppEndpoint",
+    "LlamaCppEndpointError",
+    "LlamaCppError",
+    "LlamaCppService",
+    "normalize_llama_cpp_endpoint",
+]

--- a/src/tau_coding/extensions/builtins/llama_cpp/state.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/state.py
@@ -1,0 +1,402 @@
+"""Safe, user-level state for the trusted llama.cpp integration.
+
+Only endpoint-keyed discovery metadata lives here.  Credentials are kept in
+Tau's credential store and are referenced by an opaque generation name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from tau_coding.paths import TauPaths
+
+LLAMA_CPP_STATE_SCHEMA_VERSION = 1
+LLAMA_CPP_CREDENTIAL_PREFIX = "llama.cpp:"
+
+
+class LlamaCppStateError(RuntimeError):
+    """Raised for an unreadable or unsupported llama.cpp state file."""
+
+
+@dataclass(frozen=True, slots=True)
+class LlamaCppStoredModel:
+    """Allowlisted model metadata safe to retain outside the server."""
+
+    id: str
+    display_name: str | None = None
+    context_window: int | None = None
+    input_modalities: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id or self.id != self.id.strip():
+            raise LlamaCppStateError("Stored llama.cpp model id must be a non-empty exact string")
+        if self.display_name is not None and (
+            not isinstance(self.display_name, str) or not self.display_name.strip()
+        ):
+            raise LlamaCppStateError("Stored llama.cpp display name must be non-empty")
+        if self.context_window is not None and (
+            not isinstance(self.context_window, int)
+            or isinstance(self.context_window, bool)
+            or self.context_window <= 0
+        ):
+            raise LlamaCppStateError("Stored context window must be a positive integer")
+        if self.input_modalities is not None:
+            if not isinstance(self.input_modalities, tuple) or not self.input_modalities:
+                raise LlamaCppStateError("Stored input modalities must be a non-empty tuple")
+            if any(item not in {"text", "image"} for item in self.input_modalities):
+                raise LlamaCppStateError("Stored input modalities are unsupported")
+            if len(set(self.input_modalities)) != len(self.input_modalities):
+                raise LlamaCppStateError("Stored input modalities must be unique")
+
+    def to_json(self) -> dict[str, object]:
+        value: dict[str, object] = {"id": self.id}
+        if self.display_name is not None:
+            value["display_name"] = self.display_name
+        if self.context_window is not None:
+            value["context_window"] = self.context_window
+        if self.input_modalities is not None:
+            value["input_modalities"] = list(self.input_modalities)
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class LlamaCppIntegrationState:
+    """One endpoint's safe integration snapshot."""
+
+    endpoint: str
+    selected_model: str | None = None
+    credential_ref: str | None = None
+    models: tuple[LlamaCppStoredModel, ...] = ()
+    checked_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.endpoint, str) or not self.endpoint.strip():
+            raise LlamaCppStateError("Llama.cpp state endpoint must be non-empty")
+        if self.selected_model is not None and not isinstance(self.selected_model, str):
+            raise LlamaCppStateError("Selected llama.cpp model must be a string or None")
+        if self.credential_ref is not None and not _valid_credential_ref(self.credential_ref):
+            raise LlamaCppStateError("Credential reference is not owned by llama.cpp")
+        if not isinstance(self.models, tuple) or any(
+            not isinstance(model, LlamaCppStoredModel) for model in self.models
+        ):
+            raise LlamaCppStateError("Llama.cpp state models are malformed")
+        ids = [model.id for model in self.models]
+        if len(ids) != len(set(ids)):
+            raise LlamaCppStateError("Llama.cpp state model ids must be unique")
+        if self.selected_model is not None and self.selected_model not in ids:
+            raise LlamaCppStateError("Selected llama.cpp model is not in the safe snapshot")
+        if self.checked_at is not None and not isinstance(self.checked_at, str):
+            raise LlamaCppStateError("Checked timestamp must be a string or None")
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "endpoint": self.endpoint,
+            "selected_model": self.selected_model,
+            "credential_ref": self.credential_ref,
+            "models": [model.to_json() for model in self.models],
+            "checked_at": self.checked_at,
+        }
+
+
+class LlamaCppStateStore:
+    """Locked and atomically replaced endpoint-keyed integration state."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        lock_path: Path | None = None,
+        paths: TauPaths | None = None,
+    ) -> None:
+        resolved_paths = paths or TauPaths()
+        self.path = path or resolved_paths.llama_cpp_state_path
+        self.lock_path = lock_path or self.path.with_name(f"{self.path.name}.lock")
+
+    def get(self, endpoint: str) -> LlamaCppIntegrationState | None:
+        with self._locked():
+            _, endpoints = self._read_unlocked()
+            return endpoints.get(endpoint)
+
+    def active(self) -> LlamaCppIntegrationState | None:
+        with self._locked():
+            active_endpoint, endpoints = self._read_unlocked()
+            return endpoints.get(active_endpoint) if active_endpoint else None
+
+    def all(self) -> tuple[LlamaCppIntegrationState, ...]:
+        with self._locked():
+            _, endpoints = self._read_unlocked()
+            return tuple(endpoints.values())
+
+    def save(
+        self,
+        state: LlamaCppIntegrationState,
+        *,
+        replace_endpoint: str | None = None,
+    ) -> None:
+        """Publish one endpoint snapshot and make it the saved endpoint.
+
+        ``replace_endpoint`` lets configuration replace the prior active
+        endpoint in the same atomic state-file transaction. Discovery updates
+        omit it so a caller can retain endpoint-keyed snapshots when desired.
+        """
+        with self._locked():
+            active_endpoint, endpoints = self._read_unlocked()
+            del active_endpoint
+            if replace_endpoint is not None and replace_endpoint != state.endpoint:
+                endpoints.pop(replace_endpoint, None)
+            endpoints[state.endpoint] = state
+            self._write_unlocked(state.endpoint, endpoints)
+
+    def remove(self, endpoint: str) -> tuple[str, ...]:
+        """Remove one endpoint and return credential refs no longer referenced."""
+        with self._locked():
+            active_endpoint, endpoints = self._read_unlocked()
+            before = _credential_refs(endpoints.values())
+            endpoints.pop(endpoint, None)
+            next_active = active_endpoint if active_endpoint != endpoint else None
+            self._write_unlocked(next_active, endpoints)
+            return tuple(sorted(before - _credential_refs(endpoints.values())))
+
+    def clear(self) -> tuple[str, ...]:
+        """Remove all integration settings, returning referenced credentials."""
+        with self._locked():
+            _, endpoints = self._read_unlocked()
+            refs = tuple(sorted(_credential_refs(endpoints.values())))
+            if self.path.exists():
+                self.path.unlink()
+                _fsync_directory(self.path.parent)
+            return refs
+
+    def referenced_credentials(self) -> frozenset[str]:
+        with self._locked():
+            _, endpoints = self._read_unlocked()
+            return frozenset(_credential_refs(endpoints.values()))
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if self.lock_path.parent != self.path.parent:
+            self.lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # mkdir(mode=...) does not tighten an already-existing directory. The
+        # state directory is user-private even when it was created earlier by
+        # another Tau process.
+        with suppress(OSError):
+            self.path.parent.chmod(0o700)
+        if self.lock_path.parent != self.path.parent:
+            with suppress(OSError):
+                self.lock_path.parent.chmod(0o700)
+        try:
+            with self.lock_path.open("a+b") as handle:
+                self.lock_path.chmod(0o600)
+                _lock(handle)
+                try:
+                    _remove_temporary_files(self.path)
+                    yield
+                finally:
+                    _unlock(handle)
+        except LlamaCppStateError:
+            raise
+        except OSError as exc:
+            raise LlamaCppStateError(f"Could not access llama.cpp state: {exc}") from exc
+
+    def _read_unlocked(
+        self,
+    ) -> tuple[str | None, dict[str, LlamaCppIntegrationState]]:
+        if not self.path.exists():
+            return None, {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise LlamaCppStateError(f"Could not read llama.cpp state: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise LlamaCppStateError("Llama.cpp state must be a JSON object")
+
+        # Accept the early single-endpoint shape from the accepted plan.  It is
+        # read-only compatible and is upgraded only on the next intentional save.
+        if "endpoints" not in payload and "endpoint" in payload:
+            allowed = {
+                "schema_version",
+                "endpoint",
+                "selected_model",
+                "credential_ref",
+                "models",
+                "checked_at",
+            }
+            if set(payload) - allowed or payload.get("schema_version") != 1:
+                raise LlamaCppStateError("Unsupported llama.cpp state schema")
+            state = _state_from_json(
+                {key: value for key, value in payload.items() if key != "schema_version"}
+            )
+            return state.endpoint, {state.endpoint: state}
+
+        if set(payload) - {"schema_version", "active_endpoint", "endpoints"}:
+            raise LlamaCppStateError("Unknown field in llama.cpp state")
+        if payload.get("schema_version") != LLAMA_CPP_STATE_SCHEMA_VERSION:
+            raise LlamaCppStateError("Unsupported llama.cpp state schema version")
+        active_endpoint = payload.get("active_endpoint")
+        endpoints_raw = payload.get("endpoints")
+        if active_endpoint is not None and not isinstance(active_endpoint, str):
+            raise LlamaCppStateError("Active llama.cpp endpoint is malformed")
+        if not isinstance(endpoints_raw, dict):
+            raise LlamaCppStateError("Llama.cpp endpoints must be an object")
+        endpoints: dict[str, LlamaCppIntegrationState] = {}
+        for key, raw in endpoints_raw.items():
+            if not isinstance(key, str) or not key.strip() or not isinstance(raw, dict):
+                raise LlamaCppStateError("Llama.cpp endpoint state is malformed")
+            state = _state_from_json(raw)
+            if key != state.endpoint:
+                raise LlamaCppStateError("Llama.cpp endpoint key does not match its state")
+            endpoints[key] = state
+        if active_endpoint is not None and active_endpoint not in endpoints:
+            raise LlamaCppStateError("Active llama.cpp endpoint is not stored")
+        return active_endpoint, endpoints
+
+    def _write_unlocked(
+        self,
+        active_endpoint: str | None,
+        endpoints: Mapping[str, LlamaCppIntegrationState],
+    ) -> None:
+        payload = {
+            "schema_version": LLAMA_CPP_STATE_SCHEMA_VERSION,
+            "active_endpoint": active_endpoint,
+            "endpoints": {
+                endpoint: state.to_json() for endpoint, state in sorted(endpoints.items())
+            },
+        }
+        data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        temporary: Path | None = None
+        fd = -1
+        try:
+            fd, raw = tempfile.mkstemp(
+                prefix=f".{self.path.name}.", suffix=".tmp", dir=self.path.parent
+            )
+            temporary = Path(raw)
+            temporary.chmod(0o600)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            temporary = None
+            self.path.chmod(0o600)
+            _fsync_directory(self.path.parent)
+        except OSError as exc:
+            raise LlamaCppStateError(f"Could not write llama.cpp state: {exc}") from exc
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            if temporary is not None:
+                with suppress(OSError):
+                    temporary.unlink()
+
+
+def _state_from_json(raw: Mapping[str, object]) -> LlamaCppIntegrationState:
+    allowed = {"endpoint", "selected_model", "credential_ref", "models", "checked_at"}
+    if set(raw) - allowed:
+        raise LlamaCppStateError("Unknown field in llama.cpp endpoint state")
+    endpoint = raw.get("endpoint")
+    models_raw = raw.get("models", [])
+    if not isinstance(endpoint, str) or not isinstance(models_raw, list):
+        raise LlamaCppStateError("Malformed llama.cpp endpoint state")
+    if not isinstance(raw.get("selected_model"), (str, type(None))):
+        raise LlamaCppStateError("Malformed selected llama.cpp model")
+    if not isinstance(raw.get("credential_ref"), (str, type(None))):
+        raise LlamaCppStateError("Malformed llama.cpp credential reference")
+    models = tuple(_model_from_json(item) for item in models_raw)
+    return LlamaCppIntegrationState(
+        endpoint=endpoint,
+        selected_model=cast(str | None, raw.get("selected_model")),
+        credential_ref=cast(str | None, raw.get("credential_ref")),
+        models=models,
+        checked_at=cast(str | None, raw.get("checked_at")),
+    )
+
+
+def _model_from_json(raw: object) -> LlamaCppStoredModel:
+    if not isinstance(raw, dict):
+        raise LlamaCppStateError("Malformed stored llama.cpp model")
+    allowed = {"id", "display_name", "context_window", "input_modalities"}
+    if set(raw) - allowed:
+        raise LlamaCppStateError("Unknown field in stored llama.cpp model")
+    modalities = raw.get("input_modalities")
+    if modalities is not None and not isinstance(modalities, list):
+        raise LlamaCppStateError("Malformed stored input modalities")
+    return LlamaCppStoredModel(
+        id=cast(str, raw.get("id")),
+        display_name=cast(str | None, raw.get("display_name")),
+        context_window=cast(int | None, raw.get("context_window")),
+        input_modalities=tuple(modalities) if modalities is not None else None,
+    )
+
+
+def _credential_refs(states: Iterable[LlamaCppIntegrationState]) -> set[str]:
+    return {state.credential_ref for state in states if state.credential_ref}
+
+
+def _valid_credential_ref(value: object) -> bool:
+    if not isinstance(value, str) or not value.startswith(LLAMA_CPP_CREDENTIAL_PREFIX):
+        return False
+    suffix = value.removeprefix(LLAMA_CPP_CREDENTIAL_PREFIX)
+    # secrets.token_urlsafe() emits this conservative alphabet. Reject path
+    # separators and control characters so state can never name an unrelated
+    # credential or become a path-like injection surface.
+    return bool(suffix) and all(character.isalnum() or character in "-_" for character in suffix)
+
+
+def _remove_temporary_files(path: Path) -> None:
+    """Remove only this store's interrupted atomic-write artifacts."""
+    pattern = f".{path.name}.*.tmp"
+    for temporary in path.parent.glob(pattern):
+        with suppress(OSError):
+            temporary.unlink()
+
+
+def _lock(handle: object) -> None:
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)  # type: ignore[attr-defined]
+    except ImportError:
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+    except OSError as exc:
+        raise LlamaCppStateError(f"Could not lock llama.cpp state: {exc}") from exc
+
+
+def _unlock(handle: object) -> None:
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)  # type: ignore[attr-defined]
+    except ImportError:
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+
+
+def _fsync_directory(path: Path) -> None:
+    with suppress(OSError):
+        descriptor = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+__all__ = [
+    "LLAMA_CPP_CREDENTIAL_PREFIX",
+    "LLAMA_CPP_STATE_SCHEMA_VERSION",
+    "LlamaCppIntegrationState",
+    "LlamaCppStateError",
+    "LlamaCppStateStore",
+    "LlamaCppStoredModel",
+]

--- a/src/tau_coding/extensions/provider_registry.py
+++ b/src/tau_coding/extensions/provider_registry.py
@@ -153,6 +153,16 @@ class DynamicProviderRegistry:
         return self._generation_id
 
     @property
+    def credentials(self) -> CredentialReader:
+        """Return the credential reader shared with runtime construction."""
+        return self._credentials
+
+    @property
+    def environment(self) -> Mapping[str, str]:
+        """Return the environment snapshot shared with runtime construction."""
+        return self._environment
+
+    @property
     def durable_providers(self) -> tuple[ProviderConfig, ...]:
         """Return the exact complete durable baseline objects."""
         return tuple(self._durable.values())
@@ -205,6 +215,29 @@ class DynamicProviderRegistry:
         for layer in removed:
             self._cancel_token(layer.token)
         return True
+
+    def update(self, source_id: str, provider: DynamicProvider) -> bool:
+        """Publish a new definition without invalidating paired local backends.
+
+        Snapshot updates are not source-layer replacements: preserving the
+        provider token lets a backend operation finish while its provider's
+        model list changes. Registration remains the API for adding or
+        replacing a source layer and retains its cancellation semantics.
+        """
+        self._assert_active()
+        normalized_source = _source_id(source_id)
+        layers = self._layers.get(provider.id)
+        if not layers:
+            return False
+        for index, layer in enumerate(layers):
+            if layer.token.source_id == normalized_source:
+                layers[index] = DynamicProviderLayer(
+                    token=layer.token,
+                    provider=provider,
+                    registration_order=layer.registration_order,
+                )
+                return True
+        return False
 
     def unregister_source(self, source_id: str) -> None:
         """Remove every layer and cancel every task owned by one source."""

--- a/src/tau_coding/extensions/providers.py
+++ b/src/tau_coding/extensions/providers.py
@@ -9,6 +9,8 @@ from inspect import isawaitable
 from types import MappingProxyType
 from typing import Protocol
 
+import httpx
+
 from tau_agent.provider import CancellationToken, ModelProvider
 from tau_agent.types import JSONPrimitive, JSONValue
 from tau_ai.env import (
@@ -239,7 +241,12 @@ class ProviderModelSnapshot:
 
 @dataclass(frozen=True, slots=True)
 class OpenAICompatibleTransport:
-    """Descriptor for Tau's existing OpenAI-compatible streaming transport."""
+    """Descriptor for Tau's existing OpenAI-compatible streaming transport.
+
+    ``client`` is an optional externally owned client seam for trusted adapters
+    and deterministic tests. Providers never close it; the caller owns its
+    lifetime. Normal transports leave it unset and use Tau's standard client.
+    """
 
     base_url: str
     api: ProviderApi = "openai-completions"
@@ -248,6 +255,7 @@ class OpenAICompatibleTransport:
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS
+    client: httpx.AsyncClient | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         _require_non_empty(self.base_url, "Transport base URL")

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from inspect import isawaitable
 from pathlib import Path
 from time import time_ns
-from typing import Literal, Protocol
+from typing import Literal, Protocol, cast
+
+import httpx
 
 import tau_coding.built_in_extensions as built_in_extension_registry
 from tau_agent.events import AgentEvent, AgentStartEvent
@@ -22,7 +25,7 @@ from tau_agent.tools import (
     ToolUpdateCallback,
 )
 from tau_agent.types import JSONValue
-from tau_coding.built_in_extensions import BuiltInExtension
+from tau_coding.built_in_extensions import BuiltInExtension, BuiltInExtensionContext
 from tau_coding.commands import (
     CommandContext,
     CommandRegistry,
@@ -30,6 +33,7 @@ from tau_coding.commands import (
     SlashCommand,
     create_default_command_registry,
 )
+from tau_coding.credentials import CredentialStore, FileCredentialStore, credentials_path
 from tau_coding.extensions.api import (
     AGENT_EVENT_TYPES,
     AGENT_EVENT_WILDCARD,
@@ -71,6 +75,7 @@ from tau_coding.extensions.provider_registry import (
 )
 from tau_coding.extensions.providers import CredentialReader, DynamicProvider
 from tau_coding.local_backends import LocalBackend, LocalBackendRegistry
+from tau_coding.paths import TauPaths
 from tau_coding.project_trust import ExtensionTrustResult, ProjectTrustEvent
 from tau_coding.provider_config import ProviderConfig
 from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
@@ -178,6 +183,9 @@ class ExtensionRuntime:
         credentials: CredentialReader | None = None,
         environment: Mapping[str, str] | None = None,
         built_in_extensions: Sequence[BuiltInExtension] | None = None,
+        paths: TauPaths | None = None,
+        built_in_credentials: CredentialStore | None = None,
+        built_in_http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._generation = ExtensionGeneration()
         self._built_in_extensions = tuple(
@@ -189,6 +197,26 @@ class ExtensionRuntime:
         self._durable_providers = tuple(durable_providers)
         self._provider_credentials = credentials
         self._provider_environment = environment
+        built_in_paths = paths or TauPaths()
+        resolved_built_in_credentials: CredentialStore = (
+            built_in_credentials
+            if built_in_credentials is not None
+            else (
+                cast(CredentialStore, credentials)
+                if credentials is not None
+                and all(
+                    callable(getattr(credentials, name, None))
+                    for name in ("set", "delete", "names")
+                )
+                else FileCredentialStore(credentials_path(built_in_paths))
+            )
+        )
+        self._built_in_context = BuiltInExtensionContext(
+            paths=built_in_paths,
+            credential_store=resolved_built_in_credentials,
+            environment=dict(environment) if environment is not None else dict(os.environ),
+            http_client=built_in_http_client,
+        )
         self._provider_registry = DynamicProviderRegistry(
             self._durable_providers,
             generation_id=self._generation.id,
@@ -245,12 +273,23 @@ class ExtensionRuntime:
             return
         self._built_ins_loaded = True
         for declaration in self._built_in_extensions:
+            setup = declaration.setup
+            if declaration.setup_with_context is not None:
+
+                def setup_with_runtime_context(
+                    api: ExtensionAPI,
+                    declaration: BuiltInExtension = declaration,
+                ) -> None:
+                    assert declaration.setup_with_context is not None
+                    declaration.setup_with_context(api, self._built_in_context)
+
+                setup = setup_with_runtime_context
             self._setup_extension(
                 LoadedExtension(
                     name=declaration.name,
                     path=None,
                     source_id=declaration.source_id,
-                    setup=declaration.setup,
+                    setup=setup,
                     source="built-in",
                     hidden=declaration.hidden,
                 )
@@ -434,6 +473,10 @@ class ExtensionRuntime:
     def register_provider(self, source_id: str, provider: DynamicProvider) -> None:
         """Register or atomically replace one exact extension source layer."""
         self._provider_registry.register(source_id, provider)
+
+    def update_provider(self, source_id: str, provider: DynamicProvider) -> bool:
+        """Publish a provider snapshot without invalidating paired backends."""
+        return self._provider_registry.update(source_id, provider)
 
     def register_local_backend(self, source_id: str, backend: LocalBackend) -> None:
         """Register a backend against its exact source-owned provider layer."""
@@ -680,6 +723,26 @@ class ExtensionRuntime:
         if self._harness_unsubscribe is not None:
             self._harness_unsubscribe()
         self._harness_unsubscribe = subscribe(self._on_agent_event)
+
+    @property
+    def provider_credentials(self) -> CredentialReader | None:
+        """Return the read-only credential reader used by dynamic runtimes."""
+        return self._provider_credentials
+
+    @property
+    def provider_environment(self) -> Mapping[str, str] | None:
+        """Return the environment snapshot used by dynamic provider auth."""
+        return self._provider_environment
+
+    @property
+    def built_in_credentials(self) -> CredentialStore:
+        """Return the injected mutable store used by trusted built-ins."""
+        return self._built_in_context.credential_store
+
+    @property
+    def built_in_http_client(self) -> httpx.AsyncClient | None:
+        """Return the externally owned HTTP client used by trusted built-ins."""
+        return self._built_in_context.http_client
 
     def set_ui_bridge(self, ui: UiBridge) -> None:
         """Install the frontend UI bridge (TUI, print-mode fallback, or test)."""

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -35,6 +35,16 @@ class TauPaths:
         return self.logs_dir / "agent-calls.jsonl"
 
     @property
+    def extension_state_dir(self) -> Path:
+        """Return the user-level state directory owned by built-in extensions."""
+        return self.home / "state" / "extensions"
+
+    @property
+    def llama_cpp_state_path(self) -> Path:
+        """Return the safe built-in llama.cpp integration state path."""
+        return self.extension_state_dir / "llama.cpp.json"
+
+    @property
     def user_skills_dir(self) -> Path:
         """Return Tau's user-level skills directory."""
         return self.home / "skills"

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -152,7 +152,7 @@ async def create_dynamic_model_provider(
         # resembling gpt-* or *codex* must not reroute to /responses.
         infer_api_from_model=False,
     )
-    return OpenAICompatibleProvider(config)
+    return OpenAICompatibleProvider(config, client=transport.client)
 
 
 async def _resolve_dynamic_runtime_auth(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -461,16 +461,29 @@ class CodingSession:
         # Always stage a fresh eligible-only runtime for a destination snapshot;
         # never reuse source-project code across replacement trust boundaries.
         previous_runtime = config.extension_runtime
-        credential_store = FileCredentialStore(
-            credentials_path(unfiltered_resource_paths.paths)
-            if unfiltered_resource_paths.paths is not None
-            else None
+        runtime_paths = unfiltered_resource_paths.paths or TauPaths(
+            home=unfiltered_resource_paths.root,
+            agents_home=unfiltered_resource_paths.agents_root or Path.home() / ".agents",
+        )
+        credential_store = FileCredentialStore(credentials_path(runtime_paths))
+        injected_credentials = (
+            previous_runtime.provider_credentials if previous_runtime is not None else None
         )
         extension_runtime = ExtensionRuntime(
+            paths=runtime_paths,
+            credentials=injected_credentials or credential_store,
+            environment=(
+                previous_runtime.provider_environment if previous_runtime is not None else None
+            ),
+            built_in_credentials=(
+                previous_runtime.built_in_credentials if previous_runtime is not None else None
+            ),
+            built_in_http_client=(
+                previous_runtime.built_in_http_client if previous_runtime is not None else None
+            ),
             durable_providers=(
                 config.provider_settings.providers if config.provider_settings else ()
             ),
-            credentials=credential_store,
         )
         extension_runtime.load(
             unfiltered_resource_paths,
@@ -1754,7 +1767,17 @@ class CodingSession:
             durable_providers=(
                 self._provider_settings.providers if self._provider_settings else ()
             ),
-            credentials=self._credential_store,
+            credentials=self._extension_runtime.provider_credentials or self._credential_store,
+            environment=self._extension_runtime.provider_environment,
+            built_in_credentials=self._extension_runtime.built_in_credentials,
+            built_in_http_client=self._extension_runtime.built_in_http_client,
+            paths=(
+                self._resource_paths.paths
+                or TauPaths(
+                    home=self._resource_paths.root,
+                    agents_home=self._resource_paths.agents_root or Path.home() / ".agents",
+                )
+            ),
         )
         staged_runtime.load(
             unfiltered_paths,
@@ -3494,7 +3517,8 @@ async def _prepare_provider_selection(
                 runtime = await create_dynamic_model_provider(
                     dynamic,
                     model=model,
-                    credential_store=credential_store or FileCredentialStore(),
+                    credential_store=provider_registry.credentials,
+                    environment=provider_registry.environment,
                 )
             except (ProviderConfigError, RuntimeError) as exc:
                 raise ProviderConfigError(str(exc)) from exc

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -7171,7 +7171,8 @@ async def run_tui_app(
             and provider_name is None
             and model is None
         )
-        if (provider_name is None or model is None) and not dynamic_resume:
+        explicit_dynamic = provider_name is not None and model is not None
+        if not dynamic_resume and not explicit_dynamic:
             raise
     startup_message: str | None = None
     startup_error_notice: str | None = None

--- a/src/tau_coding/tui/local_backends.py
+++ b/src/tau_coding/tui/local_backends.py
@@ -260,7 +260,8 @@ class LocalBackendScreen(ModalScreen[None]):
         self.app.push_screen(
             LocalConfirmScreen(
                 "Reset local backend?",
-                "Remove this backend's saved integration settings and credentials?",
+                "Remove this backend's saved integration settings? Stored credentials "
+                "require a separate confirmation.",
                 theme=self.theme,
             ),
             callback=self._handle_reset_confirmation,

--- a/tests/test_llama_cpp_extension.py
+++ b/tests/test_llama_cpp_extension.py
@@ -1,0 +1,822 @@
+"""Deterministic Phase 5 tests for the trusted llama.cpp integration."""
+
+from __future__ import annotations
+
+import json
+import stat
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+import httpx
+import pytest
+
+from conftest import isolate_home
+from tau_agent.harness import SimpleCancellationToken
+from tau_coding.credentials import FileCredentialStore
+from tau_coding.extensions import ExtensionRuntime
+from tau_coding.extensions.builtins.llama_cpp import service as llama_service
+from tau_coding.extensions.builtins.llama_cpp.service import (
+    LLAMA_CPP_API_KEY_ENV,
+    LLAMA_CPP_DEFAULT_ENDPOINT,
+    LLAMA_CPP_ENDPOINT_ENV,
+    LlamaCppError,
+    LlamaCppService,
+    normalize_llama_cpp_endpoint,
+)
+from tau_coding.extensions.builtins.llama_cpp.state import (
+    LLAMA_CPP_CREDENTIAL_PREFIX,
+    LlamaCppIntegrationState,
+    LlamaCppStateError,
+    LlamaCppStateStore,
+    LlamaCppStoredModel,
+)
+from tau_coding.extensions.providers import ProviderRefreshContext, ResolvedProviderAuth
+from tau_coding.local_backends import LocalOperationContext
+from tau_coding.paths import TauPaths
+from tau_coding.provider_runtime import create_dynamic_model_provider
+from tau_coding.resources import TauResourcePaths
+
+pytestmark = pytest.mark.anyio
+
+SERVER = "http://llama.test:8080"
+MODEL = LlamaCppStoredModel(
+    "qwen-local",
+    display_name="Qwen local",
+    context_window=32768,
+    input_modalities=("text",),
+)
+
+
+def _context(action: str = "refresh") -> LocalOperationContext:
+    return LocalOperationContext(
+        signal=SimpleCancellationToken(),
+        action=action,  # type: ignore[arg-type]
+        generation_id="test-generation",
+        backend_id="llama.cpp",
+        source_id="built-in:llama.cpp",
+        _is_current=lambda: True,
+        _progress=lambda _: None,
+    )
+
+
+def _state(
+    endpoint: str = SERVER,
+    *,
+    selected_model: str | None = "qwen-local",
+    credential_ref: str | None = None,
+    models: tuple[LlamaCppStoredModel, ...] = (MODEL,),
+    checked_at: str | None = "2026-08-20T00:00:00Z",
+) -> LlamaCppIntegrationState:
+    return LlamaCppIntegrationState(
+        endpoint=endpoint,
+        selected_model=selected_model,
+        credential_ref=credential_ref,
+        models=models,
+        checked_at=checked_at,
+    )
+
+
+def _client(
+    handler: Callable[[httpx.Request], httpx.Response | Exception],
+) -> tuple[httpx.AsyncClient, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def dispatch(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        result = handler(request)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(dispatch)), requests
+
+
+def _healthy_handler(
+    models: list[Mapping[str, object]] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    payload = models if models is not None else [{"id": "qwen-local", "name": "Qwen local"}]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        if request.url.path == "/v1/models":
+            return httpx.Response(200, json={"object": "list", "data": payload})
+        return httpx.Response(404)
+
+    return handler
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    client: httpx.AsyncClient | None = None,
+    credentials: object | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> tuple[LlamaCppService, LlamaCppStateStore, FileCredentialStore]:
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    state_store = LlamaCppStateStore(paths=paths)
+    credential_store = FileCredentialStore(paths.home / "credentials.json")
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials or credential_store,
+        environment=environment,
+        client=client,
+    )
+    return service, state_store, credential_store
+
+
+def _runtime(
+    tmp_path: Path,
+    *,
+    client: httpx.AsyncClient | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> tuple[ExtensionRuntime, TauPaths, FileCredentialStore]:
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    credentials = FileCredentialStore(paths.home / "credentials.json")
+    runtime = ExtensionRuntime(
+        paths=paths,
+        credentials=credentials,
+        built_in_credentials=credentials,
+        environment=environment,
+        built_in_http_client=client,
+    )
+    runtime.load(
+        TauResourcePaths(
+            root=paths.home,
+            agents_root=paths.agents_home,
+            paths=paths,
+            cwd=tmp_path / "project",
+        ),
+        include_resource_dirs=False,
+        include_user_dir=False,
+    )
+    return runtime, paths, credentials
+
+
+@pytest.mark.parametrize(
+    ("value", "root", "inference"),
+    [
+        ("http://LOCALHOST:8080", "http://LOCALHOST:8080", "http://LOCALHOST:8080/v1"),
+        ("http://localhost:8080/", "http://localhost:8080", "http://localhost:8080/v1"),
+        ("http://localhost:8080/v1", "http://localhost:8080", "http://localhost:8080/v1"),
+        (
+            "http://localhost:8080/api/v1/",
+            "http://localhost:8080/api",
+            "http://localhost:8080/api/v1",
+        ),
+    ],
+)
+def test_endpoint_normalization(value: str, root: str, inference: str) -> None:
+    endpoint = normalize_llama_cpp_endpoint(value)
+    assert endpoint.server_root == root
+    assert endpoint.inference_base == inference
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "localhost:8080", "ftp://localhost", "http://user:pass@localhost", "http://localhost?a=1"],
+)
+def test_endpoint_normalization_rejects_unsafe_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        normalize_llama_cpp_endpoint(value)
+
+
+def test_endpoint_precedence_is_stored_then_environment_then_default(tmp_path: Path) -> None:
+    state_store = LlamaCppStateStore(
+        paths=TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    )
+    state_store.save(_state(endpoint=f"{SERVER}/saved"))
+    stored = LlamaCppService(
+        state_store=state_store,
+        environment={LLAMA_CPP_ENDPOINT_ENV: "http://env.test:9000"},
+    )
+    assert stored.endpoint.server_root == f"{SERVER}/saved"
+
+    environment = LlamaCppService(
+        state_store=LlamaCppStateStore(
+            paths=TauPaths(home=tmp_path / "other", agents_home=tmp_path / "agents")
+        ),
+        environment={LLAMA_CPP_ENDPOINT_ENV: "http://env.test:9000/v1"},
+    )
+    assert environment.endpoint.server_root == "http://env.test:9000"
+
+    dormant = LlamaCppService(
+        state_store=LlamaCppStateStore(
+            paths=TauPaths(home=tmp_path / "empty", agents_home=tmp_path / "agents")
+        ),
+        environment={},
+    )
+    assert dormant.endpoint.server_root == LLAMA_CPP_DEFAULT_ENDPOINT
+    assert dormant.configured is False
+
+
+@pytest.mark.anyio
+async def test_auth_headers_cover_stored_environment_fallback_and_no_auth(tmp_path: Path) -> None:
+    client, requests = _client(_healthy_handler())
+    service, state_store, credentials = _service(
+        tmp_path,
+        client=client,
+        environment={LLAMA_CPP_API_KEY_ENV: "environment-key"},
+    )
+    ref = f"{LLAMA_CPP_CREDENTIAL_PREFIX}stored"
+    credentials.set(ref, "stored-key")
+    state_store.save(_state(credential_ref=ref))
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={LLAMA_CPP_API_KEY_ENV: "environment-key"},
+        client=client,
+    )
+    await service.refresh(_context())
+    assert requests[0].headers["authorization"] == "Bearer stored-key"
+
+    state_store.clear()
+    requests.clear()
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={
+            LLAMA_CPP_ENDPOINT_ENV: SERVER,
+            LLAMA_CPP_API_KEY_ENV: "environment-key",
+        },
+        client=client,
+    )
+    await service.refresh(_context())
+    assert requests[0].headers["authorization"] == "Bearer environment-key"
+
+    requests.clear()
+    service = LlamaCppService(
+        state_store=state_store,
+        client=client,
+        environment={LLAMA_CPP_ENDPOINT_ENV: SERVER},
+    )
+    await service.refresh(_context())
+    assert "authorization" not in requests[0].headers
+    await client.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_discovery_reports_authentication_http_failures(
+    tmp_path: Path, status_code: int
+) -> None:
+    client, _ = _client(lambda request: httpx.Response(status_code, text="denied"))
+    service, state_store, _ = _service(tmp_path, client=client)
+    state_store.save(_state())
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=FileCredentialStore(tmp_path / "tau" / "credentials.json"),
+        client=client,
+    )
+    result = await service.refresh(_context())
+    assert result.backend_status is not None
+    assert result.backend_status.stale is True
+    assert "rejected" in result.diagnostics[0].message
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_discovery_timeout_and_health_loading_are_actionable(tmp_path: Path) -> None:
+    def timeout(request: httpx.Request) -> Exception:
+        return httpx.ReadTimeout("timed out", request=request)
+
+    client, _ = _client(timeout)
+    service, state_store, _ = _service(tmp_path, client=client)
+    state_store.save(_state())
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=FileCredentialStore(tmp_path / "tau" / "credentials.json"),
+        client=client,
+    )
+    with pytest.raises(LlamaCppError, match="Timed out"):
+        await service.discover(ResolvedProviderAuth())
+    result = await service.refresh(_context())
+    assert result.backend_status is not None
+    assert "Timed out" in result.backend_status.diagnostics[0].message
+    await client.aclose()
+
+    loading_client, _ = _client(lambda request: httpx.Response(503, json={"status": "loading"}))
+    loading_service, _, _ = _service(tmp_path / "loading", client=loading_client)
+    with pytest.raises(LlamaCppError, match="still loading"):
+        await loading_service.discover(ResolvedProviderAuth())
+    await loading_client.aclose()
+    await client.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {"data": []},
+        {"data": [{"id": "same"}, {"id": "same"}]},
+        {"data": [{"name": "missing"}]},
+    ],
+)
+async def test_malformed_empty_and_multiple_model_responses(
+    tmp_path: Path, payload: object
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        if payload is None:
+            return httpx.Response(200, text="")
+        return httpx.Response(200, json=payload)
+
+    client, _ = _client(handler)
+    service, _, _ = _service(tmp_path, client=client)
+    if payload == {"data": []}:
+        discovery = await service.discover(ResolvedProviderAuth())
+        assert discovery.models == ()
+    else:
+        with pytest.raises(LlamaCppError, match="malformed|duplicate|exact id"):
+            await service.discover(ResolvedProviderAuth())
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_malformed_model_payloads_raise_without_guessing_metadata(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "gpt-5.4-local",
+                        "name": "",
+                        "context_length": 32768,
+                        "input_modalities": ["text", "unknown"],
+                        "object": "model",
+                        "owned_by": "llama",
+                        "secret_metadata": "do-not-persist",
+                    }
+                ]
+            },
+        )
+
+    client, _ = _client(handler)
+    service, state_store, _ = _service(tmp_path, client=client)
+    discovery = await service.discover(ResolvedProviderAuth())
+    model = discovery.models[0]
+    assert model.id == "gpt-5.4-local"
+    assert model.context_window == 32768
+    assert model.input_modalities is None
+    assert model.compat == {"object": "model", "owned_by": "llama"}
+    state_store.save(
+        _state(
+            selected_model=model.id,
+            models=(LlamaCppStoredModel(model.id, context_window=32768),),
+        )
+    )
+    assert "secret_metadata" not in state_store.path.read_text()
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_dormant_cache_and_offline_refresh_are_network_free(tmp_path: Path) -> None:
+    dormant, _, _ = _service(tmp_path / "dormant", environment={})
+    assert dormant.configured is False
+    assert dormant.provider().models == ()
+    assert (await dormant.status(_context("refresh"))).state == "unconfigured"
+
+    client, requests = _client(lambda request: httpx.Response(500))
+    cached, state_store, credentials = _service(tmp_path / "cached", client=client)
+    state_store.save(_state())
+    cached = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    provider = cached.provider()
+    snapshot = await cached.refresh_provider_models(
+        ProviderRefreshContext(
+            signal=SimpleCancellationToken(),
+            allow_network=False,
+            cached_models=provider.models,
+            auth=ResolvedProviderAuth(),
+        )
+    )
+    assert snapshot.models == provider.models
+    assert requests == []
+    offline = await cached.refresh(_context())
+    assert offline.backend_status is not None
+    assert offline.backend_status.stale is True
+    assert offline.backend_status.cached is True
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_refresh_marks_missing_active_model_stale_without_replacing_it(
+    tmp_path: Path,
+) -> None:
+    client, _ = _client(_healthy_handler([{"id": "replacement", "name": "Replacement"}]))
+    service, state_store, credentials = _service(tmp_path, client=client)
+    state_store.save(_state())
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+
+    result = await service.refresh(_context())
+
+    assert result.backend_status is not None
+    assert result.backend_status.state == "stale"
+    assert result.backend_status.selected_model is None
+    assert result.backend_status.models[0].id == "replacement"
+    assert any("qwen-local" in item.message for item in result.backend_status.diagnostics)
+    assert service.provider().default_model is None
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_gpt_and_codex_model_ids_use_local_chat_transport(tmp_path: Path) -> None:
+    client, _ = _client(_healthy_handler())
+    service, state_store, credentials = _service(tmp_path, client=client)
+    state_store.save(
+        _state(
+            selected_model="gpt-5.4-local",
+            models=(
+                LlamaCppStoredModel("gpt-5.4-local"),
+                LlamaCppStoredModel("codex-local"),
+            ),
+        )
+    )
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    provider = service.provider()
+    for model in ("gpt-5.4-local", "codex-local"):
+        runtime = await create_dynamic_model_provider(
+            provider,
+            model=model,
+            credential_store=credentials,
+            environment={},
+        )
+        assert runtime._config.api == "openai-completions"
+        assert runtime._config.infer_api_from_model is False
+        await runtime.aclose()
+    await client.aclose()
+
+
+def test_state_is_atomic_locked_private_and_recovers_interrupted_writes(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    store = LlamaCppStateStore(paths=paths)
+    store.save(_state())
+    assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(store.lock_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(store.path.parent.stat().st_mode) == 0o700
+
+    temporary = store.path.parent / f".{store.path.name}.interrupted.tmp"
+    temporary.write_text("partial", encoding="utf-8")
+    assert store.active() == _state()
+    assert not temporary.exists()
+
+    original = store.path.read_text(encoding="utf-8")
+    with pytest.raises(LlamaCppStateError):
+        store.path.write_text("{broken", encoding="utf-8")
+        store.active()
+    store.path.write_text(original, encoding="utf-8")
+    assert store.active() == _state()
+
+
+def test_state_schema_validation_and_legacy_recovery(tmp_path: Path) -> None:
+    path = tmp_path / "llama.json"
+    legacy = {
+        "schema_version": 1,
+        "endpoint": SERVER,
+        "selected_model": "qwen-local",
+        "credential_ref": None,
+        "models": [MODEL.to_json()],
+        "checked_at": None,
+    }
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+    store = LlamaCppStateStore(path)
+    assert store.active() == _state(checked_at=None)
+    store.save(_state(checked_at=None))
+    upgraded = json.loads(path.read_text(encoding="utf-8"))
+    assert "endpoints" in upgraded
+
+    path.write_text(json.dumps({"schema_version": 99}), encoding="utf-8")
+    with pytest.raises(LlamaCppStateError, match="schema version"):
+        store.active()
+    path.write_text(json.dumps({"schema_version": 1, "unknown": True}), encoding="utf-8")
+    with pytest.raises(LlamaCppStateError, match="Unknown field"):
+        store.active()
+
+
+def test_state_replace_is_atomic_on_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tau_coding.extensions.builtins.llama_cpp.state as state_module
+
+    store = LlamaCppStateStore(tmp_path / "state.json")
+    store.save(_state())
+    original = store.path.read_text(encoding="utf-8")
+
+    def fail_replace(source: str | Path, destination: str | Path) -> None:
+        del source, destination
+        raise OSError("disk full")
+
+    monkeypatch.setattr(state_module.os, "replace", fail_replace)
+    with pytest.raises(LlamaCppStateError, match="write"):
+        store.save(_state(endpoint="http://other.test"))
+    assert store.path.read_text(encoding="utf-8") == original
+    assert not tuple(store.path.parent.glob(f".{store.path.name}.*.tmp"))
+
+
+@pytest.mark.anyio
+async def test_setup_status_refresh_use_doctor_and_reset_through_real_runtime(
+    tmp_path: Path,
+) -> None:
+    current_models = [{"id": "qwen-local", "name": "Qwen local"}]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        if request.url.path == "/v1/models":
+            return httpx.Response(200, json={"data": current_models})
+        if request.method == "POST" and request.url.path == "/v1/chat/completions":
+            payload = json.loads(request.content)
+            if payload.get("tools"):
+                text = (
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1",'
+                    '"function":{"name":"tau_probe","arguments":"{}"}}]},'
+                    '"finish_reason":"tool_calls"}]}'
+                    "\n\ndata: [DONE]\n\n"
+                )
+            else:
+                text = (
+                    'data: {"choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}'
+                    "\n\ndata: [DONE]\n\n"
+                )
+            return httpx.Response(200, text=text, headers={"content-type": "text/event-stream"})
+        return httpx.Response(404)
+
+    client, requests = _client(handler)
+    runtime, paths, credentials = _runtime(tmp_path, client=client)
+    registry = runtime.local_backend_registry
+    assert registry.effective("llama.cpp") is not None
+    initial = await registry.status("llama.cpp")
+    assert initial.backend_status is not None
+    assert initial.backend_status.state == "unconfigured"
+
+    configured = await registry.configure(
+        "llama.cpp", {"endpoint": f"{SERVER}/v1", "api_key": "optional-secret"}
+    )
+    assert configured.committed is True
+    assert configured.stale is False
+    assert configured.backend_status is not None
+    assert configured.backend_status.state == "ready"
+    assert configured.backend_status.authentication_source == "stored credential"
+    assert runtime.provider_registry.effective("llama.cpp").definition.models  # type: ignore[union-attr]
+    assert credentials.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+
+    current_models[:] = [{"id": "new-local", "name": "New local"}]
+    refreshed = await registry.refresh("llama.cpp")
+    assert refreshed.stale is False
+    assert refreshed.backend_status is not None
+    assert refreshed.backend_status.models[0].id == "new-local"
+    view = registry.effective("llama.cpp")
+    assert view is not None and view.use_available
+    assert refreshed.backend_status.state == "stale"
+    assert "use" not in refreshed.backend_status.actions
+
+    diagnosed = await registry.doctor("llama.cpp")
+    assert diagnosed.backend_status is not None
+    assert any(item.stage == "streaming" for item in diagnosed.diagnostics)
+    assert any(item.stage == "tools" for item in diagnosed.diagnostics), diagnosed.diagnostics
+    assert any(request.method == "POST" for request in requests)
+
+    reset = await registry.reset("llama.cpp")
+    assert reset.committed is True
+    assert not paths.llama_cpp_state_path.exists()
+    assert credentials.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+    assert (await registry.status("llama.cpp")).backend_status.state == "unconfigured"  # type: ignore[union-attr]
+    await runtime.aclose()
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_generation_credential_commit_orphan_reset_and_partial_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, _ = _client(_healthy_handler())
+    service, state_store, credentials = _service(tmp_path, client=client)
+    first = await service.configure({"endpoint": SERVER, "api_key": "first"}, _context("configure"))
+    assert first.committed is True
+    old_ref = state_store.active().credential_ref  # type: ignore[union-attr]
+    second = await service.configure(
+        {"endpoint": SERVER, "api_key": "second"}, _context("configure")
+    )
+    assert second.committed is True
+    assert credentials.get(old_ref) is None  # type: ignore[arg-type]
+
+    original_save = state_store.save
+    monkeypatch.setattr(
+        state_store,
+        "save",
+        lambda *args, **kwargs: (_ for _ in ()).throw(LlamaCppStateError("save failed")),
+    )
+    failed = await service.configure(
+        {"endpoint": SERVER, "api_key": "third"}, _context("configure")
+    )
+    assert failed.committed is False
+    assert failed.credential_orphaned is False
+    assert state_store.active().credential_ref == state_store.get(SERVER).credential_ref  # type: ignore[union-attr]
+    assert not any(
+        credentials.get(name) == "third"
+        for name in credentials.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+    )
+    monkeypatch.setattr(state_store, "save", original_save)
+
+    original_delete = credentials.delete
+
+    def fail_new_credential(name: str) -> None:
+        if credentials.get(name) == "fourth":
+            raise OSError("credential cleanup failed")
+        original_delete(name)
+
+    monkeypatch.setattr(credentials, "delete", fail_new_credential)
+    monkeypatch.setattr(
+        state_store,
+        "save",
+        lambda *args, **kwargs: (_ for _ in ()).throw(LlamaCppStateError("save failed")),
+    )
+    orphaned = await service.configure(
+        {"endpoint": SERVER, "api_key": "fourth"}, _context("configure")
+    )
+    assert orphaned.committed is False
+    assert orphaned.credential_orphaned is True
+    assert any(
+        credentials.get(name) == "fourth"
+        for name in credentials.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+    )
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_credential_cleanup_failure_is_reported_and_reset_is_recoverable(
+    tmp_path: Path,
+) -> None:
+    client, _ = _client(_healthy_handler())
+    service, state_store, credentials = _service(tmp_path, client=client)
+    configured = await service.configure(
+        {"endpoint": SERVER, "api_key": "secret"}, _context("configure")
+    )
+    assert configured.committed
+    ref = state_store.active().credential_ref  # type: ignore[union-attr]
+    original_delete = credentials.delete
+
+    def fail_old(name: str) -> None:
+        if name == ref:
+            raise OSError("credential file unavailable")
+        original_delete(name)
+
+    credentials.delete = fail_old  # type: ignore[method-assign]
+    changed = await service.configure(
+        {"endpoint": SERVER, "api_key": "new-secret"}, _context("configure")
+    )
+    assert changed.committed is True
+    assert changed.credential_orphaned is True
+    assert any(item.stage == "credentials" for item in changed.diagnostics)
+
+    reset = await service.reset(_context("reset"))
+    assert reset.committed is True
+    assert credentials.get(ref) == "secret"
+    credentials.delete = original_delete  # type: ignore[method-assign]
+    recovered = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    assert recovered.orphaned_credentials == ()
+    assert credentials.get(ref) is None
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_print_mode_explicit_dynamic_startup_uses_cached_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from tau_coding.cli import run_print_mode
+    from tau_coding.rendering import PrintOutputMode
+
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    LlamaCppStateStore(paths=paths).save(_state())
+    project = tmp_path / "project"
+    project.mkdir()
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response | Exception:
+        requests.append(request)
+        if request.method == "GET":
+            return httpx.ConnectError("server is down", request=request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"choices":[{"delta":{"content":"hello"},"finish_reason":"stop"}]}\n'
+                "\ndata: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    def fake_client(*, timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=timeout)
+
+    monkeypatch.setattr(llama_service, "create_async_client", fake_client)
+    import tau_ai.openai_compatible as compatible
+
+    monkeypatch.setattr(compatible, "create_async_client", fake_client)
+    ok = await run_print_mode(
+        prompt="say hello",
+        model="qwen-local",
+        cwd=project,
+        provider=None,
+        output=PrintOutputMode.text,
+        resource_paths=TauResourcePaths(
+            root=paths.home, agents_root=paths.agents_home, paths=paths
+        ),
+        provider_name="llama.cpp",
+        requested_provider="llama.cpp",
+        requested_model="qwen-local",
+        trust_default="ask",
+    )
+    assert ok is True
+    assert "hello" in capsys.readouterr().out
+    assert [request.url.path for request in requests] == ["/v1/chat/completions"]
+
+
+@pytest.mark.anyio
+async def test_tui_explicit_dynamic_startup_uses_cached_state_during_downtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tau_coding import SessionManager
+    from tau_coding.tui import app as tui_app
+
+    isolate_home(monkeypatch, tmp_path)
+    paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    LlamaCppStateStore(paths=paths).save(_state())
+    project = tmp_path / "project"
+    project.mkdir()
+    manager = SessionManager(paths)
+    captured: dict[str, object] = {}
+
+    class HeadlessTui:
+        def __init__(self, session: object, **kwargs: object) -> None:
+            del kwargs
+            captured["session"] = session
+
+        async def run_async(self) -> None:
+            return None
+
+    def unavailable_client(*, timeout: float) -> httpx.AsyncClient:
+        def handler(request: httpx.Request) -> Exception:
+            raise httpx.ConnectError("server is down", request=request)
+
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=timeout)
+
+    monkeypatch.setattr(tui_app, "TauTuiApp", HeadlessTui)
+    monkeypatch.setattr(llama_service, "create_async_client", unavailable_client)
+    session_id = await tui_app.run_tui_app(
+        model="qwen-local",
+        provider_name="llama.cpp",
+        cwd=project,
+        session_manager=manager,
+    )
+    assert session_id is not None
+    session = captured["session"]
+    assert session.provider._config.base_url == f"{SERVER}/v1"  # type: ignore[union-attr]
+    assert session.provider_name == "llama.cpp"  # type: ignore[union-attr]
+    await session.aclose()  # type: ignore[union-attr]
+
+
+@pytest.mark.anyio
+async def test_builtin_source_lifecycle_is_generation_local(tmp_path: Path) -> None:
+    runtime, _, _ = _runtime(tmp_path)
+    old_registry = runtime.provider_registry
+    assert runtime.extension_metadata[0].source_id == "built-in:llama.cpp"
+    assert runtime.extension_metadata[0].hidden is True
+    assert runtime.extension_names == ()
+    assert runtime.local_backend_registry.effective("llama.cpp") is not None
+
+    runtime.reset_for_reload()
+    assert old_registry.effective("llama.cpp") is None
+    runtime.load(
+        TauResourcePaths(root=tmp_path / "tau", agents_root=tmp_path / "agents"),
+        include_resource_dirs=False,
+        include_user_dir=False,
+    )
+    assert runtime.provider_registry.effective("llama.cpp") is not None
+    await runtime.aclose()
+
+
+__all__ = []

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -242,9 +242,11 @@ still use their first-registration-wins name registries. Removing a source revea
 the preceding complete layer, including the exact durable provider baseline. The contracts are
 frontend-free and callbacks must not return Rich/Textual values.
 
-This foundation is intentionally provisional until #602's second-backend
-validation. Phase 1 does not yet add startup/session selection, built-in local
-providers, `/local`, or llama.cpp behavior.
+This foundation remains provisional until second-backend validation. The
+trusted built-in `llama.cpp` provider now exercises these contracts; its
+connection, cache, and troubleshooting behavior are covered in the [local
+inference guide]({{< relref "./local-inference.md" >}}). Router management and
+Hugging Face model mutations remain outside this phase.
 
 ### Tools
 

--- a/website/content/guides/local-inference.md
+++ b/website/content/guides/local-inference.md
@@ -1,55 +1,133 @@
 ---
-title: Local backends
-
-description: Configure and use provider-neutral local inference backends in Tau.
+title: Local inference with llama.cpp
+description: Configure Tau's built-in llama.cpp backend through /local.
 ---
 
-Tau's `/local` command is the interactive entry point for local inference. It is
-backend-neutral: the host can present llama.cpp, Ollama, vLLM, LM Studio, or a
-future extension without protocol-specific branches in the TUI.
+Tau ships llama.cpp as a trusted, hidden built-in local backend. The
+provider-neutral entry point is `/local`; there is no `/llama` or `/llama-cpp`
+command. The built-in provider ID is `llama.cpp`, distinct from an older
+user-created `llama-cpp` catalog provider.
 
-## Open `/local`
+## Start llama.cpp
 
-Start Tau normally and enter:
+Install llama.cpp separately and start its OpenAI-compatible server with a
+model suitable for your work:
+
+```bash
+llama-server -hf <tool-capable-gguf>
+```
+
+The default endpoint is `http://127.0.0.1:8080`. Tau does not install, start,
+stop, scan for, or download llama.cpp models. Keep the server running while Tau
+uses it.
+
+## Configure `/local`
+
+Start Tau and enter:
 
 ```text
 /local
 ```
 
-Tau explicitly asks you to choose a registered backend. When there is one backend
-it is preselected, and a recommended backend may be marked, but you still confirm
-the choice. The backend screen then offers only the capabilities that backend
-supports: configure, refresh, use, doctor, reset, and optional model actions.
+Choose the recommended `llama.cpp` backend and confirm the choice, even when it
+is the only backend. Enter the server URL with or without `/v1`, then optionally
+enter an API key. Tau probes only the endpoint you provide; it never scans ports,
+processes, or the local network.
 
-Configuration forms are supplied as structured fields. Normal, secret, and choice
-fields are rendered by Tau, while the backend performs validation and its
-connection transaction. Cancelled or failed configuration leaves the previous
-settings and active model untouched. Close the screen to cancel owned work; late
-results from an old extension generation are ignored.
+Endpoint precedence is:
 
-## Security and persistence
+1. the endpoint currently entered in `/local`;
+2. the saved endpoint;
+3. `LLAMA_BASE_URL` for the current process;
+4. `http://127.0.0.1:8080` as the offered default.
 
-`/local` does not scan ports, processes, or the local network. A backend probes
-only an endpoint the user configured or explicitly selected. Optional or absent
-authentication does not receive a fake API key. Secret fields are not written to
-session history, diagnostics, or safe integration state.
+The default alone does not configure the backend or trigger a network request.
+An explicit saved endpoint or non-empty `LLAMA_BASE_URL` counts as configured.
+Successful setup discovers exact IDs from `/v1/models`; it never requires a fake
+model ID.
 
-Dynamic local providers are runtime overlays, not catalog entries. A backend may
-store endpoint metadata or a safe model snapshot in a backend-owned user-level
-state store, but provider definitions and credentials remain separate. Reset
-never stops an external server or deletes model files.
+### Authentication
 
-## Headless use
+Use the optional key in one of these ways:
 
-`/local` is interactive-only. Print mode reports that limitation rather than
-starting setup, probing endpoints, or selecting a model implicitly. Configure a
-backend in the TUI, then select it explicitly:
+- enter it through the secret `/local` field; Tau stores it in
+  `~/.tau/credentials.json`;
+- set `LLAMA_API_KEY` for an environment-only setup;
+- leave both empty for an unauthenticated server.
+
+A stored key wins over `LLAMA_API_KEY`. Without a key Tau sends no
+`Authorization` header. Keys never enter the llama.cpp state file, sessions,
+exports, or diagnostics. See [Project trust and security]({{< relref
+"./project-trust.md#security-boundary" >}}).
+
+## Choose a model
+
+After setup, `/model` shows server-reported model IDs and display names. Start
+explicitly when using scripts or a new TUI session:
 
 ```bash
-tau --provider <provider-id> --model <model-id> -p "summarize this project"
+tau --provider llama.cpp --model <model-id>
+tau --provider llama.cpp --model <model-id> --print "summarize this project"
 ```
 
-The generic host in this phase is the contract used by built-in and extension
-backends. The backend's own guide should document protocol-specific setup and
-troubleshooting. Existing custom OpenAI-compatible providers continue to use
-[`tau setup`]({{< relref "../reference/cli.md#provider-setup-options" >}}).
+Both print mode and the TUI load the built-in provider before validating an
+explicit selection. A saved safe snapshot can keep an explicit startup usable
+while the server is temporarily down. If several models are available,
+headless startup requires the exact `--model`; Tau never silently chooses a
+different explicit model. Local inference is not an automatic global-provider
+fallback.
+
+The safe integration snapshot is stored at
+`~/.tau/state/extensions/llama.cpp.json`. It contains only the normalized
+endpoint, selected model reference, allowlisted model metadata, and a timestamp.
+The file is versioned, locked, atomically replaced, and private. Dynamic provider
+definitions are never copied into `catalog.toml` or `providers.json`.
+
+## Status and Doctor
+
+`/local` provides status and refresh. Refresh publishes a complete model
+snapshot atomically. Temporary downtime retains the last safe snapshot and marks
+it stale; it does not erase the active provider or block unrelated providers. If
+the server stops reporting the active model, Tau keeps the current runtime
+usable, marks the snapshot stale, and does not offer a replacement model without
+an explicit selection after the original model returns.
+
+Doctor is an explicit action. It reports endpoint reachability, model discovery,
+streaming, tool-schema acceptance, and observed tool-call emission. A model that
+streams but does not emit the probe tool receives a compatibility warning rather
+than a connectivity failure. Use a tool-capable instruct model and the server's
+required chat-template options when tool calls are unavailable.
+
+## Reset
+
+Reset removes only Tau's llama.cpp integration settings and safe snapshot. It
+never stops the external server or deletes model files. Settings reset and stored
+credential deletion are separate actions; a stored credential remains until its
+separate deletion confirmation succeeds.
+
+## Troubleshooting
+
+- **Connection refused or timeout:** start `llama-server`, check the exact URL,
+  and choose `/local` → Refresh. Tau does not discover another port.
+- **HTTP 401/403:** enter the server's configured key in `/local`, or set
+  `LLAMA_API_KEY`. A stored key wins over the environment value.
+- **Loading:** wait for llama.cpp to finish loading, then refresh.
+- **Malformed or empty `/v1/models`:** inspect the server response and model
+  loading state. Tau does not invent an ID or metadata.
+- **Print mode reports an unavailable model:** configure `/local` first and pass
+  `--provider llama.cpp` plus the exact discovered `--model`. A cached snapshot
+  can work offline, but a first-time explicit model needs discovery.
+- **Tools are not called:** run Doctor. Streaming can work while a model's GGUF
+  chat template does not support tools. Use a tool-capable instruct GGUF and
+  check llama.cpp's template/server flags.
+- **An old `llama-cpp` provider remains:** it is a separate manually configured
+  provider. Use `llama.cpp` for the built-in backend, or retain the old provider
+  for its existing catalog setup.
+
+For other OpenAI-compatible endpoints, keep using [`/login custom`]({{< relref
+"../guides/providers-and-models.md#adding-a-custom--local-provider" >}}) or
+`tau setup`.
+
+Router model management, Hugging Face search/download, and implicit
+load/unload are not part of this phase. Standard OpenAI-compatible loaded-model
+inference remains supported; mutating router workflows require a later phase.

--- a/website/content/guides/project-trust.md
+++ b/website/content/guides/project-trust.md
@@ -75,6 +75,22 @@ state. Resource preparation is coherent: decline builds a global/explicit-only
 snapshot. Resume and replacement resolve the destination record's canonical cwd
 instead of reusing the source project's outcome.
 
+## Built-in local-backend security
+
+The bundled `llama.cpp` backend is trusted Tau package code. It loads before the
+project-trust decision, including with `--no-extensions`, and never creates a
+trust prompt. `/local` probes only its explicitly entered, saved, or
+`LLAMA_BASE_URL` endpoint; it does not scan ports, processes, or the local
+network. Tau never starts/stops the external server or deletes model files.
+
+The safe integration snapshot at `~/.tau/state/extensions/llama.cpp.json`
+contains only the normalized endpoint, exact model IDs, allowlisted metadata,
+and a timestamp. API keys are kept separately in `~/.tau/credentials.json` or
+read from `LLAMA_API_KEY`; no key means no `Authorization` header. Secrets do
+not enter snapshots, sessions, exports, or diagnostics. Resetting settings and
+deleting a stored credential are separate confirmations. See the [local
+inference guide]({{< relref "./local-inference.md" >}}) for troubleshooting.
+
 ## Security boundary
 
 **Project trust is an input-loading guard, not a sandbox.** It does not restrict

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -333,43 +333,43 @@ Ollama. The easiest interactive path is:
 Tau prompts for the provider details, saves the API key, writes the provider
 metadata to `~/.tau/catalog.toml`, and makes the provider available immediately.
 
-### llama.cpp quickstart
+### Built-in llama.cpp backend
 
-Tau works with llama.cpp through its OpenAI-compatible server. Start a local
-server with a GGUF model from Hugging Face:
-
-```bash
-llama-server -hf ggml-org/Qwen3.6-35B-A3B-GGUF:Q8_0
-```
-
-Some installs expose the same server as `llama serve`:
+Tau's first-class llama.cpp integration is configured through the provider-neutral
+`/local` command. Start llama.cpp independently with a real GGUF model:
 
 ```bash
-llama serve -hf ggml-org/Qwen3.6-35B-A3B-GGUF:Q8_0
+llama-server -hf <tool-capable-gguf>
 ```
 
-Then register it with Tau:
+Then open Tau and run:
+
+```text
+/local
+```
+
+Choose and confirm the recommended `llama.cpp` backend, enter the endpoint, and
+optionally enter its API key. Tau discovers the exact model IDs returned by
+`/v1/models`; it does not use a fake key or fake model. No key means no
+`Authorization` header. A saved key takes precedence over `LLAMA_API_KEY`.
+
+Use the discovered ID explicitly from the TUI or print mode:
 
 ```bash
-export LLAMA_API_KEY=local # any non-empty value unless you started llama.cpp with --api-key
-
-tau --provider llama-cpp \
-  --base-url http://localhost:8080/v1 \
-  --api-key-env LLAMA_API_KEY \
-  --model local \
-  setup
+tau --provider llama.cpp --model <model-id>
+tau --provider llama.cpp --model <model-id> --print "summarize this project"
 ```
 
-Run Tau against the local model:
+The configured endpoint and safe model snapshot are stored under
+`~/.tau/state/extensions/llama.cpp.json`; secrets stay in the credential store.
+A cached snapshot allows explicit startup during temporary server downtime.
+`/local` never scans ports or processes, stops the external server, or deletes
+model files. See the [complete llama.cpp guide]({{< relref "./local-inference.md" >}})
+for endpoint precedence, Doctor, reset, and troubleshooting.
 
-```bash
-tau --provider llama-cpp
-tau --provider llama-cpp "summarize this project"    # TUI with an initial prompt
-tau --provider llama-cpp -p "summarize this project" # one-shot print mode
-```
-
-`llama-server` listens on port `8080` by default and only enforces the bearer
-token if you launch it with `--api-key`.
+An older manually configured provider named `llama-cpp` remains separate and is
+not migrated. Use the custom-provider flow below for other OpenAI-compatible
+servers.
 
 For scripted or one-off setup with another OpenAI-compatible server, use the
 same `tau setup` flow. For example, Ollama's OpenAI-compatible endpoint usually

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -70,11 +70,19 @@ The full list is in the [Slash commands reference]({{< relref "../reference/slas
 ### Local backends
 
 `/local` first opens an explicit backend chooser. One backend is preselected but
-still requires confirmation; a recommended backend is only a marker. The host
-renders backend-declared text, secret, and choice fields and exposes only the
-optional actions the backend reports. Configure, refresh, status, doctor, reset,
-and model-management work asynchronously, show structured progress, and are
-cancelled when the screen closes. State-changing actions require an idle agent.
+still requires confirmation; a recommended backend is only a marker. Tau's
+built-in `llama.cpp` backend asks for an endpoint and optional secret key,
+discovers exact `/v1/models` IDs, and exposes status, refresh, use, Doctor, and
+reset. The host renders backend-declared text, secret, and choice fields and
+exposes only the optional actions the backend reports.
+
+Configure, refresh, status, Doctor, and reset work asynchronously, show
+structured progress/diagnostics, and are cancelled when the screen closes.
+Cached model snapshots remain visible as stale during server downtime.
+State-changing actions require an idle agent. Reset does not stop llama.cpp or
+delete model files; credential deletion is separately confirmed. For explicit
+startup and troubleshooting, see the [local inference guide]({{< relref
+"./local-inference.md" >}}).
 
 ## Running shell commands directly
 

--- a/website/content/internals/architecture.md
+++ b/website/content/internals/architecture.md
@@ -45,6 +45,12 @@ its exact source-owned provider layer prevents a shadowing extension from using
 or resetting another source's integration. See the [local backends
 guide]({{< relref "../guides/local-inference.md" >}}).
 
+TUI and print startup share the same trust-aware preparation boundary: load the
+trusted built-ins and eligible extensions, restore safe dynamic snapshots,
+resolve an explicit provider/model, then construct the candidate runtime. A
+saved llama.cpp snapshot can therefore support explicit startup during server
+downtime without making the local backend an implicit fallback.
+
 ## Dependency direction
 
 Dependencies only point one way: `tau_coding → tau_agent → tau_ai`. UI code

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -12,7 +12,7 @@ tau [OPTIONS] [PROMPT] [COMMAND] [ARGS]
 
 - With no arguments, `tau` opens the interactive [TUI]({{< relref "../guides/tui.md" >}}).
 - A positional `PROMPT` opens the TUI and submits it as the first turn.
-- `/local` is available in the TUI for registered local backends; print mode reports that it is interactive-only.
+- `/local` is available in the TUI for registered local backends; print mode reports that setup is interactive-only.
 - `-p/--print` (or `--mode`) runs that same positional prompt in [print mode]({{< relref "../guides/print-mode.md" >}}) instead of the TUI.
 - Put flags before the prompt — Tau treats everything after the last recognized flag as prompt text, including tokens that look like flags.
 
@@ -110,8 +110,16 @@ tau --print --session <session-id> "Follow-up message"
 
 Explicit `--provider`, `--model`, and system-prompt options override the saved
 startup choices for this invocation. After configuring a local backend in the
-TUI, pass its provider and exact discovered model explicitly in print mode; Tau
-does not run `/local` setup or probe local endpoints headlessly. `--session` cannot be combined with
+TUI, pass its provider and exact discovered model explicitly in print mode:
+
+```bash
+tau --provider llama.cpp --model <model-id> --print "summarize this project"
+```
+
+Tau does not run `/local` setup or select a model implicitly headlessly. An
+endpoint-keyed safe snapshot can let an explicit local startup continue while
+llama.cpp is temporarily down; a first-time explicit model still needs discovery.
+`--session` cannot be combined with
 `--new-session` or `--session-id`. An unknown session id exits with an error.
 
 `--resume`, `--prompt`, `-o/--output`, and `-x` are removed; each now exits

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -14,6 +14,7 @@ those locations and file formats.
 ├── catalog.toml        # optional provider/model catalog overlay
 ├── providers.json      # provider/model preferences
 ├── credentials.json    # saved API keys / OAuth tokens (0600, atomic writes)
+├── state/extensions/    # built-in integration state, including llama.cpp
 ├── settings.json       # general settings (trust default, shell prefix)
 ├── trust.json          # versioned project-input trust decisions
 ├── tui.json            # TUI theme, keybindings, and layout
@@ -104,6 +105,13 @@ Tau separates provider metadata from runtime preferences:
 - `~/.tau/catalog.toml` optionally adds personal providers or overlays built-ins.
 - `~/.tau/providers.json` stores runtime preferences such as the default provider,
   default model, scoped models, headers, and timeout/retry settings.
+
+The built-in llama.cpp backend stores only its normalized endpoint and safe
+server-reported model snapshot at `~/.tau/state/extensions/llama.cpp.json`.
+Optional credentials remain in `credentials.json` or `LLAMA_API_KEY`; dynamic
+llama.cpp provider definitions are not written to `catalog.toml` or
+`providers.json`. See the [local inference guide]({{< relref
+"../guides/local-inference.md" >}}).
 
 Tau intentionally reads catalog overlays only from the user-level
 `~/.tau/catalog.toml`. There is no project-level `.tau/catalog.toml`, so cloning a

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -22,7 +22,7 @@ command palette with **Ctrl+K**.
 | `/scoped-models` | Choose favorite models for the Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
-| `/local` | Choose and manage a registered local backend; interactive-only |
+| `/local` | Choose and manage a registered local backend; interactive-only. The built-in `llama.cpp` backend supports setup, refresh, use, Doctor, and reset. |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
 | `/prompts` | Search loaded prompt templates; press Enter to insert an invocation or Ctrl+E to edit the file |


### PR DESCRIPTION
## Summary

- add the trusted built-in `llama.cpp` integration and local backend
- add endpoint discovery, safe state/credential handling, refresh/configure/reset/doctor flows
- preserve cached-model startup during server downtime and route local GPT/Codex-like IDs through the local chat transport
- update developer notes and user/reference documentation

## Validation

- `uv run pytest tests/test_llama_cpp_extension.py` — 31 passed
- `uv run ruff check .` — passed
- `uv run mypy` — passed
- `git diff --check` — passed

Targets the Phase 4 umbrella branch at base commit `6d8c4431200991f0e8f53ed48be540912c8a418f`.
