### PR TITLE
feat: support Pi prompt argument variables

### DIFF
--- a/dev-notes/architecture/phase-9-skills-prompts.md
+++ b/dev-notes/architecture/phase-9-skills-prompts.md
@@ -137,18 +137,24 @@ named `.agents/prompts/example.md` can be invoked with:
 ```
 
 Tau expands the command before sending the prompt to the model. Invocation text
-after the command is available as `{{ arguments }}` or `{{ args }}`:
+after the command supports Pi-compatible argument variables:
+
+- `$1`, `$2`, ... for positional arguments
+- `$@` or `$ARGUMENTS` for all arguments
+- `${N:-default}` for positional defaults
+- `${@:N}` and `${@:N:L}` for simple slices
 
 ```md
-Review {{ arguments }} for correctness.
+Review $@ for correctness.
 ```
 
-If the prompt template has no `{{ arguments }}` or `{{ args }}` placeholder,
-Tau appends the invocation arguments after a blank line. Other placeholders are
-left blank during slash-command expansion so a custom prompt can include optional
-fields without crashing the TUI.
+If the prompt template has no argument placeholder, Tau appends the invocation
+arguments after a blank line. Legacy `{{ arguments }}` and `{{ args }}`
+placeholders remain supported. Other placeholders are left blank during
+slash-command expansion so a custom prompt can include optional fields without
+crashing the TUI.
 
-Template variables use simple `{{ variable }}` placeholders:
+Direct template rendering also supports simple `{{ variable }}` placeholders:
 
 ```md
 Review {{ target }} for {{ focus }}.

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -53,7 +53,9 @@ from tau_coding.prompt_templates import (
     expand_prompt_template_command,
     load_prompt_templates,
     load_prompt_templates_with_diagnostics,
+    parse_prompt_template_arguments,
     render_prompt_template,
+    substitute_prompt_template_args,
 )
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
@@ -278,6 +280,8 @@ __all__ = [
     "load_shell_settings",
     "load_prompt_templates",
     "load_prompt_templates_with_diagnostics",
+    "parse_prompt_template_arguments",
+    "substitute_prompt_template_args",
     "load_skills",
     "load_skills_with_diagnostics",
     "openai_compatible_config_from_provider",

--- a/src/tau_coding/data/docs/skills.md
+++ b/src/tau_coding/data/docs/skills.md
@@ -25,7 +25,7 @@ A skill with `disable-model-invocation: true` in its `SKILL.md` frontmatter is e
 
 ## Prompt templates
 
-Templates load from user and project `.tau/prompts/` and `.agents/prompts/` directories. They are prompt shortcuts, not background knowledge, and may contain `{{ variable }}` placeholders.
+Templates load from user and project `.tau/prompts/` and `.agents/prompts/` directories. They are prompt shortcuts, not background knowledge, and support Pi-compatible argument placeholders such as `$1`, `$@`, `$ARGUMENTS`, defaults, and slices. Legacy `{{ arguments }}` and `{{ args }}` placeholders remain supported.
 
 Use a skill for reference know-how and a template for a frequently repeated prompt. Run `/reload` after changing resources in an active TUI session.
 

--- a/src/tau_coding/prompt_templates.py
+++ b/src/tau_coding/prompt_templates.py
@@ -16,6 +16,9 @@ from tau_coding.resources import (
 )
 
 _TEMPLATE_VARIABLE_RE = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
+_PROMPT_ARGUMENT_RE = re.compile(
+    r"\$\{(\d+|ARGUMENTS|@):-([^}]*)\}|\$\{@:(\d+)(?::(\d+))?\}|\$(ARGUMENTS|@|\d+)"
+)
 _ARGUMENT_TEMPLATE_VARIABLES = {"arguments", "args"}
 _RESERVED_TEMPLATE_NAMES = frozenset({"prompts", "skills", "tools", "reload"})
 
@@ -72,6 +75,64 @@ def load_prompt_templates_with_diagnostics(
     return sorted(templates_by_name.values(), key=lambda template: template.name), diagnostics
 
 
+def parse_prompt_template_arguments(text: str) -> list[str]:
+    """Parse prompt invocation arguments using Pi's simple quote rules."""
+    arguments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+
+    for character in text:
+        if quote is not None:
+            if character == quote:
+                quote = None
+            else:
+                current.append(character)
+        elif character in {"'", '"'}:
+            quote = character
+        elif character.isspace():
+            if current:
+                arguments.append("".join(current))
+                current = []
+        else:
+            current.append(character)
+
+    if current:
+        arguments.append("".join(current))
+    return arguments
+
+
+def substitute_prompt_template_args(content: str, arguments: Sequence[str]) -> str:
+    """Substitute Pi-compatible positional and aggregate prompt arguments."""
+    all_arguments = " ".join(arguments)
+
+    def replace(match: re.Match[str]) -> str:
+        default_target = match.group(1)
+        if default_target is not None:
+            default_value = match.group(2) or ""
+            if default_target in {"@", "ARGUMENTS"}:
+                value = all_arguments
+            else:
+                index = int(default_target) - 1
+                value = arguments[index] if 0 <= index < len(arguments) else ""
+            return value or default_value
+
+        slice_start = match.group(3)
+        if slice_start is not None:
+            start = max(int(slice_start) - 1, 0)
+            slice_length = match.group(4)
+            if slice_length is None:
+                return " ".join(arguments[start:])
+            return " ".join(arguments[start : start + int(slice_length)])
+
+        simple = match.group(5) or ""
+        if simple in {"@", "ARGUMENTS"}:
+            return all_arguments
+        index = int(simple) - 1
+        return arguments[index] if 0 <= index < len(arguments) else ""
+
+    return _PROMPT_ARGUMENT_RE.sub(replace, content)
+
+
 def render_prompt_template(
     template: PromptTemplate,
     variables: Mapping[str, str],
@@ -103,9 +164,11 @@ def expand_prompt_template_command(
 ) -> str | None:
     """Expand `/name [arguments]` text with a loaded prompt template.
 
-    Template names are matched by markdown filename stem. Invocation arguments are
-    available to templates as `{{ arguments }}` or `{{ args }}`. If a template has
-    no placeholders, arguments are appended after a blank line.
+    Template names are matched by markdown filename stem. Invocation arguments use
+    Pi-compatible `$1`, `$2`, `$@`, and `$ARGUMENTS` placeholders, including default
+    values and simple slices. Legacy `{{ arguments }}` and `{{ args }}` placeholders
+    remain supported. If a template has no argument placeholder, arguments are
+    appended after a blank line.
     """
     stripped = text.strip()
     if not stripped.startswith("/") or stripped.startswith("//") or stripped.startswith("/skill:"):
@@ -119,18 +182,21 @@ def expand_prompt_template_command(
     if template is None:
         return None
 
+    arguments = parse_prompt_template_arguments(args)
+    argument_text = " ".join(arguments)
+    rendered = substitute_prompt_template_args(template.content, arguments)
     rendered = render_prompt_template(
-        template,
-        {"arguments": args, "args": args},
+        PromptTemplate(template.name, template.path, rendered, template.description),
+        {"arguments": argument_text, "args": argument_text},
         missing="",
     )
-    if args and not _template_references_arguments(template.content):
+    if arguments and not _template_references_arguments(template.content):
         return f"{rendered.rstrip()}\n\n{args}"
     return rendered
 
 
 def _template_references_arguments(content: str) -> bool:
-    return any(
+    return bool(_PROMPT_ARGUMENT_RE.search(content)) or any(
         match.group(1) in _ARGUMENT_TEMPLATE_VARIABLES
         for match in _TEMPLATE_VARIABLE_RE.finditer(content)
     )
@@ -148,8 +214,10 @@ def _find_prompt_template(
 
 
 def _parse_prompt_template_command(text: str) -> tuple[str, str]:
-    command, separator, args = text[1:].partition(" ")
-    return command.strip().lower(), args.strip() if separator else ""
+    match = re.match(r"^/([^\s]+)(?:\s+([\s\S]*))?$", text)
+    if match is None:
+        return "", ""
+    return match.group(1).lower(), (match.group(2) or "").strip()
 
 
 def _load_prompt_templates_from_dir(prompts_dir: Path) -> list[PromptTemplate]:

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -140,6 +140,33 @@ def test_expand_prompt_template_command_replaces_slash_command() -> None:
     )
 
 
+def test_expand_prompt_template_command_supports_pi_argument_variables() -> None:
+    template = PromptTemplate(
+        name="example",
+        path=Path("example.md"),
+        content="first=$1 second=$2 all=$@ named=$ARGUMENTS",
+    )
+
+    assert expand_prompt_template_command('/example one "two words"', [template]) == (
+        "first=one second=two words all=one two words named=one two words"
+    )
+
+
+def test_expand_prompt_template_command_supports_pi_argument_defaults_and_slices() -> None:
+    template = PromptTemplate(
+        name="example",
+        path=Path("example.md"),
+        content="count=${1:-7} rest=${@:2} limited=${@:2:1} all=${@:-none}",
+    )
+
+    assert expand_prompt_template_command("/example", [template]) == (
+        "count=7 rest= limited= all=none"
+    )
+    assert expand_prompt_template_command("/example one two three", [template]) == (
+        "count=one rest=two three limited=two all=one two three"
+    )
+
+
 def test_expand_prompt_template_command_blanks_missing_custom_variables() -> None:
     template = PromptTemplate(
         name="review",

--- a/website/content/guides/skills-and-prompts.md
+++ b/website/content/guides/skills-and-prompts.md
@@ -126,7 +126,12 @@ search every loaded template. Press **Enter** to insert its invocation without
 submitting it, or **Ctrl+E** to edit its Markdown directly. Save with **Ctrl+S**;
 Tau reloads resources automatically. The filenames `prompts.md` and `tools.md` are
 reserved for built-in commands; Tau ignores templates with those names and
-reports a resource diagnostic. Templates can include variables with `{{ name }}`:
+reports a resource diagnostic. Templates use the same argument variables as Pi:
+
+- `$1`, `$2`, ... for positional arguments
+- `$@` or `$ARGUMENTS` for all arguments joined with spaces
+- `${1:-default}` and `${@:-default}` for defaults
+- `${@:N}` or `${@:N:L}` for simple argument slices
 
 ```md
 ---
@@ -134,12 +139,16 @@ description: Implement a feature in an isolated git worktree.
 ---
 
 Implement this feature safely in a new worktree:
-{{ feature }}
+Feature: $1
+Additional instructions: ${@:2}
 ```
 
-If a template has no placeholders, your arguments are appended after a blank
-line. Variables are filled from the arguments you pass after the invocation,
-for example `/wt add caching`.
+Invoke it with `/wt add caching`. Quoted arguments are preserved as one
+positional argument, for example `/wt add "shared caching"`. Legacy
+`{{ arguments }}` and `{{ args }}` placeholders remain supported.
+
+If a template has no argument placeholder, your arguments are appended after a
+blank line.
 
 The filenames `prompts.md` and `skills.md` are reserved for the built-in `/prompts`
 and `/skills` pickers. Tau ignores either template and reports a resource diagnostic;


### PR DESCRIPTION
## Summary

- support Pi-compatible prompt template arguments: `$1`, `$2`, `$@`, `$ARGUMENTS`, defaults, and slices
- parse quoted prompt invocation arguments like Pi
- retain legacy `{{ arguments }}` and `{{ args }}` compatibility
- update prompt documentation and tests

## User experience

Custom prompts can now be shared between Pi and Tau without changing argument placeholders.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
