### PR TITLE
Phase 6: harden local inference contracts

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -28,5 +28,7 @@ User-facing documentation lives in `website/content/` and is published at
   level per model instead of assuming the global `medium` default.
 - `llama-cpp-phase-5.md` — built-in llama.cpp connection, safe state, `/local`,
   failure handling, and Phase 5 validation.
+- `architecture/phase-6-local-inference-hardening.md` — second-backend contract
+  validation, lifecycle hardening, migration, and security decisions.
 
 The roadmap is tracked in [GitHub issue #1](https://github.com/huggingface/tau/issues/1).

--- a/dev-notes/architecture/dynamic-provider-registry.md
+++ b/dev-notes/architecture/dynamic-provider-registry.md
@@ -19,8 +19,9 @@ The new pieces are:
 - an explicit OpenAI transport switch that prevents dynamic model names from
   selecting `/responses` heuristically.
 
-These APIs remain provisional until #602 Phase 6 validates them with a second
-backend.
+Phase 6 validates these APIs with a permanent second fake backend and a
+small test-only Ollama adapter. The adapter uses separate provider and local
+status endpoints without adding provider-specific concepts to the contract.
 
 ## Why dynamic providers are not durable settings
 

--- a/dev-notes/architecture/index.md
+++ b/dev-notes/architecture/index.md
@@ -59,6 +59,7 @@ For the practical frontend contract, see [Building a Custom TUI](../custom-tui.m
 - [Pre-extension Hardening Summary](./pre-extension-hardening.md)
 - [Phase 21: Extensions](./phase-21-extensions.md)
 - [Trusted hidden built-in extensions](./trusted-built-in-extensions.md)
+- [Phase 6: Local inference hardening and second-backend validation](./phase-6-local-inference-hardening.md)
 - [Phase 22: Compaction Replay Foundation](./phase-22-compaction-foundation.md)
 - [Phase 23: Advanced TUI and Product Polish](./phase-23-tui-polish.md)
 - [Bounded TUI Transcript Rendering](./tui-long-transcript-performance.md)

--- a/dev-notes/architecture/phase-6-local-inference-hardening.md
+++ b/dev-notes/architecture/phase-6-local-inference-hardening.md
@@ -1,0 +1,99 @@
+---
+title: "Phase 6: Local inference hardening and second-backend validation"
+---
+
+Phase 6 closes the generic local-provider validation loop from issue #602. It
+keeps the shipped implementation intentionally small: llama.cpp remains the
+only built-in local backend, while a deterministic second fake and a test-only
+Ollama adapter exercise the public seams.
+
+## What changed
+
+- A permanent fake second backend covers different normal, secret, and choice
+  configuration fields, source-bound provider/backend layers, atomic failed
+  configuration, cancellation, stale-result rejection, progress redaction, and
+  optional capabilities.
+- The Ollama adapter spike lives under `tests/fixtures/`; it is not imported by
+  Tau production code and does not register an Ollama backend. It uses the
+  official OpenAI-compatible `/v1/models` shape for provider discovery and the
+  native `/api/tags` and `/api/ps` shapes for installed/running status.
+- Refresh/reload stress tests cover coalescing, generation retirement, hostile
+  cancellation, bounded cleanup, and late-result containment. Credential tests
+  cover generation references, offline setup, state-file redaction, and
+  cleanup-orphan behavior.
+- A missing llama.cpp selection remains a stable reference rather than being
+  overwritten by a newly discovered model. Status and model selection mark that
+  snapshot stale. Explicit Doctor may probe a sole currently reported model for
+  diagnostics, but it never changes the active selection.
+
+## Contract pressure from Ollama
+
+The spike did not require llama.cpp vocabulary in the generic APIs. It did
+confirm three useful boundaries:
+
+1. Provider discovery and local status can use different protocol endpoints.
+   `DynamicProvider.refresh_models` returns one complete provider snapshot,
+   while `LocalBackend.status` returns installed/running state through the
+   open-ended `LocalModel.state` field.
+2. `NoAuth` is a real use case. Ollama's local OpenAI-compatible endpoint does
+   not need a synthetic key or an `Authorization` header.
+3. Backend capability operations remain optional and host-renderable. The host
+   owns fields, confirmation, cancellation, and rendering; protocol adapters
+   return structured values and never construct Textual widgets.
+
+The observed official API references are:
+
+- <https://docs.ollama.com/api/openai-compatibility>
+- <https://docs.ollama.com/api/tags>
+- <https://docs.ollama.com/api/ps>
+
+The spike deliberately does not promise native Ollama model management. It
+only validates that an adapter with separate discovery/status endpoints fits the
+provider-neutral contracts.
+
+## Lifecycle and security decisions
+
+Registries remain generation-local. Retirement invalidates source/layer tokens,
+cancels owned work once, waits only through the documented bounded cancellation
+window, and keeps a still-running callback supervised until it finishes. A late
+callback cannot publish into a replacement generation. A prepared runtime owns
+its provider and backend resources; a failed candidate closes only its own
+resources, and final close is idempotent.
+
+Built-in llama.cpp state is user-level, versioned, locked, private, and
+atomically replaced. It stores only normalized endpoints, exact model IDs,
+allowlisted metadata, a selected reference, and a timestamp. API keys remain in
+the credential store or environment. The old `llama-cpp` catalog provider is
+not migrated or overwritten, and Ollama remains a documented custom-provider
+option rather than a shipped backend.
+
+No Phase 7 router mutations are included. There is no production Ollama
+backend, Hugging Face search/download, llama.cpp load/unload implementation, or
+implicit model-file operation in this phase.
+
+## Migration guidance
+
+Existing manually configured OpenAI-compatible local providers continue to
+work. To move a llama.cpp setup to the built-in integration:
+
+1. Start the server independently.
+2. Open `/local`, choose and confirm the recommended llama.cpp backend, and
+   enter the endpoint and optional key.
+3. Use the exact model ID returned by `/v1/models` in `/model` or with
+   `--provider llama.cpp --model <id>`.
+4. Remove an old `llama-cpp` catalog entry only after the new session works.
+
+Tau does not copy old fake keys, fake model IDs, catalog definitions, project
+settings, or environment endpoints into the built-in state. Reset removes only
+built-in settings; server processes and model files are never touched.
+
+## Verification
+
+```bash
+uv run pytest tests/test_local_backends.py tests/test_extension_providers.py \
+  tests/test_llama_cpp_extension.py tests/test_phase6_hardening.py \
+  tests/test_ollama_adapter_spike.py -q
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/data/docs/architecture.md
+++ b/src/tau_coding/data/docs/architecture.md
@@ -47,4 +47,12 @@ and progress values. The Textual adapter renders those values and owns
 cancellation, confirmation, and idle checks. No local-backend or Textual code
 belongs in `tau_agent` or `tau_ai`.
 
+Phase 6 validates the boundary with a permanent second fake backend and a
+test-only Ollama adapter. An adapter may use separate provider-discovery and
+backend-status endpoints, expose installed/running state through generic model
+state, and use `NoAuth`; none of those cases require llama.cpp concepts in the
+contract. Refresh cancellation is bounded and generation-safe, and a late
+operation cannot publish after retirement. Router mutations remain a later
+phase.
+
 In a Tau checkout, read `AGENTS.md`, `website/content/internals/architecture.md`, and relevant `dev-notes/architecture/` documents before broad architectural changes.

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -46,7 +46,7 @@ Project extensions cannot approve themselves. They execute arbitrary Python and
 remain disabled without both approval and the explicit code opt-in. Trust is not
 a process/filesystem/network/tool/model sandbox.
 
-## Dynamic providers (provisional)
+## Dynamic providers
 
 `tau.register_provider(DynamicProvider(...))` adds a frontend-free provider layer
 to the current staged extension runtime. Definitions can be dormant (zero models)
@@ -90,10 +90,13 @@ retirement. Failures retain the current snapshot and emit one bounded, secret-fr
 diagnostic. Nested compatibility data is deeply immutable while registered.
 Callbacks receive structured data, not Rich or Textual objects.
 
-This API remains provisional pending second-backend validation. The trusted
-built-in `llama.cpp` provider now uses these contracts; its connection, cache,
-and troubleshooting behavior are covered in `local-inference.md`. Router
-management and Hugging Face model mutations remain outside this phase.
+Phase 6 validates these contracts with a permanent second fake backend and a
+small test-only Ollama adapter. The trusted built-in `llama.cpp` provider uses
+the same seams; no production Ollama backend is shipped. Provider discovery and
+backend status may use different protocol endpoints, and `NoAuth` is a first-
+class option. Router management and Hugging Face model mutations remain outside
+this phase; see `architecture/phase-6-local-inference-hardening.md` for the
+validation and migration notes.
 
 ## Local-backend registrations
 

--- a/src/tau_coding/data/docs/local-inference.md
+++ b/src/tau_coding/data/docs/local-inference.md
@@ -125,6 +125,22 @@ separate deletion confirmation succeeds.
   configured provider. Use `llama.cpp` for the built-in backend, or keep the old
   provider for its existing catalog configuration.
 
+## Migration from manual local providers
+
+Existing custom OpenAI-compatible providers continue to work. To move a
+manually configured llama.cpp server to the built-in integration, open
+`/local`, choose and confirm the recommended backend, enter the endpoint and
+optional key, then use the exact ID returned by `/v1/models`. The built-in
+provider ID is `llama.cpp`; an older `llama-cpp` catalog entry is not migrated,
+rewritten, or removed automatically. Remove that entry only after verifying the
+new session. Ollama and other local servers remain supported through the custom
+provider path and are not registered as Tau backends.
+
+Tau never copies old fake keys, fake model IDs, catalog definitions, project
+settings, or environment endpoints into the built-in state. Reset removes only
+built-in settings and safe snapshots; it never stops a server or deletes model
+files.
+
 For project trust and the security boundary, see `security.md`. For command
 flags and print/TUI startup, see `cli.md`, `tui.md`, and `models.md`.
 

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -45,6 +45,8 @@ preceding layer or the durable baseline.
 Dynamic providers support required, optional, or absent authentication without
 fake keys. Secrets resolve immediately before refresh or runtime creation and are
 excluded from representations, diagnostics, snapshots, sessions, and exports.
+The contract is validated by a permanent second fake backend and a test-only
+Ollama adapter; Ollama is not a shipped Tau backend.
 
 ## Existing custom providers
 
@@ -67,4 +69,5 @@ Provider/model selection precedence is explicit CLI selection, the resumed
 transcript's provider-aware model entry, the session record for legacy sessions,
 a durable default, and then a usable durable provider. Dynamic local providers
 are selected only by explicit startup, a resumed local session, or an in-session
-`/model`/`/local` action.
+`/model`/`/local` action. The old `llama-cpp` catalog provider is not migrated;
+configure the built-in `llama.cpp` layer separately through `/local`.

--- a/src/tau_coding/data/docs/security.md
+++ b/src/tau_coding/data/docs/security.md
@@ -55,3 +55,12 @@ when isolation is required.
 
 For endpoint, auth, cached-downtime, Doctor, and model-selection troubleshooting,
 see `local-inference.md`.
+
+## Migration boundary
+
+The built-in `llama.cpp` integration does not import or rewrite an existing
+`llama-cpp` catalog entry. Configure it separately through `/local`, verify the
+exact model ID returned by `/v1/models`, and remove the old entry only when it
+is no longer needed. Ollama, gateways, and other local servers remain on the
+manual custom-provider path. No Phase 6 operation starts, stops, downloads, or
+deletes an external server or model file.

--- a/src/tau_coding/extensions/__init__.py
+++ b/src/tau_coding/extensions/__init__.py
@@ -85,6 +85,7 @@ from tau_coding.extensions.runtime import (
     InputHookOutcome,
 )
 from tau_coding.local_backends import (
+    LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS,
     ConfigureLocalBackend,
     DoctorLocalBackend,
     DownloadModel,
@@ -119,6 +120,7 @@ __all__ = [
     "AGENT_EVENT_TYPES",
     "AGENT_EVENT_WILDCARD",
     "LIFECYCLE_EVENT_TYPES",
+    "LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS",
     "BoundSession",
     "ComponentBridge",
     "ConfigureLocalBackend",

--- a/src/tau_coding/extensions/builtins/llama_cpp/service.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/service.py
@@ -167,6 +167,10 @@ class LlamaCppService:
             active = None
             self._state_error = str(exc)
         self._active_state = active
+        if active is not None and active.selected_model is not None:
+            cached_ids = {model.id for model in active.models}
+            if active.selected_model not in cached_ids:
+                self._stale_selected_model = active.selected_model
         self._endpoint_error: str | None = None
         endpoint = self._resolve_effective_endpoint(active)
         self._endpoint = endpoint or normalize_llama_cpp_endpoint(LLAMA_CPP_DEFAULT_ENDPOINT)
@@ -480,12 +484,18 @@ class LlamaCppService:
                 diagnostics=(LocalDiagnostic(str(exc), "error", "connection"),),
             )
         selected = _selected_model(self._active_state, discovery.models)
+        if selected is None and self._stale_selected_model is not None:
+            # Doctor is an explicit diagnostic action, not a model-selection
+            # path. Probe a sole currently reported model so connectivity and
+            # tool compatibility remain useful after the active reference goes
+            # stale, while status/model selection still refuse to replace it.
+            selected = discovery.models[0].id if len(discovery.models) == 1 else None
         if selected is None:
             return LocalOperationResult(
                 backend_status=self._status_from_discovery(discovery),
                 diagnostics=(
                     LocalDiagnostic(
-                        "The server is reachable but has no selectable model.",
+                        "The server is reachable but has no selectable model for Doctor.",
                         "warning",
                         "models",
                     ),
@@ -648,9 +658,13 @@ class LlamaCppService:
             and previous_selected not in {model.id for model in discovery.models}
             else None
         )
+        # Preserve the user's exact selection as a stable reference even
+        # when the server temporarily omits it. ``selected`` is intentionally
+        # only the currently usable choice; it must not erase the reference
+        # needed for a later refresh or cached resume.
         state = LlamaCppIntegrationState(
             endpoint=discovery.endpoint.server_root,
-            selected_model=selected,
+            selected_model=previous_selected if previous_selected is not None else selected,
             credential_ref=self._active_state.credential_ref,
             models=tuple(_stored_model(model) for model in discovery.models),
             checked_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
@@ -736,7 +750,7 @@ class LlamaCppService:
             selected=(None if self._stale_selected_model is not None else selected),
             diagnostics=diagnostics,
             cached=bool(models),
-            stale=stale,
+            stale=stale or self._stale_selected_model is not None,
         )
 
     def _status(

--- a/src/tau_coding/extensions/builtins/llama_cpp/state.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/state.py
@@ -79,8 +79,14 @@ class LlamaCppIntegrationState:
     def __post_init__(self) -> None:
         if not isinstance(self.endpoint, str) or not self.endpoint.strip():
             raise LlamaCppStateError("Llama.cpp state endpoint must be non-empty")
-        if self.selected_model is not None and not isinstance(self.selected_model, str):
-            raise LlamaCppStateError("Selected llama.cpp model must be a string or None")
+        if self.selected_model is not None and (
+            not isinstance(self.selected_model, str)
+            or not self.selected_model.strip()
+            or self.selected_model != self.selected_model.strip()
+        ):
+            raise LlamaCppStateError(
+                "Selected llama.cpp model must be a non-empty exact string or None"
+            )
         if self.credential_ref is not None and not _valid_credential_ref(self.credential_ref):
             raise LlamaCppStateError("Credential reference is not owned by llama.cpp")
         if not isinstance(self.models, tuple) or any(
@@ -90,8 +96,11 @@ class LlamaCppIntegrationState:
         ids = [model.id for model in self.models]
         if len(ids) != len(set(ids)):
             raise LlamaCppStateError("Llama.cpp state model ids must be unique")
-        if self.selected_model is not None and self.selected_model not in ids:
-            raise LlamaCppStateError("Selected llama.cpp model is not in the safe snapshot")
+        # Keep a selected reference even when a later discovery no longer
+        # reports that model. The reference is not an availability claim: it
+        # lets a cached/offline resume recover the exact model if the server
+        # reports it again, while the provider layer keeps it unavailable until
+        # then.
         if self.checked_at is not None and not isinstance(self.checked_at, str):
             raise LlamaCppStateError("Checked timestamp must be a string or None")
 

--- a/src/tau_coding/local_backends.py
+++ b/src/tau_coding/local_backends.py
@@ -22,6 +22,9 @@ from tau_coding.extensions.provider_registry import (
     ProviderLayerToken,
 )
 
+LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS = 0.25
+_SUPERVISED_LOCAL_OPERATION_TASKS: set[asyncio.Task[object]] = set()
+
 LocalFieldKind = Literal["text", "secret", "choice"]
 LocalConnectionState = Literal[
     "unconfigured",
@@ -430,6 +433,7 @@ class _Operation:
     signal: SimpleCancellationToken
     task: asyncio.Task[LocalOperationResult]
     progress: list[LocalProgress]
+    cancellation_requested: bool = False
 
 
 class LocalBackendRegistry:
@@ -557,10 +561,7 @@ class LocalBackendRegistry:
         cancelled = False
         for (token, operation), state in tuple(self._operations.items()):
             if token.backend_id == backend_id and (action is None or operation == action):
-                state.signal.cancel()
-                if not state.task.done():
-                    state.task.cancel()
-                cancelled = True
+                cancelled = _request_operation_cancellation(state) or cancelled
         return cancelled
 
     async def configure(
@@ -689,10 +690,20 @@ class LocalBackendRegistry:
             self._cancel_token(token)
 
     async def aclose(self) -> None:
+        """Retire the generation and boundedly drain backend operations.
+
+        A backend is extension code and can ignore task cancellation while it
+        unwinds a network client or subprocess.  Do not let final session
+        cleanup hang forever: request cancellation once, wait for the fixed
+        containment window, and keep a still-running task strongly reachable
+        until it actually finishes.  Its context is stale, so late results are
+        discarded by :meth:`_run`.
+        """
         self.retire()
-        if self._operations:
+        operations = tuple(self._operations.values())
+        if operations:
             await asyncio.gather(
-                *(operation.task for operation in tuple(self._operations.values())),
+                *(_cancel_and_drain_operation(operation) for operation in operations),
                 return_exceptions=True,
             )
 
@@ -824,15 +835,52 @@ class LocalBackendRegistry:
         cancelled = False
         for (operation_token, operation_action), operation in tuple(self._operations.items()):
             if operation_token == token and (action is None or operation_action == action):
-                operation.signal.cancel()
-                if not operation.task.done():
-                    operation.task.cancel()
-                cancelled = True
+                cancelled = _request_operation_cancellation(operation) or cancelled
         return cancelled
 
     def _assert_active(self) -> None:
         if self._retired:
             raise LocalOperationError("Local backend registry generation is retired")
+
+
+def _request_operation_cancellation(operation: _Operation) -> bool:
+    """Signal and cancel one operation at most once."""
+    operation.signal.cancel()
+    if operation.cancellation_requested:
+        return False
+    operation.cancellation_requested = True
+    if not operation.task.done():
+        operation.task.cancel()
+    return True
+
+
+async def _cancel_and_drain_operation(operation: _Operation) -> bool:
+    """Wait through one bounded cancellation window without re-cancelling."""
+    if operation.task.done():
+        return True
+    _request_operation_cancellation(operation)
+    _SUPERVISED_LOCAL_OPERATION_TASKS.add(operation.task)
+    operation.task.add_done_callback(_release_supervised_operation)
+    try:
+        async with asyncio.timeout(LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS):
+            await asyncio.shield(operation.task)
+    except TimeoutError:
+        return operation.task.done()
+    except asyncio.CancelledError:
+        # The cleanup owner itself was cancelled.  The task remains supervised
+        # and receives no second cancellation while its backend unwinds.
+        if operation.task.done():
+            return True
+        raise
+    except Exception:
+        return True
+    return True
+
+
+def _release_supervised_operation(task: asyncio.Task[object]) -> None:
+    _SUPERVISED_LOCAL_OPERATION_TASKS.discard(task)
+    with suppress(asyncio.CancelledError):
+        task.exception()
 
 
 def _validate_values(
@@ -994,6 +1042,7 @@ def _identifier(value: str, label: str) -> None:
 
 
 __all__ = [
+    "LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS",
     "ConfigureLocalBackend",
     "DoctorLocalBackend",
     "DownloadModel",

--- a/tests/fixtures/ollama_adapter_spike.py
+++ b/tests/fixtures/ollama_adapter_spike.py
@@ -1,0 +1,169 @@
+"""Non-shipping Ollama adapter spike for Phase 6 contract validation.
+
+This file deliberately lives under tests: it is an executable contract probe,
+not a shipped Ollama integration. The endpoint shapes come from Ollama's
+current official API documentation; the test supplies deterministic responses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import httpx
+
+from tau_agent.harness import SimpleCancellationToken
+from tau_coding.extensions import (
+    DynamicProvider,
+    LocalBackend,
+    LocalBackendStatus,
+    LocalConfigureResult,
+    LocalConfigureSpec,
+    LocalConfigValues,
+    LocalModel,
+    LocalOperationContext,
+    LocalOperationResult,
+    NoAuth,
+    OpenAICompatibleTransport,
+    ProviderModel,
+    ProviderModelSnapshot,
+)
+
+
+@dataclass(slots=True)
+class OllamaAdapterSpike:
+    """Small adapter exercising only generic provider/backend seams."""
+
+    client: httpx.AsyncClient
+    endpoint: str = "http://ollama.test:11434"
+
+    def __post_init__(self) -> None:
+        self.endpoint = self.endpoint.rstrip("/")
+
+    def provider(self) -> DynamicProvider:
+        return DynamicProvider(
+            id="ollama-spike",
+            display_name="Ollama (spike)",
+            transport=OpenAICompatibleTransport(
+                base_url=f"{self.endpoint}/v1",
+                auth=NoAuth(),
+                client=self.client,
+            ),
+            refresh_models=self.refresh_models,
+        )
+
+    def backend(self) -> LocalBackend:
+        return LocalBackend(
+            id="ollama-spike",
+            provider_id="ollama-spike",
+            display_name="Ollama (spike)",
+            configure_spec=LocalConfigureSpec(),
+            configure=self.configure,
+            status=self.status,
+            refresh=self.refresh,
+        )
+
+    async def refresh_models(self, context) -> ProviderModelSnapshot:
+        if not context.allow_network:
+            return ProviderModelSnapshot(context.cached_models)
+        response = await self.client.get(f"{self.endpoint}/v1/models")
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data") if isinstance(payload, Mapping) else None
+        if not isinstance(data, list):
+            raise ValueError("Ollama /v1/models response has no data list")
+        models = tuple(
+            ProviderModel(
+                id=item["id"],
+                display_name=item.get("id"),
+                api="openai-completions",
+                compat={
+                    key: item[key]
+                    for key in ("object", "owned_by")
+                    if isinstance(item.get(key), str)
+                },
+            )
+            for item in data
+            if isinstance(item, Mapping) and isinstance(item.get("id"), str)
+        )
+        return ProviderModelSnapshot(models, models[0].id if len(models) == 1 else None)
+
+    async def configure(
+        self,
+        values: LocalConfigValues,
+        context: LocalOperationContext,
+    ) -> LocalConfigureResult:
+        del values, context
+        return LocalConfigureResult(committed=True)
+
+    async def status(
+        self, context: LocalOperationContext
+    ) -> LocalBackendStatus | LocalOperationResult:
+        del context
+        tags_response, running_response = await self._get_model_state()
+        installed = _models_from_tags(tags_response)
+        running = _running_ids(running_response)
+        models = tuple(
+            LocalModel(model_id, state="running" if model_id in running else "installed")
+            for model_id in installed
+        )
+        selected = next(iter(running), None)
+        return LocalBackendStatus(
+            state="ready",
+            endpoint_display=f"{self.endpoint}/v1",
+            models=models,
+            selected_model=selected if selected in {item.id for item in models} else None,
+            actions=("configure", "refresh", "use") if models else ("configure", "refresh"),
+        )
+
+    async def refresh(
+        self, context: LocalOperationContext
+    ) -> LocalBackendStatus | LocalOperationResult:
+        return await self.status(context)
+
+    async def _get_model_state(self) -> tuple[Mapping[str, object], Mapping[str, object]]:
+        tags = await self.client.get(f"{self.endpoint}/api/tags")
+        tags.raise_for_status()
+        running = await self.client.get(f"{self.endpoint}/api/ps")
+        running.raise_for_status()
+        tags_payload = tags.json()
+        running_payload = running.json()
+        if not isinstance(tags_payload, Mapping) or not isinstance(running_payload, Mapping):
+            raise ValueError("Ollama model state response is malformed")
+        return tags_payload, running_payload
+
+
+def _models_from_tags(payload: Mapping[str, object]) -> tuple[str, ...]:
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise ValueError("Ollama /api/tags response has no models list")
+    result = tuple(
+        item.get("name")
+        for item in models
+        if isinstance(item, Mapping) and isinstance(item.get("name"), str)
+    )
+    return tuple(model for model in result if model)
+
+
+def _running_ids(payload: Mapping[str, object]) -> frozenset[str]:
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise ValueError("Ollama /api/ps response has no models list")
+    return frozenset(
+        item.get("name")
+        for item in models
+        if isinstance(item, Mapping) and isinstance(item.get("name"), str)
+    )
+
+
+def context() -> LocalOperationContext:
+    """Return a deterministic operation context for direct adapter probes."""
+    return LocalOperationContext(
+        signal=SimpleCancellationToken(),
+        action="refresh",
+        generation_id="ollama-spike",
+        backend_id="ollama-spike",
+        source_id="test:ollama-spike",
+        _is_current=lambda: True,
+        _progress=lambda _: None,
+    )

--- a/tests/test_ollama_adapter_spike.py
+++ b/tests/test_ollama_adapter_spike.py
@@ -1,0 +1,103 @@
+"""Bounded official-API Ollama adapter spike; not a shipped backend."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from fixtures.ollama_adapter_spike import OllamaAdapterSpike, context
+from tau_coding.extensions import DynamicProviderRegistry, LocalBackendRegistry
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _client() -> tuple[httpx.AsyncClient, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def dispatch(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/v1/models":
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {"id": "qwen3:8b", "object": "model", "owned_by": "library"},
+                        {"id": "code:latest", "object": "model", "owned_by": "library"},
+                    ],
+                },
+            )
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={"models": [{"name": "qwen3:8b"}, {"name": "code:latest"}]},
+            )
+        if request.url.path == "/api/ps":
+            return httpx.Response(200, json={"models": [{"name": "qwen3:8b"}]})
+        raise AssertionError(f"unexpected Ollama spike request: {request.url}")
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(dispatch)), requests
+
+
+async def test_official_ollama_shapes_fit_without_llama_concepts() -> None:
+    client, requests = _client()
+    adapter = OllamaAdapterSpike(client)
+    providers = DynamicProviderRegistry(generation_id="generation")
+    backends = LocalBackendRegistry(providers, generation_id="generation")
+    providers.register("test:ollama-spike", adapter.provider())
+    backends.register("test:ollama-spike", adapter.backend())
+
+    provider_result = await providers.refresh("ollama-spike")
+    backend_result = await backends.refresh("ollama-spike")
+
+    assert provider_result.status == "published"
+    assert provider_result.provider is not None
+    assert [model.id for model in provider_result.provider.models] == [
+        "qwen3:8b",
+        "code:latest",
+    ]
+    assert backend_result.backend_status is not None
+    assert backend_result.backend_status.models[0].state == "running"
+    assert backend_result.backend_status.selected_model == "qwen3:8b"
+    assert [request.url.path for request in requests] == [
+        "/v1/models",
+        "/api/tags",
+        "/api/ps",
+    ]
+    await backends.aclose()
+    await providers.aclose()
+    await client.aclose()
+
+
+async def test_ollama_openai_compatibility_uses_no_auth_and_offline_cache() -> None:
+    client, requests = _client()
+    adapter = OllamaAdapterSpike(client)
+    providers = DynamicProviderRegistry(generation_id="generation")
+    providers.register("test:ollama-spike", adapter.provider())
+    provider_result = await providers.refresh("ollama-spike", allow_network=False)
+
+    assert provider_result.status == "published"
+    assert provider_result.provider is not None
+    assert provider_result.provider.models == ()
+    assert requests == []
+    await providers.aclose()
+    await client.aclose()
+
+
+async def test_ollama_spike_rejects_malformed_native_state() -> None:
+    async def dispatch(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, content=json.dumps({"models": {}}).encode())
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(dispatch))
+    adapter = OllamaAdapterSpike(client)
+    with pytest.raises(ValueError, match="models list"):
+        await adapter.status(context())
+    await client.aclose()

--- a/tests/test_phase6_hardening.py
+++ b/tests/test_phase6_hardening.py
@@ -1,0 +1,311 @@
+"""Phase 6 lifecycle, race, ownership, and persistence regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tau_agent.harness import SimpleCancellationToken
+from tau_coding.credentials import FileCredentialStore
+from tau_coding.extensions import (
+    DynamicProvider,
+    DynamicProviderRegistry,
+    ExtensionRuntime,
+    LocalBackend,
+    LocalBackendRegistry,
+    LocalBackendStatus,
+    LocalConfigureResult,
+    LocalConfigureSpec,
+    LocalModel,
+    LocalOperationContext,
+    NoAuth,
+    OpenAICompatibleTransport,
+    ProviderModel,
+    ProviderModelSnapshot,
+)
+from tau_coding.extensions.builtins.llama_cpp.service import (
+    LlamaCppService,
+)
+from tau_coding.extensions.builtins.llama_cpp.state import (
+    LLAMA_CPP_CREDENTIAL_PREFIX,
+    LlamaCppIntegrationState,
+    LlamaCppStateError,
+    LlamaCppStateStore,
+    LlamaCppStoredModel,
+)
+from tau_coding.local_backends import (
+    LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS,
+    LocalOperationResult,
+)
+from tau_coding.paths import TauPaths
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _provider(provider_id: str = "second", *, refresh_models=None) -> DynamicProvider:
+    return DynamicProvider(
+        id=provider_id,
+        display_name=provider_id,
+        models=(ProviderModel("model"),),
+        default_model="model",
+        transport=OpenAICompatibleTransport(
+            base_url="http://second.test/v1",
+            auth=NoAuth(),
+        ),
+        refresh_models=refresh_models,
+    )
+
+
+def _context(action: str, backend_id: str = "second") -> LocalOperationContext:
+    return LocalOperationContext(
+        signal=SimpleCancellationToken(),
+        action=action,  # type: ignore[arg-type]
+        generation_id="generation",
+        backend_id=backend_id,
+        source_id="test:second",
+        _is_current=lambda: True,
+        _progress=lambda _: None,
+    )
+
+
+async def test_refresh_stress_keeps_latest_snapshot_and_closes_generation() -> None:
+    calls = 0
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def refresh(context) -> ProviderModelSnapshot:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
+        model = f"model-{calls}"
+        return ProviderModelSnapshot((ProviderModel(model),), model)
+
+    runtime = ExtensionRuntime()
+    registry = runtime.provider_registry
+    registry.register("test:second", _provider(refresh_models=refresh))
+    waiters = [asyncio.create_task(registry.refresh("second")) for _ in range(20)]
+    await entered.wait()
+    release.set()
+    results = await asyncio.gather(*waiters)
+
+    assert calls == 1
+    assert {result.status for result in results} == {"published"}
+    assert registry.effective("second").definition.models[0].id == "model-1"  # type: ignore[union-attr]
+    await runtime.aclose()
+    assert registry.effective("second") is None
+
+
+async def test_refresh_from_retired_generation_cannot_publish() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def refresh(context) -> ProviderModelSnapshot:
+        entered.set()
+        await release.wait()
+        return ProviderModelSnapshot((ProviderModel("stale"),), "stale")
+
+    runtime = ExtensionRuntime()
+    registry = runtime.provider_registry
+    registry.register("test:second", _provider())
+    # Replace the callback while keeping the test provider's public shape.
+    current = registry.effective("second").definition  # type: ignore[union-attr]
+    registry.register(
+        "test:second",
+        DynamicProvider(
+            id=current.id,
+            display_name=current.display_name,
+            models=current.models,
+            default_model=current.default_model,
+            transport=current.transport,
+            refresh_models=refresh,
+        ),
+    )
+    pending = asyncio.create_task(registry.refresh("second"))
+    await entered.wait()
+    runtime.reset_for_reload()
+    release.set()
+    result = await pending
+
+    assert result.status == "cancelled"
+    assert registry.effective("second") is None
+    await runtime.aclose()
+
+
+async def test_local_retire_bounds_cancellation_resistant_backend() -> None:
+    providers = DynamicProviderRegistry(generation_id="generation")
+    providers.register("test:second", _provider())
+    registry = LocalBackendRegistry(providers, generation_id="generation")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def operation(context: LocalOperationContext) -> LocalOperationResult:
+        entered.set()
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                # Simulate a backend finishing network cleanup later. The
+                # registry must not inject another cancellation into this path.
+                continue
+        return LocalOperationResult(backend_status=LocalBackendStatus(state="ready"))
+
+    backend = LocalBackend(
+        id="second",
+        provider_id="second",
+        display_name="Second",
+        configure_spec=LocalConfigureSpec(),
+        configure=lambda values, context: LocalConfigureResult(),
+        status=operation,
+        refresh=operation,
+    )
+    registry.register("test:second", backend)
+    pending = asyncio.create_task(registry.refresh("second"))
+    await entered.wait()
+
+    started = asyncio.get_running_loop().time()
+    close_task = asyncio.create_task(registry.aclose())
+    await asyncio.sleep(LOCAL_OPERATION_CANCELLATION_TIMEOUT_SECONDS / 2)
+    assert not close_task.done()
+    await close_task
+    elapsed = asyncio.get_running_loop().time() - started
+    assert elapsed < 1.0
+    assert pending.done() is False
+
+    release.set()
+    result = await asyncio.wait_for(pending, timeout=0.5)
+    assert result.stale is True
+    await providers.aclose()
+
+
+async def test_local_replacement_discards_late_result_and_new_operation_wins() -> None:
+    providers = DynamicProviderRegistry(generation_id="generation")
+    providers.register("test:second", _provider())
+    registry = LocalBackendRegistry(providers, generation_id="generation")
+    old_started = asyncio.Event()
+    old_release = asyncio.Event()
+
+    async def old_refresh(context: LocalOperationContext) -> LocalBackendStatus:
+        old_started.set()
+        await old_release.wait()
+        return LocalBackendStatus(state="ready", models=(LocalModel("old"),))
+
+    async def new_refresh(context: LocalOperationContext) -> LocalBackendStatus:
+        return LocalBackendStatus(state="ready", models=(LocalModel("new"),))
+
+    def backend(refresh):
+        return LocalBackend(
+            id="second",
+            provider_id="second",
+            display_name="Second",
+            configure_spec=LocalConfigureSpec(),
+            configure=lambda values, context: LocalConfigureResult(),
+            status=refresh,
+            refresh=refresh,
+        )
+
+    registry.register("test:second", backend(old_refresh))
+    old_task = asyncio.create_task(registry.refresh("second"))
+    await old_started.wait()
+    registry.register("test:second", backend(new_refresh))
+    old_release.set()
+    assert (await old_task).stale is True
+    fresh = await registry.refresh("second")
+    assert fresh.backend_status is not None
+    assert fresh.backend_status.models[0].id == "new"
+    await registry.aclose()
+    await providers.aclose()
+
+
+async def test_missing_model_reference_survives_refresh_and_restart(tmp_path: Path) -> None:
+    endpoint = "http://local.test:8080"
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    state_store = LlamaCppStateStore(paths=paths)
+    state_store.save(
+        LlamaCppIntegrationState(
+            endpoint=endpoint,
+            selected_model="returning-model",
+            models=(LlamaCppStoredModel("other-model"),),
+        )
+    )
+    credentials = FileCredentialStore(paths.home / "credentials.json")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                json={"status": "ok"}
+                if request.url.path == "/health"
+                else {"data": [{"id": "other-model"}]},
+            )
+        )
+    )
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    assert service.provider().default_model is None
+    result = await service.refresh(_context("refresh", "llama.cpp"))
+    assert result.backend_status is not None
+    assert result.backend_status.stale is True
+    assert state_store.active().selected_model == "returning-model"  # type: ignore[union-attr]
+
+    restarted = LlamaCppService(
+        state_store=LlamaCppStateStore(paths=paths),
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    assert restarted.provider().default_model is None
+    restarted_status = await restarted.status(_context("refresh", "llama.cpp"))
+    assert restarted_status.stale is True
+    assert restarted.provider().default_model is None
+    await client.aclose()
+
+
+@pytest.mark.parametrize("selected_model", ["", " returning-model"])
+def test_state_rejects_non_exact_stale_model_references(selected_model: str) -> None:
+    with pytest.raises(LlamaCppStateError, match="non-empty exact"):
+        LlamaCppIntegrationState(endpoint="http://local.test", selected_model=selected_model)
+
+
+async def test_secret_state_and_diagnostics_never_contain_key(tmp_path: Path) -> None:
+    secret = "phase-six-secret"
+    paths = TauPaths(home=tmp_path / "tau", agents_home=tmp_path / "agents")
+    state_store = LlamaCppStateStore(paths=paths)
+    credentials = FileCredentialStore(paths.home / "credentials.json")
+
+    async def dispatch(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(dispatch))
+    service = LlamaCppService(
+        state_store=state_store,
+        credential_store=credentials,
+        environment={},
+        client=client,
+    )
+    result = await service.configure(
+        {"endpoint": "http://127.0.0.1:8080", "api_key": secret},
+        _context("configure", "llama.cpp"),
+    )
+    serialized = state_store.path.read_text(encoding="utf-8")
+    assert secret not in serialized
+    assert secret not in repr(result)
+    assert secret not in repr(service.provider())
+    refs = credentials.names(prefix=LLAMA_CPP_CREDENTIAL_PREFIX)
+    assert len(refs) == 1
+    assert credentials.get(refs[0]) == secret
+    payload = json.loads(serialized)
+    assert payload["endpoints"]["http://127.0.0.1:8080"]["credential_ref"] == refs[0]
+    await client.aclose()

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -126,7 +126,7 @@ Use those lifecycle hooks to stop and restart background work and to remount UI.
 def setup(tau):
     # registration
     tau.register_tool(agent_tool)            # tau_agent.tools.AgentTool
-    tau.register_provider(dynamic_provider)  # provisional, process-local
+    tau.register_provider(dynamic_provider)  # process-local
     tau.register_command("name", handler, description="...")
     tau.add_prompt_guideline("Never commit directly to main")
     tau.on("event_name", handler)            # or @tau.on("event_name")
@@ -188,7 +188,7 @@ cannot use, reset, or manage models through the shadowed layer. Retired or
 reloaded generations cancel their backend work and ignore late results. See the
 [local backends guide]({{< relref "./local-inference.md" >}}).
 
-### Dynamic providers (provisional)
+### Dynamic providers
 
 `register_provider` installs a complete `DynamicProvider` layer owned by the
 calling extension source and current runtime generation. A provider may start
@@ -242,11 +242,13 @@ still use their first-registration-wins name registries. Removing a source revea
 the preceding complete layer, including the exact durable provider baseline. The contracts are
 frontend-free and callbacks must not return Rich/Textual values.
 
-This foundation remains provisional until second-backend validation. The
-trusted built-in `llama.cpp` provider now exercises these contracts; its
-connection, cache, and troubleshooting behavior are covered in the [local
-inference guide]({{< relref "./local-inference.md" >}}). Router management and
-Hugging Face model mutations remain outside this phase.
+Phase 6 validates these contracts with a permanent second fake backend and a
+small test-only Ollama adapter. The trusted built-in `llama.cpp` provider uses
+the same seams; no production Ollama backend is shipped. Provider discovery and
+backend status may use different protocol endpoints, and `NoAuth` is a first-
+class option. Its connection, cache, and troubleshooting behavior are covered
+in the [local inference guide]({{< relref "./local-inference.md" >}}). Router
+management and Hugging Face model mutations remain outside this phase.
 
 ### Tools
 
@@ -628,7 +630,7 @@ tau -e ./tau-subagents
 ## Not yet supported
 
 Compared to Pi's extension system, v1 does not yet include: package
-management (`pi install`-style), startup/session selection for provisional
+management (`pi install`-style), startup/session selection for external
 custom providers, extension-authored TUI widgets (custom *message* rendering
 via `register_message_renderer` *is* supported; the host-provided `context.ui`
 dialogs *are* supported), custom

--- a/website/content/guides/local-inference.md
+++ b/website/content/guides/local-inference.md
@@ -124,9 +124,23 @@ separate deletion confirmation succeeds.
   provider. Use `llama.cpp` for the built-in backend, or retain the old provider
   for its existing catalog setup.
 
-For other OpenAI-compatible endpoints, keep using [`/login custom`]({{< relref
-"../guides/providers-and-models.md#adding-a-custom--local-provider" >}}) or
-`tau setup`.
+## Migration from manual local providers
+
+Existing custom OpenAI-compatible providers continue to work. To move a
+manually configured llama.cpp server to the built-in integration, open
+`/local`, choose and confirm the recommended backend, enter the endpoint and
+optional key, then use the exact ID returned by `/v1/models`. The built-in
+provider ID is `llama.cpp`; an older `llama-cpp` catalog entry is not migrated,
+rewritten, or removed automatically. Remove it only after verifying the new
+session. Ollama and other local servers remain on the custom-provider path and
+are not shipped Tau backends.
+
+Tau never copies old fake keys, fake model IDs, catalog definitions, project
+settings, or environment endpoints into built-in state. Reset removes only
+built-in settings and safe snapshots; it never stops a server or deletes model
+files. For other OpenAI-compatible endpoints, keep using [`/login custom`]({{<
+relref "../guides/providers-and-models.md#adding-a-custom--local-provider" >}})
+or `tau setup`.
 
 Router model management, Hugging Face search/download, and implicit
 load/unload are not part of this phase. Standard OpenAI-compatible loaded-model

--- a/website/content/guides/project-trust.md
+++ b/website/content/guides/project-trust.md
@@ -91,6 +91,10 @@ not enter snapshots, sessions, exports, or diagnostics. Resetting settings and
 deleting a stored credential are separate confirmations. See the [local
 inference guide]({{< relref "./local-inference.md" >}}) for troubleshooting.
 
+The built-in integration does not import or rewrite an existing `llama-cpp`
+catalog entry. Configure `llama.cpp` separately through `/local`; Ollama and
+other local servers remain on the manual custom-provider path.
+
 ## Security boundary
 
 **Project trust is an input-loading guard, not a sandbox.** It does not restrict

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -300,8 +300,9 @@ for current behavior and availability.
 
 ## Dynamic extension providers
 
-Tau's extension API has a provisional, process-local `DynamicProvider` contract.
-Unlike providers created by `/login custom` or `tau setup`, these definitions are
+Tau's extension API has a process-local `DynamicProvider` contract validated
+by a permanent second fake backend and a test-only Ollama adapter. Unlike
+providers created by `/login custom` or `tau setup`, these definitions are
 source/generation-owned overlays and are never copied into `catalog.toml`,
 `providers.json`, sessions, or generic disk storage. Source ownership is a stable
 host identity derived from the canonical extension entry path—not the display
@@ -319,7 +320,7 @@ provides the generic TUI flow for registered dynamic local backends. Dynamic
 providers still do not become durable catalog entries or automatic startup
 fallbacks: configure a backend, then choose its provider/model explicitly. See
 the [local backends guide]({{< relref "./local-inference.md" >}}) and
-[Extensions]({{< relref "./extensions.md#dynamic-providers-provisional" >}}).
+[Extensions]({{< relref "./extensions.md#dynamic-providers" >}}).
 
 ## Adding a custom / local provider
 
@@ -368,8 +369,9 @@ model files. See the [complete llama.cpp guide]({{< relref "./local-inference.md
 for endpoint precedence, Doctor, reset, and troubleshooting.
 
 An older manually configured provider named `llama-cpp` remains separate and is
-not migrated. Use the custom-provider flow below for other OpenAI-compatible
-servers.
+not migrated. Configure the built-in `llama.cpp` layer through `/local`, and use
+the custom-provider flow below for Ollama and other OpenAI-compatible servers.
+Tau does not ship an Ollama backend.
 
 For scripted or one-off setup with another OpenAI-compatible server, use the
 same `tau setup` flow. For example, Ollama's OpenAI-compatible endpoint usually

--- a/website/content/internals/architecture.md
+++ b/website/content/internals/architecture.md
@@ -45,6 +45,13 @@ its exact source-owned provider layer prevents a shadowing extension from using
 or resetting another source's integration. See the [local backends
 guide]({{< relref "../guides/local-inference.md" >}}).
 
+Phase 6 validates the boundary with a permanent second fake backend and a
+test-only Ollama adapter. Provider discovery and backend status may use
+separate endpoints, installed/running state fits generic model state, and
+`NoAuth` needs no special-case backend API. Refresh cancellation is bounded and
+generation-safe; late work cannot publish after retirement. Router mutations
+remain a later phase.
+
 TUI and print startup share the same trust-aware preparation boundary: load the
 trusted built-ins and eligible extensions, restore safe dynamic snapshots,
 resolve an explicit provider/model, then construct the candidate runtime. A


### PR DESCRIPTION
## Summary

Completes Phase 6 hardening on top of `2da6a1d93495776452afbe055c324fd74d485f6d`.

- preserves stale llama.cpp model references without silently replacing them;
- bounds cancellation-resistant local-backend cleanup and supervises late work;
- adds permanent second fake coverage and a test-only official-API Ollama spike;
- adds lifecycle, refresh race, resource, state, credential, and secret regressions;
- documents contract validation, migration, security, architecture, and Phase 7 boundaries.

The Ollama adapter is test-only. No production Ollama backend or llama.cpp router mutation is included.

## Verification

- `uv run pytest` — 1694 passed, 2 skipped (Windows-only)
- focused Phase 6/llama.cpp/local tests — 53 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --source website --minify` — successful; existing taxonomy warning
- `uv build` — successful
- `git diff --check`

## Base

Umbrella base: `2da6a1d93495776452afbe055c324fd74d485f6d` (`feat/602-built-in-local-inference`).
