### PR TITLE
Add ExtensionContext.paths to expose resolved TauPaths

### DIFF
--- a/dev-notes/architecture/phase-21-extensions.md
+++ b/dev-notes/architecture/phase-21-extensions.md
@@ -183,6 +183,23 @@ class ExtensionAPI:
 over the bound `CodingSession`; action methods raise `ExtensionError` if
 called before binding (Pi's throwing-stubs-then-`bindCore` model).
 
+`context.paths -> TauPaths` is the resolved, read-only filesystem-path snapshot
+for the active extension generation. A host-supplied `TauResourcePaths.paths`
+is authoritative, preserving custom `TauPaths.home` and `TauPaths.agents_home`.
+When it is absent, the runtime derives `TauPaths(home=resource_paths.root,
+agents_home=resource_paths.agents_root or ~/.agents)`. This keeps Tau's
+`root`/`home` (user data and extension discovery) distinct from
+`agents_root`/`agents_home` (`.agents` resources) and from project `cwd`.
+`ExtensionRuntime(paths=custom_paths)` exposes its constructor value immediately;
+`load` then replaces it with the loaded resource snapshot. Consequently, a
+custom setup can intentionally use separate Tau and `.agents` roots without a
+path architecture rewrite.
+
+The snapshot is generation-scoped. `/reload` and fresh-generation session
+replacement invalidate the old context, so even reading `context.paths` from a
+captured old context raises `ExtensionError`; handlers must read the new
+context's paths after the replacement.
+
 `transcript -> tuple[AgentMessage, ...]` gives read access to the active-path
 parent conversation (`CodingSession.messages`). It is the Tau analogue of the
 only conversation surface Pi hands extensions — `ctx.sessionManager.getBranch()`

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -80,6 +80,24 @@ Project extensions cannot approve themselves. They execute arbitrary Python and
 remain disabled without both approval and the explicit code opt-in. Trust is not
 a process/filesystem/network/tool/model sandbox.
 
+## Resolved filesystem paths
+
+`tau.context.paths` is a read-only `TauPaths` snapshot for the active session.
+If `TauResourcePaths.paths` was supplied by the host, it is authoritative and
+preserves custom `TauPaths.home` and `TauPaths.agents_home` locations. Without
+an explicit `TauPaths`, Tau derives one as
+`TauPaths(home=resource_paths.root, agents_home=resource_paths.agents_root or ~/.agents)`.
+Thus `root`/`home` controls Tau's user data and extension directory, while
+`agents_root`/`agents_home` controls `.agents` resources; the project `cwd`
+remains separate. `ExtensionRuntime(paths=custom_paths)` exposes those
+constructor paths immediately, before `load`; a later `load` makes its
+`TauResourcePaths` snapshot authoritative.
+
+The snapshot belongs to the extension generation. After `/reload` (and other
+fresh-generation replacement flows), a context captured from the outgoing
+generation is stale: even reading `context.paths` raises `ExtensionError`. Read
+`context.paths` again from the new generation's context.
+
 ## Dynamic providers
 
 `tau.register_provider(DynamicProvider(...))` adds a frontend-free provider layer

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from tau_coding.extensions.providers import DynamicProvider
     from tau_coding.extensions.runtime import ExtensionRuntime
     from tau_coding.local_backends import LocalBackend
+    from tau_coding.paths import TauPaths
     from tau_coding.tui.config import TuiTheme
 
 AGENT_EVENT_TYPES: frozenset[str] = frozenset(
@@ -889,6 +890,12 @@ class ExtensionContext:
         """Return the session working directory."""
         self._generation.assert_active()
         return self._runtime.session_view.cwd
+
+    @property
+    def paths(self) -> TauPaths:
+        """Return the resolved Tau filesystem paths for this session."""
+        self._generation.assert_active()
+        return self._runtime.paths
 
     @property
     def model(self) -> str:

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -248,6 +248,7 @@ class ExtensionRuntime:
         self._renderer_failures_reported: set[str] = set()
         self._load_diagnostics: list[ResourceDiagnostic] = []
         self._runtime_diagnostics: list[ResourceDiagnostic] = []
+        self._paths: TauPaths = TauPaths()
         self._session: BoundSession | None = None
         self._ui: UiBridge = ui or NullUiBridge()
         self._turn_requested: TurnRequestedCallback | None = None
@@ -266,6 +267,7 @@ class ExtensionRuntime:
         include_user_dir: bool = True,
     ) -> None:
         """Load built-ins, then discover extensions and run isolated setup."""
+        self._paths = paths.paths or TauPaths(home=paths.root)
         self._load_built_ins()
         result = load_extensions(
             paths,
@@ -850,6 +852,11 @@ class ExtensionRuntime:
     def local_backend_registry(self) -> LocalBackendRegistry:
         """Return this staged runtime generation's local-backend registry."""
         return self._local_backend_registry
+
+    @property
+    def paths(self) -> TauPaths:
+        """Return the resolved Tau filesystem paths for this runtime."""
+        return self._paths
 
     @property
     def extension_names(self) -> tuple[str, ...]:

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -248,7 +248,9 @@ class ExtensionRuntime:
         self._renderer_failures_reported: set[str] = set()
         self._load_diagnostics: list[ResourceDiagnostic] = []
         self._runtime_diagnostics: list[ResourceDiagnostic] = []
-        self._paths: TauPaths = TauPaths()
+        # Keep constructor-provided paths visible until ``load`` installs the
+        # authoritative resource-path snapshot.
+        self._paths: TauPaths = paths or TauPaths()
         self._session: BoundSession | None = None
         self._ui: UiBridge = ui or NullUiBridge()
         self._turn_requested: TurnRequestedCallback | None = None
@@ -267,7 +269,10 @@ class ExtensionRuntime:
         include_user_dir: bool = True,
     ) -> None:
         """Load built-ins, then discover extensions and run isolated setup."""
-        self._paths = paths.paths or TauPaths(home=paths.root)
+        self._paths = paths.paths or TauPaths(
+            home=paths.root,
+            agents_home=paths.agents_root or Path.home() / ".agents",
+        )
         self._load_built_ins()
         result = load_extensions(
             paths,

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1939,6 +1939,25 @@ def _make_tool(name: str, *, content: str) -> AgentTool:
     return AgentTool(name=name, label=name, description="d", parameters={}, execute_fn=executor)
 
 
+def test_context_paths_exposes_resolved_paths_from_load(tmp_path: Path) -> None:
+    runtime = ExtensionRuntime()
+    resolved = TauPaths(home=tmp_path / "custom-home")
+    runtime.load(TauResourcePaths(root=tmp_path / "unused-root", paths=resolved))
+    api = cast(ExtensionAPI, _register_inline_extension(runtime, "reader"))
+    runtime.bind(RecordingSession(tmp_path))
+
+    assert api.context.paths is resolved
+
+
+def test_context_paths_falls_back_to_resource_root_home(tmp_path: Path) -> None:
+    runtime = ExtensionRuntime()
+    runtime.load(TauResourcePaths(root=tmp_path / "home-tau"))
+    api = cast(ExtensionAPI, _register_inline_extension(runtime, "reader"))
+    runtime.bind(RecordingSession(tmp_path))
+
+    assert api.context.paths.home == tmp_path / "home-tau"
+
+
 # -- coding-session integration ---------------------------------------------------
 
 
@@ -2058,6 +2077,16 @@ async def test_session_lifecycle_recreates_built_in_in_a_fresh_generation(
     with pytest.raises(ExtensionError, match="stale after reload"):
         _ = old_api.name
     await session.aclose()
+
+
+async def test_session_exposes_extension_paths_at_moved_home(tmp_path: Path) -> None:
+    await CodingSession.load(
+        _session_config(tmp_path, FakeProvider([]), extension_body=API_CAPTURING_EXTENSION)
+    )
+    module = _loaded_extension_module("integration")
+    api = cast(ExtensionAPI, module.APIS[-1])  # type: ignore[attr-defined]
+
+    assert api.context.paths.home == tmp_path / "home-tau"
 
 
 async def test_session_exposes_extension_tools_and_commands(tmp_path: Path) -> None:
@@ -2871,6 +2900,8 @@ async def test_reset_for_reload_invalidates_prior_context_and_ui(tmp_path: Path)
 
     with pytest.raises(ExtensionError, match="stale after reload"):
         _ = context.cwd
+    with pytest.raises(ExtensionError, match="stale after reload"):
+        _ = context.paths
     with pytest.raises(ExtensionError, match="stale after reload"):
         _ = context.transcript
     with pytest.raises(ExtensionError, match="stale after reload"):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1939,9 +1939,16 @@ def _make_tool(name: str, *, content: str) -> AgentTool:
     return AgentTool(name=name, label=name, description="d", parameters={}, execute_fn=executor)
 
 
-def test_context_paths_exposes_resolved_paths_from_load(tmp_path: Path) -> None:
-    runtime = ExtensionRuntime()
-    resolved = TauPaths(home=tmp_path / "custom-home")
+def test_context_paths_exposes_constructor_paths_during_extension_use(tmp_path: Path) -> None:
+    resolved = TauPaths(
+        home=tmp_path / "custom-home",
+        agents_home=tmp_path / "custom-agents",
+    )
+    runtime = ExtensionRuntime(paths=resolved)
+
+    # Constructor paths are usable before loading and remain authoritative when
+    # the resource snapshot explicitly carries the same custom paths.
+    assert runtime.paths is resolved
     runtime.load(TauResourcePaths(root=tmp_path / "unused-root", paths=resolved))
     api = cast(ExtensionAPI, _register_inline_extension(runtime, "reader"))
     runtime.bind(RecordingSession(tmp_path))
@@ -1949,13 +1956,19 @@ def test_context_paths_exposes_resolved_paths_from_load(tmp_path: Path) -> None:
     assert api.context.paths is resolved
 
 
-def test_context_paths_falls_back_to_resource_root_home(tmp_path: Path) -> None:
+def test_context_paths_falls_back_to_resource_root_and_agents_root(tmp_path: Path) -> None:
     runtime = ExtensionRuntime()
-    runtime.load(TauResourcePaths(root=tmp_path / "home-tau"))
+    runtime.load(
+        TauResourcePaths(
+            root=tmp_path / "home-tau",
+            agents_root=tmp_path / "home-agents",
+        )
+    )
     api = cast(ExtensionAPI, _register_inline_extension(runtime, "reader"))
     runtime.bind(RecordingSession(tmp_path))
 
     assert api.context.paths.home == tmp_path / "home-tau"
+    assert api.context.paths.agents_home == tmp_path / "home-agents"
 
 
 # -- coding-session integration ---------------------------------------------------

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -213,6 +213,24 @@ or async and always receive `(event, context)`; the context is freshly created
 for each dispatch. Action methods raise `ExtensionError` if called before the session
 is bound — register handlers in `setup` and act on events instead.
 
+#### Resolved filesystem paths
+
+`tau.context.paths` is a read-only `TauPaths` snapshot for the active session.
+If the host supplies `TauResourcePaths.paths`, that object is authoritative and
+preserves custom `TauPaths.home` and `TauPaths.agents_home` locations. Otherwise
+Tau derives one as
+`TauPaths(home=resource_paths.root, agents_home=resource_paths.agents_root or ~/.agents)`.
+In other words, `root`/`home` controls Tau's user data and extension directory,
+while `agents_root`/`agents_home` controls `.agents` resources; the project
+`cwd` remains separate. `ExtensionRuntime(paths=custom_paths)` exposes its
+constructor paths immediately, before `load`; a later `load` makes its
+`TauResourcePaths` snapshot authoritative.
+
+The snapshot belongs to the extension generation. After `/reload` (and other
+fresh-generation replacement flows), a context captured from the outgoing
+generation is stale: even reading `context.paths` raises `ExtensionError`. Read
+`context.paths` again from the new generation's context.
+
 ### Local-backend registrations
 
 An extension can pair a provider layer with a provider-neutral local backend:

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -184,6 +184,7 @@ def setup(tau):
     tau.context.inference_provider_mode        # "automatic" or "fixed"
     tau.context.session_id, tau.context.session_name
     tau.context.thinking_level, tau.context.system_prompt
+    tau.context.paths                 # resolved TauPaths snapshot
     tau.context.is_running, tau.context.has_ui
     tau.context.transcript   # parent conversation, deep-copied AgentMessages
 
@@ -212,6 +213,24 @@ reject the operation. The current resolved route is available as
 or async and always receive `(event, context)`; the context is freshly created
 for each dispatch. Action methods raise `ExtensionError` if called before the session
 is bound — register handlers in `setup` and act on events instead.
+
+#### Resolved filesystem paths
+
+`tau.context.paths` is a read-only `TauPaths` snapshot for the active session.
+If the host supplies `TauResourcePaths.paths`, that object is authoritative and
+preserves custom `TauPaths.home` and `TauPaths.agents_home` locations. Otherwise
+Tau derives one as
+`TauPaths(home=resource_paths.root, agents_home=resource_paths.agents_root or ~/.agents)`.
+In other words, `root`/`home` controls Tau's user data and extension directory,
+while `agents_root`/`agents_home` controls `.agents` resources; the project
+`cwd` remains separate. `ExtensionRuntime(paths=custom_paths)` exposes its
+constructor paths immediately, before `load`; a later `load` makes its
+`TauResourcePaths` snapshot authoritative.
+
+The snapshot belongs to the extension generation. After `/reload` (and other
+fresh-generation replacement flows), a context captured from the outgoing
+generation is stale: even reading `context.paths` raises `ExtensionError`. Read
+`context.paths` again from the new generation's context.
 
 ### Local-backend registrations
 


### PR DESCRIPTION
`ExtensionRuntime.load()` receives a `TauResourcePaths` that carries the resolved `TauPaths`, but never stores it. `ExtensionContext` exposes `cwd`, `model`, `session_id`, and other session values, but nothing about the Tau home, so an extension has no way to find `TauPaths.home` when a host moved it with `TauPaths(home=...)`. Extensions end up hardcoding `~/.tau`, which reads and writes the wrong location once the home moves (the tau-subagents extension does this in four places, recorded as a workaround in its ADR 0003).

Fix: `ExtensionRuntime.load()` now stores `paths.paths or TauPaths(home=paths.root)`, the same fallback `session.py` already uses to build the trust store, and exposes it through a new `ExtensionRuntime.paths` property. `ExtensionContext.paths` reads that property under the same `assert_active()` generation check as every other context property, so a context captured before a `/reload` raises `ExtensionError` instead of reading the reloaded world.

Verification:
- New test `test_context_paths_exposes_resolved_paths_from_load` and `test_context_paths_falls_back_to_resource_root_home` fail on `main` with `AttributeError: 'ExtensionContext' object has no attribute 'paths'` and pass on this branch (both run in the same Docker image).
- `test_session_exposes_extension_paths_at_moved_home` exercises the real `CodingSession.load()` path end to end, same fail-before/pass-after check.
- Added a `context.paths` staleness assertion next to the existing `context.cwd` one in `test_reset_for_reload_invalidates_prior_context_and_ui`.
- Full suite (`uv run pytest`), `ruff check .`, `ruff format --check .`, and `mypy` all pass.

Fixes #598
