### PR TITLE
Prepare Tau 0.3.13 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.12"
+version = "0.3.13"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.3.13",
+    "date": "2026-08-21",
+    "sections": {
+      "New": [
+        "Drive Tau from editors and other subprocess hosts through a Pi-compatible JSONL RPC mode, including prompting, state, models, sessions, compaction, direct shell commands, exports, and session naming.",
+        "Install trusted local or Git-hosted extensions with tau install, including pinned Git refs, staging validation, and overwrite protection.",
+        "Use Pi-compatible prompt template arguments such as $1, $@, $ARGUMENTS, defaults, and slices while retaining legacy Tau placeholders."
+      ],
+      "Changed": [
+        "List Tau's utility commands in tau --help and add Discord community links to the documentation website and README."
+      ],
+      "Fixed": [
+        "Send agent_settled reliably after completed, failed, and interrupted runs so extensions receive the final idle state after cleanup.",
+        "Keep TUI prompts readable when the terminal is too narrow for the normal prompt gutter."
+      ]
+    }
+  },
+  {
     "version": "0.3.12",
     "date": "2026-08-17",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -781,7 +781,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.12" in console.export_text()
+    assert "τ = 2π  0.3.13" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.12"
+version = "0.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the Tau 0.3.13 patch release.

- bump `tau-ai` from 0.3.12 to 0.3.13
- update `uv.lock` and the version-sensitive sidebar test
- add structured release notes for changes since v0.3.12

## Release highlights

- add Pi-compatible JSONL RPC mode and align frontend-critical contracts
- add `tau install` for trusted local and Git-hosted extensions
- support Pi-compatible prompt template argument variables
- improve CLI help, extension settlement, narrow TUI prompts, and community links

## Validation

- `uv run pytest` — 1568 passed, 2 Windows-only tests skipped
- `uv run mypy` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv build` — built 0.3.13 wheel and source distribution
- `cd website && hugo --minify` — passed with the existing taxonomy warning
- `cd website && npx --yes pagefind@latest --site public` — passed
- `uv run tau --version` — `tau 0.3.13`

## Publishing

After merge, publish GitHub Release `v0.3.13` from `main`. The release event triggers the trusted PyPI publishing workflow.
