### PR TITLE
Add Ox Alpha to OpenCode Zen and Go catalogs

### DIFF
--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -6586,7 +6586,7 @@ kind = "openai-compatible"
 base_url = "https://opencode.ai/zen/go/v1"
 api_key_env = "OPENCODE_API_KEY"
 credential_name = "opencode-go"
-models = ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.1", "glm-5.2", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.7", "minimax-m3", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"]
+models = ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5.1", "glm-5.2", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.7", "minimax-m3", "ox-alpha-free", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"]
 default_model = "kimi-k2.7-code"
 docs_url = "https://opencode.ai/docs/go"
 api = "openai-completions"
@@ -6605,6 +6605,7 @@ thinking_parameter = "reasoning_effort"
 "mimo-v2.5-pro" = 262144
 "minimax-m2.7" = 204800
 "minimax-m3" = 204800
+"ox-alpha-free" = 1000000
 "qwen3.6-plus" = 1000000
 "qwen3.7-max" = 1000000
 "qwen3.7-plus" = 1000000
@@ -6639,6 +6640,14 @@ input = ["text"]
 [providers.model_metadata."minimax-m3"]
 input = ["text", "image"]
 
+[providers.model_metadata."ox-alpha-free"]
+name = "Ox Alpha Free"
+reasoning = true
+input = ["text", "image"]
+max_tokens = 131072
+thinking_level_map = { minimal = "low", low = "low", medium = "high", high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["off"]
+
 [providers.model_metadata."qwen3.6-plus"]
 input = ["text", "image"]
 
@@ -6655,7 +6664,7 @@ kind = "openai-compatible"
 base_url = "https://opencode.ai/zen/v1"
 api_key_env = "OPENCODE_API_KEY"
 credential_name = "opencode"
-models = ["big-pickle", "deepseek-v4-flash", "deepseek-v4-flash-free", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.5-pro", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "grok-4.5", "grok-build-0.1", "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5-free", "minimax-m2.5", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-free", "north-mini-code-free", "qwen3.5-plus", "qwen3.6-plus"]
+models = ["big-pickle", "deepseek-v4-flash", "deepseek-v4-flash-free", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.5-pro", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra", "grok-4.5", "grok-build-0.1", "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5-free", "minimax-m2.5", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-free", "north-mini-code-free", "qwen3.5-plus", "qwen3.6-plus", "x-preview-f-free"]
 default_model = "kimi-k2.7-code"
 docs_url = "https://opencode.ai/docs/zen"
 api = "openai-completions"
@@ -6750,6 +6759,15 @@ input = ["text", "image"]
 
 [providers.model_metadata."qwen3.6-plus"]
 input = ["text", "image"]
+
+[providers.model_metadata."x-preview-f-free"]
+name = "Ox Alpha Free"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 131072
+thinking_level_map = { minimal = "low", low = "low", medium = "high", high = "high", xhigh = "max" }
+unsupported_thinking_levels = ["off"]
 
 [[providers]]
 name = "github-copilot"

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -187,6 +187,7 @@ def test_builtin_catalog_separates_openai_api_and_codex_context_limits() -> None
                 "kimi-k2.7-code",
                 "mimo-v2.5",
                 "minimax-m3",
+                "ox-alpha-free",
                 "qwen3.6-plus",
                 "qwen3.7-plus",
             },
@@ -210,6 +211,7 @@ def test_builtin_catalog_separates_openai_api_and_codex_context_limits() -> None
                 "minimax-m3",
                 "qwen3.5-plus",
                 "qwen3.6-plus",
+                "x-preview-f-free",
             },
         ),
         (


### PR DESCRIPTION
Adds OpenCode's new Ox Alpha stealth model to both OpenCode catalogs. It's free (zero retention), 1M context, 131k max output, text + image, and ships under a different id on each endpoint: `x-preview-f-free` on Zen, `ox-alpha-free` on Go.

The model always reasons and only accepts `low`, `high`, or `max` for `reasoning_effort` — the provider defaults (`off`, `medium`) get a 400 from upstream. So each entry declares `unsupported_thinking_levels = ["off"]` and a `thinking_level_map` collapsing Tau's levels onto the three the model accepts (minimal/low → low, medium/high → high, xhigh → max). Note this differs from the Kimi K3 convention in `dev-notes/kimi-k3-model-catalog.md`, which has the same low/high/max constraint but drops `minimal`/`medium` instead of folding them in — happy to switch if you'd rather keep the two consistent.

Model ids and metadata were taken from the live `/models` endpoints and models.dev rather than the announcement posts. Ox Alpha routes through `chat/completions` on both endpoints, so it needs no transport work. The vision-model sets in `test_provider_catalog.py` are exact-match assertions, hence the test change.

Verified locally: both entries resolve to the expected effort values at every level, and the catalog/config/thinking suites pass. Not exercised against the live API — no key in that session.

---

Out of scope here, but noted while diffing the catalogs against the live endpoints. **Drop-in adds** (all `chat/completions`, catalog-data only): `kimi-k3` is missing from both providers even though Tau already carries it for `kimi-code` and Hugging Face; Go is missing `glm-5.3`, `qwen3.8-max`, `mimo-v2-pro`, `mimo-v2-omni`, `hy3` and several models Zen already has (`kimi-k2.5`, `glm-5`, `minimax-m2.5`, `qwen3.5-plus`, `grok-4.5`, `gpt-5.6-luna`); Zen is missing the `hy3-free` and `nemotron-3.5-lightning-free` tiers.

**Blocked on transport, not data.** Zen serves several families over non-`chat/completions` routes, which the `opencode` entry (`openai-compatible` / `openai-completions`) doesn't currently express per model:

| Family | Zen route | What it needs |
| --- | --- | --- |
| `muse-spark-1.2`, `muse-spark-1.2-contributor-free`, `grok-4.6` | `/zen/v1/responses` | per-model `api = "openai-responses"`, as the Zen GPT entries already do |
| Claude (`claude-opus-5`, `claude-sonnet-5`, …) | `/zen/v1/messages` | per-model `api = "anthropic-messages"`; GitHub Copilot sets this precedent |
| Gemini (`gemini-3.7-flash`, `gemini-3.5-flash-lite`, …) | `/zen/v1/models/{id}` (`@ai-sdk/google`) | `google-generative-ai`, which today is only ever set at provider level — never per model |

That last row is why the Zen entry carries no Claude or Gemini at all; it's a transport gap rather than a curation choice.

**Worth a second look:** `grok-4.5` is already in the Zen catalog with no `api` override, so it inherits `openai-completions` while the docs list it under `/responses` — either Zen accepts both or that entry is subtly wrong. And `north-mini-code-free` is in our Zen catalog but no longer returned by `/models` (still on models.dev), so it looks retired. `laguna-s-2.1-free` is live on `/models` but absent from the docs table, so its route is unconfirmed.
