### PR TITLE
Add Gemini 3.6/3.7 Flash and 3.5 Flash Lite to the Google catalog

### DIFF
--- a/dev-notes/gemini-flash-catalog.md
+++ b/dev-notes/gemini-flash-catalog.md
@@ -1,0 +1,40 @@
+# Gemini Flash catalog refresh
+
+Tau's `google` catalog entry stopped at `gemini-3.5-flash` (May 2026). Google has
+since shipped two more Flash generations and a 3.5 Lite, and repointed the
+`-latest` aliases at them:
+
+| Model | Released | Input | Output | Reasoning effort |
+| --- | --- | --- | --- | --- |
+| `gemini-3.5-flash-lite` | 2026-07-21 | $0.30 | $2.50 | minimal, low, medium, high |
+| `gemini-3.6-flash` | 2026-07-21 | $0.75 | $3.75 | minimal, low, medium, high |
+| `gemini-3.7-flash` | 2026-08-13 | $0.75 | $3.75 | low, medium, high |
+
+All three keep the 1,048,576-token context and 65,536-token output ceiling of the
+rest of the Gemini 3 line. Like every Gemini 3 model already in the catalog, they
+cannot disable thinking, so each declares `unsupported_thinking_levels = ["off"]`.
+Gemini 3.7 Flash additionally drops `minimal`, which the 3.5 and 3.6 generations
+accept.
+
+## Aliases
+
+`gemini-flash-latest` is the provider default and now resolves to Gemini 3.7
+Flash; `gemini-flash-lite-latest` resolves to Gemini 3.5 Flash Lite. Both alias
+entries still carried Gemini 2.5-era pricing ($0.30/$2.50 and $0.10/$0.40) and
+allowed `off`, so cost reporting and the thinking picker were both wrong for
+anyone on the default model. Their metadata now matches the models they point at.
+
+Aliases move when Google moves them, so this metadata is a snapshot and needs
+rechecking whenever a new Flash generation ships.
+
+## Verify
+
+```bash
+uv run pytest tests/test_provider_catalog.py tests/test_provider_config.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+After `/login google`, choose `google:gemini-3.7-flash` from `/model` or start
+Tau with `--provider google --model gemini-3.7-flash`.

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -701,7 +701,7 @@ kind = "google-generative-ai"
 base_url = "https://generativelanguage.googleapis.com/v1beta"
 api_key_env = "GEMINI_API_KEY"
 credential_name = "google"
-models = ["gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools", "gemini-3.5-flash", "gemini-flash-latest", "gemini-flash-lite-latest", "gemma-4-26b-a4b-it", "gemma-4-31b-it"]
+models = ["gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.6-flash", "gemini-3.7-flash", "gemini-flash-latest", "gemini-flash-lite-latest", "gemma-4-26b-a4b-it", "gemma-4-31b-it"]
 default_model = "gemini-flash-latest"
 docs_url = "https://ai.google.dev/gemini-api/docs"
 api = "google-generative-ai"
@@ -719,6 +719,9 @@ gemini-3-flash-preview = 1048576
 "gemini-3.1-pro-preview" = 1048576
 "gemini-3.1-pro-preview-customtools" = 1048576
 "gemini-3.5-flash" = 1048576
+"gemini-3.5-flash-lite" = 1048576
+"gemini-3.6-flash" = 1048576
+"gemini-3.7-flash" = 1048576
 gemini-flash-latest = 1048576
 gemini-flash-lite-latest = 1048576
 gemma-4-26b-a4b-it = 262144
@@ -805,13 +808,41 @@ max_tokens = 65536
 cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 0 }
 unsupported_thinking_levels = ["off"]
 
+[providers.model_metadata."gemini-3.5-flash-lite"]
+name = "Gemini 3.5 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0.03, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gemini-3.6-flash"]
+name = "Gemini 3.6 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.75, output = 3.75, cacheRead = 0.075, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
+
+[providers.model_metadata."gemini-3.7-flash"]
+name = "Gemini 3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.75, output = 3.75, cacheRead = 0.075, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal"]
+
 [providers.model_metadata.gemini-flash-latest]
 name = "Gemini Flash Latest"
 reasoning = true
 input = ["text", "image"]
 context_window = 1048576
 max_tokens = 65536
-cost = { input = 0.3, output = 2.5, cacheRead = 0.075, cacheWrite = 0 }
+cost = { input = 0.75, output = 3.75, cacheRead = 0.075, cacheWrite = 0 }
+unsupported_thinking_levels = ["off", "minimal"]
 
 [providers.model_metadata.gemini-flash-lite-latest]
 name = "Gemini Flash-Lite Latest"
@@ -819,7 +850,8 @@ reasoning = true
 input = ["text", "image"]
 context_window = 1048576
 max_tokens = 65536
-cost = { input = 0.1, output = 0.4, cacheRead = 0.025, cacheWrite = 0 }
+cost = { input = 0.3, output = 2.5, cacheRead = 0.03, cacheWrite = 0 }
+unsupported_thinking_levels = ["off"]
 
 [providers.model_metadata.gemma-4-26b-a4b-it]
 name = "Gemma 4 26B A4B IT"


### PR DESCRIPTION
Tau's `google` entry stopped at `gemini-3.5-flash` (May 2026). This adds the two Flash generations Google has shipped since, plus 3.5 Flash Lite: `gemini-3.6-flash` and `gemini-3.7-flash` ($0.75/$3.75) and `gemini-3.5-flash-lite` ($0.30/$2.50), all 1M context / 65k output. Like the rest of the Gemini 3 line they can't disable thinking, so each declares `unsupported_thinking_levels = ["off"]`; 3.7 also drops `minimal`.

The more consequential half is the aliases. `gemini-flash-latest` is the provider default and now resolves to 3.7 Flash, but our entry still carried Gemini 2.5-era pricing ($0.30/$2.50) and offered a thinking level the model rejects — so anyone on the default model got wrong cost reporting and a broken `off`. Same story for `gemini-flash-lite-latest` ($0.10/$0.40, now 3.5 Lite). Both are updated to match what they point at. Since aliases move when Google moves them, `dev-notes/gemini-flash-catalog.md` records that this is a snapshot.

Metadata comes from models.dev; I didn't call Google's `ListModels` with a live key, so the alias targets are worth a second pair of eyes.

Verified locally: thinking levels and costs resolve as expected for all five entries, and the catalog/config/thinking suites, ruff, and format checks pass. Independent of #629 — different provider, no shared lines.
