### PR TITLE
fix(tui): make streamed assistant rendering redraw-safe via an active draft

### DIFF
--- a/dev-notes/tui-active-assistant-draft.md
+++ b/dev-notes/tui-active-assistant-draft.md
@@ -1,0 +1,128 @@
+# TUI: durable transcript history vs. the active assistant draft
+
+This note explains how the interactive TUI represents an in-flight assistant
+response, why that representation is separate from durable transcript history,
+and how it maps to Pi's design.
+
+## The problem this design solves
+
+Older Tau versions split one live assistant turn across three kinds of state:
+
+- streamed answer text in `TuiState.assistant_buffer`;
+- streamed thinking inserted directly into `TuiState.items`;
+- "which widget is live" pointers on `TranscriptView`.
+
+Any transcript rebuild during a response (Ctrl+T, slash commands, terminal
+resize, theme changes — anything calling `TauTuiApp._refresh()`) reconstructed
+the provisional thinking rows as ordinary history and dropped the live widget
+pointers. The next streamed delta then mounted a *second* live widget, and
+message completion removed only the copy it still knew about, permanently
+duplicating thinking or answer text on screen. The session file was always
+correct; this was purely a TUI projection/ownership bug.
+
+## The state model
+
+`TuiState` now has exactly two representations of assistant output:
+
+- **Durable history** — `TuiState.items`, a list of finalized `ChatItem`s.
+  Nothing provisional ever goes in here.
+- **The active draft** — `TuiState.active_assistant`, an
+  `ActiveAssistantDraft(stream_id, message)`. This is the *only* provisional
+  source of truth for a streaming response.
+
+The draft holds the latest *cumulative* `AssistantMessage` snapshot, not an
+accumulation of deltas. Tau's event protocol already guarantees that
+`MessageUpdateEvent.message` is the complete partial message so far (providers
+deep-copy it per event; see `src/tau_ai/stream.py::_snapshot`). Deltas are only
+a rendering optimization; the cumulative message is semantic truth. This
+matters because a redraw can land *between* the adapter update and the widget
+update in either order — with a cumulative snapshot both orders converge, while
+delta concatenation would double-append.
+
+State transitions are lifecycle methods, not field pokes:
+
+- `begin_assistant(message)` — new draft, new monotonically increasing
+  `stream_id`. Defensively interrupts any unfinished previous draft first.
+- `update_assistant(message)` — adopt the newest cumulative snapshot.
+- `finish_assistant(message)` — clear the draft and project the canonical
+  final blocks into `items` exactly once.
+- `discard_assistant()` — clear without projecting (used for error/aborted
+  ends, where the terminal message itself is projected via
+  `add_assistant_error`, and for deferred overflow errors).
+- `interrupt_assistant()` — project the *entire* partial turn (thinking and
+  text alike) into `items`, then clear. Used by cancellation and by flushes
+  when a terminal event never arrived. One policy for the whole turn: partial
+  output is retained, matching the aborted message the session file records.
+
+## The view: widgets are a projection, never the only copy
+
+`TranscriptView` renders two things, in order:
+
+1. the bounded window of durable `state.items`;
+2. if the window is at the latest end, the *active tail* — the draft projected
+   into ordered blocks by the pure helper
+   `project_active_assistant_blocks(message, show_thinking, stream_id)`.
+
+The projection preserves provider content order (`thinking → text → thinking`
+stays interleaved), omits empty blocks, ignores tool calls (they render as tool
+execution rows), and collapses each contiguous run of thinking blocks into one
+placeholder when thinking is hidden — the same rules Pi applies in
+`AssistantMessageComponent.updateContent`.
+
+Every mounted tail widget is owned by one `_ActiveAssistantRender`, keyed by
+`(kind, stream_id, content_index)`. Because a full `_redraw()` rebuilds this
+owner from `state.active_assistant`, **a redraw reconstructs live ownership**
+instead of orphaning live rows — the core fix.
+
+Incremental updates go through one semantic operation,
+`sync_active_assistant(draft, changed_content_index, …)`:
+
+- same block topology → write only the missing text suffix through Textual's
+  `MarkdownStream` (no full reparse per delta);
+- a redraw already rendered the suffix → no-op (text is equal);
+- the provider corrected content → replace the widget text outright;
+- additive topology growth (a new block started) → mount only the new blocks;
+- anything else (stream replacement, visibility flip, corrections that remove
+  blocks) → rebuild the whole tail from the projection.
+
+Completion (`finish_active_assistant`) claims the render before its first
+`await`, then either finalizes and rebinds the owned widgets in place onto the
+canonical `ChatItem`s (the common case, preserving widget identity and
+selection for unrelated history) or removes only the owned widgets and mounts
+canonical rows idempotently (`append_item` and the mount path both refuse to
+mount an item that already has a mounted widget).
+
+## Stale async work
+
+Synchronous rebuilds (`_redraw`, Ctrl+T, tail rebuilds) each bump
+`_render_generation`. Async operations capture the generation before awaiting
+and stop after any await if it changed — the synchronous rebuild that bumped it
+already rendered current state, so the stale continuation must not mount,
+remove, or re-register anything. Combined with the per-stream `stream_id`,
+this means work started for an older render or an older assistant stream can
+never resurrect removed output. Writes that land on an already-unmounted
+widget are harmless because the widget is detached from the DOM.
+
+## Mapping to Pi
+
+Pi keeps one `streamingMessage` (cumulative partial `AssistantMessage`) plus
+one `streamingComponent` for the whole turn: `message_start` creates the
+component, every `message_update` re-renders it from the cumulative snapshot,
+`message_end` updates it from the authoritative final message, and a chat
+rebuild re-adds the component after durable history
+(`interactive-mode.ts`, `assistant-message.ts`). Tau follows the same
+ownership model — `ActiveAssistantDraft` ↔ `streamingMessage`,
+`_ActiveAssistantRender` ↔ `streamingComponent` — while keeping Tau-specific
+behavior: a bounded transcript window, individually selectable per-block
+widgets, and incremental `MarkdownStream` suffix writes instead of full
+re-renders per update.
+
+## Testing
+
+- `tests/test_tui_adapter.py` covers the draft lifecycle (begin/update/finish,
+  corrections, interruption, replacement streams, overflow deferral).
+- `tests/test_tui_app.py` covers redraw/Ctrl+T/slash-command/theme/resize
+  during streaming, interleaved block ordering, hidden-run placeholders,
+  cancellation and abort boundaries, windowed scrollback, and deterministic
+  race tests that gate `MarkdownStream.write`/`stop` with `asyncio.Event` to
+  interleave redraws at exact await points.

--- a/src/tau_coding/tui/__init__.py
+++ b/src/tau_coding/tui/__init__.py
@@ -22,7 +22,7 @@ from tau_coding.tui.config import (
     save_tui_settings,
     tui_settings_path,
 )
-from tau_coding.tui.state import ChatItem, TuiState
+from tau_coding.tui.state import ActiveAssistantDraft, ChatItem, TuiState
 from tau_coding.tui.widgets import (
     CompactSessionInfo,
     SessionSidebar,
@@ -36,6 +36,7 @@ from tau_coding.tui.widgets import (
 )
 
 __all__ = [
+    "ActiveAssistantDraft",
     "BUILTIN_TUI_THEME_NAMES",
     "ChatItem",
     "CompletionOption",

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -11,7 +11,6 @@ from tau_agent.events import (
     ToolExecutionUpdateEvent,
 )
 from tau_agent.messages import AssistantMessage, CustomMessage, ToolCall, UserMessage
-from tau_ai.events import TextDeltaEvent, ThinkingDeltaEvent
 from tau_coding.events import (
     AutoRetryStartEvent,
     CodingSessionEvent,
@@ -27,7 +26,6 @@ from tau_coding.tui.state import TuiState, _is_file_mutation_only_message
 class TuiEventAdapter:
     def __init__(self, state: TuiState) -> None:
         self.state = state
-        self._assistant_start_item_index: int | None = None
         self._pending_overflow_error: AssistantMessage | None = None
         self._tool_batch_ids: dict[str, int] = {}
         self._file_mutation_continuation_calls: set[str] = set()
@@ -58,15 +56,13 @@ class TuiEventAdapter:
             return
         if isinstance(event, MessageStartEvent):
             if isinstance(event.message, AssistantMessage):
-                self.state.assistant_buffer = event.message.text
-                self._assistant_start_item_index = len(self.state.items)
+                self.state.begin_assistant(event.message)
             return
         if isinstance(event, MessageUpdateEvent):
-            nested = event.assistant_message_event
-            if isinstance(nested, TextDeltaEvent):
-                self.state.assistant_buffer += nested.delta
-            elif isinstance(nested, ThinkingDeltaEvent):
-                self.state.add_thinking_delta(nested.delta)
+            # The cumulative snapshot is semantic truth; deltas are only a
+            # rendering optimization applied by the view layer.
+            if isinstance(event.message, AssistantMessage):
+                self.state.update_assistant(event.message)
             return
         if isinstance(event, MessageEndEvent):
             message = event.message
@@ -79,12 +75,11 @@ class TuiEventAdapter:
                     details=message.details if isinstance(message.details, dict) else None,
                 )
             elif isinstance(message, AssistantMessage):
-                # Replace provisional delta rows with the final canonical
-                # message so persisted block boundaries and ordering win.
-                start = self._assistant_start_item_index
-                if start is not None:
-                    del self.state.items[start:]
+                # The draft is the only provisional representation; the state
+                # lifecycle methods below clear it synchronously so state never
+                # exposes both the draft and the canonical projection at once.
                 if message.stop_reason in {"error", "aborted"}:
+                    self.state.discard_assistant()
                     if is_context_overflow_error(message):
                         # Keep the provider failure provisional while session-level
                         # overflow compaction and retry are still in progress.
@@ -97,7 +92,7 @@ class TuiEventAdapter:
                         self.state.running = False
                 else:
                     self._pending_overflow_error = None
-                    self.state.add_assistant_message(message, include_tool_calls=False)
+                    self.state.finish_assistant(message)
                     previous_was_tool = False
                     batch_id: int | None = None
                     allows_mutation_continuation = _is_file_mutation_only_message(message)
@@ -112,8 +107,6 @@ class TuiEventAdapter:
                             previous_was_tool = True
                         else:
                             previous_was_tool = False
-                self.state.assistant_buffer = ""
-                self._assistant_start_item_index = None
             return
         if isinstance(event, ToolExecutionStartEvent):
             self._flush()
@@ -149,6 +142,6 @@ class TuiEventAdapter:
             self.state.add_item("status", f"… {event.error_message}")
 
     def _flush(self) -> None:
-        if self.state.assistant_buffer:
-            self.state.add_item("assistant", self.state.assistant_buffer)
-            self.state.assistant_buffer = ""
+        # A missing terminal event must not leave an active draft behind; the
+        # state lifecycle method retains the whole partial turn consistently.
+        self.state.interrupt_assistant()

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -60,8 +60,6 @@ from tau_agent.provider import CancellationToken
 from tau_agent.provider_events import (
     AssistantErrorEvent,
     AssistantMessageEvent,
-    TextDeltaEvent,
-    ThinkingDeltaEvent,
 )
 from tau_agent.tools import AgentTool
 from tau_agent.types import JSONValue
@@ -4868,6 +4866,7 @@ class TauTuiApp(App[None]):
             if active_run_id != self._prompt_run_id:
                 return
             message = _format_prompt_error(exc, self.session)
+            self.state.interrupt_assistant()
             self.state.error = message
             self.state.add_item("error", message)
             self.state.running = False
@@ -4893,18 +4892,28 @@ class TauTuiApp(App[None]):
             self._refresh_chrome()
             return
         if isinstance(event, AgentEndEvent):
-            await transcript.finish_assistant_message()
-            self._refresh_chrome()
+            # Fallback cleanup only: a genuinely unfinished draft was flushed
+            # into durable items by the adapter, so rebuild once to show it.
+            if transcript.has_stale_active_tail(self.state.active_assistant):
+                self._refresh()
+            else:
+                self._refresh_chrome()
             return
         if isinstance(event, MessageStartEvent):
+            if isinstance(event.message, AssistantMessage) and transcript.has_stale_active_tail(
+                self.state.active_assistant
+            ):
+                # A replacement stream interrupted the previous draft; rebuild
+                # so the projected partial turn and the fresh tail cannot
+                # double-mount.
+                self._refresh()
             return
         if isinstance(event, MessageUpdateEvent):
-            nested = event.assistant_message_event
-            if isinstance(nested, TextDeltaEvent):
-                await transcript.append_assistant_delta(nested.delta, theme=theme)
-            elif isinstance(nested, ThinkingDeltaEvent):
-                await transcript.append_thinking_delta(
-                    nested.delta,
+            if isinstance(event.message, AssistantMessage):
+                nested = event.assistant_message_event
+                await transcript.sync_active_assistant(
+                    self.state.active_assistant,
+                    changed_content_index=getattr(nested, "content_index", None),
                     theme=theme,
                     show_thinking=self.state.show_thinking,
                 )
@@ -4932,28 +4941,20 @@ class TauTuiApp(App[None]):
                     )
                 ]
                 canonical_items = self.state.items[-len(visible_blocks) :] if visible_blocks else []
-                if (
-                    any(isinstance(block, ThinkingContent) for block in visible_blocks)
-                    or len(visible_blocks) > 1
-                ):
-                    # Replace only this message's provisional streaming widgets;
-                    # unrelated history remains mounted and selectable.
-                    await transcript.finish_structured_assistant_message(
-                        canonical_items,
-                        theme=theme,
-                        show_thinking=self.state.show_thinking,
-                    )
-                else:
-                    canonical_item = canonical_items[-1] if canonical_items else None
-                    await transcript.finish_assistant_message(
-                        event.message.text,
-                        item=canonical_item,
-                    )
+                # The adapter already cleared the draft and appended the
+                # canonical items; one idempotent completion path replaces the
+                # active tail while unrelated history keeps its identity.
+                await transcript.finish_active_assistant(
+                    canonical_items,
+                    theme=theme,
+                    show_thinking=self.state.show_thinking,
+                )
                 self._refresh_chrome()
                 return
             return
         if isinstance(event, ToolExecutionStartEvent):
-            await transcript.finish_assistant_message()
+            if transcript.has_stale_active_tail(self.state.active_assistant):
+                self._refresh()
             item = self.state.find_tool_item(event.tool_call_id)
             if item is not None:
                 expanded = self.state.show_tool_results or item.always_show_tool_result
@@ -4974,7 +4975,6 @@ class TauTuiApp(App[None]):
             self._refresh_chrome()
             return
         if isinstance(event, ToolExecutionUpdateEvent):
-            await transcript.finish_assistant_message()
             updated_item = self.state.find_tool_item(event.tool_call_id)
             if updated_item is not None:
                 expanded = self.state.show_tool_results or updated_item.always_show_tool_result
@@ -4988,7 +4988,8 @@ class TauTuiApp(App[None]):
             self._refresh_chrome()
             return
         if isinstance(event, (AutoRetryStartEvent, CompactionStartEvent)):
-            await transcript.finish_assistant_message()
+            if transcript.has_stale_active_tail(self.state.active_assistant):
+                self._refresh()
             if self.state.items and (
                 isinstance(event, AutoRetryStartEvent) or event.reason == "overflow"
             ):
@@ -5020,6 +5021,10 @@ class TauTuiApp(App[None]):
             return
         if isinstance(event, QueueUpdateEvent):
             self._refresh_chrome()
+            return
+        if transcript.has_stale_active_tail(self.state.active_assistant):
+            # Session settlement flushed an unfinished draft into durable items.
+            self._refresh()
             return
         self._refresh_chrome()
 
@@ -5064,7 +5069,9 @@ class TauTuiApp(App[None]):
             worker.cancel()
         self._prompt_worker = None
         self.state.running = False
-        self.state.assistant_buffer = ""
+        # Retain the whole partial turn (thinking and text alike), matching the
+        # aborted assistant message the session records.
+        self.state.interrupt_assistant()
         self._sync_text_selection_state()
         self._refresh()
         if notify:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -78,11 +78,25 @@ class ChatItem:
 
 
 @dataclass(slots=True)
+class ActiveAssistantDraft:
+    """The single in-flight assistant turn, mirrored from cumulative stream events.
+
+    The draft is the only provisional source of truth for streamed thinking and
+    text. ``message`` always holds the latest cumulative snapshot from the
+    provider; ``stream_id`` lets views reject async work started for an older
+    assistant stream.
+    """
+
+    stream_id: int
+    message: AssistantMessage
+
+
+@dataclass(slots=True)
 class TuiState:
     """Mutable display state for the interactive TUI."""
 
     items: list[ChatItem] = field(default_factory=list)
-    assistant_buffer: str = ""
+    active_assistant: ActiveAssistantDraft | None = None
     running: bool = False
     error: str | None = None
     show_tool_results: bool = False
@@ -112,6 +126,50 @@ class TuiState:
         compare=False,
     )
     _next_tool_batch_id: int = field(default=0, init=False, repr=False, compare=False)
+    _next_assistant_stream_id: int = field(default=0, init=False, repr=False, compare=False)
+
+    def begin_assistant(self, message: AssistantMessage) -> ActiveAssistantDraft:
+        """Start a new in-flight assistant draft from the initial cumulative snapshot.
+
+        Any unfinished previous draft is interrupted as a whole first so a
+        replacement stream can never silently drop or merge partial output.
+        """
+        self.interrupt_assistant()
+        self._next_assistant_stream_id += 1
+        self.active_assistant = ActiveAssistantDraft(
+            stream_id=self._next_assistant_stream_id,
+            message=message,
+        )
+        return self.active_assistant
+
+    def update_assistant(self, message: AssistantMessage) -> ActiveAssistantDraft:
+        """Adopt the latest cumulative assistant snapshot as the draft's content."""
+        if self.active_assistant is None:
+            return self.begin_assistant(message)
+        self.active_assistant.message = message
+        return self.active_assistant
+
+    def finish_assistant(self, message: AssistantMessage) -> None:
+        """Atomically clear the draft and project the canonical final blocks once."""
+        self.active_assistant = None
+        self.add_assistant_message(message, include_tool_calls=False)
+
+    def discard_assistant(self) -> None:
+        """Clear the draft without projecting it (its terminal message projects instead)."""
+        self.active_assistant = None
+
+    def interrupt_assistant(self) -> None:
+        """Project the entire partial draft into durable items, then clear it.
+
+        Interruption applies one policy to the whole turn: partial thinking and
+        text are both retained, matching the aborted message the session file
+        records. A missing draft is a no-op.
+        """
+        draft = self.active_assistant
+        if draft is None:
+            return
+        self.active_assistant = None
+        self.add_assistant_message(draft.message, include_tool_calls=False)
 
     def add_item(
         self,
@@ -519,13 +577,6 @@ class TuiState:
         if skill_invocation.additional_instructions:
             self.add_item("user", skill_invocation.additional_instructions)
 
-    def add_thinking_delta(self, delta: str) -> None:
-        """Append a thinking/reasoning fragment to the current thinking block."""
-        if self.items and self.items[-1].role == "thinking":
-            self.items[-1].text += delta
-            return
-        self.add_item("thinking", delta)
-
     def find_tool_item(self, tool_call_id: str) -> ChatItem | None:
         """Return the transcript item for a tool call id in O(1)."""
         return self._tool_items_by_call_id.get(tool_call_id)
@@ -618,7 +669,7 @@ class TuiState:
         self._tool_items_by_call_id.clear()
         self._grouped_calls_by_call_id.clear()
         self._batched_items_by_call_id.clear()
-        self.assistant_buffer = ""
+        self.active_assistant = None
         self.error = None
 
     def set_skills(self, skills: Iterable[Skill]) -> None:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -32,6 +32,7 @@ from textual.widgets import Collapsible, Static
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets.markdown import MarkdownBlock, MarkdownStream
 
+from tau_agent.messages import AssistantMessage, TextContent, ThinkingContent
 from tau_agent.tools import AgentTool, ToolCall
 from tau_coding.context_window import estimate_text_tokens
 from tau_coding.prompt_templates import PromptTemplate
@@ -43,6 +44,7 @@ from tau_coding.tui.config import TAU_DARK_THEME, TuiRoleStyle, TuiTheme
 from tau_coding.tui.state import (
     RESULTFUL_FILE_GROUP_NAMES,
     TOOL_TIMER_MIN_SECONDS,
+    ActiveAssistantDraft,
     ChatItem,
     TuiState,
     format_elapsed,
@@ -352,6 +354,107 @@ TRANSCRIPT_WINDOW_PAGE_ITEMS = 80
 TRANSCRIPT_WINDOW_OVERSCAN_ITEMS = 40
 
 
+@dataclass(frozen=True, slots=True)
+class ActiveAssistantBlock:
+    """One visible block projected from the in-flight assistant draft.
+
+    ``key`` is stable for the lifetime of one assistant stream: it combines the
+    stream id with the source content index (or the index of the first thinking
+    block in a hidden run), so views can match mounted widgets to blocks across
+    redraws and cumulative snapshot updates.
+    """
+
+    key: tuple[str, int, int]
+    role: Literal["assistant", "thinking"]
+    text: str
+    content_index: int | None
+
+
+def project_active_assistant_blocks(
+    message: AssistantMessage,
+    *,
+    show_thinking: bool,
+    stream_id: int,
+) -> tuple[ActiveAssistantBlock, ...]:
+    """Project a cumulative assistant snapshot into ordered visible blocks.
+
+    Provider content order is preserved (``thinking -> text -> thinking`` stays
+    interleaved), empty blocks are omitted, tool calls are ignored (they render
+    through tool execution rows), and each contiguous run of thinking blocks
+    collapses to one placeholder when thinking is hidden, matching Pi.
+    """
+    blocks: list[ActiveAssistantBlock] = []
+    content = message.content
+    index = 0
+    while index < len(content):
+        block = content[index]
+        if isinstance(block, TextContent):
+            if block.text:
+                blocks.append(
+                    ActiveAssistantBlock(
+                        key=("text", stream_id, index),
+                        role="assistant",
+                        text=block.text,
+                        content_index=index,
+                    )
+                )
+            index += 1
+            continue
+        if isinstance(block, ThinkingContent):
+            run_start = index
+            visible: list[tuple[int, str]] = []
+            while index < len(content):
+                candidate = content[index]
+                if not isinstance(candidate, ThinkingContent):
+                    break
+                if candidate.thinking:
+                    visible.append((index, candidate.thinking))
+                index += 1
+            if not visible:
+                continue
+            if show_thinking:
+                for content_index, thinking in visible:
+                    blocks.append(
+                        ActiveAssistantBlock(
+                            key=("thinking", stream_id, content_index),
+                            role="thinking",
+                            text=thinking,
+                            content_index=content_index,
+                        )
+                    )
+            else:
+                blocks.append(
+                    ActiveAssistantBlock(
+                        key=("hidden", stream_id, run_start),
+                        role="thinking",
+                        text=_HIDDEN_THINKING_PLACEHOLDER,
+                        content_index=None,
+                    )
+                )
+            continue
+        index += 1
+    return tuple(blocks)
+
+
+@dataclass(slots=True)
+class _ActiveAssistantRender:
+    """Owner of every mounted widget belonging to one in-flight assistant turn."""
+
+    stream_id: int
+    blocks: tuple[ActiveAssistantBlock, ...]
+    widgets: dict[
+        tuple[str, int, int],
+        TranscriptMessageWidget | StreamingTranscriptMessageWidget,
+    ]
+
+    def ordered_widgets(
+        self,
+    ) -> list[TranscriptMessageWidget | StreamingTranscriptMessageWidget]:
+        return [
+            self.widgets[block.key] for block in self.blocks if block.key in self.widgets
+        ]
+
+
 class TranscriptWindowBoundary(Static):
     """Small paging sentinel shown when transcript items are outside the DOM window."""
 
@@ -624,7 +727,12 @@ class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
             return
         self.item.text += fragment
         self.selection_text += fragment
-        await self.stream.write(fragment)
+        try:
+            await self.stream.write(fragment)
+        except RuntimeError:
+            # An unmount stopped the stream while this write was in flight; the
+            # widget is detached and any replacement renders the full text.
+            self._stream = None
 
     async def _stop_stream(self) -> None:
         """Stop the Textual markdown stream, flushing pending fragments first."""
@@ -679,14 +787,15 @@ class TranscriptView(VerticalScroll):
             self.styles.min_width = min_width
         self._render_state: TuiState | None = None
         self._render_theme: TuiTheme = TAU_DARK_THEME
-        self._active_assistant_widget: StreamingTranscriptMessageWidget | None = None
-        self._active_thinking_widget: StreamingTranscriptMessageWidget | None = None
-        self._active_message_widgets: list[Widget] = []
-        self._hidden_thinking_placeholder_visible = False
+        self._active_render: _ActiveAssistantRender | None = None
+        self._render_generation = 0
         self._follow_output = True
         self._follow_scroll_pending = False
         self._window_start = 0
         self._window_end = 0
+        # True while the user has paged the bounded window into history so its
+        # lower edge is detached from the latest transcript item.
+        self._window_detached = False
         self._window_shift_pending = False
         self._item_widgets: dict[
             int, TranscriptMessageWidget | StreamingTranscriptMessageWidget
@@ -701,6 +810,7 @@ class TranscriptView(VerticalScroll):
     def follow_output(self) -> None:
         """Return to follow mode for a user-driven turn or explicit jump to bottom."""
         self._follow_output = True
+        self._window_detached = False
         self.anchor(True)
         self._request_follow_scroll(force=True)
 
@@ -775,6 +885,7 @@ class TranscriptView(VerticalScroll):
 
         self._window_start = new_start
         self._window_end = new_end
+        self._window_detached = new_end < len(state.items)
         self._redraw(scroll_end=False, preserve_window=True)
 
         def restore_anchor() -> None:
@@ -795,21 +906,81 @@ class TranscriptView(VerticalScroll):
 
         self.call_after_refresh(restore_anchor)
 
-    async def _finalize_active_thinking_message(self) -> None:
-        """Stop streaming for a completed thinking block before another block starts."""
-        widget = self._active_thinking_widget
-        if widget is None:
-            return
-        await widget.finalize()
-        self._active_thinking_widget = None
+    def has_stale_active_tail(self, draft: ActiveAssistantDraft | None) -> bool:
+        """Return whether mounted active widgets belong to a superseded stream."""
+        render = self._active_render
+        if render is None:
+            return False
+        return draft is None or draft.stream_id != render.stream_id
 
-    async def _finalize_active_assistant_message(self) -> None:
-        """Stop streaming for a completed assistant block before another block starts."""
-        widget = self._active_assistant_widget
-        if widget is None:
+    def _drop_active_render(self) -> None:
+        """Remove all widgets owned by the in-flight assistant tail, if any."""
+        self._render_generation += 1
+        render = self._active_render
+        self._active_render = None
+        if render is None:
             return
-        await widget.finalize()
-        self._active_assistant_widget = None
+        stale = [widget for widget in render.ordered_widgets() if widget.parent is self]
+        if stale:
+            self.remove_children(stale)
+
+    def _first_active_widget(
+        self,
+    ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget | None:
+        """Return the first mounted widget of the active tail, if any."""
+        render = self._active_render
+        if render is None:
+            return None
+        for widget in render.ordered_widgets():
+            if widget.parent is self:
+                return widget
+        return None
+
+    def _active_block_widget(
+        self,
+        block: ActiveAssistantBlock,
+        *,
+        theme: TuiTheme,
+        with_text: bool,
+    ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
+        """Create the widget for one projected active block.
+
+        Streaming blocks may start empty (``with_text=False``) so their content
+        arrives through one incremental ``MarkdownStream`` write instead of a
+        full parse; synchronous rebuild paths pass the full text instead.
+        """
+        if block.content_index is None:
+            return TranscriptMessageWidget(
+                ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                theme=theme,
+                show_tool_results=False,
+            )
+        return StreamingTranscriptMessageWidget(
+            ChatItem(role=block.role, text=block.text if with_text else ""),
+            theme=theme,
+        )
+
+    def _build_active_tail(
+        self,
+        draft: ActiveAssistantDraft,
+        *,
+        show_thinking: bool,
+        theme: TuiTheme,
+        with_text: bool,
+    ) -> tuple[_ActiveAssistantRender, list[Widget]]:
+        """Project the draft and create (but do not mount) its tail widgets."""
+        blocks = project_active_assistant_blocks(
+            draft.message,
+            show_thinking=show_thinking,
+            stream_id=draft.stream_id,
+        )
+        render = _ActiveAssistantRender(stream_id=draft.stream_id, blocks=blocks, widgets={})
+        widgets: list[Widget] = []
+        for block in blocks:
+            widget = self._active_block_widget(block, theme=theme, with_text=with_text)
+            render.widgets[block.key] = widget
+            widgets.append(widget)
+        return render, widgets
 
     def update_from_state(
         self,
@@ -844,6 +1015,9 @@ class TranscriptView(VerticalScroll):
         self._render_theme = theme
         should_follow = self._should_follow_output
         previous_scroll_y = self.scroll_y
+        # The active tail is rebuilt wholesale from the draft below; dropping it
+        # first keeps it out of the canonical reconciliation loop.
+        self._drop_active_render()
         window_items = state.items[self._window_start : self._window_end]
         message_children = [
             child
@@ -911,10 +1085,17 @@ class TranscriptView(VerticalScroll):
                 flush(target)
 
         flush(self._bottom_boundary)
-        self._active_thinking_widget = None
-        self._hidden_thinking_placeholder_visible = any(
-            widget.selection_text == _HIDDEN_THINKING_PLACEHOLDER for _, widget in pending
-        ) or _last_transcript_child_is_hidden_thinking_placeholder(self.children)
+        draft = state.active_assistant
+        if draft is not None and self._window_is_latest:
+            render, tail_widgets = self._build_active_tail(
+                draft,
+                show_thinking=state.show_thinking,
+                theme=theme,
+                with_text=True,
+            )
+            if tail_widgets:
+                self.mount(*tail_widgets, before=self._bottom_boundary)
+            self._active_render = render
         self.refresh(layout=True)
         if should_follow:
             self._request_follow_scroll()
@@ -927,14 +1108,23 @@ class TranscriptView(VerticalScroll):
         state = self._render_state
         if state is None:
             return
+        # Any async widget work started before this synchronous rebuild is now
+        # stale and must not mount or register anything when it resumes.
+        self._render_generation += 1
         theme = self._render_theme
         total = len(state.items)
         if not preserve_window or self._window_end <= self._window_start:
             self._window_end = total
             self._window_start = max(0, total - TRANSCRIPT_WINDOW_ITEMS)
+            self._window_detached = False
         else:
             self._window_start = min(self._window_start, total)
-            self._window_end = min(max(self._window_end, self._window_start), total)
+            if self._window_detached:
+                self._window_end = min(max(self._window_end, self._window_start), total)
+            else:
+                # The window is pinned to the latest end; adopt items appended
+                # since the last redraw instead of truncating them.
+                self._window_end = total
             if self._window_end - self._window_start > TRANSCRIPT_WINDOW_ITEMS:
                 self._window_start = self._window_end - TRANSCRIPT_WINDOW_ITEMS
 
@@ -950,10 +1140,7 @@ class TranscriptView(VerticalScroll):
         ]
         if removable:
             self.remove_children(removable)
-        self._active_assistant_widget = None
-        self._active_thinking_widget = None
-        self._active_message_widgets = []
-        self._hidden_thinking_placeholder_visible = False
+        self._active_render = None
         self._item_widgets.clear()
         self._top_boundary = None
         self._bottom_boundary = None
@@ -995,19 +1182,20 @@ class TranscriptView(VerticalScroll):
         if self._window_end < total:
             self._bottom_boundary = TranscriptWindowBoundary("later", total - self._window_end)
             widgets.append(self._bottom_boundary)
-        elif state.assistant_buffer:
-            self._active_assistant_widget = StreamingTranscriptMessageWidget(
-                ChatItem(role="assistant", text=state.assistant_buffer),
+        elif state.active_assistant is not None:
+            # A redraw must reconstruct live ownership of the in-flight turn;
+            # it must never leave active blocks behind as unowned static rows.
+            render, tail_widgets = self._build_active_tail(
+                state.active_assistant,
+                show_thinking=state.show_thinking,
                 theme=theme,
+                with_text=True,
             )
-            self._active_message_widgets.append(self._active_assistant_widget)
-            widgets.append(self._active_assistant_widget)
+            widgets.extend(tail_widgets)
+            self._active_render = render
 
         if widgets:
             self.mount(*widgets)
-        self._hidden_thinking_placeholder_visible = (
-            hidden_thinking_widget is not None and self._window_end == total
-        )
         self.refresh(layout=True)
         if scroll_end:
             self._request_follow_scroll()
@@ -1023,13 +1211,25 @@ class TranscriptView(VerticalScroll):
         invocation: str | None = None,
         result_markup: str | None = None,
     ) -> TranscriptMessageWidget | StreamingTranscriptMessageWidget:
-        """Append one item, paging to the latest window only for followed output."""
+        """Append one item, paging to the latest window only for followed output.
+
+        Appending is identity-idempotent: an item that already has a mounted
+        widget is returned as-is so concurrent completion paths cannot mount a
+        second copy. Rows appended while an assistant is streaming are inserted
+        before the active tail so the in-flight turn stays last.
+        """
         should_follow = self._should_follow_output if not scroll_end else True
-        await self._finalize_active_assistant_message()
-        await self._finalize_active_thinking_message()
         self._render_theme = theme
         state = self._render_state
         item_index = _identity_index(state.items, item) if state is not None else None
+
+        existing = self._item_widgets.get(id(item))
+        if existing is not None and existing.parent is self:
+            if item_index is not None:
+                self._window_end = max(self._window_end, item_index + 1)
+            if should_follow:
+                self._request_follow_scroll(force=scroll_end)
+            return existing
 
         if state is not None and item_index is not None and self._window_end < item_index:
             if should_follow:
@@ -1060,12 +1260,8 @@ class TranscriptView(VerticalScroll):
             return widget
         if state is not None and item_index is not None:
             self._window_end = max(self._window_end, item_index + 1)
-        await self.mount(widget, before=self._bottom_boundary)
+        await self.mount(widget, before=self._first_active_widget() or self._bottom_boundary)
         self._item_widgets[id(item)] = widget
-        self._active_assistant_widget = None
-        self._active_thinking_widget = None
-        self._active_message_widgets = []
-        self._hidden_thinking_placeholder_visible = False
 
         if (
             state is not None
@@ -1141,173 +1337,240 @@ class TranscriptView(VerticalScroll):
             self._request_follow_scroll()
         return True
 
-    async def start_assistant_message(
+    async def sync_active_assistant(
         self,
+        draft: ActiveAssistantDraft | None,
         *,
-        theme: TuiTheme = TAU_DARK_THEME,
-        scroll_end: bool = False,
-    ) -> StreamingTranscriptMessageWidget:
-        """Create the active assistant message widget if needed."""
-        if self._active_assistant_widget is not None:
-            return self._active_assistant_widget
-        await self._finalize_active_thinking_message()
-        should_follow = self._should_follow_output if not scroll_end else True
-        widget = StreamingTranscriptMessageWidget(
-            ChatItem(role="assistant", text=""),
-            theme=theme,
-        )
-        self._render_theme = theme
-        await self.mount(widget, before=self._bottom_boundary)
-        self._active_assistant_widget = widget
-        self._active_message_widgets.append(widget)
-        if should_follow:
-            self._request_follow_scroll(force=scroll_end)
-        return widget
-
-    async def append_assistant_delta(
-        self,
-        delta: str,
-        *,
-        theme: TuiTheme = TAU_DARK_THEME,
-        scroll_end: bool = False,
-    ) -> None:
-        """Append streamed assistant text when the latest window is mounted."""
-        if not self._window_is_latest:
-            return
-        should_follow = self._should_follow_output if not scroll_end else True
-        widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
-        await widget.append_fragment(delta)
-        if should_follow:
-            self._request_follow_scroll(force=scroll_end)
-
-    async def append_thinking_delta(
-        self,
-        delta: str,
-        *,
+        changed_content_index: int | None = None,
         theme: TuiTheme = TAU_DARK_THEME,
         show_thinking: bool,
         scroll_end: bool = False,
     ) -> None:
-        """Append streamed thinking text or one hidden-thinking placeholder."""
-        state = self._render_state
-        if state is not None:
-            # The adapter adds provisional thinking items before this method runs.
-            was_latest = self._window_end >= max(0, len(state.items) - 1)
-            if was_latest:
-                self._window_end = len(state.items)
-            else:
-                if self._bottom_boundary is not None:
-                    self._bottom_boundary.update_count(len(state.items) - self._window_end)
-                return
+        """Reconcile the mounted active tail with the cumulative draft snapshot.
+
+        The cumulative block text is authoritative: the normal path writes only
+        the missing suffix of the changed block through ``MarkdownStream``, a
+        redraw that already rendered the suffix makes this a no-op, and a
+        corrected snapshot replaces the widget text outright. Any block
+        topology, visibility, or stream change rebuilds the whole tail from the
+        pure projection instead of guessing from individual widget pointers.
+        """
+        self._render_theme = theme
         should_follow = self._should_follow_output if not scroll_end else True
-        if not show_thinking:
-            if self._hidden_thinking_placeholder_visible:
-                return
-            widget = TranscriptMessageWidget(
-                ChatItem(
-                    role="thinking",
-                    text=_HIDDEN_THINKING_PLACEHOLDER,
-                ),
-                theme=theme,
-                show_tool_results=False,
-            )
-            await self.mount(widget, before=self._active_assistant_widget or self._bottom_boundary)
-            self._active_message_widgets.append(widget)
-            self._active_thinking_widget = None
-            self._hidden_thinking_placeholder_visible = True
-            self.refresh(layout=True)
+        if draft is None:
+            self._drop_active_render()
+            return
+        if not self._window_is_latest:
+            # The user is viewing an older transcript window; never mount the
+            # live tail there. It is reconstructed when the window pages back.
+            return
+        blocks = project_active_assistant_blocks(
+            draft.message,
+            show_thinking=show_thinking,
+            stream_id=draft.stream_id,
+        )
+        render = self._active_render
+        old_keys = tuple(block.key for block in render.blocks) if render is not None else ()
+        new_keys = tuple(block.key for block in blocks)
+        if (
+            render is None
+            or render.stream_id != draft.stream_id
+            or old_keys != new_keys[: len(old_keys)]
+        ):
+            # Non-additive topology change (correction, replacement stream, or
+            # visibility flip): rebuild the whole tail from the projection.
+            await self._rebuild_active_render(draft.stream_id, blocks, theme=theme)
             if should_follow:
+                # Removing the old tail can shrink content and clamp the scroll
+                # position, which would otherwise silently disable follow mode.
+                # Safe: should_follow was captured before any mutation, so a
+                # user who scrolled away is never forced back to the bottom.
+                self._follow_output = True
                 self._request_follow_scroll(force=scroll_end)
             return
-        self._hidden_thinking_placeholder_visible = False
-        if self._active_thinking_widget is None:
-            self._active_thinking_widget = StreamingTranscriptMessageWidget(
-                ChatItem(role="thinking", text=""),
+        render.blocks = blocks
+        generation = self._render_generation
+        for block in blocks[: len(old_keys)]:
+            if block.content_index is None:
+                continue
+            if changed_content_index is not None and block.content_index != changed_content_index:
+                continue
+            widget = render.widgets.get(block.key)
+            if not isinstance(widget, StreamingTranscriptMessageWidget):
+                continue
+            current = widget.selection_text
+            if block.text == current:
+                continue
+            if block.text.startswith(current):
+                await widget.append_fragment(block.text[len(current) :])
+            else:
+                # The provider corrected the partial snapshot; replacement wins
+                # over blind concatenation.
+                await widget.replace_text(block.text)
+            if self._render_generation != generation:
+                # A synchronous rebuild superseded this update; it already
+                # rendered the current draft state.
+                return
+        for block in blocks[len(old_keys) :]:
+            # Purely additive topology growth: mount only the new blocks so the
+            # already-streaming prefix keeps its widgets and scroll position.
+            widget = self._active_block_widget(
+                block,
                 theme=theme,
+                with_text=block.content_index is None,
             )
-            await self.mount(
-                self._active_thinking_widget,
-                before=self._active_assistant_widget or self._bottom_boundary,
-            )
-            self._active_message_widgets.append(self._active_thinking_widget)
-        await self._active_thinking_widget.append_fragment(delta)
+            render.widgets[block.key] = widget
+            await self.mount(widget, before=self._bottom_boundary)
+            if self._render_generation != generation:
+                if widget.parent is self:
+                    widget.remove()
+                return
+            if isinstance(widget, StreamingTranscriptMessageWidget):
+                await widget.append_fragment(block.text)
+                if self._render_generation != generation:
+                    return
         if should_follow:
             self._request_follow_scroll(force=scroll_end)
 
-    async def finish_assistant_message(
+    async def _rebuild_active_render(
         self,
-        text: str | None = None,
+        stream_id: int,
+        blocks: tuple[ActiveAssistantBlock, ...],
         *,
-        item: ChatItem | None = None,
+        theme: TuiTheme,
     ) -> None:
-        """Finalize the active assistant widget after the provider sends the full message."""
-        widget = self._active_assistant_widget
-        if widget is None:
-            if item is not None:
-                await self.append_item(item, theme=self._render_theme)
-            elif text:
-                await self.append_item(
-                    ChatItem(role="assistant", text=text),
-                    theme=self._render_theme,
-                )
-            return
-        await widget.finalize(text)
-        if item is not None:
-            widget.item = item
-            self._item_widgets[id(item)] = widget
-        self._active_assistant_widget = None
-        self._active_message_widgets = [
-            candidate for candidate in self._active_message_widgets if candidate is not widget
-        ]
-        self._hidden_thinking_placeholder_visible = False
+        """Replace the whole mounted active tail with freshly projected blocks."""
+        self._drop_active_render()
+        render = _ActiveAssistantRender(stream_id=stream_id, blocks=blocks, widgets={})
+        self._active_render = render
+        generation = self._render_generation
+        mounted: list[Widget] = []
+        for block in blocks:
+            # Streaming widgets start empty so their content arrives through
+            # one incremental MarkdownStream write below.
+            widget = self._active_block_widget(
+                block,
+                theme=theme,
+                with_text=block.content_index is None,
+            )
+            render.widgets[block.key] = widget
+            mounted.append(widget)
+        if mounted:
+            await self.mount(*mounted, before=self._bottom_boundary)
+            if self._render_generation != generation:
+                # A concurrent synchronous rebuild took ownership while these
+                # widgets were mounting; remove the late copies it cannot know.
+                for stale_widget in mounted:
+                    if stale_widget.parent is self:
+                        stale_widget.remove()
+                return
+        for block in blocks:
+            if block.content_index is None:
+                continue
+            widget = render.widgets[block.key]
+            if isinstance(widget, StreamingTranscriptMessageWidget):
+                await widget.append_fragment(block.text)
+                if self._render_generation != generation:
+                    return
+        self.refresh(layout=True)
 
-    async def finish_structured_assistant_message(
+    async def finish_active_assistant(
         self,
         items: Sequence[ChatItem],
         *,
         theme: TuiTheme = TAU_DARK_THEME,
         show_thinking: bool,
     ) -> None:
-        """Replace only the provisional assistant tail with canonical ordered blocks."""
-        should_follow = self._should_follow_output
-        for widget in tuple(self._active_message_widgets):
-            if widget.parent is self:
-                await widget.remove()
-        self._active_message_widgets.clear()
-        self._active_assistant_widget = None
-        self._active_thinking_widget = None
-        self._hidden_thinking_placeholder_visible = False
-        for item_id, widget in tuple(self._item_widgets.items()):
-            if widget.parent is None:
-                del self._item_widgets[item_id]
+        """Replace the active assistant tail with its canonical items exactly once.
 
+        When the canonical items map one-to-one onto the owned active widgets,
+        the widgets are finalized and rebound in place so unrelated history keeps
+        its identity. Otherwise only widgets owned by the claimed active render
+        are removed and canonical rows are mounted idempotently.
+        """
+        self._render_theme = theme
+        should_follow = self._should_follow_output
+        # Claim the active render before the first await so no other completion
+        # or synchronization path can operate on the same widgets.
+        render = self._active_render
+        self._active_render = None
         state = self._render_state
+        if state is not None and self._window_detached:
+            # The user is viewing an older window; canonical rows render when
+            # the window pages back. Only drop any leftover active widgets.
+            leftover = (
+                [widget for widget in render.ordered_widgets() if widget.parent is self]
+                if render is not None
+                else []
+            )
+            if leftover:
+                self.remove_children(leftover)
+            if self._bottom_boundary is not None:
+                self._bottom_boundary.update_count(len(state.items) - self._window_end)
+            return
         if state is not None:
             self._window_end = len(state.items)
-        hidden_widget: TranscriptMessageWidget | None = None
-        mounted: list[Widget] = []
-        for item in items:
-            if item.role == "thinking" and not show_thinking:
-                if hidden_widget is None:
-                    hidden_widget = TranscriptMessageWidget(
-                        ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
-                        theme=theme,
-                        show_tool_results=False,
-                    )
-                    mounted.append(hidden_widget)
-                self._item_widgets[id(item)] = hidden_widget
-                continue
-            hidden_widget = None
-            widget = TranscriptMessageWidget(
-                item,
-                theme=theme,
-                show_tool_results=False,
-            )
-            self._item_widgets[id(item)] = widget
-            mounted.append(widget)
-        if mounted:
-            await self.mount(*mounted, before=self._bottom_boundary)
-        self._hidden_thinking_placeholder_visible = hidden_widget is not None
+            self._window_start = min(self._window_start, self._window_end)
+        generation = self._render_generation
+
+        entries = _canonical_assistant_entries(items, show_thinking=show_thinking)
+        if render is not None and self._entries_match_render(entries, render):
+            for entry, block in zip(entries, render.blocks, strict=True):
+                widget = render.widgets[block.key]
+                if entry.hidden:
+                    for hidden_item in entry.items:
+                        self._item_widgets[id(hidden_item)] = widget
+                    continue
+                item = entry.items[0]
+                assert isinstance(widget, StreamingTranscriptMessageWidget)
+                await widget.finalize(item.text)
+                if self._render_generation != generation:
+                    # A synchronous rebuild replaced the transcript from state;
+                    # reconcile once rather than re-registering stale widgets.
+                    self._redraw(scroll_end=should_follow, preserve_window=True)
+                    return
+                widget.item = item
+                self._item_widgets[id(item)] = widget
+        else:
+            if render is not None:
+                stale = [
+                    widget for widget in render.ordered_widgets() if widget.parent is self
+                ]
+                if stale:
+                    self.remove_children(stale)
+            for item_id, widget in tuple(self._item_widgets.items()):
+                if widget.parent is None:
+                    del self._item_widgets[item_id]
+            hidden_widget: TranscriptMessageWidget | None = None
+            mounted: list[Widget] = []
+            for item in items:
+                existing = self._item_widgets.get(id(item))
+                if existing is not None and existing.parent is self:
+                    hidden_widget = None
+                    continue
+                if item.role == "thinking" and not show_thinking:
+                    if hidden_widget is None:
+                        hidden_widget = TranscriptMessageWidget(
+                            ChatItem(role="thinking", text=_HIDDEN_THINKING_PLACEHOLDER),
+                            theme=theme,
+                            show_tool_results=False,
+                        )
+                        mounted.append(hidden_widget)
+                    self._item_widgets[id(item)] = hidden_widget
+                    continue
+                hidden_widget = None
+                widget = TranscriptMessageWidget(
+                    item,
+                    theme=theme,
+                    show_tool_results=False,
+                )
+                self._item_widgets[id(item)] = widget
+                mounted.append(widget)
+            if mounted:
+                await self.mount(*mounted, before=self._bottom_boundary)
+                if self._render_generation != generation:
+                    self._redraw(scroll_end=should_follow, preserve_window=True)
+                    return
 
         if (
             state is not None
@@ -1317,7 +1580,37 @@ class TranscriptView(VerticalScroll):
             self._window_start = max(0, self._window_end - TRANSCRIPT_WINDOW_ITEMS)
             self._redraw(scroll_end=should_follow, preserve_window=True)
         elif should_follow:
+            # Finalization can momentarily shrink content and clamp the scroll
+            # position; restore follow mode explicitly before scrolling. Safe:
+            # should_follow was captured on entry, so a user who scrolled away
+            # is never forced back to the bottom.
+            self._follow_output = True
             self._request_follow_scroll()
+        self.refresh(layout=True)
+
+    def _entries_match_render(
+        self,
+        entries: Sequence[_CanonicalAssistantEntry],
+        render: _ActiveAssistantRender,
+    ) -> bool:
+        """Return whether canonical entries map one-to-one onto owned widgets."""
+        if len(entries) != len(render.blocks):
+            return False
+        for entry, block in zip(entries, render.blocks, strict=True):
+            widget = render.widgets.get(block.key)
+            if widget is None or widget.parent is not self:
+                return False
+            if entry.hidden != (block.content_index is None):
+                return False
+            if entry.hidden:
+                if not isinstance(widget, TranscriptMessageWidget):
+                    return False
+            elif (
+                not isinstance(widget, StreamingTranscriptMessageWidget)
+                or entry.items[0].role != block.role
+            ):
+                return False
+        return True
 
     @property
     def lines(self) -> tuple[TranscriptLine, ...]:
@@ -1344,14 +1637,34 @@ def _identity_index(items: Sequence[ChatItem], target: ChatItem) -> int | None:
     return None
 
 
-def _last_transcript_child_is_hidden_thinking_placeholder(children: Sequence[Widget]) -> bool:
-    for child in reversed(children):
-        if isinstance(child, TranscriptMessageWidget | StreamingTranscriptMessageWidget):
-            return (
-                child.item.role == "thinking"
-                and child.selection_text == _HIDDEN_THINKING_PLACEHOLDER
-            )
-    return False
+@dataclass(slots=True)
+class _CanonicalAssistantEntry:
+    """One canonical row projected from finalized assistant items.
+
+    ``items`` holds several adjacent thinking items only when they collapse to
+    one hidden-thinking placeholder row.
+    """
+
+    items: list[ChatItem]
+    hidden: bool
+
+
+def _canonical_assistant_entries(
+    items: Sequence[ChatItem],
+    *,
+    show_thinking: bool,
+) -> list[_CanonicalAssistantEntry]:
+    """Group canonical assistant items into rows, coalescing hidden thinking runs."""
+    entries: list[_CanonicalAssistantEntry] = []
+    for item in items:
+        if item.role == "thinking" and not show_thinking:
+            if entries and entries[-1].hidden:
+                entries[-1].items.append(item)
+            else:
+                entries.append(_CanonicalAssistantEntry(items=[item], hidden=True))
+            continue
+        entries.append(_CanonicalAssistantEntry(items=[item], hidden=False))
+    return entries
 
 
 def _transcript_widget(

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -41,6 +41,20 @@ def _update(event) -> MessageUpdateEvent:  # noqa: ANN001
     return MessageUpdateEvent(message=event.partial, assistant_message_event=event)
 
 
+def _text_update(text: str, *, content_index: int = 0) -> MessageUpdateEvent:
+    """Build a cumulative text snapshot update, as real providers emit."""
+    partial = AssistantMessage(content=[TextContent(text=text)])
+    return _update(TextDeltaEvent(content_index=content_index, delta=text, partial=partial))
+
+
+def _thinking_update(thinking: str, *, content_index: int = 0) -> MessageUpdateEvent:
+    """Build a cumulative thinking snapshot update, as real providers emit."""
+    partial = AssistantMessage(content=[ThinkingContent(thinking=thinking)])
+    return _update(
+        ThinkingDeltaEvent(content_index=content_index, delta=thinking, partial=partial)
+    )
+
+
 def test_tui_adapter_tracks_running_state() -> None:
     state = TuiState()
     adapter = TuiEventAdapter(state)
@@ -96,16 +110,20 @@ def test_tui_adapter_replaces_recovered_overflow_with_terminal_retry_error() -> 
 def test_tui_adapter_builds_assistant_item_from_nested_stream_events() -> None:
     state = TuiState()
     adapter = TuiEventAdapter(state)
-    partial = AssistantMessage()
 
-    adapter.apply(MessageStartEvent(message=partial))
-    adapter.apply(_update(TextDeltaEvent(content_index=0, delta="Hel", partial=partial)))
-    adapter.apply(_update(TextDeltaEvent(content_index=0, delta="lo", partial=partial)))
-    assert state.assistant_buffer == "Hello"
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    assert state.active_assistant is not None
+    assert state.items == []
+
+    adapter.apply(_text_update("Hel"))
+    adapter.apply(_text_update("Hello"))
+    assert state.active_assistant is not None
+    assert state.active_assistant.message.text == "Hello"
+    assert state.items == []
 
     adapter.apply(MessageEndEvent(message=AssistantMessage(content="Hello")))
 
-    assert state.assistant_buffer == ""
+    assert state.active_assistant is None
     assert [(item.role, item.text) for item in state.items] == [("assistant", "Hello")]
 
 
@@ -131,16 +149,138 @@ def test_tui_adapter_builds_user_and_compact_skill_items() -> None:
     ]
 
 
-def test_tui_adapter_groups_nested_thinking_deltas() -> None:
+def test_tui_adapter_keeps_streamed_thinking_out_of_items() -> None:
     state = TuiState()
     adapter = TuiEventAdapter(state)
-    partial = AssistantMessage()
 
-    adapter.apply(_update(ThinkingDeltaEvent(content_index=0, delta="hidden ", partial=partial)))
-    adapter.apply(_update(ThinkingDeltaEvent(content_index=0, delta="reasoning", partial=partial)))
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    adapter.apply(_thinking_update("hidden "))
+    adapter.apply(_thinking_update("hidden reasoning"))
 
-    assert [(item.role, item.text) for item in state.items] == [("thinking", "hidden reasoning")]
+    assert state.items == []
+    assert state.active_assistant is not None
+    assert [
+        block.thinking
+        for block in state.active_assistant.message.content
+        if isinstance(block, ThinkingContent)
+    ] == ["hidden reasoning"]
     assert state.show_thinking is False
+
+
+def test_tui_adapter_update_adopts_cumulative_snapshot_exactly() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+
+    snapshot = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="plan"),
+            TextContent(text="first"),
+            ThinkingContent(thinking="more"),
+            TextContent(text="second"),
+        ]
+    )
+    adapter.apply(
+        _update(TextDeltaEvent(content_index=3, delta="second", partial=snapshot))
+    )
+
+    assert state.active_assistant is not None
+    assert state.active_assistant.message is snapshot
+    assert state.items == []
+
+
+def test_tui_adapter_final_end_projects_canonical_blocks_exactly_once() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    adapter.apply(_thinking_update("plan"))
+
+    final = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="plan"),
+            TextContent(text="before"),
+            ThinkingContent(thinking="continue"),
+            TextContent(text="done"),
+        ]
+    )
+    adapter.apply(MessageEndEvent(message=final))
+
+    assert state.active_assistant is None
+    assert [(item.role, item.text) for item in state.items] == [
+        ("thinking", "plan"),
+        ("assistant", "before"),
+        ("thinking", "continue"),
+        ("assistant", "done"),
+    ]
+
+
+def test_tui_adapter_final_content_wins_over_partial_snapshot() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    adapter.apply(_text_update("draft that will be corrected"))
+
+    adapter.apply(MessageEndEvent(message=AssistantMessage(content="corrected")))
+
+    assert state.active_assistant is None
+    assert [(item.role, item.text) for item in state.items] == [("assistant", "corrected")]
+
+
+def test_tui_adapter_bare_agent_end_flushes_unfinished_draft_once() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(AgentStartEvent())
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    partial = AssistantMessage(
+        content=[ThinkingContent(thinking="plan"), TextContent(text="partial answer")]
+    )
+    adapter.apply(
+        _update(TextDeltaEvent(content_index=1, delta="partial answer", partial=partial))
+    )
+
+    adapter.apply(AgentEndEvent())
+    adapter.apply(AgentSettledEvent())
+
+    assert state.active_assistant is None
+    assert state.running is False
+    assert [(item.role, item.text) for item in state.items] == [
+        ("thinking", "plan"),
+        ("assistant", "partial answer"),
+    ]
+
+
+def test_tui_adapter_replacement_start_interrupts_whole_previous_turn() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    partial = AssistantMessage(
+        content=[ThinkingContent(thinking="plan"), TextContent(text="partial")]
+    )
+    adapter.apply(_update(TextDeltaEvent(content_index=1, delta="partial", partial=partial)))
+    first_stream_id = state.active_assistant.stream_id if state.active_assistant else None
+
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+
+    assert state.active_assistant is not None
+    assert first_stream_id is not None
+    assert state.active_assistant.stream_id != first_stream_id
+    assert state.active_assistant.message.content == []
+    assert [(item.role, item.text) for item in state.items] == [
+        ("thinking", "plan"),
+        ("assistant", "partial"),
+    ]
+
+
+def test_tui_state_clear_removes_active_draft() -> None:
+    state = TuiState()
+    adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    adapter.apply(_text_update("partial"))
+
+    state.clear()
+
+    assert state.active_assistant is None
+    assert state.items == []
 
 
 def test_tui_state_restores_persisted_assistant_blocks_in_order() -> None:
@@ -728,18 +868,27 @@ def test_tui_adapter_records_retry_and_queue_status() -> None:
 
 
 def test_tui_adapter_records_assistant_error_and_aborted_message() -> None:
-    state = TuiState(running=True, assistant_buffer="partial")
+    state = TuiState(running=True)
     adapter = TuiEventAdapter(state)
+    adapter.apply(MessageStartEvent(message=AssistantMessage()))
+    adapter.apply(_text_update("partial"))
 
     adapter.apply(
         MessageEndEvent(
-            message=AssistantMessage(stop_reason="error", error_message="provider failed")
+            message=AssistantMessage(
+                content="partial",
+                stop_reason="error",
+                error_message="provider failed",
+            )
         )
     )
 
     assert state.error == "provider failed"
-    assert [(item.role, item.text) for item in state.items] == [("error", "Error: provider failed")]
-    assert state.assistant_buffer == ""
+    assert [(item.role, item.text) for item in state.items] == [
+        ("assistant", "partial"),
+        ("error", "Error: provider failed"),
+    ]
+    assert state.active_assistant is None
 
 
 def test_tui_state_restores_partial_assistant_response_and_error() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -42,12 +42,20 @@ from tau_agent import (
     UserMessage,
 )
 from tau_agent.messages import assistant_content
-from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
+from tau_agent.provider_events import (
+    TextDeltaEvent,
+    TextEndEvent,
+    TextStartEvent,
+    ThinkingDeltaEvent,
+    ThinkingEndEvent,
+    ThinkingStartEvent,
+)
 from tau_coding.catalog_loader import user_catalog_path
 from tau_coding.commands import CommandResult
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.events import (
     AgentSettledEvent,
+    AutoRetryStartEvent,
     CodingSessionEvent,
     CompactionEndEvent,
     CompactionStartEvent,
@@ -1879,8 +1887,14 @@ async def test_streaming_transcript_applies_role_foreground() -> None:
 
         # Streamed thinking is dimmed immediately, matching the finalized block
         # instead of shifting color on the next redraw.
-        await transcript.append_thinking_delta(
-            "reasoning", theme=TAU_DARK_THEME, show_thinking=True
+        app.state.update_assistant(
+            AssistantMessage(content=[ThinkingContent(thinking="reasoning")])
+        )
+        await transcript.sync_active_assistant(
+            app.state.active_assistant,
+            changed_content_index=0,
+            theme=TAU_DARK_THEME,
+            show_thinking=True,
         )
         await pilot.pause()
         thinking = next(
@@ -1888,7 +1902,17 @@ async def test_streaming_transcript_applies_role_foreground() -> None:
         )
         assert thinking.styles.color == Color.parse(thinking_fg)
 
-        await transcript.append_assistant_delta("answer", theme=TAU_DARK_THEME)
+        app.state.update_assistant(
+            AssistantMessage(
+                content=[ThinkingContent(thinking="reasoning"), TextContent(text="answer")]
+            )
+        )
+        await transcript.sync_active_assistant(
+            app.state.active_assistant,
+            changed_content_index=1,
+            theme=TAU_DARK_THEME,
+            show_thinking=True,
+        )
         await pilot.pause()
         assistant = next(
             w for w in app.query(StreamingTranscriptMessageWidget) if w.item.role == "assistant"
@@ -2207,6 +2231,21 @@ async def test_transcript_resize_preserves_mounted_message_widgets() -> None:
         assert tuple(app.query(TranscriptMessageWidget)) == before
 
 
+async def _stream_assistant_snapshot(
+    app: TauTuiApp,
+    transcript: TranscriptView,
+    cumulative_text: str,
+) -> None:
+    """Advance one streamed answer to a cumulative snapshot through the draft API."""
+    app.state.update_assistant(AssistantMessage(content=[TextContent(text=cumulative_text)]))
+    await transcript.sync_active_assistant(
+        app.state.active_assistant,
+        changed_content_index=0,
+        theme=TAU_DARK_THEME,
+        show_thinking=app.state.show_thinking,
+    )
+
+
 @pytest.mark.anyio
 async def test_streaming_transcript_deltas_do_not_force_scroll_end_during_scrollback() -> None:
     app = TauTuiApp(
@@ -2238,8 +2277,8 @@ async def test_streaming_transcript_deltas_do_not_force_scroll_end_during_scroll
 
         transcript.scroll_end = tracking_scroll_end  # type: ignore[method-assign]
 
-        await transcript.append_assistant_delta("alpha")
-        await transcript.append_assistant_delta(" beta")
+        await _stream_assistant_snapshot(app, transcript, "alpha")
+        await _stream_assistant_snapshot(app, transcript, "alpha beta")
         await pilot.pause()
 
     assert forced_scrolls == 0
@@ -2262,7 +2301,7 @@ async def test_streaming_transcript_deltas_follow_when_at_bottom() -> None:
         await pilot.pause()
         assert transcript.is_vertical_scroll_end
 
-        await transcript.append_assistant_delta("alpha\n" * 20)
+        await _stream_assistant_snapshot(app, transcript, "alpha\n" * 20)
         for _ in range(5):
             await pilot.pause()
             if transcript.is_vertical_scroll_end:
@@ -2297,7 +2336,7 @@ async def test_streaming_transcript_deltas_preserve_user_scrollback() -> None:
         scrollback_y = transcript.scroll_y
         assert not transcript.is_vertical_scroll_end
 
-        await transcript.append_assistant_delta("alpha\n" * 20)
+        await _stream_assistant_snapshot(app, transcript, "alpha\n" * 20)
         await pilot.pause()
 
         assert transcript.scroll_y == scrollback_y
@@ -2321,7 +2360,7 @@ async def test_streaming_transcript_deltas_do_not_apply_stale_follow_scroll() ->
         await pilot.pause()
         assert transcript.is_vertical_scroll_end
 
-        await transcript.append_assistant_delta("alpha\n" * 20)
+        await _stream_assistant_snapshot(app, transcript, "alpha\n" * 20)
         transcript.scroll_to(
             y=max(0, transcript.max_scroll_y - 5),
             animate=False,
@@ -2373,7 +2412,7 @@ async def test_streaming_transcript_fractional_scrollback_after_refollow_stops_f
         scrollback_y = transcript.scroll_y
         assert not transcript.is_vertical_scroll_end
 
-        await transcript.append_assistant_delta("alpha\n" * 20)
+        await _stream_assistant_snapshot(app, transcript, "alpha\n" * 20)
         await pilot.pause()
 
         assert transcript.scroll_y == scrollback_y
@@ -2511,21 +2550,22 @@ async def test_tui_message_start_does_not_mount_empty_assistant_message() -> Non
 
 @pytest.mark.anyio
 async def test_tui_streaming_deltas_update_active_message_without_full_refresh() -> None:
-    partial = AssistantMessage()
+    first = AssistantMessage(content=[TextContent(text="alpha ")])
+    second = AssistantMessage(content=[TextContent(text="alpha beta")])
     session = FakeSession(
         events=[
             AgentStartEvent(),
-            MessageStartEvent(message=partial),
+            MessageStartEvent(message=AssistantMessage()),
             MessageUpdateEvent(
-                message=partial,
+                message=first,
                 assistant_message_event=TextDeltaEvent(
-                    content_index=0, delta="alpha ", partial=partial
+                    content_index=0, delta="alpha ", partial=first
                 ),
             ),
             MessageUpdateEvent(
-                message=partial,
+                message=second,
                 assistant_message_event=TextDeltaEvent(
-                    content_index=0, delta="beta", partial=partial
+                    content_index=0, delta="beta", partial=second
                 ),
             ),
             MessageEndEvent(message=AssistantMessage(content="alpha beta")),
@@ -3378,7 +3418,7 @@ async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized()
         await pilot.pause()
         transcript = app.query_one("#transcript", TranscriptView)
 
-        await transcript.append_assistant_delta("```python\n" + long_code_line)
+        await _stream_assistant_snapshot(app, transcript, "```python\n" + long_code_line)
         await pilot.pause()
 
         streaming_fence = app.query_one("MarkdownFence")
@@ -3386,7 +3426,14 @@ async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized()
         assert streaming_fence.styles.scrollbar_size_horizontal == 0
         assert streaming_fence.show_horizontal_scrollbar is False
 
-        await transcript.finish_assistant_message("```python\n" + long_code_line + "\n```")
+        app.state.finish_assistant(
+            AssistantMessage(content="```python\n" + long_code_line + "\n```")
+        )
+        await transcript.finish_active_assistant(
+            [app.state.items[-1]],
+            theme=TAU_DARK_THEME,
+            show_thinking=False,
+        )
         await pilot.pause()
 
         finalized_fence = app.query_one("MarkdownFence")
@@ -5075,7 +5122,10 @@ async def test_tui_mid_run_custom_follow_up_renders_card_not_raw_content() -> No
 @pytest.mark.anyio
 async def test_structured_assistant_redraw_preserves_extension_custom_card() -> None:
     raw = "<task-notification>agent-1 completed</task-notification>"
-    partial = AssistantMessage()
+    thinking = AssistantMessage(content=[ThinkingContent(thinking="plan")])
+    answer = AssistantMessage(
+        content=[ThinkingContent(thinking="plan"), TextContent(text="done")]
+    )
     final = AssistantMessage(content=[ThinkingContent(thinking="plan"), TextContent(text="done")])
     session = FakeSession(
         events=[
@@ -5087,21 +5137,21 @@ async def test_structured_assistant_redraw_preserves_extension_custom_card() -> 
                     details={"description": "Summarize codebase"},
                 )
             ),
-            MessageStartEvent(message=partial),
+            MessageStartEvent(message=AssistantMessage()),
             MessageUpdateEvent(
-                message=partial,
+                message=thinking,
                 assistant_message_event=ThinkingDeltaEvent(
                     content_index=0,
                     delta="plan",
-                    partial=partial,
+                    partial=thinking,
                 ),
             ),
             MessageUpdateEvent(
-                message=partial,
+                message=answer,
                 assistant_message_event=TextDeltaEvent(
                     content_index=1,
                     delta="done",
-                    partial=partial,
+                    partial=answer,
                 ),
             ),
             MessageEndEvent(message=final),
@@ -5125,7 +5175,6 @@ async def test_structured_assistant_redraw_preserves_extension_custom_card() -> 
 @pytest.mark.anyio
 async def test_structured_assistant_finalization_preserves_existing_widget_identity() -> None:
     raw = "<task-notification>agent-1 completed</task-notification>"
-    partial = AssistantMessage()
     session = FakeSession(
         messages=[
             CustomMessage(
@@ -5136,21 +5185,25 @@ async def test_structured_assistant_finalization_preserves_existing_widget_ident
         ],
         events=[
             AgentStartEvent(),
-            MessageStartEvent(message=partial),
+            MessageStartEvent(message=AssistantMessage()),
             MessageUpdateEvent(
-                message=partial,
+                message=AssistantMessage(content=[ThinkingContent(thinking="plan")]),
                 assistant_message_event=ThinkingDeltaEvent(
                     content_index=0,
                     delta="plan",
-                    partial=partial,
+                    partial=AssistantMessage(content=[ThinkingContent(thinking="plan")]),
                 ),
             ),
             MessageUpdateEvent(
-                message=partial,
+                message=AssistantMessage(
+                    content=[ThinkingContent(thinking="plan"), TextContent(text="done")]
+                ),
                 assistant_message_event=TextDeltaEvent(
                     content_index=1,
                     delta="done",
-                    partial=partial,
+                    partial=AssistantMessage(
+                        content=[ThinkingContent(thinking="plan"), TextContent(text="done")]
+                    ),
                 ),
             ),
             MessageEndEvent(
@@ -5178,18 +5231,21 @@ async def test_structured_assistant_finalization_preserves_existing_widget_ident
 
 @pytest.mark.anyio
 async def test_structured_assistant_ignores_empty_final_content_blocks() -> None:
-    partial = AssistantMessage()
     session = FakeSession(
         messages=[UserMessage(content="earlier")],
         events=[
             AgentStartEvent(),
-            MessageStartEvent(message=partial),
+            MessageStartEvent(message=AssistantMessage()),
             MessageUpdateEvent(
-                message=partial,
+                message=AssistantMessage(
+                    content=[ThinkingContent(thinking=""), TextContent(text="done")]
+                ),
                 assistant_message_event=TextDeltaEvent(
                     content_index=1,
                     delta="done",
-                    partial=partial,
+                    partial=AssistantMessage(
+                        content=[ThinkingContent(thinking=""), TextContent(text="done")]
+                    ),
                 ),
             ),
             MessageEndEvent(
@@ -5208,6 +5264,783 @@ async def test_structured_assistant_ignores_empty_final_content_blocks() -> None
 
         transcript = app.query_one("#transcript", TranscriptView)
         assert [line.text for line in transcript.lines] == ["earlier", "done"]
+
+
+def _streamed_thinking_turn_events() -> list[CodingSessionEvent]:
+    """Return a realistic stream whose update messages are cumulative snapshots."""
+    start = AssistantMessage()
+    thinking_started = AssistantMessage(
+        content=[ThinkingContent(thinking="")],
+    )
+    first_thinking = AssistantMessage(
+        content=[ThinkingContent(thinking="plan ")],
+    )
+    complete_thinking = AssistantMessage(
+        content=[ThinkingContent(thinking="plan the review")],
+    )
+    text_started = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="plan the review"),
+            TextContent(text=""),
+        ],
+    )
+    complete_message = AssistantMessage(
+        content=[
+            ThinkingContent(thinking="plan the review"),
+            TextContent(text="verdict"),
+        ],
+    )
+    return [
+        AgentStartEvent(),
+        MessageStartEvent(message=start),
+        MessageUpdateEvent(
+            message=thinking_started,
+            assistant_message_event=ThinkingStartEvent(
+                content_index=0,
+                partial=thinking_started,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=first_thinking,
+            assistant_message_event=ThinkingDeltaEvent(
+                content_index=0,
+                delta="plan ",
+                partial=first_thinking,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=complete_thinking,
+            assistant_message_event=ThinkingDeltaEvent(
+                content_index=0,
+                delta="the review",
+                partial=complete_thinking,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=complete_thinking,
+            assistant_message_event=ThinkingEndEvent(
+                content_index=0,
+                content="plan the review",
+                partial=complete_thinking,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=text_started,
+            assistant_message_event=TextStartEvent(
+                content_index=1,
+                partial=text_started,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=complete_message,
+            assistant_message_event=TextDeltaEvent(
+                content_index=1,
+                delta="verdict",
+                partial=complete_message,
+            ),
+        ),
+        MessageUpdateEvent(
+            message=complete_message,
+            assistant_message_event=TextEndEvent(
+                content_index=1,
+                content="verdict",
+                partial=complete_message,
+            ),
+        ),
+        MessageEndEvent(message=complete_message),
+        AgentEndEvent(),
+    ]
+
+
+async def _apply_tui_stream_event(app: TauTuiApp, event: CodingSessionEvent) -> None:
+    """Apply one event through the same state-then-view order used by the app."""
+    app.adapter.apply(event)
+    await app._apply_streaming_transcript_event(event)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("show_thinking", [False, True])
+async def test_midstream_redraw_keeps_one_complete_thinking_block(show_thinking: bool) -> None:
+    """A redraw between deltas must not orphan or duplicate the live thinking block."""
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = show_thinking
+        redrawn = False
+        for event in _streamed_thinking_turn_events():
+            nested = (
+                event.assistant_message_event if isinstance(event, MessageUpdateEvent) else None
+            )
+            if isinstance(nested, ThinkingDeltaEvent) and nested.delta == "the review":
+                app._refresh()
+                await pilot.pause()
+                redrawn = True
+            await _apply_tui_stream_event(app, event)
+        assert redrawn
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        thinking = (
+            "plan the review"
+            if show_thinking
+            else "Thinking… Press Ctrl+T to show thinking tokens."
+        )
+        assert [line.text for line in transcript.lines] == ["review", thinking, "verdict"]
+
+
+@pytest.mark.anyio
+async def test_midstream_thinking_toggle_keeps_one_complete_thinking_block() -> None:
+    """Ctrl+T between deltas must rebuild, rather than split, the active block."""
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        toggled = False
+        for event in _streamed_thinking_turn_events():
+            nested = (
+                event.assistant_message_event if isinstance(event, MessageUpdateEvent) else None
+            )
+            if isinstance(nested, ThinkingDeltaEvent) and nested.delta == "the review":
+                await pilot.press("ctrl+t")
+                await pilot.pause()
+                toggled = True
+            await _apply_tui_stream_event(app, event)
+        assert toggled
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+
+@pytest.mark.anyio
+async def test_midstream_redraw_after_text_started_keeps_block_order() -> None:
+    """Rebuilding a live thinking-and-text turn must keep one ordered projection."""
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        redrawn = False
+        for event in _streamed_thinking_turn_events():
+            await _apply_tui_stream_event(app, event)
+            nested = (
+                event.assistant_message_event if isinstance(event, MessageUpdateEvent) else None
+            )
+            if isinstance(nested, TextDeltaEvent):
+                app._refresh()
+                await pilot.pause()
+                redrawn = True
+        assert redrawn
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+
+def _text_snapshot_update(message: AssistantMessage, *, content_index: int) -> MessageUpdateEvent:
+    """Wrap a cumulative snapshot in a text-delta update event."""
+    return MessageUpdateEvent(
+        message=message,
+        assistant_message_event=TextDeltaEvent(
+            content_index=content_index,
+            delta="",
+            partial=message,
+        ),
+    )
+
+
+def _thinking_snapshot_update(
+    message: AssistantMessage,
+    *,
+    content_index: int,
+) -> MessageUpdateEvent:
+    """Wrap a cumulative snapshot in a thinking-delta update event."""
+    return MessageUpdateEvent(
+        message=message,
+        assistant_message_event=ThinkingDeltaEvent(
+            content_index=content_index,
+            delta="",
+            partial=message,
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_midstream_redraw_between_text_deltas_keeps_one_answer_row() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        first = AssistantMessage(content=[TextContent(text="ver")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(first, content_index=0))
+        app._refresh()
+        await pilot.pause()
+        second = AssistantMessage(content=[TextContent(text="verdict")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(second, content_index=0))
+        await _apply_tui_stream_event(
+            app, MessageEndEvent(message=AssistantMessage(content="verdict"))
+        )
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == ["review", "verdict"]
+
+
+@pytest.mark.anyio
+async def test_midstream_thinking_toggle_after_text_keeps_thinking_before_answer() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        thinking = AssistantMessage(content=[ThinkingContent(thinking="plan the review")])
+        await _apply_tui_stream_event(app, _thinking_snapshot_update(thinking, content_index=0))
+        started = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="ver")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(started, content_index=1))
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        complete = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(complete, content_index=1))
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+        await _apply_tui_stream_event(app, MessageEndEvent(message=complete))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+
+@pytest.mark.anyio
+async def test_repeated_thinking_toggles_midstream_keep_single_projection() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=1))
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        for _ in range(2):
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "Thinking… Press Ctrl+T to show thinking tokens.",
+            "verdict",
+        ]
+
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+
+@pytest.mark.anyio
+async def test_slash_command_refresh_during_stream_keeps_single_projection() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="ver")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=1))
+
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.text = "/session"
+        await app._submit_prompt_from_editor(streaming_behavior="steer")
+        await pilot.pause()
+
+        complete = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(complete, content_index=1))
+        await _apply_tui_stream_event(app, MessageEndEvent(message=complete))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        lines = [line.text for line in transcript.lines]
+        assert lines.count("plan the review") == 1
+        assert lines.count("verdict") == 1
+
+
+@pytest.mark.anyio
+async def test_theme_change_and_resize_during_stream_keep_single_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(content=[ThinkingContent(thinking="plan the review")])
+        await _apply_tui_stream_event(app, _thinking_snapshot_update(snapshot, content_index=0))
+
+        app._set_tui_theme("tau-light")
+        await pilot.pause()
+        await pilot.resize_terminal(90, 24)
+        await pilot.pause()
+
+        complete = AssistantMessage(
+            content=[ThinkingContent(thinking="plan the review"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(complete, content_index=1))
+        await _apply_tui_stream_event(app, MessageEndEvent(message=complete))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan the review",
+            "verdict",
+        ]
+
+
+@pytest.mark.anyio
+async def test_interleaved_thinking_text_stream_matches_final_canonical_order() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        stages = [
+            AssistantMessage(content=[ThinkingContent(thinking="plan")]),
+            AssistantMessage(
+                content=[ThinkingContent(thinking="plan"), TextContent(text="first")]
+            ),
+            AssistantMessage(
+                content=[
+                    ThinkingContent(thinking="plan"),
+                    TextContent(text="first"),
+                    ThinkingContent(thinking="more"),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    ThinkingContent(thinking="plan"),
+                    TextContent(text="first"),
+                    ThinkingContent(thinking="more"),
+                    TextContent(text="second"),
+                ]
+            ),
+        ]
+        for index, stage in enumerate(stages):
+            update = (
+                _thinking_snapshot_update(stage, content_index=index)
+                if index % 2 == 0
+                else _text_snapshot_update(stage, content_index=index)
+            )
+            await _apply_tui_stream_event(app, update)
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        live_lines = [line.text for line in transcript.lines]
+        assert live_lines == ["review", "plan", "first", "more", "second"]
+
+        await _apply_tui_stream_event(app, MessageEndEvent(message=stages[-1]))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == live_lines
+
+
+@pytest.mark.anyio
+async def test_adjacent_hidden_thinking_blocks_share_one_placeholder() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(
+            content=[
+                ThinkingContent(thinking="first plan"),
+                ThinkingContent(thinking="second plan"),
+                TextContent(text="answer"),
+            ]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=2))
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        placeholder = "Thinking… Press Ctrl+T to show thinking tokens."
+        assert [line.text for line in transcript.lines] == ["review", placeholder, "answer"]
+
+        await _apply_tui_stream_event(app, MessageEndEvent(message=snapshot))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+        assert [line.text for line in transcript.lines] == ["review", placeholder, "answer"]
+
+
+@pytest.mark.anyio
+async def test_final_message_correction_replaces_partial_content() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        draft = AssistantMessage(content=[TextContent(text="draft that will change")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(draft, content_index=0))
+        await _apply_tui_stream_event(
+            app, MessageEndEvent(message=AssistantMessage(content="corrected"))
+        )
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == ["review", "corrected"]
+
+
+@pytest.mark.anyio
+async def test_empty_final_content_removes_streamed_tail() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        draft = AssistantMessage(content=[TextContent(text="draft")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(draft, content_index=0))
+        await _apply_tui_stream_event(app, MessageEndEvent(message=AssistantMessage(content=[])))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == ["review"]
+        assert not list(app.query(StreamingTranscriptMessageWidget))
+
+
+@pytest.mark.anyio
+async def test_aborted_stream_projects_partial_turn_and_single_error() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(
+            content=[ThinkingContent(thinking="plan"), TextContent(text="partial")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=1))
+        aborted = AssistantMessage(
+            content=[ThinkingContent(thinking="plan"), TextContent(text="partial")],
+            stop_reason="aborted",
+            error_message="Operation aborted",
+        )
+        await _apply_tui_stream_event(app, MessageEndEvent(message=aborted))
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        lines = [line.text for line in transcript.lines]
+        assert lines.count("plan") == 1
+        assert lines.count("partial") == 1
+        assert sum(1 for line in lines if line.startswith("Error:")) == 1
+
+
+@pytest.mark.anyio
+async def test_local_cancellation_retains_whole_partial_turn() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(
+            content=[ThinkingContent(thinking="plan"), TextContent(text="partial")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=1))
+
+        app._cancel_active_prompt(notify=False)
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert app.state.active_assistant is None
+        assert [line.text for line in transcript.lines] == ["review", "plan", "partial"]
+        assert not list(app.query(StreamingTranscriptMessageWidget))
+
+
+@pytest.mark.anyio
+async def test_retry_status_row_mounts_before_active_tail() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(content=[TextContent(text="partial")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=0))
+        await _apply_tui_stream_event(
+            app,
+            AutoRetryStartEvent(
+                attempt=1,
+                max_attempts=3,
+                delay_ms=0,
+                error_message="Retrying provider request.",
+            ),
+        )
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "… Retrying provider request.",
+            "partial",
+        ]
+
+
+@pytest.mark.anyio
+async def test_replacement_stream_preserves_previous_partial_turn() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        partial = AssistantMessage(
+            content=[ThinkingContent(thinking="plan"), TextContent(text="partial")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(partial, content_index=1))
+
+        # A replacement start without a terminal event for the previous stream.
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        await pilot.pause()
+        replacement = AssistantMessage(content=[TextContent(text="second answer")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(replacement, content_index=0))
+        await _apply_tui_stream_event(app, MessageEndEvent(message=replacement))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "plan",
+            "partial",
+            "second answer",
+        ]
+
+
+@pytest.mark.anyio
+async def test_scrolled_back_window_does_not_mount_live_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tau_coding.tui import widgets as tui_widgets
+
+    monkeypatch.setattr(tui_widgets, "TRANSCRIPT_WINDOW_ITEMS", 6)
+    monkeypatch.setattr(tui_widgets, "TRANSCRIPT_WINDOW_PAGE_ITEMS", 2)
+    app = TauTuiApp(
+        FakeSession(messages=[UserMessage(content=f"message {index}") for index in range(12)])
+    )
+
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one("#transcript", TranscriptView)
+        transcript.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        assert transcript._window_end < len(app.state.items)
+
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(content=[TextContent(text="streamed answer")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=0))
+        await pilot.pause()
+
+        assert not list(app.query(StreamingTranscriptMessageWidget))
+        assert "streamed answer" not in [line.text for line in transcript.lines]
+
+
+@pytest.mark.anyio
+async def test_redraw_during_suspended_markdown_write_keeps_single_copy() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+    suspended = asyncio.Event()
+    release = asyncio.Event()
+    original_write = MarkdownStream.write
+
+    async def gated_write(self: MarkdownStream, fragment: str) -> None:
+        suspended.set()
+        await release.wait()
+        await original_write(self, fragment)
+
+    MarkdownStream.write = gated_write  # type: ignore[method-assign]
+    try:
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            await _apply_tui_stream_event(app, AgentStartEvent())
+            await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+            transcript = app.query_one("#transcript", TranscriptView)
+            snapshot = AssistantMessage(content=[TextContent(text="alpha")])
+            app.adapter.apply(_text_snapshot_update(snapshot, content_index=0))
+            pending = asyncio.create_task(
+                app._apply_streaming_transcript_event(
+                    _text_snapshot_update(snapshot, content_index=0)
+                )
+            )
+            await suspended.wait()
+
+            app._refresh()
+            await pilot.pause()
+
+            release.set()
+            await pending
+            await pilot.pause()
+
+            widgets = [
+                widget
+                for widget in app.query(StreamingTranscriptMessageWidget)
+                if widget.parent is transcript
+            ]
+            assert len(widgets) == 1
+            assert widgets[0].selection_text == "alpha"
+            assert [line.text for line in transcript.lines] == ["review", "alpha"]
+            assert transcript._active_render is not None
+    finally:
+        MarkdownStream.write = original_write  # type: ignore[method-assign]
+
+
+@pytest.mark.anyio
+async def test_redraw_during_suspended_finalization_keeps_single_copy() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+    suspended = asyncio.Event()
+    release = asyncio.Event()
+    original_stop = MarkdownStream.stop
+
+    async def gated_stop(self: MarkdownStream) -> None:
+        suspended.set()
+        await release.wait()
+        await original_stop(self)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        snapshot = AssistantMessage(content=[TextContent(text="alpha")])
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=0))
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        end_event = MessageEndEvent(message=AssistantMessage(content="alpha"))
+        app.adapter.apply(end_event)
+        MarkdownStream.stop = gated_stop  # type: ignore[method-assign]
+        try:
+            pending = asyncio.create_task(app._apply_streaming_transcript_event(end_event))
+            await suspended.wait()
+
+            app._refresh()
+            await pilot.pause()
+
+            release.set()
+            await pending
+        finally:
+            MarkdownStream.stop = original_stop  # type: ignore[method-assign]
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        assert [line.text for line in transcript.lines] == ["review", "alpha"]
+        canonical = app.state.items[-1]
+        mounted = transcript._item_widgets.get(id(canonical))
+        assert mounted is not None
+        assert mounted.parent is transcript
+        assert transcript._active_render is None
+
+
+@pytest.mark.anyio
+async def test_stale_write_from_replaced_stream_cannot_resurrect_output() -> None:
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+    suspended = asyncio.Event()
+    release = asyncio.Event()
+    original_write = MarkdownStream.write
+    gate_first_write = True
+
+    async def gated_write(self: MarkdownStream, fragment: str) -> None:
+        nonlocal gate_first_write
+        if gate_first_write:
+            gate_first_write = False
+            suspended.set()
+            await release.wait()
+        await original_write(self, fragment)
+
+    MarkdownStream.write = gated_write  # type: ignore[method-assign]
+    try:
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            await _apply_tui_stream_event(app, AgentStartEvent())
+            await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+            old_snapshot = AssistantMessage(content=[TextContent(text="old text")])
+            app.adapter.apply(_text_snapshot_update(old_snapshot, content_index=0))
+            pending = asyncio.create_task(
+                app._apply_streaming_transcript_event(
+                    _text_snapshot_update(old_snapshot, content_index=0)
+                )
+            )
+            await suspended.wait()
+
+            # Replacement stream begins while the old write is suspended.
+            await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+            await pilot.pause()
+            replacement = AssistantMessage(content=[TextContent(text="new text")])
+            await _apply_tui_stream_event(
+                app, _text_snapshot_update(replacement, content_index=0)
+            )
+
+            release.set()
+            await pending
+            await pilot.pause()
+
+            transcript = app.query_one("#transcript", TranscriptView)
+            lines = [line.text for line in transcript.lines]
+            assert lines.count("old text") == 1
+            assert lines.count("new text") == 1
+            assert lines == ["review", "old text", "new text"]
+    finally:
+        MarkdownStream.write = original_write  # type: ignore[method-assign]
 
 
 @pytest.mark.anyio
@@ -7912,7 +8745,7 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
 
     async with app.run_test() as pilot:
         app.state.running = True
-        app.state.add_thinking_delta("internal plan")
+        app.state.add_item("thinking", "internal plan")
         app.state.add_item("assistant", "final answer")
         app._refresh()
         await pilot.pause()
@@ -7940,24 +8773,30 @@ async def test_tui_app_toggles_thinking_tokens_from_keybinding_while_running() -
 
 @pytest.mark.anyio
 async def test_tui_app_hidden_thinking_placeholder_stays_before_streamed_answer() -> None:
-    partial = AssistantMessage()
+    thinking = AssistantMessage(content=[ThinkingContent(thinking="private plan")])
+    answer = AssistantMessage(
+        content=[ThinkingContent(thinking="private plan"), TextContent(text="public answer")]
+    )
+    final = AssistantMessage(
+        content=[ThinkingContent(thinking="private plan"), TextContent(text="public answer")]
+    )
     session = FakeSession(
         events=[
             AgentStartEvent(),
+            MessageStartEvent(message=AssistantMessage()),
             MessageUpdateEvent(
-                message=partial,
+                message=thinking,
                 assistant_message_event=ThinkingDeltaEvent(
-                    content_index=0, delta="private plan", partial=partial
+                    content_index=0, delta="private plan", partial=thinking
                 ),
             ),
-            MessageStartEvent(message=partial),
             MessageUpdateEvent(
-                message=partial,
+                message=answer,
                 assistant_message_event=TextDeltaEvent(
-                    content_index=0, delta="public answer", partial=partial
+                    content_index=1, delta="public answer", partial=answer
                 ),
             ),
-            MessageEndEvent(message=AssistantMessage(content="public answer")),
+            MessageEndEvent(message=final),
             AgentEndEvent(),
         ]
     )
@@ -8030,10 +8869,10 @@ async def test_tui_app_thinking_toggle_preserves_unrelated_items() -> None:
 
     async with app.run_test() as pilot:
         app.state.add_item("user", "first prompt")
-        app.state.add_thinking_delta("plan one")
+        app.state.add_item("thinking", "plan one")
         app.state.add_item("assistant", "first answer")
         app.state.add_item("user", "second prompt")
-        app.state.add_thinking_delta("plan two")
+        app.state.add_item("thinking", "plan two")
         app.state.add_item("assistant", "second answer")
         app._refresh()
         await pilot.pause()

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6044,6 +6044,93 @@ async def test_stale_write_from_replaced_stream_cannot_resurrect_output() -> Non
 
 
 @pytest.mark.anyio
+async def test_thinking_toggle_during_suspended_finalization_keeps_single_copy() -> None:
+    """Ctrl+T processed while finalization is suspended must not duplicate rows."""
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+    suspended = asyncio.Event()
+    release = asyncio.Event()
+    original_stop = MarkdownStream.stop
+
+    async def gated_stop(self: MarkdownStream) -> None:
+        suspended.set()
+        await release.wait()
+        await original_stop(self)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        thinking = AssistantMessage(content=[ThinkingContent(thinking="plan")])
+        await _apply_tui_stream_event(app, _thinking_snapshot_update(thinking, content_index=0))
+        snapshot = AssistantMessage(
+            content=[ThinkingContent(thinking="plan"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(snapshot, content_index=1))
+        await pilot.pause()
+
+        end_event = MessageEndEvent(message=snapshot)
+        app.adapter.apply(end_event)
+        MarkdownStream.stop = gated_stop  # type: ignore[method-assign]
+        try:
+            pending = asyncio.create_task(app._apply_streaming_transcript_event(end_event))
+            await suspended.wait()
+
+            app.action_toggle_thinking()
+            await pilot.pause()
+
+            release.set()
+            await pending
+        finally:
+            MarkdownStream.stop = original_stop  # type: ignore[method-assign]
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        lines = [line.text for line in transcript.lines]
+        placeholder = "Thinking… Press Ctrl+T to show thinking tokens."
+        assert lines.count("verdict") == 1
+        assert sum(1 for line in lines if line in {"plan", placeholder}) == 1
+
+
+@pytest.mark.anyio
+async def test_interrupted_stream_rows_survive_next_turn_finalization() -> None:
+    """A cancelled stream's projected rows must survive the next turn's completion."""
+    app = TauTuiApp(FakeSession(messages=[UserMessage(content="review")]))
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        earlier = AssistantMessage(content=[ThinkingContent(thinking="earlier thoughts")])
+        await _apply_tui_stream_event(app, _thinking_snapshot_update(earlier, content_index=0))
+
+        app._cancel_active_prompt(notify=False)
+        await pilot.pause()
+
+        await _apply_tui_stream_event(app, AgentStartEvent())
+        await _apply_tui_stream_event(app, MessageStartEvent(message=AssistantMessage()))
+        later = AssistantMessage(content=[ThinkingContent(thinking="later thoughts")])
+        await _apply_tui_stream_event(app, _thinking_snapshot_update(later, content_index=0))
+        final = AssistantMessage(
+            content=[ThinkingContent(thinking="later thoughts"), TextContent(text="verdict")]
+        )
+        await _apply_tui_stream_event(app, _text_snapshot_update(final, content_index=1))
+        await _apply_tui_stream_event(app, MessageEndEvent(message=final))
+        await _apply_tui_stream_event(app, AgentEndEvent())
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript", TranscriptView)
+        assert [line.text for line in transcript.lines] == [
+            "review",
+            "earlier thoughts",
+            "later thoughts",
+            "verdict",
+        ]
+
+
+@pytest.mark.anyio
 async def test_tui_app_prompts_picker_filters_and_inserts_without_submitting() -> None:
     session = FakeSession()
     session.prompt_templates = (


### PR DESCRIPTION
## Problem

The TUI can show streamed thinking text or answer text two times. This occurs when the app rebuilds the transcript during a response. Ctrl+T, slash commands, a terminal resize, or a theme change can start a rebuild.

The old code kept one live turn in three places:

- The answer text was in `TuiState.assistant_buffer`.
- The thinking text was in `TuiState.items`.
- The live widget pointers were in `TranscriptView`.

A rebuild made the live thinking rows into ordinary history rows. It also removed the live widget pointers. The next delta then made a second live widget. Completion removed only one copy. The other copy stayed on the screen. The session file was always correct. Only the TUI display was incorrect.

## Solution

This change uses the same ownership model as Pi.

- `TuiState.items` now holds only finalized history.
- One `ActiveAssistantDraft` object holds the full in-flight turn. It keeps the last cumulative message snapshot and a stream ID.
- The adapter reads the cumulative `MessageUpdateEvent.message` as the truth. It does not add deltas together.
- A pure helper projects the draft into ordered blocks. It keeps the provider block order. It shows one placeholder for each unbroken run of hidden thinking blocks.
- One `_ActiveAssistantRender` object owns all live tail widgets. A full redraw makes this owner again from the draft. A redraw can no longer make live rows into rows without an owner.
- `sync_active_assistant()` does the incremental updates. The usual path writes only the missing text suffix through `MarkdownStream`. New blocks mount without a rebuild of the other blocks. A correction or a replacement stream causes a full rebuild of the tail.
- `finish_active_assistant()` completes the turn one time only. When the block layout agrees, it binds the live widgets to the canonical items in place. Unrelated history widgets keep their identity.
- A render generation counter and the stream ID stop stale async work. Stale work cannot mount or register removed widgets.
- Cancellation and flush keep the full partial turn. This agrees with the aborted message in the session file.

## Tests

- Adapter tests cover the draft lifecycle, corrections, interruption, and replacement streams.
- App tests cover a redraw, Ctrl+T, a slash command, a theme change, and a resize during a stream.
- App tests also cover block order, hidden thinking runs, empty final content, abort, cancel, retry, and windowed scrollback.
- Deterministic race tests hold `MarkdownStream.write()` and `stop()` with `asyncio.Event`. They then start a redraw at an exact await point.

The performance behavior does not change. The usual path writes only a suffix for each delta. It does not parse the full markdown again. It does not remount unrelated history.

## Validation

- `uv run pytest tests/test_tui_adapter.py tests/test_tui_app.py` passes (432 tests).
- `uv run ruff check .` and `uv run mypy src` pass.
- The full suite passes. One unrelated test fails on `main` also, because of local environment tools.

A manual TUI smoke test with slow streaming is still necessary before merge.

## Documentation

See `dev-notes/tui-active-assistant-draft.md`. It explains the draft model, the redraw behavior, and the map to Pi's design.

## Example of the problem

If I ran `/session` or some other command while the model was thinking, it would duplicate the thinking block. I also had cases where the full output block was duplicated as well, but found that harder to reproduce. You can see below that the first thinking block is duplicated. After the fix, I couldn't reproduce that.

<img width="674" height="481" alt="Screenshot 2026-08-21 at 17 30 56" src="https://github.com/user-attachments/assets/655e819f-533e-4efa-818e-2710bccdc6aa" />

