### PR TITLE
Align ToolResultMessage.text with assistant messages

### DIFF
--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -191,7 +191,7 @@ class ToolResultMessage(WireModel):
 
     @property
     def text(self) -> str:
-        return content_text(self.content)
+        return "".join(block.text for block in self.content if isinstance(block, TextContent))
 
 
 class BashExecutionMessage(WireModel):


### PR DESCRIPTION
## Why

`ToolResultMessage.content` is always a block list after construction, same as `AssistantMessage`. `.text` should extract visible text the same way.

## Change

`ToolResultMessage.text` now joins `TextContent` blocks directly, instead of calling `content_text` (which also handles a stored string shape used by user messages).

No behavior change.

## Checks

- `uv run pytest tests/test_agent_types.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
