### PR TITLE
Add automatic Hugging Face route failover

### DIFF
--- a/dev-notes/hugging-face-automatic-route-failover.md
+++ b/dev-notes/hugging-face-automatic-route-failover.md
@@ -1,0 +1,95 @@
+# Hugging Face automatic route failover
+
+## What changed
+
+Tau now distinguishes two session-scoped Hugging Face routing modes:
+
+- `automatic`: an unsuffixed first request becomes sticky after a successful
+  `x-inference-provider` response, but the route remains recoverable.
+- `fixed`: a route selected through provider preferences or the extension API is
+  explicit user intent and is never silently replaced.
+
+When a sticky automatic route exhausts its provider-level retries with HTTP 408,
+409, 425, 429, or 5xx before emitting content, the coding session clears the
+resolved suffix and continues the same agent run once through Hugging Face's
+unsuffixed automatic router. A successful response supplies the replacement
+route header, which becomes the new automatic session pin.
+
+## Why core owns recovery
+
+The provider adapter knows how to repeat one HTTP request, but it cannot change
+application-owned session metadata or restart the interrupted agent run with a
+new runtime. An extension can select a route, but its only public way to trigger
+another turn adds a user message. `tau_coding.CodingSession` already owns safe
+continuation, persistence, cancellation, auto-retry events, and overflow
+recovery, so it is the correct boundary for route failover.
+
+The split remains:
+
+- `tau_ai`: retry the same wire request and preserve provider diagnostics.
+- `tau_agent`: portable provider/tool loop with no Hugging Face assumptions.
+- `tau_coding`: classify a terminal route failure, replace the runtime, continue
+  without another user message, and persist the route mode and result.
+- Hugging Face extension: discover live routes and let users choose automatic or
+  fixed mode.
+
+## Safety rules
+
+Failover happens only when all conditions hold:
+
+1. the logical Tau provider is `huggingface`;
+2. the session mode is `automatic`;
+3. a resolved route is currently pinned;
+4. provider diagnostics contain a retryable HTTP status; and
+5. the failed assistant message has no text, thinking, or tool-call content.
+
+Only one automatic reroute is attempted per prompt. The fallback itself is not
+rerouted again, preventing loops. Fixed routes still receive their configured
+same-route retries and then surface the terminal error.
+
+## Persistence and compatibility
+
+Session indexes now store `inference_provider_mode` next to the existing
+`inference_provider`. The current route remains a projection used for startup and
+resume; logical model identity and transcript entries remain unchanged.
+
+Older records with a route but no mode load as `fixed`. That conservative default
+prevents an upgrade from overriding a route that may have been selected manually.
+Records without a route load as `automatic`.
+
+The extension API exposes both the current resolved route and its mode. Existing
+extensions remain compatible: passing a route to `set_inference_provider` now
+means fixed, while passing `None` means automatic.
+
+## User-visible behavior
+
+`/session` reports either:
+
+```text
+Hugging Face inference provider: automatic (currently baseten)
+Hugging Face inference provider: deepinfra (fixed)
+```
+
+Automatic recovery emits `agent_end(will_retry=true)`, `auto_retry_start`, the
+continuation events, `auto_retry_end`, and finally `agent_settled`. Print-mode
+renderers treat a successful retry as a successful command. The TUI removes the
+intermediate terminal error when retry progress begins.
+
+Failover may lose provider-local prefix cache state and require a cold prefill.
+It also cannot bypass account-wide or router-wide rate limits.
+
+## Validation
+
+Deterministic tests cover automatic failover and repinning, exact continuation
+context without an extra user message, fixed-route non-failover, legacy session
+compatibility, extension-visible mode, frontend retry rendering, and session
+metadata round trips.
+
+Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -6,7 +6,7 @@ import contextlib
 import sys
 from os import environ
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import anyio
 import typer
@@ -890,6 +890,16 @@ async def run_openai_rpc_mode(
         and selection.provider.name == "huggingface"
         else None
     )
+    inference_provider_mode = (
+        record.inference_provider_mode
+        if resume_session_id is not None
+        and record.provider_name == "huggingface"
+        and selection.provider.name == "huggingface"
+        and record.model == selection.model
+        else "fixed"
+        if inference_provider is not None
+        else "automatic"
+    )
     provider = create_model_provider(
         selection.provider,
         model=selection.model,
@@ -906,6 +916,7 @@ async def run_openai_rpc_mode(
             session_manager=manager,
             provider_name=selection.provider.name,
             inference_provider=inference_provider,
+            inference_provider_mode=inference_provider_mode,
             provider_settings=settings,
             runtime_provider_config=selection.provider,
             shell_command_prefix=shell_settings.shell_command_prefix,
@@ -971,6 +982,16 @@ async def run_openai_print_mode(
         and selection.provider.name == "huggingface"
         else None
     )
+    inference_provider_mode = (
+        record.inference_provider_mode
+        if resume_session_id is not None
+        and record.provider_name == "huggingface"
+        and selection.provider.name == "huggingface"
+        and record.model == selection.model
+        else "fixed"
+        if inference_provider is not None
+        else "automatic"
+    )
     provider = create_model_provider(
         selection.provider,
         model=selection.model,
@@ -1000,6 +1021,7 @@ async def run_openai_print_mode(
             trust_override=trust_override,
             trust_default=shell_settings.default_project_trust,
             startup_model_override=provider_name is not None or model is not None,
+            inference_provider_mode=inference_provider_mode,
         )
     finally:
         await provider.aclose()
@@ -1071,6 +1093,7 @@ async def run_print_mode(
     session_manager: SessionManager | None = None,
     provider_name: str = DEFAULT_PROVIDER_NAME,
     inference_provider: str | None = None,
+    inference_provider_mode: Literal["automatic", "fixed"] | None = None,
     provider_settings: ProviderSettings | None = None,
     runtime_provider_config: ProviderConfig | None = None,
     shell_command_prefix: str | None = None,
@@ -1099,6 +1122,7 @@ async def run_print_mode(
             session_manager=session_manager,
             provider_name=provider_name,
             inference_provider=inference_provider,
+            inference_provider_mode=inference_provider_mode,
             provider_settings=provider_settings,
             runtime_provider_config=runtime_provider_config,
             shell_command_prefix=shell_command_prefix,

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -434,8 +434,13 @@ def _status_command(context: CommandContext) -> CommandResult:
         f"Context window: {session.context_window_tokens}",
     ]
     if session.provider_name == "huggingface":
-        route = getattr(session, "inference_provider", None) or "automatic"
-        lines.append(f"Hugging Face inference provider: {route}")
+        route = getattr(session, "inference_provider", None)
+        mode = getattr(session, "inference_provider_mode", "fixed" if route else "automatic")
+        if mode == "automatic":
+            route_status = f"automatic (currently {route})" if route else "automatic"
+        else:
+            route_status = f"{route} (fixed)" if route else "fixed"
+        lines.append(f"Hugging Face inference provider: {route_status}")
     context_window_source = getattr(session, "context_window_source", None)
     if context_window_source:
         lines.append(f"Context window source: {context_window_source}")

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -2,6 +2,8 @@
 
 Tau extensions are Python modules that can register custom tools and slash commands, observe lifecycle events, intercept tool calls and results, show UI dialogs, and customize message rendering.
 
+For Hugging Face-specific routing extensions, `set_inference_provider(<provider>)` selects a fixed route while `set_inference_provider(None)` restores recoverable automatic routing. Read both `context.inference_provider` (current route) and `context.inference_provider_mode` (`automatic` or `fixed`) when presenting route status.
+
 ## Start here
 
 For complete API documentation, read the repository's published guide when working in a Tau checkout:

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -6,6 +6,8 @@ Tau separates provider/model streaming (`tau_ai`), the portable harness (`tau_ag
 
 Use `/login` and `/model` for built-in providers. The custom-provider flow supports OpenAI-compatible endpoints. Durable provider settings live under Tau's home directory; consult the published `website/content/guides/providers-and-models.md` in a Tau checkout for the current schema and authentication behavior.
 
+Hugging Face routing has two session modes. Automatic mode keeps the provider from the first successful response as a sticky route, but retries once through unsuffixed routing after that route exhausts retryable pre-output HTTP failures. A configured or extension-selected provider is fixed and never silently overridden. The external Hugging Face extension controls these modes with `/hf route`; core owns safe continuation, persistence, and reroute diagnostics.
+
 ## Changing the built-in catalog
 
 For changes to a first-party provider or model, use this workflow:

--- a/src/tau_coding/diagnostics.py
+++ b/src/tau_coding/diagnostics.py
@@ -73,6 +73,26 @@ class AgentCallDiagnosticLogger:
         self._append(entry)
         return self.path
 
+    def log_huggingface_route_failover(
+        self,
+        *,
+        context: AgentCallDiagnosticContext,
+        failed_route: str,
+        replacement_route: str | None,
+        success: bool,
+        error_message: str | None,
+    ) -> Path:
+        """Log one completed automatic Hugging Face route failover."""
+        entry = _base_entry(context, phase="agent_loop_route_failover", kind="route_failover")
+        entry["route_failover"] = {
+            "from": failed_route,
+            "to": replacement_route,
+            "success": success,
+            **({"error": error_message} if error_message is not None else {}),
+        }
+        self._append(entry)
+        return self.path
+
     def _append(self, entry: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("a", encoding="utf-8") as file:

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -788,6 +788,12 @@ class ExtensionContext:
         return self._runtime.session_view.inference_provider
 
     @property
+    def inference_provider_mode(self) -> str:
+        """Return whether Hugging Face routing is automatic or explicitly fixed."""
+        self._generation.assert_active()
+        return self._runtime.session_view.inference_provider_mode
+
+    @property
     def session_id(self) -> str | None:
         """Return the current session id, if the session is indexed."""
         self._generation.assert_active()

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -87,6 +87,9 @@ class BoundSession(Protocol):
     def inference_provider(self) -> str | None: ...
 
     @property
+    def inference_provider_mode(self) -> str: ...
+
+    @property
     def session_id(self) -> str | None: ...
 
     @property

--- a/src/tau_coding/rendering/json.py
+++ b/src/tau_coding/rendering/json.py
@@ -4,7 +4,7 @@ import typer
 
 from tau_agent.events import MessageEndEvent
 from tau_agent.messages import AssistantMessage
-from tau_coding.events import CodingSessionEvent
+from tau_coding.events import AutoRetryEndEvent, CodingSessionEvent
 
 
 class JsonEventRenderer:
@@ -12,6 +12,8 @@ class JsonEventRenderer:
         self._failed = False
 
     def render(self, event: CodingSessionEvent) -> None:
+        if isinstance(event, AutoRetryEndEvent) and event.success:
+            self._failed = False
         if (
             isinstance(event, MessageEndEvent)
             and isinstance(event.message, AssistantMessage)

--- a/src/tau_coding/rendering/plain.py
+++ b/src/tau_coding/rendering/plain.py
@@ -4,7 +4,7 @@ import typer
 
 from tau_agent.events import MessageEndEvent
 from tau_agent.messages import AssistantMessage
-from tau_coding.events import CodingSessionEvent
+from tau_coding.events import AutoRetryEndEvent, CodingSessionEvent
 
 
 class FinalTextRenderer:
@@ -14,6 +14,10 @@ class FinalTextRenderer:
         self._error_messages: list[str] = []
 
     def render(self, event: CodingSessionEvent) -> None:
+        if isinstance(event, AutoRetryEndEvent) and event.success:
+            self._failed = False
+            self._error_messages.clear()
+            return
         if not isinstance(event, MessageEndEvent) or not isinstance(
             event.message, AssistantMessage
         ):

--- a/src/tau_coding/rendering/transcript.py
+++ b/src/tau_coding/rendering/transcript.py
@@ -14,7 +14,7 @@ from tau_agent.events import (
 )
 from tau_agent.messages import AssistantMessage, CustomMessage, ToolCall
 from tau_ai.events import TextDeltaEvent
-from tau_coding.events import AutoRetryStartEvent, CodingSessionEvent
+from tau_coding.events import AutoRetryEndEvent, AutoRetryStartEvent, CodingSessionEvent
 from tau_coding.extensions.api import CustomMessageMarkup
 from tau_coding.tui.state import format_tool_call_block
 
@@ -52,6 +52,9 @@ class TranscriptRenderer:
         if isinstance(event, AutoRetryStartEvent):
             self._newline()
             self._console.print(Text(f"… {event.error_message}", style="bright_black"))
+            return
+        if isinstance(event, AutoRetryEndEvent) and event.success:
+            self._failed = False
             return
         if isinstance(event, ToolExecutionEndEvent):
             status = "✗" if event.is_error else "✓"

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -121,7 +121,7 @@ from tau_coding.session_export import (
     export_session_artifact,
     normalize_export_format,
 )
-from tau_coding.session_manager import SessionManager
+from tau_coding.session_manager import InferenceProviderMode, SessionManager
 from tau_coding.session_stats import SessionStats, calculate_session_stats
 from tau_coding.skills import Skill, expand_skill_command, load_skills_with_diagnostics
 from tau_coding.system_prompt import (
@@ -252,6 +252,7 @@ class CodingSessionConfig:
     command_registry: CommandRegistry | None = None
     provider_name: str = "openai"
     inference_provider: str | None = None
+    inference_provider_mode: InferenceProviderMode | None = None
     provider_settings: ProviderSettings | None = None
     runtime_provider_config: ProviderConfig | None = None
     auto_compact_token_threshold: int | None = None
@@ -331,6 +332,9 @@ class CodingSession:
         self._command_registry = command_registry or create_default_command_registry()
         self._provider_name = config.provider_name
         self._inference_provider = config.inference_provider
+        self._inference_provider_mode: InferenceProviderMode = config.inference_provider_mode or (
+            "fixed" if config.inference_provider is not None else "automatic"
+        )
         self._provider_settings = config.provider_settings
         self._runtime_provider_config = config.runtime_provider_config
         self._resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
@@ -559,6 +563,11 @@ class CodingSession:
     def inference_provider(self) -> str | None:
         """Return the pinned Hugging Face backing provider, if any."""
         return self._inference_provider
+
+    @property
+    def inference_provider_mode(self) -> InferenceProviderMode:
+        """Return whether Hugging Face routing is automatic or explicitly fixed."""
+        return self._inference_provider_mode
 
     @property
     def available_providers(self) -> tuple[str, ...]:
@@ -1096,6 +1105,7 @@ class CodingSession:
             validate_provider_model(provider, model)
         self._harness.config.model = model
         self._inference_provider = _configured_inference_provider(provider, model)
+        self._inference_provider_mode = _configured_inference_provider_mode(provider, model)
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         self._sync_image_support()
@@ -1106,6 +1116,7 @@ class CodingSession:
                 model=model,
                 provider_name=self.provider_name,
                 inference_provider=self._inference_provider,
+                inference_provider_mode=self._inference_provider_mode,
                 preserve_inference_provider=False,
             )
 
@@ -1119,6 +1130,7 @@ class CodingSession:
 
         self._harness.config.model = model
         self._inference_provider = _configured_inference_provider(provider, model)
+        self._inference_provider_mode = _configured_inference_provider_mode(provider, model)
         self._sync_thinking_level_to_active_model()
         self._refresh_runtime_provider()
         self._sync_image_support()
@@ -1140,6 +1152,7 @@ class CodingSession:
                 "Inference-provider routing requires the huggingface provider"
             )
         normalized = validate_huggingface_inference_provider(route) if route is not None else None
+        mode: InferenceProviderMode = "fixed" if normalized is not None else "automatic"
         provider, provider_config = self._build_runtime_provider(
             inference_provider=normalized,
         )
@@ -1150,10 +1163,16 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
                 inference_provider=normalized,
+                inference_provider_mode=mode,
                 preserve_inference_provider=False,
             )
         self._inference_provider = normalized
-        self._config = replace(self._config, inference_provider=normalized)
+        self._inference_provider_mode = mode
+        self._config = replace(
+            self._config,
+            inference_provider=normalized,
+            inference_provider_mode=mode,
+        )
         self._activate_runtime_provider(provider, provider_config)
         return normalized or "automatic (will pin after the next successful response)"
 
@@ -1251,6 +1270,7 @@ class CodingSession:
         self._harness.config.provider = provider
         self._provider_name = provider_config.name
         self._inference_provider = _configured_inference_provider(provider_config, model)
+        self._inference_provider_mode = _configured_inference_provider_mode(provider_config, model)
         self._runtime_provider_config = provider_config
         self._invalidate_runtime_model_limits()
         self._harness.config.model = model
@@ -1264,6 +1284,7 @@ class CodingSession:
                 model=model,
                 provider_name=self.provider_name,
                 inference_provider=self._inference_provider,
+                inference_provider_mode=self._inference_provider_mode,
                 preserve_inference_provider=False,
             )
 
@@ -1369,7 +1390,11 @@ class CodingSession:
             return
 
     def _observe_response_headers(self, headers: Mapping[str, str]) -> None:
-        if self.provider_name != "huggingface" or self._inference_provider is not None:
+        if (
+            self.provider_name != "huggingface"
+            or self._inference_provider_mode != "automatic"
+            or self._inference_provider is not None
+        ):
             return
         route = next(
             (value for key, value in headers.items() if key.casefold() == "x-inference-provider"),
@@ -1393,11 +1418,123 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
                 inference_provider=route,
+                inference_provider_mode="automatic",
                 preserve_inference_provider=False,
             )
         self._inference_provider = route
-        self._config = replace(self._config, inference_provider=route)
+        self._config = replace(
+            self._config,
+            inference_provider=route,
+            inference_provider_mode="automatic",
+        )
         self._activate_runtime_provider(provider, provider_config)
+
+    def will_auto_retry(self, message: AssistantMessage) -> bool:
+        """Return whether session orchestration will retry this assistant error."""
+        return is_context_overflow_error(message) or self._should_auto_failover_huggingface_route(
+            message
+        )
+
+    def _should_auto_failover_huggingface_route(
+        self,
+        message: AssistantMessage,
+    ) -> bool:
+        return (
+            self.provider_name == "huggingface"
+            and self._inference_provider_mode == "automatic"
+            and self._inference_provider is not None
+            and is_retryable_huggingface_route_error(message)
+        )
+
+    def _reset_automatic_inference_provider_for_failover(self) -> str:
+        failed_route = self._inference_provider
+        if failed_route is None:
+            raise ProviderConfigError("Hugging Face failover requires a pinned route")
+        provider, provider_config = self._build_runtime_provider(inference_provider=None)
+        self._owned_providers.append(provider)
+        if self._config.session_manager is not None and self._config.session_id is not None:
+            self._config.session_manager.touch_session(
+                self._config.session_id,
+                model=self.model,
+                provider_name=self.provider_name,
+                inference_provider=None,
+                inference_provider_mode="automatic",
+                preserve_inference_provider=False,
+            )
+        self._inference_provider = None
+        self._config = replace(
+            self._config,
+            inference_provider=None,
+            inference_provider_mode="automatic",
+        )
+        self._activate_runtime_provider(provider, provider_config)
+        return failed_route
+
+    async def _run_huggingface_route_failover(
+        self,
+        *,
+        context: AgentCallDiagnosticContext,
+    ) -> AsyncIterator[CodingSessionEvent]:
+        """Retry the interrupted run once through unsuffixed Hugging Face routing."""
+        failed_route = self._reset_automatic_inference_provider_for_failover()
+        retry_start = AutoRetryStartEvent(
+            attempt=1,
+            max_attempts=1,
+            delay_ms=0,
+            error_message=f"Hugging Face route {failed_route} failed; rerouting automatically",
+        )
+        await self._extension_runtime.emit_event(retry_start)
+        yield retry_start
+
+        retry_events = self._harness.continue_()
+        self._invalidate_context_usage_cache()
+        final_error: str | None = None
+        try:
+            async for retry_event in retry_events:
+                if isinstance(retry_event, ToolExecutionEndEvent):
+                    self._invalidate_context_usage_cache()
+                if (
+                    isinstance(retry_event, MessageEndEvent)
+                    and isinstance(retry_event.message, AssistantMessage)
+                    and retry_event.message.stop_reason in {"error", "aborted"}
+                ):
+                    final_error = retry_event.message.error_message or "Provider request aborted"
+                    if retry_event.message.stop_reason == "error":
+                        self._last_diagnostic_log_path = (
+                            self._diagnostic_logger.log_assistant_error(
+                                context=context,
+                                phase="agent_loop_route_failover",
+                                message=retry_event.message,
+                            )
+                        )
+                if isinstance(retry_event, AgentEndEvent):
+                    yield SessionAgentEndEvent(
+                        messages=retry_event.messages,
+                        will_retry=False,
+                    )
+                else:
+                    yield retry_event
+        finally:
+            aclose = getattr(retry_events, "aclose", None)
+            if aclose is not None:
+                with suppress(Exception):
+                    await aclose()
+
+        failover_succeeded = final_error is None
+        self._last_diagnostic_log_path = self._diagnostic_logger.log_huggingface_route_failover(
+            context=context,
+            failed_route=failed_route,
+            replacement_route=self._inference_provider,
+            success=failover_succeeded,
+            error_message=final_error,
+        )
+        retry_end = AutoRetryEndEvent(
+            success=failover_succeeded,
+            attempt=1,
+            final_error=final_error,
+        )
+        await self._extension_runtime.emit_event(retry_end)
+        yield retry_end
 
     def _build_runtime_provider(
         self,
@@ -1714,6 +1851,7 @@ class CodingSession:
                 command_registry=self._config.command_registry,
                 provider_name=provider_name,
                 inference_provider=record.inference_provider,
+                inference_provider_mode=record.inference_provider_mode,
                 provider_settings=self._provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=self._auto_compact_token_threshold,
@@ -1779,12 +1917,16 @@ class CodingSession:
             )
 
         inference_provider = _configured_inference_provider(runtime_provider_config, model)
+        inference_provider_mode = _configured_inference_provider_mode(
+            runtime_provider_config, model
+        )
         record = (
             manager.prepare_session(
                 cwd=self.cwd,
                 model=model,
                 provider_name=provider_name,
                 inference_provider=inference_provider,
+                inference_provider_mode=inference_provider_mode,
             )
             if inference_provider is not None
             else manager.prepare_session(
@@ -1803,6 +1945,7 @@ class CodingSession:
                 session_id=record.id,
                 provider_name=provider_name,
                 inference_provider=inference_provider,
+                inference_provider_mode=inference_provider_mode,
                 provider_settings=self._provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 thinking_level=thinking_level,
@@ -1865,6 +2008,7 @@ class CodingSession:
         self._command_registry = replacement._command_registry
         self._provider_name = replacement._provider_name
         self._inference_provider = replacement._inference_provider
+        self._inference_provider_mode = replacement._inference_provider_mode
         self._provider_settings = replacement._provider_settings
         self._runtime_provider_config = replacement._runtime_provider_config
         self._resource_paths = replacement._resource_paths
@@ -1950,6 +2094,7 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
                 inference_provider=self._inference_provider,
+                inference_provider_mode=self._inference_provider_mode,
                 session_id=self._config.session_id,
             )
         self._config = replace(self._config, index_on_first_persist=False)
@@ -2069,6 +2214,7 @@ class CodingSession:
         settled_event: AgentSettledEvent | None = None
         auto_name_attempted = False
         overflow_message: AssistantMessage | None = None
+        route_failure_message: AssistantMessage | None = None
         try:
             prompt_message: AgentMessage
             if custom_type is not None:
@@ -2105,8 +2251,15 @@ class CodingSession:
                     )
                     if is_context_overflow_error(event.message):
                         overflow_message = event.message
+                    elif self._should_auto_failover_huggingface_route(event.message):
+                        route_failure_message = event.message
                 if isinstance(event, AgentEndEvent):
-                    yield SessionAgentEndEvent(messages=event.messages, will_retry=False)
+                    yield SessionAgentEndEvent(
+                        messages=event.messages,
+                        will_retry=(
+                            overflow_message is not None or route_failure_message is not None
+                        ),
+                    )
                 else:
                     yield event
                 # Let frontends render the confirmed, expanded prompt before
@@ -2138,21 +2291,26 @@ class CodingSession:
                     yield retry_start
                     events = self._harness.continue_()
                     self._invalidate_context_usage_cache()
+                    overflow_retry_error: str | None = None
                     async for retry_event in events:
                         if isinstance(retry_event, ToolExecutionEndEvent):
                             self._invalidate_context_usage_cache()
                         if (
                             isinstance(retry_event, MessageEndEvent)
                             and isinstance(retry_event.message, AssistantMessage)
-                            and retry_event.message.stop_reason == "error"
+                            and retry_event.message.stop_reason in {"error", "aborted"}
                         ):
-                            self._last_diagnostic_log_path = (
-                                self._diagnostic_logger.log_assistant_error(
-                                    context=context,
-                                    phase="agent_loop_retry",
-                                    message=retry_event.message,
-                                )
+                            overflow_retry_error = (
+                                retry_event.message.error_message or "Provider request aborted"
                             )
+                            if retry_event.message.stop_reason == "error":
+                                self._last_diagnostic_log_path = (
+                                    self._diagnostic_logger.log_assistant_error(
+                                        context=context,
+                                        phase="agent_loop_retry",
+                                        message=retry_event.message,
+                                    )
+                                )
                         if isinstance(retry_event, AgentEndEvent):
                             yield SessionAgentEndEvent(
                                 messages=retry_event.messages,
@@ -2160,9 +2318,16 @@ class CodingSession:
                             )
                         else:
                             yield retry_event
-                    session_event_4 = AutoRetryEndEvent(success=True, attempt=1, final_error=None)
+                    session_event_4 = AutoRetryEndEvent(
+                        success=overflow_retry_error is None,
+                        attempt=1,
+                        final_error=overflow_retry_error,
+                    )
                     await self._extension_runtime.emit_event(session_event_4)
                     yield session_event_4
+            elif route_failure_message is not None:
+                async for failover_event in self._run_huggingface_route_failover(context=context):
+                    yield failover_event
             else:
                 await self._try_auto_compact(context=context, phase="auto_compact_after_prompt")
         except Exception as exc:
@@ -2191,6 +2356,7 @@ class CodingSession:
         self._persisted_message_ids.clear()
         events: AsyncIterator[AgentEvent] | None = None
         settled_event: AgentSettledEvent | None = None
+        route_failure_message: AssistantMessage | None = None
         try:
             events = self._harness.continue_()
             self._invalidate_context_usage_cache()
@@ -2207,10 +2373,18 @@ class CodingSession:
                         phase="agent_loop",
                         message=event.message,
                     )
+                    if self._should_auto_failover_huggingface_route(event.message):
+                        route_failure_message = event.message
                 if isinstance(event, AgentEndEvent):
-                    yield SessionAgentEndEvent(messages=event.messages, will_retry=False)
+                    yield SessionAgentEndEvent(
+                        messages=event.messages,
+                        will_retry=route_failure_message is not None,
+                    )
                 else:
                     yield event
+            if route_failure_message is not None:
+                async for failover_event in self._run_huggingface_route_failover(context=context):
+                    yield failover_event
             await self._try_auto_compact(context=context, phase="auto_compact_after_continue")
         except Exception as exc:
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -2436,6 +2610,7 @@ class CodingSession:
                 model=self.model,
                 provider_name=self.provider_name,
                 inference_provider=self._inference_provider,
+                inference_provider_mode=self._inference_provider_mode,
                 preserve_inference_provider=False,
             )
 
@@ -2799,6 +2974,19 @@ def is_context_overflow_error(message: AssistantMessage) -> bool:
     return any(marker in normalized for marker in markers)
 
 
+def is_retryable_huggingface_route_error(message: AssistantMessage) -> bool:
+    """Return whether a pre-output Hugging Face HTTP failure is safe to reroute."""
+    if message.content:
+        return False
+    for diagnostic in message.diagnostics or []:
+        if diagnostic.type != "provider_error" or diagnostic.details is None:
+            continue
+        status_code = diagnostic.details.get("status_code")
+        if isinstance(status_code, int) and not isinstance(status_code, bool):
+            return status_code in {408, 409, 425, 429} or status_code >= 500
+    return False
+
+
 def _detach_missing_parents(entries: list[SessionEntry]) -> list[SessionEntry]:
     """Return entries with dangling parent pointers detached from external history."""
     entry_ids = {entry.id for entry in entries}
@@ -3119,6 +3307,13 @@ def _configured_inference_provider(
     if not isinstance(provider, OpenAICompatibleProviderConfig) or provider.name != "huggingface":
         return None
     return provider.inference_providers.get(model)
+
+
+def _configured_inference_provider_mode(
+    provider: ProviderConfig | None,
+    model: str,
+) -> InferenceProviderMode:
+    return "fixed" if _configured_inference_provider(provider, model) is not None else "automatic"
 
 
 def _default_thinking_level_for_active_model(session: CodingSession) -> ThinkingLevel:

--- a/src/tau_coding/session_manager.py
+++ b/src/tau_coding/session_manager.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
+from typing import Literal
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict
@@ -21,6 +22,8 @@ _WINDOWS_RESERVED_FILE_STEMS = frozenset(
     | {f"lpt{index}" for index in range(1, 10)}
 )
 _SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+InferenceProviderMode = Literal["automatic", "fixed"]
 
 
 def validate_session_id(session_id: str) -> None:
@@ -50,6 +53,7 @@ class SessionRecordModel(BaseModel):
     model: str
     provider_name: str | None = None
     inference_provider: str | None = None
+    inference_provider_mode: InferenceProviderMode | None = None
     title: str | None = None
     created_at: float
     updated_at: float
@@ -68,6 +72,7 @@ class CodingSessionRecord:
     updated_at: float
     provider_name: str | None = None
     inference_provider: str | None = None
+    inference_provider_mode: InferenceProviderMode = "automatic"
 
     @classmethod
     def from_model(cls, model: SessionRecordModel) -> CodingSessionRecord:
@@ -82,6 +87,10 @@ class CodingSessionRecord:
             updated_at=model.updated_at,
             provider_name=model.provider_name,
             inference_provider=model.inference_provider,
+            inference_provider_mode=(
+                model.inference_provider_mode
+                or ("fixed" if model.inference_provider is not None else "automatic")
+            ),
         )
 
     def to_model(self) -> SessionRecordModel:
@@ -96,6 +105,7 @@ class CodingSessionRecord:
             updated_at=self.updated_at,
             provider_name=self.provider_name,
             inference_provider=self.inference_provider,
+            inference_provider_mode=self.inference_provider_mode,
         )
 
 
@@ -143,6 +153,7 @@ class SessionManager:
         model: str,
         provider_name: str | None = None,
         inference_provider: str | None = None,
+        inference_provider_mode: InferenceProviderMode | None = None,
         title: str | None = None,
         session_id: str | None = None,
     ) -> CodingSessionRecord:
@@ -152,6 +163,7 @@ class SessionManager:
             model=model,
             provider_name=provider_name,
             inference_provider=inference_provider,
+            inference_provider_mode=inference_provider_mode,
             title=title,
             session_id=session_id,
         )
@@ -165,6 +177,7 @@ class SessionManager:
         model: str,
         provider_name: str | None = None,
         inference_provider: str | None = None,
+        inference_provider_mode: InferenceProviderMode | None = None,
         title: str | None = None,
         session_id: str | None = None,
     ) -> CodingSessionRecord:
@@ -174,6 +187,7 @@ class SessionManager:
             model=model,
             provider_name=provider_name,
             inference_provider=inference_provider,
+            inference_provider_mode=inference_provider_mode,
             title=title,
             session_id=session_id,
         )
@@ -204,6 +218,7 @@ class SessionManager:
         model: str,
         provider_name: str | None = None,
         inference_provider: str | None = None,
+        inference_provider_mode: InferenceProviderMode | None = None,
         title: str | None = None,
         session_id: str | None = None,
     ) -> CodingSessionRecord:
@@ -225,6 +240,10 @@ class SessionManager:
             model=model,
             provider_name=provider_name,
             inference_provider=inference_provider,
+            inference_provider_mode=(
+                inference_provider_mode
+                or ("fixed" if inference_provider is not None else "automatic")
+            ),
             title=title,
             created_at=now,
             updated_at=now,
@@ -268,6 +287,7 @@ class SessionManager:
         model: str | None = None,
         provider_name: str | None = None,
         inference_provider: str | None = None,
+        inference_provider_mode: InferenceProviderMode | None = None,
         preserve_inference_provider: bool = True,
         title: str | None = None,
     ) -> CodingSessionRecord | None:
@@ -283,6 +303,11 @@ class SessionManager:
             provider_name=provider_name if provider_name is not None else existing.provider_name,
             inference_provider=(
                 existing.inference_provider if preserve_inference_provider else inference_provider
+            ),
+            inference_provider_mode=(
+                existing.inference_provider_mode
+                if preserve_inference_provider or inference_provider_mode is None
+                else inference_provider_mode
             ),
             title=title if title is not None else existing.title,
             created_at=existing.created_at,

--- a/src/tau_coding/tui/adapter.py
+++ b/src/tau_coding/tui/adapter.py
@@ -146,6 +146,9 @@ class TuiEventAdapter:
                 self._pending_overflow_error = None
             return
         if isinstance(event, AutoRetryStartEvent):
+            if self.state.items and self.state.items[-1].role == "error":
+                self.state.items.pop()
+            self.state.error = None
             self.state.add_item("status", f"… {event.error_message}")
 
     def _flush(self) -> None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4854,7 +4854,9 @@ class TauTuiApp(App[None]):
                     and event.message.stop_reason == "error"
                 ):
                     _attach_diagnostic_log_path_to_error(self.state, self.session)
-                    _attach_retry_hint_to_error(self.state, event.message)
+                    will_auto_retry = getattr(self.session, "will_auto_retry", None)
+                    if not (callable(will_auto_retry) and will_auto_retry(event.message)):
+                        _attach_retry_hint_to_error(self.state, event.message)
                 elif (
                     isinstance(event, CompactionEndEvent)
                     and event.reason == "overflow"
@@ -6852,13 +6854,22 @@ def _create_startup_session_record(
             model=selection.model,
             provider_name=selection.provider.name,
             inference_provider=inference_provider,
+            inference_provider_mode="fixed",
         )
     except TypeError:
-        return manager.prepare_session(
-            cwd=cwd,
-            model=selection.model,
-            provider_name=selection.provider.name,
-        )
+        try:
+            return manager.prepare_session(
+                cwd=cwd,
+                model=selection.model,
+                provider_name=selection.provider.name,
+                inference_provider=inference_provider,
+            )
+        except TypeError:
+            return manager.prepare_session(
+                cwd=cwd,
+                model=selection.model,
+                provider_name=selection.provider.name,
+            )
 
 
 def _resolve_tui_startup_selection(
@@ -6987,6 +6998,15 @@ def _startup_inference_provider(
     return provider.inference_providers.get(selection.model)
 
 
+def _startup_inference_provider_mode(
+    selection: ProviderSelection,
+    record: CodingSessionRecord | None,
+) -> Literal["automatic", "fixed"]:
+    if record is not None and record.model == selection.model:
+        return record.inference_provider_mode
+    return "fixed" if _startup_inference_provider(selection, None) is not None else "automatic"
+
+
 async def run_tui_app(
     *,
     model: str | None,
@@ -7029,6 +7049,7 @@ async def run_tui_app(
     startup_error_notice: str | None = None
     runtime_provider_config: ProviderConfig | None = selection.provider
     inference_provider = _startup_inference_provider(selection, record)
+    inference_provider_mode = _startup_inference_provider_mode(selection, record)
     try:
         provider = create_model_provider(
             selection.provider,
@@ -7075,6 +7096,7 @@ async def run_tui_app(
                 session_manager=manager,
                 provider_name=selection.provider.name,
                 inference_provider=inference_provider,
+                inference_provider_mode=inference_provider_mode,
                 provider_settings=provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=auto_compact_token_threshold,

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -62,7 +62,11 @@ from tau_coding.events import AgentSettledEvent, QueueUpdateEvent
 from tau_coding.extensions.runtime import InputHookOutcome
 from tau_coding.prompt_templates import PromptTemplate
 from tau_coding.provider_config import ProviderModelMetadata
-from tau_coding.session import _ordered_tree_entries, parse_terminal_command
+from tau_coding.session import (
+    _ordered_tree_entries,
+    is_retryable_huggingface_route_error,
+    parse_terminal_command,
+)
 
 
 async def _collect_session_events(session_stream: object) -> list[object]:
@@ -106,6 +110,25 @@ def _config(
     )
 
 
+def _provider_http_error(
+    status_code: int,
+    message: str = "Rate limit exceeded",
+) -> AssistantErrorEvent:
+    return AssistantErrorEvent(
+        reason="error",
+        error=AssistantMessage(
+            stop_reason="error",
+            error_message=message,
+            diagnostics=[
+                AssistantMessageDiagnostic(
+                    type="provider_error",
+                    details={"status_code": status_code},
+                )
+            ],
+        ),
+    )
+
+
 class SwitchableFakeProvider:
     def __init__(self, config: object) -> None:
         self.config = config
@@ -113,6 +136,48 @@ class SwitchableFakeProvider:
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class HeaderObservingFakeProvider(FakeProvider):
+    def __init__(
+        self,
+        scripts: list[list[AssistantMessageEvent]],
+        observer: object | None,
+        route: str,
+    ) -> None:
+        super().__init__(scripts)
+        self._observer = observer
+        self._route = route
+
+    def stream_response(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[AgentMessage],
+        tools: list[AgentTool],
+        signal: CancellationToken | None = None,
+        session_id: str | None = None,
+    ) -> AsyncIterator[AssistantMessageEvent]:
+        source = super().stream_response(
+            model=model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            signal=signal,
+            session_id=session_id,
+        )
+
+        async def iterator() -> AsyncIterator[AssistantMessageEvent]:
+            if callable(self._observer):
+                self._observer({"x-inference-provider": self._route})
+            async for event in source:
+                yield event
+
+        return iterator()
+
+    async def aclose(self) -> None:
+        return None
 
 
 class ModelLimitsFakeProvider(FakeProvider):
@@ -3806,8 +3871,365 @@ async def test_huggingface_session_pins_successful_automatic_route(
     observer({"X-Inference-Provider": "deepinfra"})
 
     assert session.inference_provider == "deepinfra"
+    assert session.inference_provider_mode == "automatic"
     assert created[-1][0] == "deepinfra"
     assert manager.get_session(record.id).inference_provider == "deepinfra"  # type: ignore[union-attr]
+
+    assert session.set_inference_provider("fireworks-ai") == "fireworks-ai"
+    assert session.inference_provider_mode == "fixed"
+    assert manager.get_session(record.id).inference_provider_mode == "fixed"  # type: ignore[union-attr]
+    assert session.set_inference_provider(None) == (
+        "automatic (will pin after the next successful response)"
+    )
+    assert session.inference_provider_mode == "automatic"
+    assert manager.get_session(record.id).inference_provider_mode == "automatic"  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    ("status_code", "content", "expected"),
+    [
+        (429, [], True),
+        (503, [], True),
+        (400, [], False),
+        (429, [TextContent(text="partial")], False),
+    ],
+)
+def test_huggingface_route_failover_requires_retryable_pre_output_error(
+    status_code: int,
+    content: list[TextContent],
+    expected: bool,
+) -> None:
+    message = AssistantMessage(
+        content=content,
+        stop_reason="error",
+        diagnostics=[
+            AssistantMessageDiagnostic(
+                type="provider_error",
+                details={"status_code": status_code},
+            )
+        ],
+    )
+
+    assert is_retryable_huggingface_route_error(message) is expected
+
+
+@pytest.mark.anyio
+async def test_huggingface_automatic_pin_fails_over_and_repins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model = "moonshotai/Kimi-K3"
+    created: list[tuple[str | None, FakeProvider]] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+        inference_provider: str | None = None,
+        response_headers_observer: object | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level
+        if inference_provider == "deepinfra":
+            provider: FakeProvider = FakeProvider([[_provider_http_error(429)]])
+        elif inference_provider is None:
+            provider = HeaderObservingFakeProvider(
+                [
+                    [
+                        assistant_start(model="moonshotai/Kimi-K3"),
+                        assistant_done(message=AssistantMessage(content="Recovered")),
+                    ]
+                ],
+                response_headers_observer,
+                "baseten",
+            )
+        else:
+            provider = FakeProvider([])
+        created.append((inference_provider, provider))
+        return provider
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    provider_config = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        models=(model,),
+        default_model=model,
+    )
+    tau_paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
+    manager = SessionManager(tau_paths)
+    record = manager.create_session(
+        cwd=tmp_path,
+        model=model,
+        provider_name="huggingface",
+        inference_provider="deepinfra",
+        inference_provider_mode="automatic",
+        title="Failover test",
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(record.path),
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+            provider_name="huggingface",
+            inference_provider="deepinfra",
+            inference_provider_mode="automatic",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            runtime_provider_config=provider_config,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    events = await _collect_session_events(session.prompt("Continue the task"))
+
+    assert [route for route, _provider in created] == ["deepinfra", None, "baseten"]
+    assert session.inference_provider == "baseten"
+    assert session.inference_provider_mode == "automatic"
+    persisted = manager.get_session(record.id)
+    assert persisted is not None
+    assert persisted.inference_provider == "baseten"
+    assert persisted.inference_provider_mode == "automatic"
+    agent_ends = [event for event in events if getattr(event, "type", None) == "agent_end"]
+    assert [event.will_retry for event in agent_ends] == [True, False]
+    assert any(
+        getattr(event, "type", None) == "auto_retry_start"
+        and "deepinfra failed; rerouting automatically" in event.error_message
+        for event in events
+    )
+    retry_end = next(event for event in events if getattr(event, "type", None) == "auto_retry_end")
+    assert retry_end.success is True
+    assert any(
+        isinstance(event, MessageEndEvent)
+        and isinstance(event.message, AssistantMessage)
+        and event.message.text == "Recovered"
+        for event in events
+    )
+    automatic_provider = created[1][1]
+    assert [message.text for message in automatic_provider.calls[0][2]] == ["Continue the task"]
+    diagnostic = json.loads(tau_paths.agent_calls_log_path.read_text().splitlines()[-1])
+    assert diagnostic["kind"] == "route_failover"
+    assert diagnostic["route_failover"] == {
+        "from": "deepinfra",
+        "to": "baseten",
+        "success": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_huggingface_automatic_failover_stops_after_one_failed_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model = "moonshotai/Kimi-K3"
+    created: list[str | None] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+        inference_provider: str | None = None,
+        response_headers_observer: object | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level, response_headers_observer
+        created.append(inference_provider)
+        return FakeProvider(
+            [
+                [
+                    AssistantErrorEvent(
+                        reason="error",
+                        error=AssistantMessage(
+                            stop_reason="error",
+                            error_message="Rate limit exceeded",
+                            diagnostics=[
+                                AssistantMessageDiagnostic(
+                                    type="provider_error",
+                                    details={"status_code": 429},
+                                )
+                            ],
+                        ),
+                    )
+                ]
+            ]
+        )
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    provider_config = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        models=(model,),
+        default_model=model,
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="huggingface",
+            inference_provider="deepinfra",
+            inference_provider_mode="automatic",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            runtime_provider_config=provider_config,
+            resource_paths=TauResourcePaths(
+                root=tmp_path / ".tau",
+                paths=TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"),
+            ),
+        )
+    )
+
+    events = await _collect_session_events(session.prompt("Continue the task"))
+
+    assert created == ["deepinfra", None]
+    assert session.inference_provider is None
+    assert session.inference_provider_mode == "automatic"
+    [retry_end] = [event for event in events if getattr(event, "type", None) == "auto_retry_end"]
+    assert retry_end.success is False
+    assert retry_end.final_error == "Rate limit exceeded"
+
+
+@pytest.mark.anyio
+async def test_huggingface_continue_uses_automatic_route_failover(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model = "moonshotai/Kimi-K3"
+    created: list[str | None] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+        inference_provider: str | None = None,
+        response_headers_observer: object | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level, response_headers_observer
+        created.append(inference_provider)
+        if inference_provider == "deepinfra":
+            return FakeProvider([[_provider_http_error(429)]])
+        return FakeProvider(
+            [
+                [
+                    assistant_start(model="moonshotai/Kimi-K3"),
+                    assistant_done(message=AssistantMessage(content="Recovered continuation")),
+                ]
+            ]
+        )
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    provider_config = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        models=(model,),
+        default_model=model,
+    )
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(MessageEntry(message=UserMessage(content="Continue the task")))
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=model,
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="huggingface",
+            inference_provider="deepinfra",
+            inference_provider_mode="automatic",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            runtime_provider_config=provider_config,
+            resource_paths=TauResourcePaths(
+                root=tmp_path / ".tau",
+                paths=TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"),
+            ),
+        )
+    )
+
+    events = await _collect_session_events(session.continue_())
+
+    assert created == ["deepinfra", None]
+    assert any(
+        isinstance(event, MessageEndEvent)
+        and isinstance(event.message, AssistantMessage)
+        and event.message.text == "Recovered continuation"
+        for event in events
+    )
+    [retry_end] = [event for event in events if getattr(event, "type", None) == "auto_retry_end"]
+    assert retry_end.success is True
+
+
+@pytest.mark.anyio
+async def test_huggingface_fixed_pin_does_not_fail_over(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    model = "moonshotai/Kimi-K3"
+    created: list[str | None] = []
+
+    def create_provider(
+        provider_config: object,
+        *,
+        credential_store: FileCredentialStore | None = None,
+        model: str | None = None,
+        thinking_level: str | None = None,
+        inference_provider: str | None = None,
+        response_headers_observer: object | None = None,
+    ) -> FakeProvider:
+        del provider_config, credential_store, model, thinking_level, response_headers_observer
+        created.append(inference_provider)
+        return FakeProvider(
+            [
+                [
+                    AssistantErrorEvent(
+                        reason="error",
+                        error=AssistantMessage(
+                            stop_reason="error",
+                            error_message="Rate limit exceeded",
+                            diagnostics=[
+                                AssistantMessageDiagnostic(
+                                    type="provider_error",
+                                    details={"status_code": 429},
+                                )
+                            ],
+                        ),
+                    )
+                ]
+            ]
+        )
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create_provider)
+    provider_config = OpenAICompatibleProviderConfig(
+        name="huggingface",
+        models=(model,),
+        default_model=model,
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="huggingface",
+            inference_provider="deepinfra",
+            inference_provider_mode="fixed",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            runtime_provider_config=provider_config,
+            resource_paths=TauResourcePaths(
+                root=tmp_path / ".tau",
+                paths=TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"),
+            ),
+        )
+    )
+
+    events = await _collect_session_events(session.prompt("Continue the task"))
+
+    assert created == ["deepinfra"]
+    assert session.inference_provider == "deepinfra"
+    assert session.inference_provider_mode == "fixed"
+    assert not any(getattr(event, "type", None) == "auto_retry_start" for event in events)
+    [agent_end] = [event for event in events if getattr(event, "type", None) == "agent_end"]
+    assert agent_end.will_retry is False
 
 
 @pytest.mark.anyio
@@ -3874,6 +4296,7 @@ async def test_huggingface_session_re_resolves_pin_on_model_switch(
     ]
     assert session.model == "deepseek-ai/DeepSeek-V4-Flash"
     assert session.inference_provider == "fireworks-ai"
+    assert session.inference_provider_mode == "fixed"
     assert manager.get_session(record.id).inference_provider == "fireworks-ai"  # type: ignore[union-attr]
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,6 +15,7 @@ class FakeSession:
         self.cwd = tmp_path
         self.provider_name = "openai"
         self.inference_provider: str | None = None
+        self.inference_provider_mode = "automatic"
         self.model = "fake-model"
         self.available_models = ("fake-model", "other-model")
         self.available_model_choices = (
@@ -67,6 +68,7 @@ class FakeSession:
 
     def set_inference_provider(self, route: str | None) -> str:
         self.inference_provider = route
+        self.inference_provider_mode = "fixed" if route is not None else "automatic"
         return route or "automatic (will pin after the next successful response)"
 
     def set_provider(self, provider_name: str) -> None:
@@ -249,6 +251,23 @@ def test_session_command_includes_session_details(tmp_path: Path) -> None:
     assert (
         create_default_command_registry().execute(FakeSession(tmp_path), "/status").handled is False
     )
+
+
+def test_session_command_distinguishes_automatic_and_fixed_huggingface_routes(
+    tmp_path: Path,
+) -> None:
+    session = FakeSession(tmp_path)
+    session.provider_name = "huggingface"
+    session.inference_provider = "baseten"
+
+    automatic = create_default_command_registry().execute(session, "/session")
+    session.inference_provider_mode = "fixed"
+    fixed = create_default_command_registry().execute(session, "/session")
+
+    assert automatic.message is not None
+    assert "Hugging Face inference provider: automatic (currently baseten)" in automatic.message
+    assert fixed.message is not None
+    assert "Hugging Face inference provider: baseten (fixed)" in fixed.message
 
 
 def test_route_command_is_not_built_in(tmp_path: Path) -> None:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -102,6 +102,7 @@ class RecordingSession:
         self.model = "fake"
         self.provider_name = "fake"
         self.inference_provider: str | None = None
+        self.inference_provider_mode = "automatic"
         self.session_id = "session-1"
         self.system_prompt = "You are Tau."
         self.is_running = running
@@ -136,6 +137,7 @@ class RecordingSession:
 
     def set_inference_provider(self, route: str | None) -> str:
         self.inference_provider = route
+        self.inference_provider_mode = "fixed" if route is not None else "automatic"
         return route or "automatic (will pin after the next successful response)"
 
 
@@ -1873,11 +1875,14 @@ def test_extension_can_read_and_change_inference_provider(tmp_path: Path) -> Non
     runtime.bind(session)
 
     assert api.context.inference_provider is None
+    assert api.context.inference_provider_mode == "automatic"
     assert api.set_inference_provider("deepinfra") == "deepinfra"
     assert api.context.inference_provider == "deepinfra"
+    assert api.context.inference_provider_mode == "fixed"
     assert api.set_inference_provider(None) == (
         "automatic (will pin after the next successful response)"
     )
+    assert api.context.inference_provider_mode == "automatic"
 
 
 # -- reload staleness guard (Pi's assertActive/invalidate) ---------------------

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -15,7 +15,7 @@ from tau_agent import (
     ToolExecutionUpdateEvent,
 )
 from tau_agent.provider_events import TextDeltaEvent, ThinkingDeltaEvent
-from tau_coding.events import AutoRetryStartEvent, QueueUpdateEvent
+from tau_coding.events import AutoRetryEndEvent, AutoRetryStartEvent, QueueUpdateEvent
 from tau_coding.rendering import FinalTextRenderer, JsonEventRenderer, TranscriptRenderer
 
 
@@ -140,6 +140,21 @@ def test_transcript_renderer_fails_on_assistant_error(
     captured = capsys.readouterr()
     assert renderer.finish() is False
     assert "Error: provider failed" in captured.err
+
+
+@pytest.mark.parametrize(
+    "renderer_type",
+    [TranscriptRenderer, FinalTextRenderer, JsonEventRenderer],
+)
+def test_renderers_finish_successfully_after_recovered_auto_retry(
+    renderer_type: type[TranscriptRenderer] | type[FinalTextRenderer] | type[JsonEventRenderer],
+) -> None:
+    renderer = renderer_type()
+
+    renderer.render(_error_end("provider failed"))
+    renderer.render(AutoRetryEndEvent(success=True, attempt=1))
+
+    assert renderer.finish() is True
 
 
 def test_final_text_renderer_prints_only_final_message(

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -24,6 +24,7 @@ def test_session_manager_creates_and_lists_sessions(tmp_path: Path) -> None:
 
     assert record.provider_name == "huggingface"
     assert record.inference_provider == "deepinfra"
+    assert record.inference_provider_mode == "fixed"
     assert record.path.parent.parent == tmp_path / ".tau" / "sessions"
     assert "project-" in record.path.parent.name
     assert len(record.path.parent.name.rsplit("-", maxsplit=1)[-1]) == 6
@@ -234,6 +235,35 @@ def test_session_manager_ignores_extra_index_metadata(tmp_path: Path) -> None:
     assert record.id == "session-1"
     assert record.path == session_path
     assert record.model == "gpt-5"
+
+
+def test_session_manager_treats_legacy_pinned_routes_as_fixed(tmp_path: Path) -> None:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    index_path = manager.project_index_path(cwd)
+    index_path.parent.mkdir(parents=True)
+    index_path.write_text(
+        json.dumps(
+            {
+                "id": "legacy-hf",
+                "path": str(index_path.parent / "legacy-hf.jsonl"),
+                "cwd": str(cwd.resolve()),
+                "model": "moonshotai/Kimi-K3",
+                "provider_name": "huggingface",
+                "inference_provider": "deepinfra",
+                "created_at": 1.0,
+                "updated_at": 2.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    [record] = manager.list_sessions(cwd)
+
+    assert record.inference_provider == "deepinfra"
+    assert record.inference_provider_mode == "fixed"
 
 
 def test_session_manager_gets_or_creates_default_session(tmp_path: Path) -> None:

--- a/tests/test_tui_adapter.py
+++ b/tests/test_tui_adapter.py
@@ -709,6 +709,11 @@ def test_tui_adapter_renders_skill_file_reads_with_skill_style() -> None:
 def test_tui_adapter_records_retry_and_queue_status() -> None:
     state = TuiState()
     adapter = TuiEventAdapter(state)
+    adapter.apply(
+        MessageEndEvent(
+            message=AssistantMessage(stop_reason="error", error_message="provider failed")
+        )
+    )
 
     adapter.apply(
         AutoRetryStartEvent(
@@ -723,6 +728,7 @@ def test_tui_adapter_records_retry_and_queue_status() -> None:
     assert [(item.role, item.text) for item in state.items] == [
         ("status", "… Retrying provider request 2/3 after HTTP 503.")
     ]
+    assert state.error is None
     assert state.queued_steering == ("adjust",)
     assert state.queued_follow_up == ("after",)
 

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -154,7 +154,8 @@ def setup(tau):
 
     # read-only context
     tau.context.cwd, tau.context.model, tau.context.provider_name
-    tau.context.inference_provider             # Hugging Face route, or None
+    tau.context.inference_provider             # current Hugging Face route, or None
+    tau.context.inference_provider_mode        # "automatic" or "fixed"
     tau.context.session_id, tau.context.system_prompt
     tau.context.is_running, tau.context.has_ui
     tau.context.transcript   # parent conversation, deep-copied AgentMessages
@@ -167,9 +168,13 @@ def setup(tau):
 ```
 
 `set_inference_provider(route)` lets provider-specific extensions select a
-Hugging Face inference-provider route for the active session; pass `None` to
-return to automatic routing. Other providers reject the operation. The current
-pin is available as `context.inference_provider`.
+Hugging Face inference-provider route for the active session. A provider name
+sets `context.inference_provider_mode` to `"fixed"`, so Tau honors the explicit
+selection and does not automatically fail over. Passing `None` selects
+`"automatic"` mode: the next successful response becomes a sticky route that
+Tau may replace after an exhausted retryable pre-output failure. Other providers
+reject the operation. The current resolved route is available as
+`context.inference_provider`.
 
 `setup` must be a plain `def` (not `async def`). Event handlers may be sync
 or async and always receive `(event, context)`; the context is freshly created

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -152,8 +152,11 @@ account.
 
 For a new session without an explicit preference, Hugging Face initially routes
 the model automatically. After the first successful response, Tau reads Hugging
-Face's `x-inference-provider` response header and pins that backing provider for
-the rest of the session. To choose the initial provider instead, add a per-model
+Face's `x-inference-provider` response header and keeps that backing provider as
+a sticky automatic route. If that route later exhausts its normal retries with a
+retryable HTTP failure before producing output, Tau retries the interrupted turn
+once through unsuffixed automatic routing and makes the successful replacement
+the new sticky route. To choose a fixed provider instead, add a per-model
 `inference_providers` preference to `~/.tau/providers.json`:
 
 ```json
@@ -184,17 +187,23 @@ git clone https://github.com/alejandro-ao/tau-huggingface.git
 tau -e ./tau-huggingface
 ```
 
-Then use `/route <provider>` to select a route or `/route automatic` to reset
-it. Switching models uses that model's configured pin or starts automatic
-resolution again.
+Then use `/hf route` to pick from the model's currently live routes,
+`/hf route <provider>` to select a fixed route, or `/hf route automatic` to
+return to recoverable automatic routing. Switching models uses that model's
+configured fixed route or starts automatic resolution again. `/session` reports
+`automatic (currently <provider>)` for a sticky automatic route and
+`<provider> (fixed)` for an explicit route.
 
-Transient failures retry on the same wire model, and stream failures are not
-retried after model output has started. Pinning can reduce cold prefix-cache
-misses caused by cross-provider routing, but cannot prevent eviction, TTL expiry,
-or load balancing among workers within the chosen provider. Tau does not yet
-fall back automatically from an unavailable pinned route: doing so also requires
-a user-visible reroute event and durable reroute telemetry. Use the Hugging Face
-extension or start a new automatic session to resolve another route. See
+Transient failures first retry on the same wire model, and stream failures are
+not retried or rerouted after model output has started. After those retries are
+exhausted, only sticky routes selected in automatic mode fail over; routes chosen
+through `/hf route <provider>` or the `inference_providers` preference remain
+fixed so Tau never overrides explicit user intent. Automatic failover emits
+visible retry progress and durable provider diagnostics. Pinning can reduce cold
+prefix-cache misses caused by cross-provider routing, but cannot prevent eviction,
+TTL expiry, or load balancing among workers within the chosen provider. A reroute
+may require a cold prefix prefill, and account-wide rate limits may still fail on
+the automatic retry. See
 [Configuration]({{< relref "../reference/configuration.md#provider-preferences" >}}).
 
 ### Moonshot AI API vs. Kimi Code

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -258,14 +258,18 @@ Provider preferences live in `~/.tau/providers.json`:
   `"inference_providers": { "zai-org/GLM-5.2": "deepinfra" }`. Each key must be
   a configured model and each value an explicit provider suffix advertised by
   Hugging Face—not the `fastest`, `cheapest`, or `preferred` routing policies.
-  Tau snapshots the selected suffix into new session metadata, retains it on
-  resume, and sends only the suffixed wire model; ordinary model identity and
-  catalog metadata remain unsuffixed. Without a preference, Tau starts with
-  automatic routing and pins the `x-inference-provider` reported by the first
-  successful response. `/session` reports the route; changing the active session
-  route is available in Tau 0.3.10+ through the external
+  Tau snapshots the selected suffix into new session metadata as a fixed route,
+  retains it on resume, and sends only the suffixed wire model; ordinary model
+  identity and catalog metadata remain unsuffixed. Without a preference, Tau
+  starts in automatic mode and records the `x-inference-provider` reported by
+  the first successful response as a sticky but recoverable route. After a
+  retryable pre-output HTTP failure exhausts provider-level retries, Tau clears
+  that automatic pin, retries the interrupted turn once through Hugging Face
+  automatic routing, and stores the successful replacement. Explicitly configured
+  routes never fail over. `/session` reports both mode and current route; changing
+  the active session route is available through the external
   [`tau-huggingface`](https://github.com/alejandro-ao/tau-huggingface) extension;
-  clone it and launch Tau with `tau -e ./tau-huggingface`.
+  clone it and launch Tau with `tau -e ./tau-huggingface`, then use `/hf route`.
   `timeout_seconds` defaults to `60` (> 0); `max_retries`
   defaults to `2`; `max_retry_delay_seconds` defaults to `1` (both ≥ 0).
   Retries cover transient HTTP statuses (`408`, `409`, `425`, `429`, `5xx`),
@@ -273,7 +277,10 @@ Provider preferences live in `~/.tau/providers.json`:
   otherwise successful HTTP 200 response. Anthropic retries `api_error`,
   `overloaded_error`, and `rate_limit_error`; OpenAI Codex retries transient
   events such as `server_is_overloaded`. In-stream errors remain terminal after
-  partial content to prevent duplicate output or tool calls.
+  partial content to prevent duplicate output or tool calls. Existing session
+  records that contain a Hugging Face route but predate route-mode metadata are
+  treated as fixed, preventing an upgrade from overriding a potentially explicit
+  user selection.
 - API keys and OAuth credentials are **not** stored here — they live in
   `~/.tau/credentials.json` (private but not encrypted). OAuth objects may contain
   provider metadata such as a GitHub Enterprise domain and are refreshed


### PR DESCRIPTION
## Summary

- distinguish recoverable automatic Hugging Face routes from explicit fixed routes
- retry an interrupted pre-output 408/409/425/429/5xx failure once through unsuffixed Hugging Face routing after same-route retries are exhausted
- persist the successful replacement route, route mode, and structured failover telemetry
- expose route mode to extensions while preserving `/hf route <provider>` as an explicit fixed selection and `/hf route automatic` as recoverable automatic routing
- update TUI/print rendering, documentation, and compatibility behavior for legacy sessions

## User experience

Long-running Hugging Face sessions no longer terminate immediately when their automatically selected backing provider becomes rate-limited or unavailable. Tau safely retries the same interrupted turn through Hugging Face automatic routing without adding a synthetic user message, then keeps the successful replacement provider sticky for later requests.

Explicit user intent remains authoritative: a route selected through the Hugging Face extension or `inference_providers` configuration is fixed and never silently replaced. `/session` now distinguishes `automatic (currently <provider>)` from `<provider> (fixed)`.

## Related issue

Follow-up to #559, which introduced sticky session-scoped Hugging Face routing and explicitly left controlled failover for later work.

## Manual validation

1. Start Tau with the built-in `huggingface` provider and the `tau-huggingface` extension.
2. Run `/hf route automatic` and make one successful request so `/session` reports an automatic current route.
3. Simulate or encounter a pre-output retryable HTTP failure on that backing provider.
4. Confirm Tau shows automatic reroute progress, retries without another user message, and `/session` reports the successful replacement as `automatic (currently <provider>)`.
5. Run `/hf route deepinfra` (or another live route), confirm `/session` reports it as fixed, and verify a terminal route failure does not automatically switch providers.
6. Resume the session and confirm its route and mode are retained.

## Validation

- `uv run pytest` — 1581 passed, 2 platform-specific skips
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --minify` from `website/`
