### PR TITLE
Fix extension sidebar update flicker

### DIFF
--- a/dev-notes/extension-sidebar-sections.md
+++ b/dev-notes/extension-sidebar-sections.md
@@ -23,8 +23,11 @@ if sidebar is not None and sidebar.supported:
 ```
 
 Calling `set_section` again with the same key replaces the section in place.
-`remove_section(key)` removes it. Keys are internally scoped by extension name,
-so unrelated extensions can safely choose the same local key. Registration
+For host-rendered display lines, Tau retains the mounted section root and updates
+its title and body directly; identical contributions are no-ops. Widget factories
+retain replacement semantics because the host cannot safely mutate an arbitrary
+extension widget. `remove_section(key)` removes it. Keys are internally scoped by
+extension name, so unrelated extensions can safely choose the same local key. Registration
 order is deterministic; replacing preserves position, while remove plus re-add
 moves the section to the end.
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4721,26 +4721,60 @@ class TauTuiApp(App[None]):
         title: str,
         content: SidebarContent,
     ) -> None:
-        """Add or replace a sidebar contribution while preserving key order."""
+        """Add or update a sidebar contribution while preserving key order."""
         if self.tui_settings.sidebar_position == "off":
             return
         owner = (extension_name, key)
-        contribution = _SidebarContribution(title=title, content=content)
-        widget = self._build_extension_sidebar_widget(
-            owner,
-            contribution,
-            theme=self.tui_settings.resolved_theme,
-        )
+        normalized_content: SidebarContent
+        if callable(content):
+            normalized_content = content
+        elif isinstance(content, str):
+            normalized_content = (content,)
+        else:
+            normalized_content = tuple(content)
+        contribution = _SidebarContribution(title=title, content=normalized_content)
+        theme = self.tui_settings.resolved_theme
+        previous = self._extension_sidebar_contributions.get(owner)
+        if previous == contribution and self._extension_sidebar_theme == theme:
+            return
+        mounted = self._extension_sidebar_mounted.get(owner)
+        target = self._extension_sidebar_widgets.get(owner)
+        if (
+            previous is not None
+            and not callable(previous.content)
+            and not callable(normalized_content)
+            and mounted is not None
+            and mounted is target
+            and self._extension_sidebar_theme == theme
+        ):
+            try:
+                header = Text(title, style=f"bold {theme.prompt_text}")
+                mounted.query_one(".extension-sidebar-title", Static).update(header)
+                body = mounted.query_one(".extension-sidebar-body", Container).query_one(Static)
+                body.update(_custom_markup_to_text("\n".join(normalized_content)))
+            except Exception as exc:  # noqa: BLE001 - isolation boundary
+                self._record_extension_component_failure(
+                    f"sidebar:{extension_name}:{key}",
+                    exc,
+                    notify=True,
+                    extension_name=extension_name,
+                )
+                return
+            self._extension_sidebar_contributions[owner] = contribution
+            return
+        widget = self._build_extension_sidebar_widget(owner, contribution, theme=theme)
         if widget is None:
             return
         self._extension_sidebar_contributions[owner] = contribution
         self._extension_sidebar_widgets[owner] = widget
-        self._extension_sidebar_theme = self.tui_settings.resolved_theme
+        self._extension_sidebar_theme = theme
         self._schedule_extension_swap(self._reconcile_sidebar())
 
     def _remove_extension_sidebar_section(self, extension_name: str, key: str) -> None:
         """Forget and unmount one extension-owned sidebar contribution."""
         owner = (extension_name, key)
+        if owner not in self._extension_sidebar_contributions:
+            return
         self._extension_sidebar_contributions.pop(owner, None)
         self._extension_sidebar_widgets.pop(owner, None)
         self._schedule_extension_swap(self._reconcile_sidebar())

--- a/tests/test_tui_components.py
+++ b/tests/test_tui_components.py
@@ -275,15 +275,20 @@ async def test_sidebar_sections_mount_update_and_remove_by_owned_key() -> None:
             "Beta",
         ]
 
-        bridge.set_sidebar_section("alpha", "status", title="Alpha", content=["updated"])
+        alpha_section = slot.children[0]
+        bridge.set_sidebar_section("alpha", "status", title="Alpha", content=["first"])
         await pilot.pause()
+        assert slot.children[0] is alpha_section
+
+        bridge.set_sidebar_section("alpha", "status", title="Alpha updated", content=["updated"])
         await pilot.pause()
 
+        assert slot.children[0] is alpha_section
         assert [
             section.query_one(".extension-sidebar-title", Static).render().plain
             for section in slot.children
         ] == [
-            "Alpha",
+            "Alpha updated",
             "Beta",
         ]
         alpha_body = slot.children[0].query_one(".extension-sidebar-body", Container)
@@ -296,6 +301,27 @@ async def test_sidebar_sections_mount_update_and_remove_by_owned_key() -> None:
         assert (
             slot.children[0].query_one(".extension-sidebar-title", Static).render().plain == "Beta"
         )
+
+
+@pytest.mark.anyio
+async def test_sidebar_removing_absent_key_does_not_schedule_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        scheduled = False
+
+        def schedule(coro):  # noqa: ANN001, ANN202
+            nonlocal scheduled
+            scheduled = True
+            coro.close()
+
+        monkeypatch.setattr(app, "_schedule_extension_swap", schedule)
+        _component_bridge(app).remove_sidebar_section("ext", "absent")
+
+        assert scheduled is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- preserve mounted sidebar section roots for host-rendered line updates
- skip identical updates and absent-key removals
- retain replacement semantics for extension widget factories
- document and test identity-preserving updates

## User experience

Dynamic extension status no longer disappears briefly when its title or display lines change, eliminating sidebar flicker during transcript activity.

Closes #645.

## Validation

- `uv run pytest` (1807 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`

## Manual validation

Load an extension that repeatedly calls `sidebar.set_section()` under one key while messages complete. The section root should remain mounted and its content should update without a visible gap.
