### PR TITLE
Show system prompt files in the TUI sidebar

### DIFF
--- a/dev-notes/system-prompt-sidebar.md
+++ b/dev-notes/system-prompt-sidebar.md
@@ -1,0 +1,36 @@
+# System-prompt files in the TUI sidebar
+
+## What changed
+
+The TUI sidebar now shows a **system prompt** section whenever the active session
+loaded `SYSTEM.md` or `APPEND_SYSTEM.md` from a user or project `.tau` directory.
+It lists only selected files that contribute to the effective prompt; shadowed or
+CLI-overridden files remain available through `/session` diagnostics.
+
+## Why
+
+System-prompt files affect every provider request but were previously invisible
+in the persistent session summary. Listing their paths makes prompt customization
+easier to notice and audit without mixing Tau-native prompt inputs into the
+sidebar's project-context file list.
+
+## Design
+
+`CodingSession.system_prompt_files` exposes the selected replacement and append
+source paths in assembly order. The TUI consumes that provider-neutral session
+metadata, formats project and home paths consistently with context files, and
+includes the paths in its redraw fingerprint so `/reload` updates the section.
+The section is omitted when no discovered prompt files are active to avoid adding
+noise to the default sidebar.
+
+## Validation
+
+Create `.tau/APPEND_SYSTEM.md`, launch Tau in that directory after trusting the
+project, and confirm the sidebar shows:
+
+```text
+system prompt
+  • .tau/APPEND_SYSTEM.md
+```
+
+Remove the file, run `/reload`, and confirm the section disappears.

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -1023,6 +1023,15 @@ class CodingSession:
         return self._context_files
 
     @property
+    def system_prompt_files(self) -> tuple[Path, ...]:
+        """Return active discovered system-prompt resource files."""
+        return tuple(
+            path
+            for path in (self._custom_system_prompt_path, self._append_system_prompt_path)
+            if path is not None
+        )
+
+    @property
     def context_token_estimate(self) -> int:
         """Return the best available token count for the active provider context."""
         return self.context_usage.total_tokens

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -87,6 +87,9 @@ class SessionSummarySource(Protocol):
     def context_files(self) -> Sequence[ProjectContextFile]: ...
 
     @property
+    def system_prompt_files(self) -> Sequence[Path]: ...
+
+    @property
     def context_token_estimate(self) -> int: ...
 
     @property
@@ -244,6 +247,7 @@ def _session_summary_fingerprint(
         ),
         tuple((template.name, template.path) for template in session.prompt_templates),
         tuple(context.path for context in session.context_files),
+        tuple(session.system_prompt_files),
     )
 
 
@@ -1845,6 +1849,16 @@ def _build_sidebar_content(
         empty="No context files",
         theme=theme,
     )
+    system_prompt_sections: tuple[RenderableType, ...] = ()
+    if session.system_prompt_files:
+        system_prompt_files = _limited_bullet_list(
+            [_context_file_label(path, cwd=session.cwd) for path in session.system_prompt_files],
+            empty="No system prompt files",
+            theme=theme,
+        )
+        system_prompt_sections = (
+            _sidebar_section("system prompt", system_prompt_files, theme=theme),
+        )
     tools = _comma_list([tool.name for tool in session.tools], empty="No tools", theme=theme)
     return _SidebarContent(
         summary_sections=(
@@ -1853,6 +1867,7 @@ def _build_sidebar_content(
             _sidebar_section("usage", usage, theme=theme),
             _sidebar_section("compaction", compaction, theme=theme),
             _sidebar_section("context", context, theme=theme),
+            *system_prompt_sections,
             _sidebar_section("tools", tools, theme=theme),
         ),
         skills=_grouped_skill_list(session.skills, cwd=session.cwd, theme=theme),

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3179,6 +3179,10 @@ async def test_session_loads_tau_native_system_prompt_files(tmp_path: Path) -> N
     assert "Project instructions" in session.system_prompt
     assert "Current date:" in session.system_prompt
     assert f"Current working directory: {tmp_path}" in session.system_prompt
+    assert session.system_prompt_files == (
+        project_tau / "SYSTEM.md",
+        tau_home / "APPEND_SYSTEM.md",
+    )
     prompt_diagnostics = [
         item for item in session.resource_diagnostics if item.kind == "system-prompt"
     ]
@@ -3205,6 +3209,7 @@ async def test_explicit_system_prompt_values_override_discovered_files(tmp_path:
     )
 
     assert session.system_prompt.startswith("Explicit base\n\nExplicit append")
+    assert session.system_prompt_files == ()
     assert all(
         "explicit startup value" in item.message
         for item in session.resource_diagnostics

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -215,6 +215,7 @@ class FakeSession:
         self.context_files = (
             ProjectContextFile(path=str(self.cwd / "AGENTS.md"), content="Follow rules."),
         )
+        self.system_prompt_files: tuple[Path, ...] = ()
         self.context_token_estimate = 12034
         self.has_provider_context_usage = True
         self.auto_compact_token_threshold = 200000
@@ -682,6 +683,30 @@ def test_session_sidebar_limits_context_files_to_five() -> None:
     assert "context-6.md" not in output
     assert "context-7.md" not in output
     assert "...(2 more)" in output
+
+
+def test_session_sidebar_lists_active_system_prompt_files() -> None:
+    session = FakeSession()
+    session.system_prompt_files = (
+        session.cwd / ".tau" / "SYSTEM.md",
+        Path.home() / ".tau" / "APPEND_SYSTEM.md",
+    )
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(session))
+
+    output = console.export_text()
+    assert "system prompt" in output
+    assert "• .tau/SYSTEM.md" in output
+    assert "• ~/.tau/APPEND_SYSTEM.md" in output
+
+
+def test_session_sidebar_omits_system_prompt_section_without_active_files() -> None:
+    console = Console(record=True, width=80)
+
+    console.print(render_session_sidebar(FakeSession()))
+
+    assert "system prompt" not in console.export_text()
 
 
 def test_comma_list_limits_by_rendered_lines_instead_of_item_count() -> None:

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -235,11 +235,14 @@ with `disable-model-invocation: true` use a hollow bullet (`◦`). If
 the sidebar content is
 taller than the available space, scroll it to see the remaining resource groups;
 the Tau version mark stays pinned at the bottom. Context files
-use a bullet list with one path per line, limited to five entries. Truncated sections
-end with `...(X more)` showing how many context entries are hidden. Project
-context paths are relative to the working directory; context
-loaded from the home directory starts with `~/`, while other context loaded from
-outside the project uses its full path.
+use a bullet list with one path per line, limited to five entries. When Tau loads a
+`SYSTEM.md` replacement or `APPEND_SYSTEM.md` addition from a user or project
+`.tau` directory, a separate **system prompt** section lists each active file.
+Tau omits that section when no system-prompt files are active. Truncated sections
+end with `...(X more)` showing how many entries are hidden. Project resource paths
+are relative to the working directory; resources loaded from the home directory
+start with `~/`, while other resources loaded from outside the project use their
+full path.
 
 The wider, borderless sidebar uses the prompt field's background color, bright
 section headings, quieter gray values, and keeps Tau's versioned `τ = 2π` mark


### PR DESCRIPTION
## Description

- expose active discovered `SYSTEM.md` and `APPEND_SYSTEM.md` paths from `CodingSession`
- show those paths in a dedicated TUI sidebar **system prompt** section
- refresh the section when prompt resources change and omit it when no files are active
- document the behavior and add session/sidebar coverage

## User experience

Users can see at a glance when user- or project-level files are changing the effective system prompt. Project paths are shown relative to the working directory and home paths use `~/`, matching context-file display conventions.

## Issue

No linked issue; this PR addresses the requested sidebar visibility for active system-prompt files.

## Manual validation

1. Create `.tau/APPEND_SYSTEM.md` in a trusted project.
2. Launch Tau in that project.
3. Confirm the sidebar shows a **system prompt** section containing `.tau/APPEND_SYSTEM.md`.
4. Remove the file and run `/reload`.
5. Confirm the section disappears.
