### PR TITLE
Let extensions append system prompt sections

### DIFF
--- a/dev-notes/architecture/phase-21-extensions.md
+++ b/dev-notes/architecture/phase-21-extensions.md
@@ -328,7 +328,10 @@ sidebar, and `/session` counts like built-ins. Tool-attached
 `prompt_snippet`/`prompt_guidelines` flow into the system prompt as for
 built-ins, and `add_prompt_guideline` contributes standalone guideline
 lines through `BuildSystemPromptOptions.extra_guidelines` (rebuilt on
-`/reload` when they change).
+`/reload` when they change). Extensions that need structured always-on context
+use `add_prompt_section(title, body)`. These source-owned free-form blocks flow
+through `BuildSystemPromptOptions.extra_sections` after CLI/resource append
+content, retain registration order, and participate in reload change detection.
 
 ### Commands
 

--- a/dev-notes/extension-prompt-sections.md
+++ b/dev-notes/extension-prompt-sections.md
@@ -1,0 +1,58 @@
+# Extension-owned system-prompt sections
+
+Issue: https://github.com/huggingface/tau/issues/648
+
+## What changed
+
+Extensions can now call:
+
+```python
+tau.add_prompt_section(title, body)
+```
+
+The body is free-form Markdown suitable for paragraphs, lists, procedures, and
+code blocks. A non-empty title renders as a level-two heading; `None` or a blank
+title creates an unlabeled block. Sections follow CLI/resource append content
+and retain extension load and registration order.
+
+## Why
+
+`add_prompt_guideline` intentionally contributes one flat bullet to Tau's
+`Guidelines` section. It cannot represent structured instructions cleanly.
+Always-on extension context also should not be moved into an optional skill or a
+global `AGENTS.md` when it applies only while that extension is active.
+
+## Design
+
+`PromptSection` is a frontend-free system-prompt assembly value. The extension
+runtime stores sections with their canonical source owner, just like standalone
+guidelines. Failed setup removes partial registrations; reload and retirement
+clear the outgoing generation. Empty bodies and multi-line titles produce
+bounded extension diagnostics rather than malformed prompt markup.
+
+`CodingSession` passes runtime sections through
+`BuildSystemPromptOptions.extra_sections` after the existing
+`append_system_prompt` value. Reload compares section snapshots so adding,
+changing, or removing an extension section rebuilds the next-turn prompt.
+An exact low-level `CodingSessionConfig.system` override remains exact and does
+not receive generated extension contributions.
+
+Pi currently supports more general per-turn system-prompt mutation through its
+`before_agent_start` hook. Tau does not yet expose that broader context-rewriting
+surface. This narrower registration API addresses the always-on structured
+context use case while preserving deterministic startup/reload assembly and
+source ownership.
+
+## Validation
+
+```bash
+uv run pytest tests/test_system_prompt.py tests/test_extensions.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+For manual validation, load `examples/extensions/prompt_section.py` with `tau -e`
+and use `/system` to confirm its heading, paragraphs, and fenced command block
+appear after any `APPEND_SYSTEM.md` content. Remove the extension or run `/reload`
+after deleting its registration and confirm the section disappears.

--- a/examples/extensions/prompt_section.py
+++ b/examples/extensions/prompt_section.py
@@ -1,0 +1,19 @@
+"""Append structured, always-on instructions to Tau's system prompt."""
+
+from tau_coding.extensions import ExtensionAPI
+
+
+def setup(tau: ExtensionAPI) -> None:
+    """Add a labeled procedure while this extension generation is active."""
+    tau.add_prompt_section(
+        "Review procedure",
+        """Read the complete diff before editing.
+
+Run the relevant checks before reporting success:
+
+```bash
+uv run pytest
+uv run ruff check .
+```
+""",
+    )

--- a/src/tau_coding/data/docs/extensions.md
+++ b/src/tau_coding/data/docs/extensions.md
@@ -22,6 +22,19 @@ Installed examples are under `examples/extensions/` next to these docs. Read the
 - `<project>/.tau/extensions/`: requires project approval and `--project-extensions`.
 - `tau -e PATH`: explicitly load a file or directory.
 
+## System-prompt contributions
+
+Use `tau.add_prompt_guideline(text)` for one behavioral bullet in Tau's
+`Guidelines` section. Use `tau.add_prompt_section(title, body)` for structured,
+always-on context containing paragraphs, lists, or code blocks. `title` may be
+`None`; otherwise Tau renders it as a level-two Markdown heading.
+
+Extension sections follow user/project `APPEND_SYSTEM.md` or explicit
+`--append-system-prompt` content, then compose in extension load and registration
+order. Empty bodies and multi-line titles are ignored with diagnostics. Prompt
+registrations are source-owned and disappear on failed setup, reload, or runtime
+retirement. See `examples/extensions/prompt_section.py`.
+
 ## Installing extensions
 
 Install a trusted local or Git extension for future runs with:

--- a/src/tau_coding/data/examples/extensions/prompt_section.py
+++ b/src/tau_coding/data/examples/extensions/prompt_section.py
@@ -1,0 +1,19 @@
+"""Append structured, always-on instructions to Tau's system prompt."""
+
+from tau_coding.extensions import ExtensionAPI
+
+
+def setup(tau: ExtensionAPI) -> None:
+    """Add a labeled procedure while this extension generation is active."""
+    tau.add_prompt_section(
+        "Review procedure",
+        """Read the complete diff before editing.
+
+Run the relevant checks before reporting success:
+
+```bash
+uv run pytest
+uv run ruff check .
+```
+""",
+    )

--- a/src/tau_coding/extensions/api.py
+++ b/src/tau_coding/extensions/api.py
@@ -1061,6 +1061,21 @@ class ExtensionAPI:
         self._generation.assert_active()
         self._runtime.register_prompt_guideline(self._source_id, self._extension_name, guideline)
 
+    def add_prompt_section(self, title: str | None, body: str) -> None:
+        """Append a free-form, optionally titled section to the system prompt.
+
+        Use this for structured, always-on extension context such as procedures,
+        paragraphs, and code blocks. Use :meth:`add_prompt_guideline` for one
+        behavioral bullet instead.
+        """
+        self._generation.assert_active()
+        self._runtime.register_prompt_section(
+            self._source_id,
+            self._extension_name,
+            title,
+            body,
+        )
+
     def on(
         self,
         event: str,

--- a/src/tau_coding/extensions/runtime.py
+++ b/src/tau_coding/extensions/runtime.py
@@ -79,6 +79,7 @@ from tau_coding.paths import TauPaths
 from tau_coding.project_trust import ExtensionTrustResult, ProjectTrustEvent
 from tau_coding.provider_config import ProviderConfig
 from tau_coding.resources import ResourceDiagnostic, TauResourcePaths
+from tau_coding.system_prompt import PromptSection
 
 # Host callback that delivers a message through the frontend's serialized run
 # path when the session is idle. Carries the same presentation metadata as a
@@ -236,6 +237,7 @@ class ExtensionRuntime:
         self._tools: dict[str, RegisteredExtensionTool] = {}
         self._commands: dict[str, ExtensionCommand] = {}
         self._prompt_guidelines: list[tuple[str, str, str]] = []
+        self._prompt_sections: list[tuple[str, str, PromptSection]] = []
         self._message_renderers: dict[str, tuple[str, str, MessageRenderer]] = {}
         self._renderer_failures_reported: set[str] = set()
         self._load_diagnostics: list[ResourceDiagnostic] = []
@@ -321,6 +323,7 @@ class ExtensionRuntime:
         self._tools.clear()
         self._commands.clear()
         self._prompt_guidelines.clear()
+        self._prompt_sections.clear()
         self._message_renderers.clear()
         self._renderer_failures_reported.clear()
         self._turn_requested = None
@@ -395,6 +398,7 @@ class ExtensionRuntime:
         self._tools.clear()
         self._commands.clear()
         self._prompt_guidelines.clear()
+        self._prompt_sections.clear()
         self._message_renderers.clear()
         self._renderer_failures_reported.clear()
         self._load_diagnostics.clear()
@@ -461,6 +465,11 @@ class ExtensionRuntime:
         self._prompt_guidelines = [
             (owner, extension, guideline)
             for owner, extension, guideline in self._prompt_guidelines
+            if owner != source_id
+        ]
+        self._prompt_sections = [
+            (owner, extension, section)
+            for owner, extension, section in self._prompt_sections
             if owner != source_id
         ]
         self._message_renderers = {
@@ -691,6 +700,46 @@ class ExtensionRuntime:
             return
         self._prompt_guidelines.append((source_id, extension_name, normalized))
 
+    def register_prompt_section(
+        self,
+        source_id: str,
+        extension_name: str,
+        title: str | None,
+        body: str,
+    ) -> None:
+        """Register a free-form system-prompt section."""
+        normalized_body = body.strip()
+        if not normalized_body:
+            self._load_diagnostics.append(
+                ResourceDiagnostic(
+                    kind="extension",
+                    name=extension_name,
+                    message="empty prompt section ignored",
+                )
+            )
+            return
+        normalized_title = title.strip() if title is not None else None
+        if normalized_title == "":
+            normalized_title = None
+        if normalized_title is not None and any(
+            separator in normalized_title for separator in ("\r", "\n")
+        ):
+            self._load_diagnostics.append(
+                ResourceDiagnostic(
+                    kind="extension",
+                    name=extension_name,
+                    message="prompt section ignored because its title spans multiple lines",
+                )
+            )
+            return
+        self._prompt_sections.append(
+            (
+                source_id,
+                extension_name,
+                PromptSection(title=normalized_title, body=normalized_body),
+            )
+        )
+
     def subscribe(self, source_id: str, event: str, handler: ExtensionHandler) -> None:
         """Subscribe an extension handler to a named event."""
         known = (
@@ -847,6 +896,11 @@ class ExtensionRuntime:
     def prompt_guidelines(self) -> tuple[str, ...]:
         """Return standalone guideline lines in registration order."""
         return tuple(guideline for _, _, guideline in self._prompt_guidelines)
+
+    @property
+    def prompt_sections(self) -> tuple[PromptSection, ...]:
+        """Return free-form prompt sections in registration order."""
+        return tuple(section for _, _, section in self._prompt_sections)
 
     # -- actions (called through ExtensionAPI) --------------------------------
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -623,6 +623,7 @@ class CodingSession:
                     ),
                     context_files=resources.context_files,
                     extra_guidelines=extension_runtime.prompt_guidelines,
+                    extra_sections=extension_runtime.prompt_sections,
                 )
             )
         )
@@ -2005,6 +2006,7 @@ class CodingSession:
         before_extensions = _extension_signatures(self._extension_runtime)
         before_tool_names = tuple(tool.name for tool in self._harness.config.tools)
         before_guidelines = self._extension_runtime.prompt_guidelines
+        before_sections = self._extension_runtime.prompt_sections
 
         # Nothing below mutates the live session. Eligible extensions are loaded
         # first so project code cannot import before the destination decision.
@@ -2108,10 +2110,12 @@ class CodingSession:
             append_system_prompt_path=resources.append_system_prompt_path,
         )
         after_guidelines = staged_runtime.prompt_guidelines
+        after_sections = staged_runtime.prompt_sections
         system_prompt_rebuilt = self._config.system is None and (
             before_system_prompt_inputs != after_system_prompt_inputs
             or before_tool_names != tuple(tool.name for tool in staged_tools)
             or before_guidelines != after_guidelines
+            or before_sections != after_sections
         )
         staged_system = self._harness.config.system
         if system_prompt_rebuilt:
@@ -2132,6 +2136,7 @@ class CodingSession:
                     ),
                     context_files=resources.context_files,
                     extra_guidelines=after_guidelines,
+                    extra_sections=after_sections,
                 )
             )
 

--- a/src/tau_coding/system_prompt.py
+++ b/src/tau_coding/system_prompt.py
@@ -22,6 +22,14 @@ class ProjectContextFile:
 
 
 @dataclass(frozen=True, slots=True)
+class PromptSection:
+    """A free-form section appended to the system prompt."""
+
+    title: str | None
+    body: str
+
+
+@dataclass(frozen=True, slots=True)
 class BuildSystemPromptOptions:
     """Options used to build Tau's system prompt."""
 
@@ -33,13 +41,16 @@ class BuildSystemPromptOptions:
     context_files: Sequence[ProjectContextFile] = ()
     current_date: date | None = None
     extra_guidelines: Sequence[str] = field(default_factory=tuple)
+    extra_sections: Sequence[PromptSection] = field(default_factory=tuple)
 
 
 def build_system_prompt(options: BuildSystemPromptOptions) -> str:
     """Build a deterministic Pi-style system prompt for Tau."""
     current_date = options.current_date or date.today()
     cwd = _format_path(options.cwd)
-    append_section = f"\n\n{options.append_system_prompt}" if options.append_system_prompt else ""
+    append_parts = [options.append_system_prompt] if options.append_system_prompt else []
+    append_parts.extend(format_prompt_section(section) for section in options.extra_sections)
+    append_section = "".join(f"\n\n{part}" for part in append_parts)
 
     if options.custom_prompt is not None:
         prompt = options.custom_prompt
@@ -68,6 +79,13 @@ def build_system_prompt(options: BuildSystemPromptOptions) -> str:
     prompt += f"\nCurrent date: {current_date.isoformat()}"
     prompt += f"\nCurrent working directory: {cwd}"
     return prompt
+
+
+def format_prompt_section(section: PromptSection) -> str:
+    """Render one optional-title free-form prompt section."""
+    if section.title is None:
+        return section.body
+    return f"## {section.title}\n\n{section.body}"
 
 
 def format_tau_documentation() -> str:

--- a/tests/test_example_extensions.py
+++ b/tests/test_example_extensions.py
@@ -67,11 +67,19 @@ def test_shipped_examples_load(tmp_path: Path) -> None:
         tmp_path,
         "hello_tool.py",
         "permission_gate.py",
+        "prompt_section.py",
         "sidebar_status.py",
     )
 
-    assert runtime.extension_names == ("hello_tool", "permission_gate", "sidebar_status")
+    assert runtime.extension_names == (
+        "hello_tool",
+        "permission_gate",
+        "prompt_section",
+        "sidebar_status",
+    )
     assert [tool.name for tool in runtime.extension_tools] == ["hello"]
+    assert runtime.prompt_sections[0].title == "Review procedure"
+    assert "```bash" in runtime.prompt_sections[0].body
 
 
 async def test_hello_tool_greets(tmp_path: Path) -> None:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -3,6 +3,7 @@
 import asyncio
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 
@@ -42,6 +43,7 @@ from tau_coding.extensions import (
     load_extensions,
 )
 from tau_coding.project_trust import ProjectTrustRequest, TrustChoice
+from tau_coding.system_prompt import PromptSection
 
 pytestmark = pytest.mark.anyio
 
@@ -928,6 +930,7 @@ def setup(tau):
     ))
     tau.register_command("orphan-command", _command)
     tau.add_prompt_guideline("orphan guideline")
+    tau.add_prompt_section("Orphan section", "orphan body")
     tau.register_message_renderer("orphan:message", _renderer)
     tau.on("input", _handler)
     entry = Path({str(entry)!r})
@@ -949,6 +952,7 @@ def setup(tau):
     assert runtime.extension_tools == ()
     assert runtime.build_command_registry().get("orphan-command") is None
     assert runtime.prompt_guidelines == ()
+    assert runtime.prompt_sections == ()
     assert runtime.render_custom_message("orphan:message", "content", None, False) is None
     outcome = await runtime.run_input_hooks("unchanged")
     assert outcome.text == "unchanged"
@@ -1035,6 +1039,25 @@ def test_prompt_guideline_registration(tmp_path: Path) -> None:
 
     assert runtime.prompt_guidelines == ("Always run the tests before claiming success",)
     assert any("empty prompt guideline" in diag.message for diag in runtime.diagnostics)
+
+
+def test_prompt_section_registration(tmp_path: Path) -> None:
+    runtime = ExtensionRuntime()
+    api = _register_inline_extension(runtime, "structured-guidance")
+    api.add_prompt_section("  Review procedure  ", "  First step.\n\n```bash\nuv run pytest\n```  ")
+    api.add_prompt_section("   ", "Untitled context")
+    api.add_prompt_section(None, "   ")
+    api.add_prompt_section("bad\ntitle", "ignored")
+
+    assert runtime.prompt_sections == (
+        PromptSection(
+            title="Review procedure",
+            body="First step.\n\n```bash\nuv run pytest\n```",
+        ),
+        PromptSection(title=None, body="Untitled context"),
+    )
+    assert any("empty prompt section" in diag.message for diag in runtime.diagnostics)
+    assert any("title spans multiple lines" in diag.message for diag in runtime.diagnostics)
 
 
 def test_unknown_event_subscription_is_a_diagnostic(tmp_path: Path) -> None:
@@ -2062,6 +2085,45 @@ async def test_extension_guideline_reaches_system_prompt(tmp_path: Path) -> None
     )
 
     assert "Never commit directly to main" in session.system_prompt
+
+
+async def test_extension_prompt_section_reaches_system_prompt_after_user_append(
+    tmp_path: Path,
+) -> None:
+    body = (
+        "def setup(tau):\n"
+        "    tau.add_prompt_section('Review procedure', "
+        "'First step.\\n\\n```bash\\nuv run pytest\\n```')\n"
+    )
+    config = _session_config(tmp_path, FakeProvider([]), extension_body=body)
+    config = replace(config, append_system_prompt="User append")
+
+    session = await CodingSession.load(config)
+
+    assert (
+        "## Review procedure\n\nFirst step.\n\n```bash\nuv run pytest\n```" in session.system_prompt
+    )
+    assert session.system_prompt.index("User append") < session.system_prompt.index(
+        "## Review procedure"
+    )
+
+
+async def test_reload_picks_up_prompt_section_changes(tmp_path: Path) -> None:
+    provider = FakeProvider([])
+    session = await CodingSession.load(_session_config(tmp_path, provider))
+    assert "## Late procedure" not in session.system_prompt
+
+    paths = _paths(tmp_path)
+    _write_extension(
+        _user_extensions_dir(paths),
+        "late_section",
+        "def setup(tau):\n    tau.add_prompt_section('Late procedure', 'Run the checks.')\n",
+    )
+
+    summary = await session.reload()
+
+    assert summary.system_prompt_rebuilt is True
+    assert "## Late procedure\n\nRun the checks." in session.system_prompt
 
 
 async def test_reload_picks_up_guideline_changes(tmp_path: Path) -> None:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -11,6 +11,7 @@ BUILTIN_RESOURCE_WHEEL_PATHS = {
     "tau_coding/data/docs/README.md",
     "tau_coding/data/docs/extensions.md",
     "tau_coding/data/examples/extensions/hello_tool.py",
+    "tau_coding/data/examples/extensions/prompt_section.py",
     "tau_coding/data/examples/extensions/sidebar_status.py",
 }
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -6,6 +6,7 @@ from tau_coding import Skill
 from tau_coding.system_prompt import (
     BuildSystemPromptOptions,
     ProjectContextFile,
+    PromptSection,
     build_system_prompt,
     collect_prompt_guidelines,
     format_available_tools,
@@ -88,6 +89,33 @@ def test_custom_prompt_replaces_default_but_keeps_append_context_and_date(tmp_pa
     assert '<project_instructions path="/repo/AGENTS.md">' in prompt
     assert "Follow rules." in prompt
     assert "Current date: 2026-06-17" in prompt
+
+
+def test_extra_sections_follow_user_append_in_registration_order(tmp_path: Path) -> None:
+    prompt = build_system_prompt(
+        BuildSystemPromptOptions(
+            cwd=tmp_path,
+            custom_prompt="Custom base.",
+            append_system_prompt="User append.",
+            extra_sections=(
+                PromptSection(
+                    title="Extension procedure", body="First step.\n\n```bash\nuv run pytest\n```"
+                ),
+                PromptSection(title=None, body="Untitled extension context."),
+            ),
+            context_files=(ProjectContextFile(path="/repo/AGENTS.md", content="Project rules."),),
+            current_date=date(2026, 6, 17),
+        )
+    )
+
+    expected = (
+        "Custom base.\n\nUser append.\n\n## Extension procedure\n\n"
+        "First step.\n\n```bash\nuv run pytest\n```\n\n"
+        "Untitled extension context."
+    )
+    assert prompt.startswith(expected)
+    assert prompt.index("User append.") < prompt.index("## Extension procedure")
+    assert prompt.index("Untitled extension context.") < prompt.index("<project_instructions")
 
 
 def test_empty_custom_prompt_is_still_custom(tmp_path: Path) -> None:

--- a/website/content/guides/extensions.md
+++ b/website/content/guides/extensions.md
@@ -165,6 +165,7 @@ def setup(tau):
     tau.register_provider(dynamic_provider)  # process-local
     tau.register_command("name", handler, description="...")
     tau.add_prompt_guideline("Never commit directly to main")
+    tau.add_prompt_section("Review procedure", "Read the diff, then run tests.")
     tau.on("event_name", handler)            # or @tau.on("event_name")
 
     # message rendering (register in setup; send once running)
@@ -327,6 +328,30 @@ something to replace.
 For behavioral guidance not tied to any tool, `add_prompt_guideline(text)`
 adds a line to the system prompt's Guidelines section (de-duplicated at
 build time; `/reload` rebuilds the prompt when guidelines change).
+
+For structured, always-on context, `add_prompt_section(title, body)` appends a
+free-form section after user/project `APPEND_SYSTEM.md` or
+`--append-system-prompt` content. The title may be `None`; a title is rendered
+as a level-two Markdown heading. Bodies may contain paragraphs, lists, and code
+blocks without being forced into a guideline bullet:
+
+````python
+def setup(tau):
+    tau.add_prompt_section(
+        "Review procedure",
+        """Read the complete diff before editing.
+
+```bash
+uv run pytest
+```
+""",
+    )
+````
+
+Sections compose in extension load and registration order. Empty bodies and
+multi-line titles are ignored with a resource diagnostic. Registrations are
+source-owned, so failed setup, `/reload`, and generation retirement remove them
+along with the extension's other contributions.
 
 ### Commands
 
@@ -713,6 +738,7 @@ See [`examples/extensions/`](https://github.com/huggingface/tau/tree/main/exampl
 - **`permission_gate.py`** — blocks dangerous bash commands with the
   `tool_call` hook.
 - **`sidebar_status.py`** — adds and updates a host-framed sidebar section.
+- **`prompt_section.py`** — appends a labeled multi-line system-prompt section.
 
 A larger, real-world extension lives in its own repository:
 [rian-dolphin/tau-subagents](https://github.com/rian-dolphin/tau-subagents)


### PR DESCRIPTION
## Description

- add `ExtensionAPI.add_prompt_section(title, body)` for free-form, optionally labeled system-prompt context
- compose extension sections after CLI/resource append content in extension load and registration order
- make registrations source- and generation-owned, with failed-setup cleanup and reload change detection
- ship and test a structured prompt-section example
- document API semantics, ordering, validation, and lifecycle behavior

## User experience

Extension authors can provide always-on procedures, paragraphs, lists, and fenced code blocks without flattening them into malformed guideline bullets or relying on optional skill invocation. Users retain control of their own append content, which stays ahead of extension sections in the effective prompt.

## Issue

Closes #648.

## Manual validation

1. Run `tau -e examples/extensions/prompt_section.py`.
2. Use `/system` and confirm a `## Review procedure` section appears with paragraphs and a fenced Bash block.
3. Add `.tau/APPEND_SYSTEM.md`, run `/reload`, and confirm its content appears before the extension section.
4. Remove or disable the extension and confirm its section no longer appears after reload/restart.
