### PR TITLE
Fix TUI crash on invalid syntax spans

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -23,6 +23,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.content import Content, Span
 from textual.content import Style as TextualStyle  # type: ignore[attr-defined]
 from textual.css.query import NoMatches
 from textual.geometry import Offset
@@ -30,7 +31,7 @@ from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Collapsible, Static
 from textual.widgets import Markdown as TextualMarkdown
-from textual.widgets.markdown import MarkdownBlock, MarkdownStream
+from textual.widgets.markdown import MarkdownBlock, MarkdownFence, MarkdownStream
 
 from tau_agent.tools import AgentTool, ToolCall
 from tau_coding.context_window import estimate_text_tokens
@@ -288,10 +289,38 @@ class TauMarkdownBlock(MarkdownBlock):
         return type(content)(content.plain, spans=spans)
 
 
+class TauMarkdownFence(MarkdownFence):
+    """Code fence that discards invalid spans produced by Textual's highlighter."""
+
+    @classmethod
+    def highlight(
+        cls,
+        code: str,
+        language: str,
+        ansi: bool = False,
+        dark: bool = False,
+    ) -> Content:
+        content = super().highlight(code, language, ansi=ansi, dark=dark)
+        text_length = len(content.plain)
+        if all(0 <= span.start < span.end <= text_length for span in content.spans):
+            return content
+        spans = [
+            Span(max(0, span.start), min(text_length, span.end), span.style)
+            for span in content.spans
+            if max(0, span.start) < min(text_length, span.end)
+        ]
+        return Content(content.plain, spans=spans)
+
+
 class ThemedMarkdownWidget(TextualMarkdown):
     """Textual Markdown widget reserved for Tau transcript streaming."""
 
-    BLOCKS = {**TextualMarkdown.BLOCKS, "paragraph_open": TauMarkdownBlock}
+    BLOCKS = {
+        **TextualMarkdown.BLOCKS,
+        "paragraph_open": TauMarkdownBlock,
+        "fence": TauMarkdownFence,
+        "code_block": TauMarkdownFence,
+    }
 
     DEFAULT_CSS = """
     ThemedMarkdownWidget MarkdownH1,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3480,6 +3480,26 @@ async def test_tui_transcript_code_block_scrollbar_matches_overflow(
 
 
 @pytest.mark.anyio
+async def test_tui_transcript_code_fence_ignores_invalid_highlighter_spans() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(content="```ini\nkeybind = alt+arrow_left=text:\\\n```")
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        label = app.query_one("#code-content", Label)
+        content = label.render()
+
+    assert isinstance(content, Content)
+    assert content.plain == "keybind = alt+arrow_left=text:\\"
+    assert all(0 <= span.start < span.end <= len(content.plain) for span in content.spans)
+
+
+@pytest.mark.anyio
 async def test_streaming_code_block_hides_horizontal_scrollbar_until_finalized() -> None:
     app = TauTuiApp(FakeSession())
     long_code_line = "value = '" + ("x" * 140) + "'"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3483,9 +3483,7 @@ async def test_tui_transcript_code_block_scrollbar_matches_overflow(
 async def test_tui_transcript_code_fence_ignores_invalid_highlighter_spans() -> None:
     app = TauTuiApp(
         FakeSession(
-            messages=[
-                AssistantMessage(content="```ini\nkeybind = alt+arrow_left=text:\\\n```")
-            ]
+            messages=[AssistantMessage(content="```ini\nkeybind = alt+arrow_left=text:\\\n```")]
         )
     )
 


### PR DESCRIPTION
## Summary

Prevent the TUI from crashing while rendering syntax-highlighted fenced code by:

- discarding invalid style spans returned by Textual's code highlighter
- using the guarded fence renderer for transcript Markdown
- adding a regression test for the exact failing INI content

## What happened

Assistant Markdown is rendered incrementally as provider chunks arrive. A chunk may end at any character, including immediately after a backslash inside a fenced code block. For example, this complete line:

```ini
keybind = alt+arrow_left=text:\x1b[1;5D
```

can temporarily be rendered as:

```ini
keybind = alt+arrow_left=text:\
```

With Textual 8.2.8, highlighting that temporary INI line returns malformed `Content`: the text is 31 characters long, but one style span is `Span(32, 32, ...)`. The zero-length, out-of-range span leaves Textual's style stack empty at an unexpected render boundary. `Style.combine()` then calls `next()` on that empty stack and raises:

```text
RuntimeError: generator raised StopIteration
```

Because rendering happens in Textual's screen refresh, this exception terminates the entire TUI. The same problem can also occur when reopening a session that persisted content ending in this state.

## Fix

`TauMarkdownFence` delegates highlighting to Textual, then validates every returned span. Valid spans are preserved unchanged; malformed or empty spans are clipped or discarded before the content reaches the `Label` renderer.

The guard is scoped to Tau's transcript code fences, so normal syntax highlighting and Textual itself remain unchanged.

## Regression coverage

The new test mounts an assistant transcript containing an INI fence whose line ends in `\`. Before this fix, entering the Textual test app reproduces the `StopIteration` crash. The test now verifies that the fence renders and all retained spans are non-empty and within the text bounds.

## Validation

- `uv run pytest tests/test_tui_app.py -q` — 381 passed
- `uv run ruff check src/tau_coding/tui/widgets.py tests/test_tui_app.py`
- `uv run mypy src/tau_coding/tui/widgets.py`
