### PR TITLE
Fix premature Google stream completion

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -24,6 +24,8 @@ User-facing documentation lives in `website/content/` and is published at
   later phases use it.
 - `adr/` — architecture decision records.
 - `catalog-model-safety.md` — checklist for adding providers and models to the built-in catalog safely.
+- `google-stream-completion.md` — why native Google streams require an explicit
+  `finishReason` before Tau reports successful completion.
 - `startup-thinking-level-fallback.md` — why startup resolves a valid thinking
   level per model instead of assuming the global `medium` default.
 - `models-dev-catalog.md` — Pi-compatible build-time models.dev catalog

--- a/dev-notes/google-stream-completion.md
+++ b/dev-notes/google-stream-completion.md
@@ -1,0 +1,49 @@
+# Google stream completion validation
+
+## What changed
+
+Tau's native Google Generative AI adapter now requires the stream to contain a
+Google `finishReason` before it emits a successful response-end event. A clean
+HTTP close without that field produces a provider error while preserving any
+partial text, thinking, or tool-call content.
+
+An empty stream that closes cleanly is retried using the provider's configured
+retry policy. Tau does not retry after model output starts because replaying the
+request could duplicate visible output or tool calls. Malformed JSON stream
+chunks are terminal provider errors rather than ignored input.
+
+## Why
+
+Google normally supplies `finishReason` in its final streamed candidate. The old
+parser converted a missing value to `stop`, so a response interrupted during a
+thinking block looked successfully complete. Agent sessions—and in-process
+subagents—could consequently end with no final text and no visible provider
+failure.
+
+The provider-neutral stream bridge already preserves partial output on an error.
+The Google adapter now reports the missing terminal marker instead of masking it,
+allowing the agent loop to stop before executing a tool call from an incomplete
+response.
+
+## How this maps to Tau's architecture
+
+The Google-specific terminal-marker rule stays in `tau_ai.google`. It emits the
+existing provider-neutral error event, and `tau_ai.stream` converts that into the
+canonical assistant error consumed by `tau_agent`. No Google protocol knowledge
+is added to the reusable agent loop or coding UI.
+
+## Validation
+
+Focused regressions in `tests/test_tau_ai.py` cover:
+
+- clean close during thinking, preserving partial thinking;
+- incomplete text/tool output, including preventing tool execution;
+- retry and exhaustion for an empty clean close;
+- valid `STOP` and `MAX_TOKENS` completion reasons; and
+- malformed/truncated JSON chunks.
+
+Run them with:
+
+```bash
+uv run pytest tests/test_tau_ai.py -k google_provider
+```

--- a/src/tau_ai/google.py
+++ b/src/tau_ai/google.py
@@ -160,6 +160,27 @@ class GoogleGenerativeAIProvider:
                                 continue
                             for parser_event in parser.feed(event):
                                 yield parser_event
+                            if parser.fatal:
+                                return
+                        if (
+                            not parser.has_finish_reason
+                            and not parser.emitted_content
+                            and self._should_retry(attempt)
+                        ):
+                            delay = retry_delay_seconds(
+                                attempt,
+                                max_delay_seconds=self._config.max_retry_delay_seconds,
+                            )
+                            yield provider_retry_event(
+                                attempt=attempt,
+                                max_retries=self._config.max_retries,
+                                delay_seconds=delay,
+                                reason="stream ended without finishReason",
+                            )
+                            attempt += 1
+                            if not await wait_for_retry(delay, signal=signal):
+                                return
+                            continue
                         for parser_event in parser.finalize():
                             yield parser_event
                         return
@@ -199,15 +220,21 @@ class GoogleGenerativeAIProvider:
 class _GoogleStreamParser:
     def __init__(self) -> None:
         self.emitted_content = False
+        self.fatal = False
         self._content_parts: list[str] = []
         self._thinking_parts: list[str] = []
         self._tool_calls: list[ToolCall] = []
         self._finish_reason: str | None = None
 
+    @property
+    def has_finish_reason(self) -> bool:
+        return self._finish_reason is not None
+
     def feed(self, event: str) -> list[ProviderEvent]:
         chunk = _loads_object(event)
         if chunk is None:
-            return []
+            self.fatal = True
+            return [ProviderErrorEvent(message="Google returned an invalid JSON stream chunk")]
         events: list[ProviderEvent] = []
         candidates = chunk.get("candidates")
         if not isinstance(candidates, list) or not candidates:
@@ -254,6 +281,8 @@ class _GoogleStreamParser:
         return events
 
     def finalize(self) -> list[ProviderEvent]:
+        if self._finish_reason is None:
+            return [ProviderErrorEvent(message="Google stream ended without finishReason")]
         content = assistant_content("".join(self._content_parts), self._tool_calls)
         if self._thinking_parts:
             content.insert(0, ThinkingContent(thinking="".join(self._thinking_parts)))

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -16,6 +16,7 @@ from tau_agent import (
     ToolResultMessage,
     UserMessage,
 )
+from tau_agent.loop import run_agent_loop
 from tau_agent.messages import assistant_content
 from tau_agent.types import JSONValue
 from tau_ai import (
@@ -679,6 +680,247 @@ async def test_google_provider_strips_unsupported_schema_keywords_from_tools() -
     assert "additionalProperties" not in parameters
     assert "additionalProperties" not in parameters["properties"]["env"]["items"]
     assert parameters["properties"]["command"] == {"type": "string"}
+
+
+@pytest.mark.anyio
+async def test_google_provider_errors_when_stream_ends_during_thinking() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":['
+                '{"text":"partial thought","thought":true}]}}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="Think")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.thinking_text == "partial thought"
+    assert events[-1].error.error_message == "Google stream ended without finishReason"
+
+
+@pytest.mark.anyio
+async def test_google_provider_does_not_execute_tool_from_incomplete_stream() -> None:
+    executed = False
+
+    async def execute(
+        tool_call_id: str,
+        arguments: Mapping[str, JSONValue],
+        signal: object | None = None,
+        on_update: object | None = None,
+    ) -> AgentToolResult:
+        nonlocal executed
+        del tool_call_id, arguments, signal, on_update
+        executed = True
+        return AgentToolResult(content="unexpected")
+
+    tool = AgentTool(
+        name="read",
+        label="read",
+        description="Read a file.",
+        parameters={"type": "object"},
+        execute_fn=execute,  # type: ignore[arg-type]
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":['
+                '{"text":"I will inspect it."},'
+                '{"functionCall":{"id":"call-1","name":"read",'
+                '"args":{"path":"README.md"}}}]}}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    messages = [UserMessage(content="Read README.md")]
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+        await _collect(
+            run_agent_loop(
+                provider=provider,
+                model="gemini-2.5-flash",
+                system="",
+                messages=messages,
+                tools=[tool],
+            )
+        )
+
+    assert executed is False
+    assert isinstance(messages[-1], AssistantMessage)
+    assert messages[-1].stop_reason == "error"
+    assert messages[-1].text == "I will inspect it."
+    assert [call.name for call in messages[-1].tool_calls] == ["read"]
+
+
+@pytest.mark.anyio
+async def test_google_provider_retries_empty_clean_close_then_errors() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text="",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 3
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Google stream ended without finishReason"
+
+
+@pytest.mark.anyio
+async def test_google_provider_accepts_explicit_stop_finish_reason() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},'
+                '"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].reason == "stop"
+    assert events[-1].message.text == "ok"
+
+
+@pytest.mark.anyio
+async def test_google_provider_maps_max_tokens_finish_reason_to_length() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"candidates":[{"content":{"parts":[{"text":"partial"}]},'
+                '"finishReason":"MAX_TOKENS"}]}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="Write a lot")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].reason == "length"
+    assert events[-1].message.stop_reason == "length"
+
+
+@pytest.mark.anyio
+async def test_google_provider_errors_on_truncated_json_chunk() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"candidates":[\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = GoogleGenerativeAIProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+                max_retries=2,
+                max_retry_delay_seconds=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gemini-2.5-flash",
+                system="",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert len(requests) == 1
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "Google returned an invalid JSON stream chunk"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- require native Google streams to include `finishReason` before reporting successful completion
- retry clean stream closes only when no model output has started
- preserve partial output as an error and prevent incomplete tool calls from executing
- reject malformed JSON stream chunks and add regression coverage

## User experience

Interrupted Google responses no longer appear as successful empty responses with `finishReason: stop`. Tau now surfaces the provider failure, including partial thinking or text where available.

## Validation

- `uv run pytest` (1826 passed, 2 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-google-stream-dist`
- `hugo --minify --destination /tmp/tau-google-stream-site`
- `npx --yes pagefind@latest --site /tmp/tau-google-stream-site`
