### PR TITLE
Prepare Tau 0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.3.13"
+version = "0.4.0"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "0.4.0",
+    "date": "2026-08-24",
+    "sections": {
+      "New": [
+        "Run tool-capable GGUF models through Tau's built-in llama.cpp local backend, with the /local workflow for endpoint configuration, diagnostics, model discovery, downloads, and load or unload management.",
+        "Keep model metadata current from models.dev with a generated offline snapshot, background /model refreshes, tau update --models, richer capability metadata, and Pi-compatible reasoning levels including max.",
+        "Recover eligible Hugging Face pre-output route failures automatically, persist successful replacement routes, and expose structured failover diagnostics while preserving explicitly fixed routes.",
+        "Build dynamic providers from trusted extensions and let extensions add live sidebar sections, structured system-prompt sections, and react to session-name or thinking-level changes.",
+        "Show active SYSTEM.md and APPEND_SYSTEM.md sources in the TUI sidebar."
+      ],
+      "Changed": [
+        "Render /system output as transcript Markdown without adding it to model context or session history.",
+        "Compose all discovered user and project APPEND_SYSTEM.md files from broad to specific before explicit CLI append content, deduplicating overlapping paths across reloads."
+      ],
+      "Fixed": [
+        "Require explicit Google finish reasons, retry empty clean closes, preserve partial failures, and reject malformed stream chunks instead of treating incomplete streams as successful.",
+        "Prevent malformed syntax-highlighter spans from crashing the TUI when rendering fenced code blocks.",
+        "Update extension-owned sidebar content in place to prevent flicker and unnecessary widget remounts."
+      ]
+    }
+  },
+  {
     "version": "0.3.13",
     "date": "2026-08-21",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -830,7 +830,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.3.13" in console.export_text()
+    assert "τ = 2π  0.4.0" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.3.13"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare the Tau 0.4.0 minor release.

- bump `tau-ai` from 0.3.13 to 0.4.0
- update `uv.lock` and the version-sensitive sidebar test
- add structured release notes for changes since v0.3.13

## Release highlights

- add built-in local inference through `/local` and llama.cpp
- generate and refresh model metadata from models.dev
- add automatic Hugging Face route failover
- expand extension APIs for dynamic providers, sidebar content, system-prompt sections, and session metadata
- improve system-prompt visibility and composition
- fix incomplete Google streams, malformed syntax-span crashes, and extension-sidebar flicker

## Validation

- `uv run pytest` — 1826 passed, 2 Windows-only tests skipped
- `uv run mypy` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv build` — built 0.4.0 wheel and source distribution
- `cd website && hugo --minify` — passed with the existing taxonomy warning
- `cd website && npx --yes pagefind@latest --site public` — passed
- `uv run tau --version` — `tau 0.4.0`

## Publishing

After merge, publish GitHub Release `v0.4.0` from `main`. The release event triggers the trusted PyPI publishing workflow.
