### PR TITLE
Add backward scoped model cycling

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -504,6 +504,7 @@ def _hotkeys_command(context: CommandContext) -> CommandResult:
         "- Esc: cancel active run",
         "- Ctrl+K: open slash-command completions",
         "- Ctrl+R: open session picker",
+        "- Ctrl+P / Shift+Ctrl+P: cycle scoped models forward / backward",
         "- Shift+Tab: cycle thinking mode",
         "- Ctrl+T: toggle thinking tokens",
         "- Ctrl+O: collapse or expand tool output",

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -2,7 +2,8 @@
 
 Tau's interactive interface uses Textual behind an adapter boundary. The
 portable `tau_agent` harness emits provider-neutral events; the TUI renders
-them and owns interaction.
+them and owns interaction. Ctrl+P cycles forward through scoped models;
+Shift+Ctrl+P cycles backward.
 
 ## `/model`
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -504,6 +504,8 @@ class CompletionActionTarget(Protocol):
 
     def action_cycle_model(self) -> None: ...
 
+    def action_cycle_model_reverse(self) -> None: ...
+
     def action_toggle_tool_results(self) -> None: ...
 
     def action_toggle_thinking(self) -> None: ...
@@ -625,8 +627,12 @@ class PromptInput(TextArea):
         self._completion_target().action_cycle_thinking()
 
     def action_cycle_model(self) -> None:
-        """Cycle the app-level scoped model."""
+        """Cycle the app-level scoped model forward."""
         self._completion_target().action_cycle_model()
+
+    def action_cycle_model_reverse(self) -> None:
+        """Cycle the app-level scoped model backward."""
+        self._completion_target().action_cycle_model_reverse()
 
     def action_toggle_tool_results(self) -> None:
         """Toggle app-level tool result display."""
@@ -816,6 +822,9 @@ class PromptInput(TextArea):
         elif event.key == keybindings.model_cycle:
             event.stop()
             self._completion_target().action_cycle_model()
+        elif event.key == keybindings.model_cycle_reverse:
+            event.stop()
+            self._completion_target().action_cycle_model_reverse()
         elif event.key == keybindings.toggle_tool_results:
             event.stop()
             self._completion_target().action_toggle_tool_results()
@@ -5796,11 +5805,18 @@ class TauTuiApp(App[None]):
         self.run_worker(self._cycle_thinking_level(), exclusive=False)
 
     def action_cycle_model(self) -> None:
-        """Cycle through scoped models."""
+        """Cycle forward through scoped models."""
+        self._cycle_model(reverse=False)
+
+    def action_cycle_model_reverse(self) -> None:
+        """Cycle backward through scoped models."""
+        self._cycle_model(reverse=True)
+
+    def _cycle_model(self, *, reverse: bool) -> None:
         if self.state.running:
             self._notify("Tau is already working. Press Escape to cancel.")
             return
-        self.run_worker(self._cycle_scoped_model(), exclusive=False)
+        self.run_worker(self._cycle_scoped_model(reverse=reverse), exclusive=False)
 
     def action_toggle_tool_results(self) -> None:
         """Toggle inline tool result details without rebuilding unrelated history."""
@@ -6445,13 +6461,13 @@ class TauTuiApp(App[None]):
             return
         self._refresh_chrome()
 
-    async def _cycle_scoped_model(self) -> None:
+    async def _cycle_scoped_model(self, *, reverse: bool = False) -> None:
         cycler = getattr(self.session, "cycle_scoped_model", None)
         if cycler is None:
             self._notify("Scoped model controls are not available.", severity="warning")
             return
         try:
-            result = cycler()
+            result = cycler(reverse=reverse)
             if isawaitable(result):
                 result = await result
         except Exception as exc:  # noqa: BLE001 - surface session state failures in the TUI
@@ -7220,6 +7236,12 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
         Binding(keybindings.thinking_cycle, "cycle_thinking", "Thinking"),
         Binding(keybindings.model_cycle, "cycle_model", "Model"),
         Binding(
+            keybindings.model_cycle_reverse,
+            "cycle_model_reverse",
+            "Previous model",
+            show=False,
+        ),
+        Binding(
             keybindings.accept_completion,
             "accept_completion",
             "Complete",
@@ -7304,6 +7326,13 @@ def _prompt_bindings(
         Binding(keybindings.thinking_cycle, "cycle_thinking", "Thinking", priority=True),
         Binding(keybindings.model_cycle, "cycle_model", "Model", priority=True),
         Binding(
+            keybindings.model_cycle_reverse,
+            "cycle_model_reverse",
+            "Previous model",
+            show=False,
+            priority=True,
+        ),
+        Binding(
             keybindings.copy_message,
             "clear_prompt",
             "Clear",
@@ -7326,6 +7355,7 @@ def _hidden_prompt_bindings(
         (keybindings.queue_follow_up, "submit_follow_up"),
         (keybindings.thinking_cycle, "cycle_thinking"),
         (keybindings.model_cycle, "cycle_model"),
+        (keybindings.model_cycle_reverse, "cycle_model_reverse"),
         (keybindings.toggle_tool_results, "toggle_tool_results"),
         (keybindings.toggle_thinking, "toggle_thinking"),
         (keybindings.copy_message, "clear_prompt"),

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -59,7 +59,7 @@ class TuiKeybindings:
     completion_previous: str = "up"
     thinking_cycle: str = "shift+tab"
     model_cycle: str = "ctrl+p"
-    model_cycle_reverse: str = "shift+ctrl+p"
+    model_cycle_reverse: str = "ctrl+shift+p"
     toggle_thinking: str = "ctrl+t"
     toggle_tool_results: str = "ctrl+o"
     copy_message: str = "ctrl+c"

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -59,6 +59,7 @@ class TuiKeybindings:
     completion_previous: str = "up"
     thinking_cycle: str = "shift+tab"
     model_cycle: str = "ctrl+p"
+    model_cycle_reverse: str = "shift+ctrl+p"
     toggle_thinking: str = "ctrl+t"
     toggle_tool_results: str = "ctrl+o"
     copy_message: str = "ctrl+c"
@@ -76,6 +77,7 @@ class TuiKeybindings:
             "completion_previous": self.completion_previous,
             "thinking_cycle": self.thinking_cycle,
             "model_cycle": self.model_cycle,
+            "model_cycle_reverse": self.model_cycle_reverse,
             "toggle_thinking": self.toggle_thinking,
             "toggle_tool_results": self.toggle_tool_results,
             "copy_message": self.copy_message,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -316,6 +316,7 @@ def test_hotkeys_command_lists_common_tui_shortcuts(tmp_path: Path) -> None:
     assert "Common keyboard shortcuts:" in result.message
     assert "Ctrl+K: open slash-command completions" in result.message
     assert "Ctrl+R: open session picker" in result.message
+    assert "Ctrl+P / Shift+Ctrl+P: cycle scoped models forward / backward" in result.message
     assert "Shift+Tab: cycle thinking mode" in result.message
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8398,7 +8398,7 @@ async def test_tui_app_cycles_scoped_model_backward_from_keybinding() -> None:
     app = TauTuiApp(session)
 
     async with app.run_test() as pilot:
-        await pilot.press("shift+ctrl+p")
+        await pilot.press("ctrl+shift+p")
         await pilot.pause()
 
     assert session.provider_name == "anthropic"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -367,15 +367,16 @@ class FakeSession:
         self.scoped_model_choices = tuple(scoped)
         return self.scoped_model_choices
 
-    def cycle_scoped_model(self) -> ModelChoice:
+    def cycle_scoped_model(self, *, reverse: bool = False) -> ModelChoice:
         if not self.scoped_model_choices:
             raise ValueError("No scoped models configured.")
         current = ModelChoice(provider_name=self.provider_name, model=self.model)
         try:
             index = self.scoped_model_choices.index(current)
         except ValueError:
-            index = -1
-        choice = self.scoped_model_choices[(index + 1) % len(self.scoped_model_choices)]
+            index = -1 if not reverse else 0
+        delta = -1 if reverse else 1
+        choice = self.scoped_model_choices[(index + delta) % len(self.scoped_model_choices)]
         self.set_model_choice(choice)
         return choice
 
@@ -8384,6 +8385,24 @@ async def test_tui_app_cycles_scoped_model_from_keybinding() -> None:
     assert session.provider_name == "openai"
     assert session.model == "other-model"
     assert notifications == []
+
+
+@pytest.mark.anyio
+async def test_tui_app_cycles_scoped_model_backward_from_keybinding() -> None:
+    session = FakeSession()
+    session.scoped_model_choices = (
+        ModelChoice(provider_name="openai", model="fake-model"),
+        ModelChoice(provider_name="openai", model="other-model"),
+        ModelChoice(provider_name="anthropic", model="third-model"),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        await pilot.press("shift+ctrl+p")
+        await pilot.pause()
+
+    assert session.provider_name == "anthropic"
+    assert session.model == "third-model"
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -26,7 +26,7 @@ def test_load_tui_settings_returns_defaults_when_file_is_missing(tmp_path: Path)
     paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
 
     assert load_tui_settings(paths) == TuiSettings()
-    assert load_tui_settings(paths).keybindings.model_cycle_reverse == "shift+ctrl+p"
+    assert load_tui_settings(paths).keybindings.model_cycle_reverse == "ctrl+shift+p"
     assert load_tui_settings(paths).keybindings.quit == "ctrl+d"
 
 

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -26,6 +26,7 @@ def test_load_tui_settings_returns_defaults_when_file_is_missing(tmp_path: Path)
     paths = TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents")
 
     assert load_tui_settings(paths) == TuiSettings()
+    assert load_tui_settings(paths).keybindings.model_cycle_reverse == "shift+ctrl+p"
     assert load_tui_settings(paths).keybindings.quit == "ctrl+d"
 
 
@@ -43,6 +44,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
             "accept_completion": "f2",
             "thinking_cycle": "f3",
             "model_cycle": "f6",
+            "model_cycle_reverse": "shift+f6",
             "toggle_thinking": "f4",
             "copy_message": "ctrl+b"
           },
@@ -62,6 +64,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     assert settings.keybindings.accept_completion == "f2"
     assert settings.keybindings.thinking_cycle == "f3"
     assert settings.keybindings.model_cycle == "f6"
+    assert settings.keybindings.model_cycle_reverse == "shift+f6"
     assert settings.keybindings.copy_message == "ctrl+b"
     assert settings.keybindings.cancel == "escape"
     assert settings.theme == "high-contrast"
@@ -169,6 +172,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
             accept_completion="f2",
             thinking_cycle="f3",
             model_cycle="f6",
+            model_cycle_reverse="shift+f6",
             toggle_thinking="f4",
             copy_message="ctrl+b",
         ),
@@ -183,6 +187,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
     assert settings.to_json()["keybindings"]["accept_completion"] == "f2"
     assert settings.to_json()["keybindings"]["thinking_cycle"] == "f3"
     assert settings.to_json()["keybindings"]["model_cycle"] == "f6"
+    assert settings.to_json()["keybindings"]["model_cycle_reverse"] == "shift+f6"
     assert settings.to_json()["keybindings"]["copy_message"] == "ctrl+b"
     assert settings.to_json()["theme"] == "high-contrast"
     assert settings.to_json()["auto_copy_selection"] is False

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -286,7 +286,8 @@ provider/model access varies by plan and policy.
   choosing one can switch the active provider too).
 - **`tau -m <model>`** or **`tau --provider <name> -m <model>`** — choose at
   launch.
-- **Ctrl+P** — cycle your *scoped* (favorite) models without opening the picker.
+- **Ctrl+P** / **Shift+Ctrl+P** — cycle your *scoped* (favorite) models
+  forward / backward without opening the picker.
   Build the list with `/scoped-models`, or press `Space` on a model in the
   `/model` picker.
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -203,9 +203,9 @@ when you want to reduce what is sent to the model.
   refreshes catalogs in the background, and updates the open list. Selecting a
   model from another provider switches the active provider too. Use
   `tau update --models` to force refresh or `TAU_OFFLINE=1` to disable it.
-- **Ctrl+P** quickly cycles through your *scoped* (favorite) models without
-  opening the picker. Manage that list with `/scoped-models` or by pressing
-  `Space` on a model in the `/model` picker.
+- **Ctrl+P** quickly cycles forward through your *scoped* (favorite) models;
+  **Shift+Ctrl+P** cycles backward. Neither opens the picker. Manage that list
+  with `/scoped-models` or by pressing `Space` on a model in the `/model` picker.
 - **`/theme`** switches between `tau-dark`, `tau-light`, `high-contrast`, and
   any custom themes you have installed. Each theme uses one shared selection
   palette for prompt autocomplete and modal lists such as `/resume`. In

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -387,7 +387,7 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
     "completion_previous": "up",
     "thinking_cycle": "shift+tab",
     "model_cycle": "ctrl+p",
-    "model_cycle_reverse": "shift+ctrl+p",
+    "model_cycle_reverse": "ctrl+shift+p",
     "toggle_thinking": "ctrl+t",
     "toggle_tool_results": "ctrl+o",
     "copy_message": "ctrl+c",

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -310,7 +310,8 @@ Provider preferences live in `~/.tau/providers.json`:
 - The selected model must be present in that provider's `models` list. Add
   custom or local model names to `models` before using them as defaults,
   CLI/TUI selections, or scoped models.
-- `scoped_models` are favorites for the **Ctrl+P** quick-cycle.
+- `scoped_models` are favorites for the **Ctrl+P** / **Shift+Ctrl+P**
+  forward / backward quick-cycle.
 - `providers.json` uses `schema_version: 2` and stores preferences only. Provider
   capabilities—model lists, context windows, transports, metadata, and thinking
   support—always come from the current effective catalog.
@@ -386,6 +387,7 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
     "completion_previous": "up",
     "thinking_cycle": "shift+tab",
     "model_cycle": "ctrl+p",
+    "model_cycle_reverse": "shift+ctrl+p",
     "toggle_thinking": "ctrl+t",
     "toggle_tool_results": "ctrl+o",
     "copy_message": "ctrl+c",

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -33,7 +33,8 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 
 | Key | Action |
 | --- | --- |
-| `Ctrl+P` | Cycle scoped (favorite) models |
+| `Ctrl+P` | Cycle scoped (favorite) models forward |
+| `Shift+Ctrl+P` | Cycle scoped (favorite) models backward |
 | `Shift+Tab` | Cycle the thinking mode |
 | `Ctrl+T` | Toggle display of thinking/reasoning tokens |
 

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -19,7 +19,7 @@ command palette with **Ctrl+K**.
 | `/name <new name>` | Rename the current session and, in supported terminals, the terminal tab title |
 | `/model` | Open the model picker |
 | `/tools` | Browse active tools and open their full descriptions |
-| `/scoped-models` | Choose favorite models for the Ctrl+P quick-cycle |
+| `/scoped-models` | Choose favorite models for the Ctrl+P / Shift+Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/local` | Choose and manage a registered local backend; interactive-only. Compatible llama.cpp routers add explicit load/unload, Hugging Face GGUF search, and server-side download actions with confirmation and reconciliation. |


### PR DESCRIPTION
## Description

- add a configurable `model_cycle_reverse` TUI binding, defaulting to `shift+ctrl+p`
- route reverse cycling through the existing scoped-model session behavior
- document the forward and backward shortcuts

## User experience

Users can move backward through scoped (favorite) models with Shift+Ctrl+P instead of repeatedly cycling forward with Ctrl+P.

## Issue

Addresses the requested backward scoped-model cycling behavior. No linked issue.

## Manual validation

1. Configure at least three scoped models with `/scoped-models`.
2. Press Ctrl+P and confirm Tau selects the next scoped model.
3. Press Shift+Ctrl+P and confirm Tau selects the previous scoped model.
4. Optionally remap `model_cycle_reverse` in `~/.tau/tui.json` and confirm the custom shortcut works.

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
