### PR TITLE
Add --thinking/-t CLI flag to set the startup thinking level

### DIFF
--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import sys
 from collections.abc import Sequence
+from functools import partial
 from os import environ
 from pathlib import Path
 from typing import Annotated, Literal
@@ -65,6 +66,7 @@ from tau_coding.session_export import (
 from tau_coding.session_manager import CodingSessionRecord, SessionManager, validate_session_id
 from tau_coding.session_preparation import prepare_coding_session
 from tau_coding.shell_config import load_shell_settings
+from tau_coding.thinking import THINKING_LEVELS, ThinkingLevel, normalize_thinking_level
 from tau_coding.tui import run_tui_app
 from tau_coding.update_check import (
     UpdateNotice,
@@ -216,6 +218,18 @@ def main(
     model: Annotated[
         str | None,
         typer.Option("--model", "-m", help="Model name to request from the provider."),
+    ] = None,
+    thinking: Annotated[
+        str | None,
+        typer.Option(
+            "--thinking",
+            "-t",
+            help=(
+                "Initial thinking level for this run "
+                f"({', '.join(THINKING_LEVELS)}). "
+                "Overrides remembered defaults without persisting."
+            ),
+        ),
     ] = None,
     setup_base_url: Annotated[
         str,
@@ -406,6 +420,13 @@ def main(
     if extension_legacy is not None:
         raise typer.BadParameter("-x was renamed to -e/--extension.")
 
+    thinking_level_override: ThinkingLevel | None = None
+    if thinking is not None:
+        try:
+            thinking_level_override = normalize_thinking_level(thinking)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+
     rpc_requested = mode is PrintOutputMode.rpc
     print_requested = print_mode or (mode is not None and not rpc_requested)
     effective_output = mode or PrintOutputMode.text
@@ -502,7 +523,12 @@ def main(
             )
         try:
             anyio.run(
-                run_openai_rpc_mode,
+                partial(
+                    run_openai_rpc_mode,
+                    thinking_level_override=thinking_level_override,
+                )
+                if thinking_level_override is not None
+                else run_openai_rpc_mode,
                 model,
                 cwd or Path.cwd(),
                 provider,
@@ -536,10 +562,15 @@ def main(
                 custom_system_prompt,
                 resolved_append_system_prompt,
             )
+            tui_runner = (
+                partial(run_openai_tui, thinking_level_override=thinking_level_override)
+                if thinking_level_override is not None
+                else run_openai_tui
+            )
             resumable_session_id = (
-                anyio.run(run_openai_tui, *tui_args)
+                anyio.run(tui_runner, *tui_args)
                 if trust_override is None
-                else anyio.run(run_openai_tui, *tui_args, trust_override)
+                else anyio.run(tui_runner, *tui_args, trust_override)
             )
         except (RuntimeError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -573,13 +604,18 @@ def main(
             custom_system_prompt,
             resolved_append_system_prompt,
         )
+        print_runner = (
+            partial(run_openai_print_mode, thinking_level_override=thinking_level_override)
+            if thinking_level_override is not None
+            else run_openai_print_mode
+        )
         if session is not None:
-            ok = anyio.run(run_openai_print_mode, *print_args, trust_override, session)
+            ok = anyio.run(print_runner, *print_args, trust_override, session)
         else:
             ok = (
-                anyio.run(run_openai_print_mode, *print_args)
+                anyio.run(print_runner, *print_args)
                 if trust_override is None
-                else anyio.run(run_openai_print_mode, *print_args, trust_override)
+                else anyio.run(print_runner, *print_args, trust_override)
             )
     except (RuntimeError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -602,6 +638,8 @@ async def run_openai_tui(
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
+    *,
+    thinking_level_override: ThinkingLevel | None = None,
 ) -> str | None:
     """Run the Textual TUI and return its resumable session id, if any."""
     release_notes_notice = startup_release_notes_notice(_current_version())
@@ -622,6 +660,7 @@ async def run_openai_tui(
         custom_system_prompt=custom_system_prompt,
         append_system_prompt=append_system_prompt,
         trust_override=trust_override,
+        thinking_level_override=thinking_level_override,
     )
 
 
@@ -895,6 +934,8 @@ async def run_openai_rpc_mode(
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
+    *,
+    thinking_level_override: ThinkingLevel | None = None,
 ) -> None:
     """Run a persistent Pi-compatible JSONL RPC session."""
     settings = load_provider_settings()
@@ -940,12 +981,17 @@ async def run_openai_rpc_mode(
         selection.provider,
         model=selection.model,
         inference_provider=inference_provider,
-        thinking_level=resolve_startup_thinking_level(selection.provider, selection.model),
+        thinking_level=resolve_startup_thinking_level(
+            selection.provider,
+            selection.model,
+            cli_override=thinking_level_override,
+        ),
     )
     session = await CodingSession.load(
         CodingSessionConfig(
             provider=provider,
             model=selection.model,
+            thinking_level_override=thinking_level_override,
             cwd=record.cwd,
             storage=jsonl_session_storage(record.path),
             session_id=record.id,
@@ -987,6 +1033,8 @@ async def run_openai_print_mode(
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
     resume_session_id: str | None = None,
+    *,
+    thinking_level_override: ThinkingLevel | None = None,
 ) -> bool:
     """Run a new or resumed print-mode turn using the configured provider."""
     settings = load_provider_settings()
@@ -1075,6 +1123,7 @@ async def run_openai_print_mode(
             thinking_level=resolve_startup_thinking_level(
                 static_selection.provider,
                 static_selection.model,
+                cli_override=thinking_level_override,
             ),
         )
         selected_provider = static_selection.provider.name
@@ -1107,6 +1156,7 @@ async def run_openai_print_mode(
             trust_default=shell_settings.default_project_trust,
             startup_model_override=False,
             inference_provider_mode=runtime_inference_mode,
+            thinking_level_override=thinking_level_override,
         )
     finally:
         # This remains the ownership path for the compatibility provider
@@ -1208,6 +1258,7 @@ async def run_print_mode(
     trust_override: TrustOverride | None = None,
     trust_default: TrustDefault = "ask",
     startup_model_override: bool = False,
+    thinking_level_override: ThinkingLevel | None = None,
 ) -> bool:
     """Run one non-interactive prompt and print streamed events.
 
@@ -1218,6 +1269,7 @@ async def run_print_mode(
         CodingSessionConfig(
             provider=provider,
             model=model,
+            thinking_level_override=thinking_level_override,
             cwd=cwd,
             storage=storage or _MemorySessionStorage(),
             resource_paths=resource_paths,

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -35,6 +35,10 @@ tau [OPTIONS] [PROMPT]
 - `--mode text|json|transcript`: choose print output and imply print mode.
 - `--provider NAME`: select an explicit provider.
 - `-m, --model ID`: select an explicit model.
+- `-t, --thinking LEVEL`: set the initial thinking level for this run
+  (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). Overrides
+  remembered and catalog defaults without persisting them; an unsupported level
+  for the selected model is an error listing the available modes.
 - `--session ID`: resume a session in the TUI or print mode.
 - `--cwd PATH`: set the coding-session working directory.
 - `-e, --extension PATH`: load an explicit extension.

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1654,6 +1654,7 @@ def resolve_startup_thinking_level(
     model: str,
     *,
     preferred: ThinkingLevel = DEFAULT_THINKING_LEVEL,
+    cli_override: ThinkingLevel | None = None,
 ) -> ThinkingLevel | None:
     """Pick a valid startup thinking level for a provider/model pair.
 
@@ -1663,9 +1664,24 @@ def resolve_startup_thinking_level(
     the remembered per-model preference wins, then the global ``preferred``
     level, then the provider/catalog default, then the first available level.
 
+    An explicit ``cli_override`` (from ``--thinking``) takes precedence over
+    everything, and unlike the fallback chain it is strict: requesting a level
+    the model does not support raises :class:`ProviderConfigError` instead of
+    silently falling back.
+
     Returns ``None`` when the model has no configurable thinking levels.
     """
     levels = provider_thinking_levels(provider, model=model)
+    if cli_override is not None:
+        if not levels:
+            raise ProviderConfigError(f"Thinking modes are unavailable for {provider.name}:{model}")
+        if cli_override not in levels:
+            allowed = ", ".join(levels)
+            raise ProviderConfigError(
+                f'Thinking mode "{cli_override}" is not available for '
+                f"{provider.name}:{model}. Available modes: {allowed}"
+            )
+        return cli_override
     if not levels:
         return None
     remembered = provider.thinking_defaults.get(model)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -335,6 +335,14 @@ class CodingSessionConfig:
     auto_compact_token_threshold: int | None = None
     auto_compact_enabled: bool = True
     thinking_level: ThinkingLevel = DEFAULT_THINKING_LEVEL
+    thinking_level_override: ThinkingLevel | None = None
+    """One-shot startup override (e.g. ``--thinking``) for the session's level.
+
+    Takes precedence over remembered per-model defaults and replayed session
+    state, is validated strictly against the active model's available levels
+    when the provider configuration is known, and is never persisted as a new
+    remembered default.
+    """
     index_on_first_persist: bool = False
     shell_command_prefix: str | None = None
     skills_enabled: bool = True
@@ -667,6 +675,7 @@ class CodingSession:
             # failure path has exactly one closer for the candidate.
             session._owned_providers.append(config.provider)  # type: ignore[arg-type]
         await session._persist_active_tool_history_repairs()
+        session._apply_thinking_level_override()
         session._sync_thinking_level_to_active_model()
         try:
             if not config.owns_initial_provider and config.provider is not None:
@@ -1739,6 +1748,27 @@ class CodingSession:
             return self._provider_settings.get_provider(self._provider_name)
         except ProviderConfigError:
             return None
+
+    def _apply_thinking_level_override(self) -> None:
+        """Apply the one-shot startup thinking override to the loaded session.
+
+        Runs once during :meth:`load`, after session state is replayed and
+        before the level is synced to the active model, so the override wins
+        over both remembered defaults and the resumed transcript state. When
+        the active provider configuration is known the override is validated
+        strictly; for dynamic providers it is applied best-effort and later
+        coerced by :meth:`_sync_thinking_level_to_active_model` if needed.
+        """
+        override = self._config.thinking_level_override
+        if override is None:
+            return
+        provider = self._active_provider_config()
+        if provider is None:
+            self._thinking_level = override
+            return
+        resolved = resolve_startup_thinking_level(provider, self.model, cli_override=override)
+        if resolved is not None:
+            self._thinking_level = resolved
 
     def _sync_thinking_level_to_active_model(self) -> None:
         provider = self._active_provider_config()
@@ -4074,6 +4104,16 @@ def _initial_thinking_level_for_config(
     model: str,
 ) -> ThinkingLevel:
     provider = _provider_config_for_name(config, config.provider_name)
+    if config.thinking_level_override is not None:
+        if provider is None:
+            return config.thinking_level_override
+        resolved = resolve_startup_thinking_level(
+            provider,
+            model,
+            cli_override=config.thinking_level_override,
+        )
+        if resolved is not None:
+            return resolved
     if provider is None:
         return config.thinking_level
     return _preferred_thinking_level_for_model(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -675,9 +675,9 @@ class CodingSession:
             # failure path has exactly one closer for the candidate.
             session._owned_providers.append(config.provider)  # type: ignore[arg-type]
         await session._persist_active_tool_history_repairs()
-        session._apply_thinking_level_override()
-        session._sync_thinking_level_to_active_model()
         try:
+            session._apply_thinking_level_override()
+            session._sync_thinking_level_to_active_model()
             if not config.owns_initial_provider and config.provider is not None:
                 session._refresh_runtime_provider()
             await session._refresh_runtime_model_limits()
@@ -1754,13 +1754,28 @@ class CodingSession:
 
         Runs once during :meth:`load`, after session state is replayed and
         before the level is synced to the active model, so the override wins
-        over both remembered defaults and the resumed transcript state. When
-        the active provider configuration is known the override is validated
-        strictly; for dynamic providers it is applied best-effort and later
-        coerced by :meth:`_sync_thinking_level_to_active_model` if needed.
+        over both remembered defaults and the resumed transcript state. The
+        override is validated strictly against either the active dynamic model
+        or the durable provider configuration when its capabilities are known.
         """
         override = self._config.thinking_level_override
         if override is None:
+            return
+        dynamic = self._active_dynamic_provider
+        if dynamic is not None:
+            model = self._active_dynamic_model
+            levels = model.thinking_levels if model is not None else None
+            if not levels:
+                raise ProviderConfigError(
+                    f"Thinking modes are unavailable for {dynamic.id}:{self.model}"
+                )
+            if override not in levels:
+                allowed = ", ".join(levels)
+                raise ProviderConfigError(
+                    f'Thinking mode "{override}" is not available for '
+                    f"{dynamic.id}:{self.model}. Available modes: {allowed}"
+                )
+            self._thinking_level = override
             return
         provider = self._active_provider_config()
         if provider is None:

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -139,6 +139,7 @@ from tau_coding.session_manager import CodingSessionRecord, SessionManager
 from tau_coding.session_preparation import prepare_coding_session
 from tau_coding.shell_config import load_shell_settings
 from tau_coding.skills import Skill
+from tau_coding.thinking import ThinkingLevel
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.autocomplete import (
     CompletionItem,
@@ -7593,6 +7594,7 @@ async def run_tui_app(
     custom_system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     trust_override: TrustOverride | None = None,
+    thinking_level_override: ThinkingLevel | None = None,
 ) -> str | None:
     """Run the Textual app and return the active id when its session is persisted."""
     if new_session and session_id is not None:
@@ -7662,6 +7664,7 @@ async def run_tui_app(
                 thinking_level=resolve_startup_thinking_level(
                     selection.provider,
                     selection.model,
+                    cli_override=thinking_level_override,
                 ),
             )
         except RuntimeError as exc:
@@ -7729,6 +7732,7 @@ async def run_tui_app(
                 project_extensions_enabled=project_extensions_enabled,
                 custom_system_prompt=custom_system_prompt,
                 append_system_prompt=append_system_prompt,
+                thinking_level_override=thinking_level_override,
                 trust_override=trust_override,
                 trust_default=shell_settings.default_project_trust,
                 trust_interactive=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1975,3 +1975,101 @@ async def test_headless_ask_declines_without_corrupting_structured_stdout(
     assert "PROTECTED-STRUCTURED-SECRET" not in provider.calls[0][1]
     assert "Project inputs" not in captured.out
     assert "Project inputs" in captured.err
+
+
+def test_thinking_flag_forwards_to_tui_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> None:
+        calls.append(kwargs.get("thinking_level_override"))
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["--thinking", "high", "--new-session"])
+
+    assert result.exit_code == 0
+    assert calls == ["high"]
+
+
+def test_thinking_flag_forwards_to_print_mode_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    async def fake_run_openai_print_mode(*args: object, **kwargs: object) -> bool:
+        calls.append(kwargs.get("thinking_level_override"))
+        return True
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_print_mode", fake_run_openai_print_mode)
+
+    result = CliRunner().invoke(app, ["--print", "-t", "low", "hello"])
+
+    assert result.exit_code == 0
+    assert calls == ["low"]
+
+
+def test_thinking_flag_forwards_to_rpc_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    async def fake_run_openai_rpc_mode(*args: object, **kwargs: object) -> None:
+        calls.append(kwargs.get("thinking_level_override"))
+
+    monkeypatch.setattr(cli, "run_openai_rpc_mode", fake_run_openai_rpc_mode)
+
+    result = CliRunner().invoke(app, ["--mode", "rpc", "--thinking", "xhigh"])
+
+    assert result.exit_code == 0
+    assert calls == ["xhigh"]
+
+
+def test_thinking_flag_rejects_invalid_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> None:
+        raise AssertionError("TUI must not start for an invalid thinking level")
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["--thinking", "maximum", "--new-session"])
+
+    assert result.exit_code == 2
+    assert "Unknown thinking mode: maximum" in _panel_text(result.output)
+
+
+def test_thinking_flag_accepts_case_insensitive_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> None:
+        calls.append(kwargs.get("thinking_level_override"))
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["-t", "HIGH", "--new-session"])
+
+    assert result.exit_code == 0
+    assert calls == ["high"]
+
+
+def test_thinking_flag_absent_forwards_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    async def fake_run_openai_tui(*args: object, **kwargs: object) -> None:
+        calls.append(kwargs.get("thinking_level_override"))
+
+    monkeypatch.setattr(cli, "_startup_update_notice", lambda: None)
+    monkeypatch.setattr(cli, "run_openai_tui", fake_run_openai_tui)
+
+    result = CliRunner().invoke(app, ["--new-session"])
+
+    assert result.exit_code == 0
+    assert calls == [None]
+
+
+def test_help_lists_thinking_option() -> None:
+    result = CliRunner().invoke(app, ["--help"], env={"COLUMNS": "160"})
+
+    output = re.sub(r"\s+", "", _strip_ansi(result.output))
+    assert result.exit_code == 0
+    assert "--thinking" in output

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -5954,3 +5954,103 @@ def test_minimal_commands_are_handled(tmp_path: Path) -> None:
     assert session.handle_command("/quit").exit_requested is True
     assert session.handle_command("/exit").exit_requested is True
     assert session.handle_command("/unknown").handled is False
+
+
+def _thinking_override_provider_config(  # noqa: D103
+    thinking_defaults: dict[str, str] | None = None,
+) -> OpenAICompatibleProviderConfig:
+    return OpenAICompatibleProviderConfig(
+        name="openai",
+        models=("reasoner",),
+        default_model="reasoner",
+        thinking_levels=("off", "low", "high"),
+        thinking_models=("reasoner",),
+        thinking_default="low",
+        thinking_parameter="reasoning_effort",
+        thinking_defaults=thinking_defaults or {},  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.anyio
+async def test_new_session_initial_thinking_respects_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    provider_config = _thinking_override_provider_config(thinking_defaults={"reasoner": "low"})
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="reasoner",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            thinking_level_override="high",
+        )
+    )
+
+    # The override beats the remembered per-model default ("low").
+    assert session.thinking_level == "high"
+    await session._ensure_session_initialized()
+    entries = await JsonlSessionStorage(tmp_path / "session.jsonl").read_all()
+    thinking_entries = [entry for entry in entries if entry.type == "thinking_level_change"]
+    assert thinking_entries[0].thinking_level == "high"
+
+
+@pytest.mark.anyio
+async def test_resumed_session_thinking_override_is_ephemeral(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    provider_config = _thinking_override_provider_config()
+    storage_path = tmp_path / "session.jsonl"
+
+    def config(thinking_level_override: object = None) -> CodingSessionConfig:
+        return CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="reasoner",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(storage_path),
+            cwd=tmp_path,
+            provider_name="openai",
+            provider_settings=ProviderSettings(providers=(provider_config,)),
+            thinking_level_override=thinking_level_override,  # type: ignore[arg-type]
+        )
+
+    first = await CodingSession.load(config())
+    assert first.thinking_level == "low"
+    await first._ensure_session_initialized()
+
+    resumed = await CodingSession.load(config(thinking_level_override="high"))
+    assert resumed.thinking_level == "high"
+
+    # The override is ephemeral: a later resume without it uses the stored level.
+    plain = await CodingSession.load(config())
+    assert plain.thinking_level == "low"
+
+    # Resuming with an unsupported override is a strict error, not a fallback.
+    with pytest.raises(ProviderConfigError, match='Thinking mode "medium" is not available'):
+        await CodingSession.load(config(thinking_level_override="medium"))
+
+
+@pytest.mark.anyio
+async def test_thinking_override_unsupported_level_raises_on_load(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    provider_config = _thinking_override_provider_config()
+
+    with pytest.raises(ProviderConfigError, match='Thinking mode "medium" is not available'):
+        await CodingSession.load(
+            CodingSessionConfig(
+                provider=FakeProvider([]),
+                model="reasoner",
+                system="You are Tau.",
+                storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+                cwd=tmp_path,
+                provider_name="openai",
+                provider_settings=ProviderSettings(providers=(provider_config,)),
+                thinking_level_override="medium",
+            )
+        )

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -6054,3 +6054,74 @@ async def test_thinking_override_unsupported_level_raises_on_load(
                 thinking_level_override="medium",
             )
         )
+
+
+def _dynamic_thinking_override_config(
+    tmp_path: Path,
+    *,
+    thinking_level_override: object,
+) -> CodingSessionConfig:
+    extension = tmp_path / "dynamic_provider.py"
+    extension.write_text(
+        """
+from tau_coding.extensions import DynamicProvider, OpenAICompatibleTransport, ProviderModel
+
+
+def setup(tau):
+    tau.register_provider(DynamicProvider(
+        id="local",
+        display_name="Local",
+        models=(ProviderModel("reasoner", thinking_levels=("off", "high")),),
+        default_model="reasoner",
+        transport=OpenAICompatibleTransport(base_url="http://example.test/v1"),
+    ))
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return CodingSessionConfig(
+        provider=None,
+        model="reasoner",
+        system="You are Tau.",
+        storage=JsonlSessionStorage(tmp_path / "dynamic-session.jsonl"),
+        cwd=tmp_path,
+        provider_name="local",
+        requested_provider="local",
+        requested_model="reasoner",
+        provider_settings=ProviderSettings(),
+        extension_paths=(extension,),
+        extensions_enabled=False,
+        thinking_level_override=thinking_level_override,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.anyio
+async def test_dynamic_provider_accepts_supported_thinking_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+
+    session = await CodingSession.load(
+        _dynamic_thinking_override_config(tmp_path, thinking_level_override="high")
+    )
+
+    assert session.thinking_level == "high"
+    assert session.available_thinking_levels == ("off", "high")
+    await session.aclose()
+
+
+@pytest.mark.anyio
+async def test_dynamic_provider_rejects_unsupported_thinking_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+
+    with pytest.raises(
+        ProviderConfigError,
+        match=(
+            r'Thinking mode "max" is not available for local:reasoner\. '
+            r"Available modes: off, high"
+        ),
+    ):
+        await CodingSession.load(
+            _dynamic_thinking_override_config(tmp_path, thinking_level_override="max")
+        )

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -828,6 +828,63 @@ def test_resolve_startup_thinking_level_returns_none_without_levels() -> None:
     assert resolve_startup_thinking_level(provider, "qwen") is None
 
 
+def test_resolve_startup_thinking_level_cli_override_wins_over_remembered() -> None:
+    provider = _kimi_code_like_provider()
+    remembered = OpenAICompatibleProviderConfig(
+        name=provider.name,
+        models=provider.models,
+        default_model=provider.default_model,
+        thinking_levels=provider.thinking_levels,
+        thinking_default=provider.thinking_default,
+        thinking_parameter=provider.thinking_parameter,
+        thinking_defaults={"k3": "xhigh"},
+        model_metadata=provider.model_metadata,
+    )
+
+    assert resolve_startup_thinking_level(remembered, "k3", cli_override="low") == "low"
+
+
+def test_resolve_startup_thinking_level_cli_override_errors_for_unsupported() -> None:
+    provider = _kimi_code_like_provider()
+
+    # kimi-for-coding only supports "medium".
+    with pytest.raises(
+        ProviderConfigError,
+        match=r'Thinking mode "max" is not available for kimi-code:kimi-for-coding',
+    ):
+        resolve_startup_thinking_level(provider, "kimi-for-coding", cli_override="max")
+
+
+def test_resolve_startup_thinking_level_cli_override_errors_without_levels() -> None:
+    provider = OpenAICompatibleProviderConfig(
+        name="local",
+        models=("qwen",),
+        default_model="qwen",
+    )
+
+    with pytest.raises(
+        ProviderConfigError,
+        match="Thinking modes are unavailable for local:qwen",
+    ):
+        resolve_startup_thinking_level(provider, "qwen", cli_override="high")
+
+
+def test_resolve_startup_thinking_level_cli_override_none_preserves_behavior() -> None:
+    provider = _kimi_code_like_provider()
+    remembered = OpenAICompatibleProviderConfig(
+        name=provider.name,
+        models=provider.models,
+        default_model=provider.default_model,
+        thinking_levels=provider.thinking_levels,
+        thinking_default=provider.thinking_default,
+        thinking_parameter=provider.thinking_parameter,
+        thinking_defaults={"k3": "xhigh"},
+        model_metadata=provider.model_metadata,
+    )
+
+    assert resolve_startup_thinking_level(remembered, "k3", cli_override=None) == "xhigh"
+
+
 def test_resolve_provider_selection_rejects_model_not_declared_for_provider() -> None:
     settings = ProviderSettings(
         default_provider="local",

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -116,3 +116,10 @@ supports `low`, `high`, and `xhigh`; because `medium` is unavailable, it opens
 at its `xhigh` catalog default instead of failing with "Thinking mode medium is
 not available". Picking an unsupported level explicitly (via `/think` or the
 thinking picker) still shows an error listing the available modes.
+
+You can also set the startup level from the command line with `--thinking`
+(`-t`), for example `tau -t high` or `tau -t max -p "explain this"`. The flag
+takes precedence over remembered and catalog defaults for that run but is not
+saved as a new default; requesting a level the selected model does not support
+exits with an error listing the available modes. Levels chosen interactively
+afterwards (via `/think` or Shift+Tab) persist as usual.

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -46,6 +46,7 @@ features and fixes.
 | `-p, --print` | Run the positional prompt in non-interactive print mode |
 | `-m, --model TEXT` | Model to request from the provider |
 | `--provider TEXT` | Configured provider name to use |
+| `-t, --thinking LEVEL` | Initial [thinking level]({{< relref "../guides/context.md#thinking-modes" >}}) for this run (`off`…`max`); overrides remembered defaults without persisting, errors if the model doesn't support it |
 | `--cwd PATH` | Working directory for the built-in tools |
 | `--mode [text\|json\|transcript\|rpc]` | Select headless output; `rpc` starts the JSONL subprocess protocol |
 | `--session TEXT` | Resume a session id in the TUI or print mode |


### PR DESCRIPTION
## What

Adds a `--thinking` / `-t` flag so you can set the thinking level when starting Tau, the same way `--model` and `--provider` already work:

```bash
tau -t high
tau -t max -p "explain this file"
tau --session abc123 --thinking low
```

Works in TUI, print, and RPC modes.

## Behavior

- **Wins over everything**: beats the remembered per-model default and the level stored in a resumed session's transcript.
- **Strict**: an unknown level (`-t maximum`) or a level the model doesn't support exits with a clear error listing the available modes — no silent fallback.
- **One-shot**: the flag is never saved as a new default. `/think` and Shift+Tab afterwards persist as usual.
- **No flag, no change**: without `--thinking`, startup resolution is exactly as before.

## How

- `resolve_startup_thinking_level()` gains a `cli_override` parameter with highest precedence (`provider_config.py`).
- New `CodingSessionConfig.thinking_level_override` field, applied once during `CodingSession.load()` — deliberately not on branch switches or mid-session model switches (`session.py`).
- Flag parsing/validation in `main()` and threading through the three mode runners (`cli.py`, `tui/app.py`).

## Testing

15 new test scenarios (flag forwarding per mode, validation errors, precedence over remembered defaults, resume override + ephemerality). Full suite: 1840 passed; ruff and mypy clean. Docs updated (`data/docs/cli.md`, website CLI reference and context guide).
