### PR TITLE
Add response timing and effective token speed

### DIFF
--- a/dev-notes/response-timing-and-speed.md
+++ b/dev-notes/response-timing-and-speed.md
@@ -43,7 +43,7 @@ usage and cost totals but do not enter the speed denominator.
 - `tau_agent.messages.ResponseTiming` owns the provider-neutral wire shape.
 - `tau_agent.loop` captures monotonic boundaries and attaches timing to the
   final assistant message.
-- `tau_coding.session_stats` aggregates the active branch's token-weighted average.
+- `tau_coding.session_stats` aggregates token-weighted TPS and arithmetic-mean TTFT.
 - `tau_coding.tui.widgets` renders speed and latest time to first output.
 
 No Textual dependency enters `tau_agent`, and provider adapters need no custom

--- a/dev-notes/response-timing-and-speed.md
+++ b/dev-notes/response-timing-and-speed.md
@@ -1,0 +1,61 @@
+# Response timing and effective output speed
+
+## What changed
+
+Tau now measures every provider response at three boundaries in the portable
+agent loop:
+
+1. request stream consumption starts;
+2. the first text, thinking, or tool-call output arrives;
+3. the response completes or fails.
+
+The loop uses a monotonic clock and stores two compact durations on the final
+`AssistantMessage`: `timeToFirstOutputMs` and `totalDurationMs`. Because session
+persistence already writes final assistant messages, timing is automatically
+saved beside provider-reported usage in JSONL. The optional field keeps older
+sessions readable; old messages simply have no timing statistics.
+
+## Why it exists
+
+The enclosing session-entry timestamp records persistence time, not request
+start, so historical JSONL could not reliably calculate response speed. Pairing
+monotonic durations with each response's output-token count makes the metric
+replayable after resume and robust against wall-clock changes.
+
+Tau calls the sidebar metric **effective output speed**:
+
+```text
+output tokens / total response duration
+```
+
+It intentionally includes request startup, provider queueing, prefill, and time
+to first output. The session value is token-weighted:
+
+```text
+sum(timed output tokens) / sum(timed response durations)
+```
+
+This avoids over-weighting short responses. Untimed older messages remain in
+usage and cost totals but do not enter the speed denominator.
+
+## Architecture mapping
+
+- `tau_agent.messages.ResponseTiming` owns the provider-neutral wire shape.
+- `tau_agent.loop` captures monotonic boundaries and attaches timing to the
+  final assistant message.
+- `tau_coding.session_stats` aggregates latest and active-branch values.
+- `tau_coding.tui.widgets` renders speed and latest time to first output.
+
+No Textual dependency enters `tau_agent`, and provider adapters need no custom
+timing implementation.
+
+## Validation
+
+```bash
+uv run pytest tests/test_agent_loop.py tests/test_agent_types.py tests/test_session.py \
+  tests/test_session_stats.py tests/test_tui_app.py
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/dev-notes/response-timing-and-speed.md
+++ b/dev-notes/response-timing-and-speed.md
@@ -43,7 +43,7 @@ usage and cost totals but do not enter the speed denominator.
 - `tau_agent.messages.ResponseTiming` owns the provider-neutral wire shape.
 - `tau_agent.loop` captures monotonic boundaries and attaches timing to the
   final assistant message.
-- `tau_coding.session_stats` aggregates latest and active-branch values.
+- `tau_coding.session_stats` aggregates the active branch's token-weighted average.
 - `tau_coding.tui.widgets` renders speed and latest time to first output.
 
 No Textual dependency enters `tau_agent`, and provider adapters need no custom

--- a/dev-notes/response-timing-and-speed.md
+++ b/dev-notes/response-timing-and-speed.md
@@ -5,9 +5,13 @@
 Tau now measures every provider response at three boundaries in the portable
 agent loop:
 
-1. request stream consumption starts;
+1. waiting for provider stream events starts;
 2. the first text, thinking, or tool-call output arrives;
 3. the response completes or fails.
+
+Only time spent awaiting the provider iterator is accumulated. Time spent by an
+upstream consumer rendering, persisting, or diagnosing an event before requesting
+the next event is excluded.
 
 The loop uses a monotonic clock and stores two compact durations on the final
 `AssistantMessage`: `timeToFirstOutputMs` and `totalDurationMs`. Because session
@@ -28,8 +32,8 @@ Tau calls the sidebar metric **effective output speed**:
 output tokens / total response duration
 ```
 
-It intentionally includes request startup, provider queueing, prefill, and time
-to first output. The session value is token-weighted:
+It includes provider queueing, network waits, prefill, and time to first output,
+but excludes Tau's work between stream pulls. The session value is token-weighted:
 
 ```text
 sum(timed output tokens) / sum(timed response durations)
@@ -41,10 +45,10 @@ usage and cost totals but do not enter the speed denominator.
 ## Architecture mapping
 
 - `tau_agent.messages.ResponseTiming` owns the provider-neutral wire shape.
-- `tau_agent.loop` captures monotonic boundaries and attaches timing to the
-  final assistant message.
+- `tau_agent.loop` accumulates monotonic provider-await durations and attaches
+  timing to the final assistant message.
 - `tau_coding.session_stats` aggregates token-weighted TPS and arithmetic-mean TTFT.
-- `tau_coding.tui.widgets` renders speed and latest time to first output.
+- `tau_coding.tui.widgets` renders average TPS and average TTFT.
 
 No Textual dependency enters `tau_agent`, and provider adapters need no custom
 timing implementation.

--- a/src/tau_agent/__init__.py
+++ b/src/tau_agent/__init__.py
@@ -31,6 +31,7 @@ from tau_agent.messages import (
     CompactionSummaryMessage,
     CustomMessage,
     ImageContent,
+    ResponseTiming,
     TextContent,
     ThinkingContent,
     ToolCall,

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -211,7 +211,6 @@ async def _assistant_events(
     signal: CancellationToken | None,
     session_id: str | None,
 ) -> AsyncIterator[AgentEvent]:
-    request_started_ns = monotonic_ns()
     source: AsyncIterator[AssistantMessageEvent] = provider.stream_response(
         model=model,
         system=system,
@@ -221,9 +220,17 @@ async def _assistant_events(
         session_id=session_id,
     )
     started = False
-    first_output_ns: int | None = None
-    async for event in source:
-        if first_output_ns is None and isinstance(
+    provider_elapsed_ns = 0
+    first_output_elapsed_ns: int | None = None
+    source_iterator = source.__aiter__()
+    while True:
+        wait_started_ns = monotonic_ns()
+        try:
+            event = await anext(source_iterator)
+        except StopAsyncIteration:
+            break
+        provider_elapsed_ns += max(0, monotonic_ns() - wait_started_ns)
+        if first_output_elapsed_ns is None and isinstance(
             event,
             (
                 TextDeltaEvent,
@@ -233,36 +240,22 @@ async def _assistant_events(
                 ToolCallEndEvent,
             ),
         ):
-            first_output_ns = monotonic_ns()
+            first_output_elapsed_ns = provider_elapsed_ns
         if isinstance(event, AssistantStartEvent):
             started = True
             yield MessageStartEvent(message=event.partial)
         elif isinstance(event, AssistantDoneEvent):
-            completed_ns = monotonic_ns()
-            terminal_first_output_ns = (
-                first_output_ns
-                if first_output_ns is not None or not event.message.content
-                else completed_ns
-            )
             event.message.timing = _response_timing(
-                request_started_ns,
-                terminal_first_output_ns,
-                completed_ns,
+                first_output_elapsed_ns,
+                provider_elapsed_ns,
             )
             if not started:
                 yield MessageStartEvent(message=event.message)
             yield MessageEndEvent(message=event.message)
         elif isinstance(event, AssistantErrorEvent):
-            completed_ns = monotonic_ns()
-            terminal_first_output_ns = (
-                first_output_ns
-                if first_output_ns is not None or not event.error.content
-                else completed_ns
-            )
             event.error.timing = _response_timing(
-                request_started_ns,
-                terminal_first_output_ns,
-                completed_ns,
+                first_output_elapsed_ns,
+                provider_elapsed_ns,
             )
             if not started:
                 yield MessageStartEvent(message=event.error)
@@ -275,18 +268,15 @@ async def _assistant_events(
 
 
 def _response_timing(
-    request_started_ns: int,
-    first_output_ns: int | None,
-    completed_ns: int,
+    first_output_elapsed_ns: int | None,
+    total_elapsed_ns: int,
 ) -> ResponseTiming:
-    """Build persistable durations from monotonic response boundaries."""
+    """Build persistable durations from time spent awaiting provider events."""
     return ResponseTiming(
         time_to_first_output_ms=(
-            max(0, first_output_ns - request_started_ns) // 1_000_000
-            if first_output_ns is not None
-            else None
+            first_output_elapsed_ns // 1_000_000 if first_output_elapsed_ns is not None else None
         ),
-        total_duration_ms=max(0, completed_ns - request_started_ns) // 1_000_000,
+        total_duration_ms=total_elapsed_ns // 1_000_000,
     )
 
 

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from time import monotonic_ns
 
 from tau_agent.events import (
     AgentEndEvent,
@@ -21,6 +22,7 @@ from tau_agent.events import (
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    ResponseTiming,
     TextContent,
     ToolCall,
     ToolResultMessage,
@@ -31,6 +33,11 @@ from tau_agent.provider_events import (
     AssistantErrorEvent,
     AssistantMessageEvent,
     AssistantStartEvent,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+    ToolCallDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
 )
 from tau_agent.tool_history import repair_tool_history
 from tau_agent.tools import AgentTool, AgentToolResult
@@ -204,6 +211,7 @@ async def _assistant_events(
     signal: CancellationToken | None,
     session_id: str | None,
 ) -> AsyncIterator[AgentEvent]:
+    request_started_ns = monotonic_ns()
     source: AsyncIterator[AssistantMessageEvent] = provider.stream_response(
         model=model,
         system=system,
@@ -213,15 +221,49 @@ async def _assistant_events(
         session_id=session_id,
     )
     started = False
+    first_output_ns: int | None = None
     async for event in source:
+        if first_output_ns is None and isinstance(
+            event,
+            (
+                TextDeltaEvent,
+                ThinkingDeltaEvent,
+                ToolCallStartEvent,
+                ToolCallDeltaEvent,
+                ToolCallEndEvent,
+            ),
+        ):
+            first_output_ns = monotonic_ns()
         if isinstance(event, AssistantStartEvent):
             started = True
             yield MessageStartEvent(message=event.partial)
         elif isinstance(event, AssistantDoneEvent):
+            completed_ns = monotonic_ns()
+            terminal_first_output_ns = (
+                first_output_ns
+                if first_output_ns is not None or not event.message.content
+                else completed_ns
+            )
+            event.message.timing = _response_timing(
+                request_started_ns,
+                terminal_first_output_ns,
+                completed_ns,
+            )
             if not started:
                 yield MessageStartEvent(message=event.message)
             yield MessageEndEvent(message=event.message)
         elif isinstance(event, AssistantErrorEvent):
+            completed_ns = monotonic_ns()
+            terminal_first_output_ns = (
+                first_output_ns
+                if first_output_ns is not None or not event.error.content
+                else completed_ns
+            )
+            event.error.timing = _response_timing(
+                request_started_ns,
+                terminal_first_output_ns,
+                completed_ns,
+            )
             if not started:
                 yield MessageStartEvent(message=event.error)
             yield MessageEndEvent(message=event.error)
@@ -230,6 +272,22 @@ async def _assistant_events(
                 message=event.partial,
                 assistant_message_event=event,
             )
+
+
+def _response_timing(
+    request_started_ns: int,
+    first_output_ns: int | None,
+    completed_ns: int,
+) -> ResponseTiming:
+    """Build persistable durations from monotonic response boundaries."""
+    return ResponseTiming(
+        time_to_first_output_ms=(
+            max(0, first_output_ns - request_started_ns) // 1_000_000
+            if first_output_ns is not None
+            else None
+        ),
+        total_duration_ms=max(0, completed_ns - request_started_ns) // 1_000_000,
+    )
 
 
 async def _execute_tool_call(

--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -55,6 +55,20 @@ class Usage(WireModel):
     cost: UsageCost = UsageCost()
 
 
+class ResponseTiming(WireModel):
+    """Monotonic request durations for one assistant response."""
+
+    time_to_first_output_ms: int | None = Field(default=None, ge=0)
+    total_duration_ms: int = Field(ge=0)
+
+    @property
+    def generation_duration_ms(self) -> int | None:
+        """Return elapsed time from first output through response completion."""
+        if self.time_to_first_output_ms is None:
+            return None
+        return max(0, self.total_duration_ms - self.time_to_first_output_ms)
+
+
 class TextContent(WireModel):
     type: Literal["text"] = "text"
     text: str
@@ -129,6 +143,7 @@ class AssistantMessage(WireModel):
     response_id: str | None = None
     diagnostics: list[AssistantMessageDiagnostic] | None = None
     usage: Usage = Usage()
+    timing: ResponseTiming | None = None
     stop_reason: StopReason = "stop"
     error_message: str | None = None
     timestamp: int = Field(default_factory=current_timestamp_ms)

--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -61,13 +61,6 @@ class ResponseTiming(WireModel):
     time_to_first_output_ms: int | None = Field(default=None, ge=0)
     total_duration_ms: int = Field(ge=0)
 
-    @property
-    def generation_duration_ms(self) -> int | None:
-        """Return elapsed time from first output through response completion."""
-        if self.time_to_first_output_ms is None:
-            return None
-        return max(0, self.total_duration_ms - self.time_to_first_output_ms)
-
 
 class TextContent(WireModel):
     type: Literal["text"] = "text"

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -5,10 +5,10 @@ portable `tau_agent` harness emits provider-neutral events; the TUI renders
 them and owns interaction. Ctrl+P cycles forward through scoped models;
 Shift+Ctrl+P cycles backward.
 
-The sidebar usage section shows effective output speed for the latest timed
-provider response and the token-weighted timed session history. Effective speed
-includes request startup, prefill, and TTFT. Older assistant messages without persisted timing still count toward token
-usage but not speed.
+The sidebar usage section shows average effective output speed across the timed
+session history. Effective speed includes request startup, prefill, and TTFT,
+and the session average is token-weighted. Older assistant messages without
+persisted timing still count toward token usage but not speed.
 
 ## `/model`
 

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -6,10 +6,12 @@ them and owns interaction. Ctrl+P cycles forward through scoped models;
 Shift+Ctrl+P cycles backward.
 
 The sidebar usage section shows `avg TPS` and `avg TTFT` across timed session
-history. Effective TPS includes request startup, prefill, and TTFT, and is
-token-weighted. TTFT is the arithmetic mean from request start to Tau's first
-text, thinking, or tool-call output event. Older assistant messages without
-persisted timing still count toward token usage but not these metrics.
+history. Effective TPS uses the accumulated time Tau spends awaiting provider
+events, including provider queueing, network waits, prefill, and TTFT; it
+excludes Tau's rendering and persistence between stream pulls. TPS is
+token-weighted. TTFT is the arithmetic mean of provider-wait time through Tau's
+first text, thinking, or tool-call output event. Older assistant messages
+without persisted timing still count toward token usage but not these metrics.
 
 ## `/model`
 

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -5,6 +5,11 @@ portable `tau_agent` harness emits provider-neutral events; the TUI renders
 them and owns interaction. Ctrl+P cycles forward through scoped models;
 Shift+Ctrl+P cycles backward.
 
+The sidebar usage section shows effective output speed for the latest timed
+provider response and the token-weighted timed session history. Effective speed
+includes request startup, prefill, and TTFT. Older assistant messages without persisted timing still count toward token
+usage but not speed.
+
 ## `/model`
 
 The picker renders cached/bundled choices immediately, then refreshes remote

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -5,10 +5,11 @@ portable `tau_agent` harness emits provider-neutral events; the TUI renders
 them and owns interaction. Ctrl+P cycles forward through scoped models;
 Shift+Ctrl+P cycles backward.
 
-The sidebar usage section shows average effective output speed across the timed
-session history. Effective speed includes request startup, prefill, and TTFT,
-and the session average is token-weighted. Older assistant messages without
-persisted timing still count toward token usage but not speed.
+The sidebar usage section shows `avg TPS` and `avg TTFT` across timed session
+history. Effective TPS includes request startup, prefill, and TTFT, and is
+token-weighted. TTFT is the arithmetic mean from request start to Tau's first
+text, thinking, or tool-call output event. Older assistant messages without
+persisted timing still count toward token usage but not these metrics.
 
 ## `/model`
 

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -27,6 +27,8 @@ class SessionStats:
     latest_cached_input_tokens: int = 0
     timed_output_tokens: int = 0
     response_duration_ms: int = 0
+    time_to_first_output_ms: int = 0
+    timed_first_output_count: int = 0
     estimated_cost: float | None = None
 
     @property
@@ -58,6 +60,13 @@ class SessionStats:
             return None
         return self.timed_output_tokens * 1000 / self.response_duration_ms
 
+    @property
+    def average_time_to_first_output_ms(self) -> float | None:
+        """Mean time from request start to the first output event."""
+        if self.timed_first_output_count <= 0:
+            return None
+        return self.time_to_first_output_ms / self.timed_first_output_count
+
 
 def calculate_session_stats(
     entries: Sequence[SessionEntry],
@@ -75,6 +84,8 @@ def calculate_session_stats(
     latest_cached_input_tokens = 0
     timed_output_tokens = 0
     response_duration_ms = 0
+    time_to_first_output_ms = 0
+    timed_first_output_count = 0
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
@@ -99,9 +110,13 @@ def calculate_session_stats(
         cache_write_tokens += usage.cache_write
         output_tokens += usage.output
         timing = message.timing
-        if timing is not None and usage.output > 0 and timing.total_duration_ms > 0:
-            timed_output_tokens += usage.output
-            response_duration_ms += timing.total_duration_ms
+        if timing is not None:
+            if usage.output > 0 and timing.total_duration_ms > 0:
+                timed_output_tokens += usage.output
+                response_duration_ms += timing.total_duration_ms
+            if timing.time_to_first_output_ms is not None:
+                time_to_first_output_ms += timing.time_to_first_output_ms
+                timed_first_output_count += 1
         if prompt_tokens == 0 and usage.output == 0:
             continue
 
@@ -133,6 +148,8 @@ def calculate_session_stats(
         latest_cached_input_tokens=latest_cached_input_tokens,
         timed_output_tokens=timed_output_tokens,
         response_duration_ms=response_duration_ms,
+        time_to_first_output_ms=time_to_first_output_ms,
+        timed_first_output_count=timed_first_output_count,
         estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
     )
 

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -25,6 +25,11 @@ class SessionStats:
     cache_write_tokens: int = 0
     latest_prompt_tokens: int = 0
     latest_cached_input_tokens: int = 0
+    timed_output_tokens: int = 0
+    response_duration_ms: int = 0
+    latest_timed_output_tokens: int = 0
+    latest_response_duration_ms: int = 0
+    latest_time_to_first_output_ms: int | None = None
     estimated_cost: float | None = None
 
     @property
@@ -49,6 +54,20 @@ class SessionStats:
             return None
         return self.latest_cached_input_tokens / self.latest_prompt_tokens
 
+    @property
+    def output_tokens_per_second(self) -> float | None:
+        """Token-weighted effective output speed across timed responses."""
+        if self.timed_output_tokens <= 0 or self.response_duration_ms <= 0:
+            return None
+        return self.timed_output_tokens * 1000 / self.response_duration_ms
+
+    @property
+    def latest_output_tokens_per_second(self) -> float | None:
+        """Effective output speed for the latest timed response."""
+        if self.latest_timed_output_tokens <= 0 or self.latest_response_duration_ms <= 0:
+            return None
+        return self.latest_timed_output_tokens * 1000 / self.latest_response_duration_ms
+
 
 def calculate_session_stats(
     entries: Sequence[SessionEntry],
@@ -64,6 +83,11 @@ def calculate_session_stats(
     cache_write_tokens = 0
     latest_prompt_tokens = 0
     latest_cached_input_tokens = 0
+    timed_output_tokens = 0
+    response_duration_ms = 0
+    latest_timed_output_tokens = 0
+    latest_response_duration_ms = 0
+    latest_time_to_first_output_ms: int | None = None
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
@@ -87,6 +111,18 @@ def calculate_session_stats(
         cached_input_tokens += usage.cache_read
         cache_write_tokens += usage.cache_write
         output_tokens += usage.output
+        timing = message.timing
+        if timing is not None:
+            latest_timed_output_tokens = usage.output
+            latest_response_duration_ms = timing.total_duration_ms
+            latest_time_to_first_output_ms = timing.time_to_first_output_ms
+            if usage.output > 0 and timing.total_duration_ms > 0:
+                timed_output_tokens += usage.output
+                response_duration_ms += timing.total_duration_ms
+        else:
+            latest_timed_output_tokens = 0
+            latest_response_duration_ms = 0
+            latest_time_to_first_output_ms = None
         if prompt_tokens == 0 and usage.output == 0:
             continue
 
@@ -116,6 +152,11 @@ def calculate_session_stats(
         cache_write_tokens=cache_write_tokens,
         latest_prompt_tokens=latest_prompt_tokens,
         latest_cached_input_tokens=latest_cached_input_tokens,
+        timed_output_tokens=timed_output_tokens,
+        response_duration_ms=response_duration_ms,
+        latest_timed_output_tokens=latest_timed_output_tokens,
+        latest_response_duration_ms=latest_response_duration_ms,
+        latest_time_to_first_output_ms=latest_time_to_first_output_ms,
         estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
     )
 

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -27,9 +27,6 @@ class SessionStats:
     latest_cached_input_tokens: int = 0
     timed_output_tokens: int = 0
     response_duration_ms: int = 0
-    latest_timed_output_tokens: int = 0
-    latest_response_duration_ms: int = 0
-    latest_time_to_first_output_ms: int | None = None
     estimated_cost: float | None = None
 
     @property
@@ -61,13 +58,6 @@ class SessionStats:
             return None
         return self.timed_output_tokens * 1000 / self.response_duration_ms
 
-    @property
-    def latest_output_tokens_per_second(self) -> float | None:
-        """Effective output speed for the latest timed response."""
-        if self.latest_timed_output_tokens <= 0 or self.latest_response_duration_ms <= 0:
-            return None
-        return self.latest_timed_output_tokens * 1000 / self.latest_response_duration_ms
-
 
 def calculate_session_stats(
     entries: Sequence[SessionEntry],
@@ -85,9 +75,6 @@ def calculate_session_stats(
     latest_cached_input_tokens = 0
     timed_output_tokens = 0
     response_duration_ms = 0
-    latest_timed_output_tokens = 0
-    latest_response_duration_ms = 0
-    latest_time_to_first_output_ms: int | None = None
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
@@ -112,17 +99,9 @@ def calculate_session_stats(
         cache_write_tokens += usage.cache_write
         output_tokens += usage.output
         timing = message.timing
-        if timing is not None:
-            latest_timed_output_tokens = usage.output
-            latest_response_duration_ms = timing.total_duration_ms
-            latest_time_to_first_output_ms = timing.time_to_first_output_ms
-            if usage.output > 0 and timing.total_duration_ms > 0:
-                timed_output_tokens += usage.output
-                response_duration_ms += timing.total_duration_ms
-        else:
-            latest_timed_output_tokens = 0
-            latest_response_duration_ms = 0
-            latest_time_to_first_output_ms = None
+        if timing is not None and usage.output > 0 and timing.total_duration_ms > 0:
+            timed_output_tokens += usage.output
+            response_duration_ms += timing.total_duration_ms
         if prompt_tokens == 0 and usage.output == 0:
             continue
 
@@ -154,9 +133,6 @@ def calculate_session_stats(
         latest_cached_input_tokens=latest_cached_input_tokens,
         timed_output_tokens=timed_output_tokens,
         response_duration_ms=response_duration_ms,
-        latest_timed_output_tokens=latest_timed_output_tokens,
-        latest_response_duration_ms=latest_response_duration_ms,
-        latest_time_to_first_output_ms=latest_time_to_first_output_ms,
         estimated_cost=(estimated_cost if has_billable_usage and has_complete_pricing else None),
     )
 

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -111,6 +111,9 @@ def calculate_session_stats(
         output_tokens += usage.output
         timing = message.timing
         if timing is not None:
+            # TPS is token-weighted and requires usable output usage. TTFT is a
+            # per-call arithmetic mean whenever output was observed, even if a
+            # later error left that response without billed output tokens.
             if usage.output > 0 and timing.total_duration_ms > 0:
                 timed_output_tokens += usage.output
                 response_duration_ms += timing.total_duration_ms

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1867,6 +1867,14 @@ def _build_sidebar_content(
     if cache_rates:
         usage.append("\ncache: ", style=theme.completion_description)
         usage.append(" · ".join(cache_rates), style=theme.completion_description)
+    speeds: list[str] = []
+    if (latest_speed := stats.latest_output_tokens_per_second) is not None:
+        speeds.append(f"{latest_speed:.1f} latest")
+    if (session_speed := stats.output_tokens_per_second) is not None:
+        speeds.append(f"{session_speed:.1f} session")
+    if speeds:
+        usage.append("\nspeed: ", style=theme.completion_description)
+        usage.append(f"{' · '.join(speeds)} tok/s", style=theme.completion_description)
 
     threshold = session.auto_compact_token_threshold
     compaction = Text(

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1867,9 +1867,13 @@ def _build_sidebar_content(
     if cache_rates:
         usage.append("\ncache: ", style=theme.completion_description)
         usage.append(" · ".join(cache_rates), style=theme.completion_description)
+    performance: list[str] = []
     if (session_speed := stats.output_tokens_per_second) is not None:
-        usage.append("\naverage speed: ", style=theme.completion_description)
-        usage.append(f"{session_speed:.1f} tok/s", style=theme.completion_description)
+        performance.append(f"avg TPS: {session_speed:.1f}")
+    if (average_ttft := stats.average_time_to_first_output_ms) is not None:
+        performance.append(f"avg TTFT: {_format_milliseconds(average_ttft)}")
+    if performance:
+        usage.append(f"\n{' · '.join(performance)}", style=theme.completion_description)
 
     threshold = session.auto_compact_token_threshold
     compaction = Text(
@@ -2532,6 +2536,12 @@ def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:
         text.append(short_path, style=theme.prompt_text)
     text.append(f" ({_git_branch(cwd)})", style=theme.completion_description)
     return text
+
+
+def _format_milliseconds(value: float) -> str:
+    if value < 1000:
+        return f"{value:.0f}ms"
+    return f"{value / 1000:.1f}s"
 
 
 def _compact_token_count(value: int) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -2539,9 +2539,10 @@ def _styled_cwd(cwd: Path, *, theme: TuiTheme) -> Text:
 
 
 def _format_milliseconds(value: float) -> str:
-    if value < 1000:
-        return f"{value:.0f}ms"
-    return f"{value / 1000:.1f}s"
+    rounded = round(value)
+    if rounded < 1000:
+        return f"{rounded}ms"
+    return f"{rounded / 1000:.1f}s"
 
 
 def _compact_token_count(value: int) -> str:

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1867,14 +1867,9 @@ def _build_sidebar_content(
     if cache_rates:
         usage.append("\ncache: ", style=theme.completion_description)
         usage.append(" · ".join(cache_rates), style=theme.completion_description)
-    speeds: list[str] = []
-    if (latest_speed := stats.latest_output_tokens_per_second) is not None:
-        speeds.append(f"{latest_speed:.1f} latest")
     if (session_speed := stats.output_tokens_per_second) is not None:
-        speeds.append(f"{session_speed:.1f} session")
-    if speeds:
-        usage.append("\nspeed: ", style=theme.completion_description)
-        usage.append(f"{' · '.join(speeds)} tok/s", style=theme.completion_description)
+        usage.append("\naverage speed: ", style=theme.completion_description)
+        usage.append(f"{session_speed:.1f} tok/s", style=theme.completion_description)
 
     threshold = session.auto_compact_token_threshold
     compaction = Text(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncIterator, Mapping
+from itertools import chain, repeat
 
 import pytest
 
@@ -85,10 +86,20 @@ async def test_agent_loop_streams_canonical_nested_events() -> None:
 
 
 @pytest.mark.anyio
-async def test_agent_loop_records_monotonic_response_timing(
+async def test_agent_loop_records_only_monotonic_provider_wait_time(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    ticks = iter([1_000_000_000, 2_250_000_000, 6_000_000_000])
+    ticks = chain(
+        [
+            0,
+            100_000_000,
+            1_000_000_000,
+            2_150_000_000,
+            10_000_000_000,
+            13_750_000_000,
+        ],
+        repeat(13_750_000_000),
+    )
     monkeypatch.setattr(loop_module, "monotonic_ns", lambda: next(ticks))
     messages: list[AgentMessage] = [UserMessage(content="Say hello")]
     assistant = AssistantMessage(content="Hello", model="fake")
@@ -108,6 +119,33 @@ async def test_agent_loop_records_monotonic_response_timing(
     assert assistant.timing is not None
     assert assistant.timing.time_to_first_output_ms == 1250
     assert assistant.timing.total_duration_ms == 5000
+
+
+@pytest.mark.anyio
+async def test_agent_loop_does_not_invent_ttft_without_an_output_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = chain(
+        [0, 100_000_000, 1_000_000_000, 2_000_000_000],
+        repeat(2_000_000_000),
+    )
+    monkeypatch.setattr(loop_module, "monotonic_ns", lambda: next(ticks))
+    assistant = AssistantMessage(content="Non-streamed", model="fake")
+    provider = FakeProvider([[assistant_start(), assistant_done(assistant)]])
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=[UserMessage(content="Say hello")],
+            tools=[],
+        )
+    )
+
+    assert assistant.timing is not None
+    assert assistant.timing.time_to_first_output_ms is None
+    assert assistant.timing.total_duration_ms == 1100
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator, Mapping
 
 import pytest
 
+import tau_agent.loop as loop_module
 from pi_event_helpers import (
     assistant_done,
     assistant_error,
@@ -81,6 +82,32 @@ async def test_agent_loop_streams_canonical_nested_events() -> None:
     updates = [event for event in events if isinstance(event, MessageUpdateEvent)]
     assert [event.assistant_message_event.delta for event in updates] == ["Hel", "lo"]  # type: ignore[union-attr]
     assert messages == [messages[0], assistant]
+
+
+@pytest.mark.anyio
+async def test_agent_loop_records_monotonic_response_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter([1_000_000_000, 2_250_000_000, 6_000_000_000])
+    monkeypatch.setattr(loop_module, "monotonic_ns", lambda: next(ticks))
+    messages: list[AgentMessage] = [UserMessage(content="Say hello")]
+    assistant = AssistantMessage(content="Hello", model="fake")
+    assistant.usage.output = 100
+    provider = FakeProvider([[assistant_start(), text_delta("Hello"), assistant_done(assistant)]])
+
+    await _collect(
+        run_agent_loop(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            messages=messages,
+            tools=[],
+        )
+    )
+
+    assert assistant.timing is not None
+    assert assistant.timing.time_to_first_output_ms == 1250
+    assert assistant.timing.total_duration_ms == 5000
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -77,7 +77,6 @@ def test_assistant_message_serializes_response_timing() -> None:
         "totalDurationMs": 5000,
     }
     assert message.timing is not None
-    assert message.timing.generation_duration_ms == 3800
 
 
 def test_assistant_message_persists_thinking_blocks_and_signatures() -> None:

--- a/tests/test_agent_types.py
+++ b/tests/test_agent_types.py
@@ -10,6 +10,7 @@ from tau_agent import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ResponseTiming,
     TextContent,
     ThinkingContent,
     ToolCall,
@@ -60,6 +61,23 @@ def test_assistant_message_serializes_resolved_response_provider() -> None:
 
     assert payload["provider"] == "huggingface"
     assert payload["responseProvider"] == "test-inference-provider"
+
+
+def test_assistant_message_serializes_response_timing() -> None:
+    message = AssistantMessage(
+        content="done",
+        timing=ResponseTiming(time_to_first_output_ms=1200, total_duration_ms=5000),
+        timestamp=123,
+    )
+
+    payload = message.model_dump(by_alias=True)
+
+    assert payload["timing"] == {
+        "timeToFirstOutputMs": 1200,
+        "totalDurationMs": 5000,
+    }
+    assert message.timing is not None
+    assert message.timing.generation_duration_ms == 3800
 
 
 def test_assistant_message_persists_thinking_blocks_and_signatures() -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -97,7 +97,7 @@ def _assert_messages(actual: object, expected: object) -> None:
     def dump(message: object) -> object:
         model_dump = getattr(message, "model_dump", None)
         if callable(model_dump):
-            return model_dump(exclude={"timestamp"})
+            return model_dump(exclude={"timestamp", "timing"})
         return message
 
     assert [dump(message) for message in actual] == [dump(message) for message in expected]  # type: ignore[union-attr]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,6 +7,7 @@ from tau_agent import (
     AssistantMessage,
     CustomMessage,
     ImageContent,
+    ResponseTiming,
     TextContent,
     ThinkingContent,
     ToolResultMessage,
@@ -83,10 +84,29 @@ def test_assistant_and_tool_result_round_trip_canonical_blocks() -> None:
 
     assert assistant_payload["content"][0]["text"] == "Hi"
     assert assistant_payload["usage"]["totalTokens"] == 0
+    assert "timing" not in assistant_payload
     assert result_payload["role"] == "toolResult"
     assert result_payload["toolName"] == "edit"
     assert entry_from_json_line(entry_to_json_line(assistant)) == assistant
     assert entry_from_json_line(entry_to_json_line(result)) == result
+
+
+def test_assistant_response_timing_round_trips_jsonl() -> None:
+    entry = MessageEntry(
+        id="timed",
+        message=AssistantMessage(
+            content="Hi",
+            timing=ResponseTiming(time_to_first_output_ms=250, total_duration_ms=1000),
+        ),
+    )
+
+    line = entry_to_json_line(entry)
+
+    assert entry_from_json_line(line) == entry
+    assert json.loads(line)["message"]["timing"] == {
+        "timeToFirstOutputMs": 250,
+        "totalDurationMs": 1000,
+    }
 
 
 def test_tool_result_image_round_trips_jsonl() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -1,6 +1,7 @@
 from tau_agent.messages import (
     AssistantMessage,
     CustomMessage,
+    ResponseTiming,
     TextContent,
     ToolCall,
     ToolResultMessage,
@@ -115,6 +116,53 @@ def test_latest_cache_hit_rate_reports_miss_after_earlier_cache_activity() -> No
     )
 
     assert stats.latest_cache_hit_rate == 0.0
+
+
+def test_calculate_session_stats_aggregates_effective_output_speed() -> None:
+    first = MessageEntry(
+        message=AssistantMessage(
+            usage=Usage(output=100),
+            timing=ResponseTiming(time_to_first_output_ms=500, total_duration_ms=2000),
+        )
+    )
+    second = MessageEntry(
+        parent_id=first.id,
+        message=AssistantMessage(
+            usage=Usage(output=300),
+            timing=ResponseTiming(time_to_first_output_ms=1000, total_duration_ms=3000),
+        ),
+    )
+
+    stats = calculate_session_stats(
+        [first, second],
+        pricing=lambda _provider, _model, _input: {},
+    )
+
+    assert stats.latest_output_tokens_per_second == 100.0
+    assert stats.output_tokens_per_second == 80.0
+    assert stats.latest_time_to_first_output_ms == 1000
+
+
+def test_calculate_session_stats_ignores_untimed_history_for_speed() -> None:
+    timed = MessageEntry(
+        message=AssistantMessage(
+            usage=Usage(output=100),
+            timing=ResponseTiming(time_to_first_output_ms=500, total_duration_ms=2000),
+        )
+    )
+    legacy = MessageEntry(
+        parent_id=timed.id,
+        message=AssistantMessage(usage=Usage(output=300)),
+    )
+
+    stats = calculate_session_stats(
+        [timed, legacy],
+        pricing=lambda _provider, _model, _input: {},
+    )
+
+    assert stats.latest_output_tokens_per_second is None
+    assert stats.output_tokens_per_second == 50.0
+    assert stats.latest_time_to_first_output_ms is None
 
 
 def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -27,7 +27,10 @@ def test_cache_hit_rate_is_zero_when_a_write_happened_but_nothing_was_read() -> 
 
 
 def test_cache_hit_rate_is_none_without_billed_input() -> None:
-    assert SessionStats().cache_hit_rate is None
+    stats = SessionStats()
+
+    assert stats.cache_hit_rate is None
+    assert stats.average_time_to_first_output_ms is None
 
 
 def test_cache_hit_rate_divides_reads_by_total_prompt_tokens() -> None:
@@ -139,6 +142,7 @@ def test_calculate_session_stats_aggregates_effective_output_speed() -> None:
     )
 
     assert stats.output_tokens_per_second == 80.0
+    assert stats.average_time_to_first_output_ms == 750.0
 
 
 def test_calculate_session_stats_ignores_untimed_history_for_speed() -> None:
@@ -159,6 +163,7 @@ def test_calculate_session_stats_ignores_untimed_history_for_speed() -> None:
     )
 
     assert stats.output_tokens_per_second == 50.0
+    assert stats.average_time_to_first_output_ms == 500.0
 
 
 def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -138,9 +138,7 @@ def test_calculate_session_stats_aggregates_effective_output_speed() -> None:
         pricing=lambda _provider, _model, _input: {},
     )
 
-    assert stats.latest_output_tokens_per_second == 100.0
     assert stats.output_tokens_per_second == 80.0
-    assert stats.latest_time_to_first_output_ms == 1000
 
 
 def test_calculate_session_stats_ignores_untimed_history_for_speed() -> None:
@@ -160,9 +158,7 @@ def test_calculate_session_stats_ignores_untimed_history_for_speed() -> None:
         pricing=lambda _provider, _model, _input: {},
     )
 
-    assert stats.latest_output_tokens_per_second is None
     assert stats.output_tokens_per_second == 50.0
-    assert stats.latest_time_to_first_output_ms is None
 
 
 def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -235,9 +235,6 @@ class FakeSession:
             latest_cached_input_tokens=1_188_000,
             timed_output_tokens=48_000,
             response_duration_ms=1_200_000,
-            latest_timed_output_tokens=1_000,
-            latest_response_duration_ms=20_000,
-            latest_time_to_first_output_ms=1_200,
             estimated_cost=1.24,
         )
         self.system_prompt = "You are Tau."
@@ -551,7 +548,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "cumulative usage" not in output
     assert "1.2m in, 48k out · ~$1.24" in output
     assert "cache: 99% latest · 95% session" in output
-    assert "speed: 50.0 latest · 40.0 session tok/s" in output
+    assert "average speed: 40.0 tok/s" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert re.search(r"\./\.tau/skills\s+• review", output)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -152,6 +152,7 @@ from tau_coding.tui.widgets import (
     TranscriptWindowBoundary,
     _comma_list,
     _compact_token_count,
+    _format_milliseconds,
     _sidebar_brand,
     _split_rich_style_colors,
     _styled_cwd,
@@ -524,6 +525,17 @@ def _visible_footer_bindings(app: TauTuiApp) -> dict[str, str]:
         for _, binding, _enabled, _tooltip in app.screen.active_bindings.values()
         if binding.show
     }
+
+
+@pytest.mark.parametrize(
+    ("milliseconds", "expected"),
+    [(999, "999ms"), (1000, "1.0s"), (999.6, "1.0s")],
+)
+def test_format_milliseconds_handles_unit_boundary(
+    milliseconds: float,
+    expected: str,
+) -> None:
+    assert _format_milliseconds(milliseconds) == expected
 
 
 def test_session_sidebar_renders_session_metadata() -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -235,6 +235,8 @@ class FakeSession:
             latest_cached_input_tokens=1_188_000,
             timed_output_tokens=48_000,
             response_duration_ms=1_200_000,
+            time_to_first_output_ms=18_000,
+            timed_first_output_count=15,
             estimated_cost=1.24,
         )
         self.system_prompt = "You are Tau."
@@ -548,7 +550,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "cumulative usage" not in output
     assert "1.2m in, 48k out · ~$1.24" in output
     assert "cache: 99% latest · 95% session" in output
-    assert "average speed: 40.0 tok/s" in output
+    assert "avg TPS: 40.0 · avg TTFT: 1.2s" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert re.search(r"\./\.tau/skills\s+• review", output)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -233,6 +233,11 @@ class FakeSession:
             cached_input_tokens=1_140_000,
             latest_prompt_tokens=1_200_000,
             latest_cached_input_tokens=1_188_000,
+            timed_output_tokens=48_000,
+            response_duration_ms=1_200_000,
+            latest_timed_output_tokens=1_000,
+            latest_response_duration_ms=20_000,
+            latest_time_to_first_output_ms=1_200,
             estimated_cost=1.24,
         )
         self.system_prompt = "You are Tau."
@@ -546,6 +551,7 @@ def test_session_sidebar_renders_session_metadata() -> None:
     assert "cumulative usage" not in output
     assert "1.2m in, 48k out · ~$1.24" in output
     assert "cache: 99% latest · 95% session" in output
+    assert "speed: 50.0 latest · 40.0 session tok/s" in output
     assert "auto at 200k" in output
     assert "read, write, edit, bash" in output
     assert re.search(r"\./\.tau/skills\s+• review", output)

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -218,8 +218,8 @@ when you want to reduce what is sent to the model.
 
 On wide-enough terminals Tau shows the session name prominently without a
 redundant section label, followed by active-branch
-turn and tool-call totals, provider-reported token usage, effective output
-speed, latest-request and session prompt-cache hit rates, estimated cost,
+turn and tool-call totals, provider-reported token usage, average effective
+output speed and TTFT, latest-request and session prompt-cache hit rates, estimated cost,
 automatic-compaction threshold,
 and loaded tools, skills, prompt templates, extensions, and context files such as
 `AGENTS.md`. Tool and extension names use compact comma-separated lists limited
@@ -253,12 +253,13 @@ and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hide
 automatically when the terminal is small, while the tab title continues to
 identify the session.
 
-Average effective output speed divides provider-reported output tokens by the
-full response duration, including request startup, prefill, and time to first
-output. The session figure is token-weighted across timed responses rather than
-an average of per-response rates. Timing is persisted on new assistant messages.
-Older history still counts toward cumulative token usage and cost but is omitted
-from speed calculations.
+`avg TPS` divides provider-reported output tokens by the full response duration,
+including request startup, prefill, and time to first output. It is
+token-weighted across timed responses rather than an average of per-response
+rates. `avg TTFT` is the arithmetic mean from request start to Tau's first text,
+thinking, or tool-call output event. Timing is persisted on new assistant
+messages. Older history still counts toward cumulative token usage and cost but
+is omitted from both performance metrics.
 
 Cumulative usage and cost cover the active branch, including history replaced by
 compaction. Input usage counts tokens processed on every

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -253,13 +253,15 @@ and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hide
 automatically when the terminal is small, while the tab title continues to
 identify the session.
 
-`avg TPS` divides provider-reported output tokens by the full response duration,
-including request startup, prefill, and time to first output. It is
-token-weighted across timed responses rather than an average of per-response
-rates. `avg TTFT` is the arithmetic mean from request start to Tau's first text,
-thinking, or tool-call output event. Timing is persisted on new assistant
-messages. Older history still counts toward cumulative token usage and cost but
-is omitted from both performance metrics.
+`avg TPS` divides provider-reported output tokens by the accumulated time Tau
+spends awaiting provider stream events. That includes provider queueing, network
+waits, prefill, and time to first output, but excludes Tau's rendering and
+persistence work between stream pulls. TPS is token-weighted across timed
+responses rather than an average of per-response rates. `avg TTFT` is the
+arithmetic mean of provider-wait time through Tau's first text, thinking, or
+tool-call output event. Timing is persisted on new assistant messages. Older
+history still counts toward cumulative token usage and cost but is omitted from
+both performance metrics.
 
 Cumulative usage and cost cover the active branch, including history replaced by
 compaction. Input usage counts tokens processed on every

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -253,12 +253,12 @@ and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hide
 automatically when the terminal is small, while the tab title continues to
 identify the session.
 
-Effective output speed divides provider-reported output tokens by the full
-response duration, including request startup, prefill, and time to first output.
-The latest figure describes the most recent timed response; the session figure
-is token-weighted across timed responses rather than an average of per-response
-rates. Timing is persisted on new assistant messages. Older history still counts
-toward cumulative token usage and cost but is omitted from speed calculations.
+Average effective output speed divides provider-reported output tokens by the
+full response duration, including request startup, prefill, and time to first
+output. The session figure is token-weighted across timed responses rather than
+an average of per-response rates. Timing is persisted on new assistant messages.
+Older history still counts toward cumulative token usage and cost but is omitted
+from speed calculations.
 
 Cumulative usage and cost cover the active branch, including history replaced by
 compaction. Input usage counts tokens processed on every

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -218,8 +218,9 @@ when you want to reduce what is sent to the model.
 
 On wide-enough terminals Tau shows the session name prominently without a
 redundant section label, followed by active-branch
-turn and tool-call totals, provider-reported token usage, latest-request and
-session prompt-cache hit rates, estimated cost, automatic-compaction threshold,
+turn and tool-call totals, provider-reported token usage, effective output
+speed, latest-request and session prompt-cache hit rates, estimated cost,
+automatic-compaction threshold,
 and loaded tools, skills, prompt templates, extensions, and context files such as
 `AGENTS.md`. Tool and extension names use compact comma-separated lists limited
 to three rendered lines. Skills and prompt templates are grouped under their
@@ -251,6 +252,13 @@ top-header or shortcut-footer rows. Named sessions remain visible in the sidebar
 and terminal tab title; `/hotkeys` lists shortcuts when needed. The sidebar hides
 automatically when the terminal is small, while the tab title continues to
 identify the session.
+
+Effective output speed divides provider-reported output tokens by the full
+response duration, including request startup, prefill, and time to first output.
+The latest figure describes the most recent timed response; the session figure
+is token-weighted across timed responses rather than an average of per-response
+rates. Timing is persisted on new assistant messages. Older history still counts
+toward cumulative token usage and cost but is omitted from speed calculations.
 
 Cumulative usage and cost cover the active branch, including history replaced by
 compaction. Input usage counts tokens processed on every

--- a/website/content/internals/agent-loop.md
+++ b/website/content/internals/agent-loop.md
@@ -59,10 +59,11 @@ payload table.
 The final `AssistantMessage` is authoritative: it persists text, thinking, and tool
 calls as ordered content blocks. Nested update events provide responsive rendering,
 while saved sessions and provider history replay use the finalized structured message.
-It also carries optional monotonic response timing: total request duration and time
-from request start to the first text, thinking, or tool-call output. Tau captures
-these around the provider-neutral stream, so saved usage and timing remain paired
-for effective output-speed and TTFT statistics.
+It also carries optional monotonic response timing: accumulated time awaiting
+provider events through completion and through the first text, thinking, or
+tool-call output. Measuring only provider-event awaits excludes frontend rendering
+and persistence work between stream pulls. Saved usage and timing remain paired for
+effective output-speed and TTFT statistics.
 Its `provider` field names Tau's configured provider. When a gateway reports a
 more specific backend, `response_provider` records the backend that served that
 request. For example, Hugging Face responses expose the selected Inference

--- a/website/content/internals/agent-loop.md
+++ b/website/content/internals/agent-loop.md
@@ -59,6 +59,10 @@ payload table.
 The final `AssistantMessage` is authoritative: it persists text, thinking, and tool
 calls as ordered content blocks. Nested update events provide responsive rendering,
 while saved sessions and provider history replay use the finalized structured message.
+It also carries optional monotonic response timing: total request duration and time
+from request start to the first text, thinking, or tool-call output. Tau captures
+these around the provider-neutral stream, so saved usage and timing remain paired
+for effective output-speed and TTFT statistics.
 Its `provider` field names Tau's configured provider. When a gateway reports a
 more specific backend, `response_provider` records the backend that served that
 request. For example, Hugging Face responses expose the selected Inference


### PR DESCRIPTION
## Description

- measure accumulated provider-stream wait through first output and completion with a monotonic clock
- persist compact `timeToFirstOutputMs` and `totalDurationMs` values on assistant messages
- calculate token-weighted average effective TPS and arithmetic-mean TTFT for the session
- show `avg TPS` and `avg TTFT` together in the TUI sidebar
- document the metrics, persistence shape, and architecture

## User experience

Tau users can now see two concise session performance metrics in the sidebar: average effective tokens per second and average time to first output. Timing includes provider queueing, network waits, prefill, and generation waits, while excluding Tau's rendering and persistence between stream pulls. Timing survives resume because it is stored beside each response's usage; older sessions continue to load and simply omit untimed responses from performance calculations.

Tau labels the second metric `avg TTFT` for familiarity, while measuring the first provider-neutral text, thinking, or tool-call output event because provider chunks are not guaranteed to contain exactly one token. Responses without an observed output event are excluded from TTFT rather than assigned their full completion duration.

## Issue

No linked issue. Addresses the request to expose session token velocity and time to first output in Tau.

## Manual validation

1. Start an interactive session with `tau`.
2. Submit a prompt that produces a streamed assistant response.
3. Confirm the sidebar usage section shows `avg TPS: <value> · avg TTFT: <duration>`.
4. Submit another prompt and confirm both session averages update.
5. Quit and resume the session; confirm metrics remain available for responses created by this version.
6. Inspect the JSONL and confirm assistant messages contain compact optional timing data:

   ```json
   "timing":{"timeToFirstOutputMs":1234,"totalDurationMs":5678}
   ```

## Validation

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
