### PR TITLE
Improve session export timeline and usage visibility

### DIFF
--- a/dev-notes/architecture/phase-20-4-session-export.md
+++ b/dev-notes/architecture/phase-20-4-session-export.md
@@ -32,6 +32,15 @@ The export contains two coordinated views:
   results, compactions, labels, model changes, thinking changes, and custom
   entries
 
+The export header also includes a compact summary of the visible session data:
+total entries, messages, tools, session events, and elapsed duration. A
+timestamp timeline groups message, tool, and event markers into separate lanes;
+selecting a marker jumps to that entry. These summaries give readers an
+immediate sense of the session before they inspect the tree or expand any
+accordions. Because session entries currently record timestamps rather than
+independent end times, the timeline shows event positions and session elapsed
+time, not per-entry execution bars.
+
 The generated file is self-contained HTML, CSS, and JavaScript, so it can be
 opened without running Tau or the Textual app. Transcript entries render as
 compact, collapsed accordion rows (icon, title, one-line preview, timestamp),

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -188,6 +188,9 @@ def render_session_html(
     details_html = _render_entry_details(visible_entries, active_path_ids, active_leaf_id)
     source_html = f'<p class="source">Source: <code>{_escape(source)}</code></p>' if source else ""
     system_prompt_html = _render_system_prompt(system_prompt)
+    message_count = sum(1 for entry in visible_entries if _entry_filter_kind(entry) == "message")
+    duration = _format_session_duration(visible_entries)
+    timeline_html = _render_session_timeline(visible_entries)
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
     jsonl_b64 = base64.b64encode(_session_jsonl_text(entry_list).encode("utf-8")).decode("ascii")
     jsonl_filename = _jsonl_filename(title, source)
@@ -330,6 +333,107 @@ def render_session_html(
       flex-wrap: wrap;
       gap: 4px 18px;
       margin-top: 8px;
+    }}
+    .session-summary {{
+      display: grid;
+      grid-template-columns: repeat(5, minmax(88px, 1fr));
+      gap: 8px;
+      max-width: 680px;
+      margin-top: 18px;
+    }}
+    .summary-card {{
+      display: flex;
+      min-height: 58px;
+      flex-direction: column;
+      justify-content: center;
+      gap: 2px;
+      padding: 8px 10px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+    }}
+    .summary-card strong {{
+      color: var(--bright);
+      font-size: 1rem;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }}
+    .summary-card span {{
+      color: var(--muted);
+      font-size: 0.64rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }}
+    .timeline-overview {{
+      margin-top: 18px;
+      padding: 12px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+    }}
+    .timeline-heading {{
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }}
+    .timeline-heading h2 {{ margin: 0; }}
+    .timeline-heading p {{ color: var(--muted); font-size: 0.68rem; }}
+    .timeline-lane {{
+      display: grid;
+      grid-template-columns: 58px minmax(0, 1fr);
+      align-items: center;
+      gap: 10px;
+      min-height: 24px;
+    }}
+    .timeline-lane + .timeline-lane {{ margin-top: 3px; }}
+    .timeline-lane-label {{
+      color: var(--muted);
+      font-size: 0.64rem;
+      text-transform: uppercase;
+    }}
+    .timeline-track {{
+      position: relative;
+      height: 18px;
+      background: var(--surface-2);
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }}
+    .timeline-track::before, .timeline-track::after {{
+      position: absolute;
+      top: 3px;
+      bottom: 3px;
+      width: 1px;
+      background: var(--line-strong);
+      content: "";
+    }}
+    .timeline-track::before {{ left: 0; }}
+    .timeline-track::after {{ right: 0; }}
+    .timeline-marker {{
+      position: absolute;
+      top: 3px;
+      width: 10px;
+      height: 10px;
+      margin-left: -5px;
+      border: 2px solid var(--bg);
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 1px var(--accent);
+    }}
+    .timeline-marker:hover {{ transform: scale(1.35); z-index: 1; }}
+    .timeline-marker--tool {{
+      background: var(--success, var(--accent));
+      box-shadow: 0 0 0 1px var(--success, var(--accent));
+    }}
+    .timeline-marker--event {{ background: var(--muted); box-shadow: 0 0 0 1px var(--muted); }}
+    .timeline-axis {{
+      display: flex;
+      justify-content: space-between;
+      margin: 6px 0 0 68px;
+      color: var(--muted);
+      font-size: 0.62rem;
+    }}
+    @media (max-width: 560px) {{
+      .session-summary {{ grid-template-columns: repeat(2, minmax(88px, 1fr)); }}
     }}
     details.system-prompt {{
       margin-top: 16px;
@@ -787,6 +891,14 @@ def render_session_html(
         Generated: <time datetime="{_attr(generated_at)}">{_escape(generated_at)}</time>
       </p>
     </div>
+    <section class="session-summary" aria-label="Session summary">
+      <div class="summary-card"><strong>{len(visible_entries)}</strong><span>Entries</span></div>
+      <div class="summary-card"><strong>{message_count}</strong><span>Messages</span></div>
+      <div class="summary-card"><strong>{tool_count}</strong><span>Tools</span></div>
+      <div class="summary-card"><strong>{event_count}</strong><span>Events</span></div>
+      <div class="summary-card"><strong>{_escape(duration)}</strong><span>Duration</span></div>
+    </section>
+    {timeline_html}
     {system_prompt_html}
     <nav class="tab-bar" role="tablist" aria-label="Export views">
       <button
@@ -1653,6 +1765,64 @@ def _summarize_text(text: str, *, limit: int = 110) -> str:
     if len(summary) <= limit:
         return summary
     return summary[: limit - 3].rstrip() + "..."
+
+
+def _format_session_duration(entries: Sequence[SessionEntry]) -> str:
+    """Format elapsed time between the first and last visible entries."""
+    if not entries:
+        return "-"
+    seconds = max(
+        0,
+        round(
+            max(entry.timestamp for entry in entries) - min(entry.timestamp for entry in entries)
+        ),
+    )
+    minutes, remainder = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {remainder:02d}s"
+    return f"{remainder}s"
+
+
+def _render_session_timeline(entries: Sequence[SessionEntry]) -> str:
+    """Render timestamp markers grouped into message, tool, and event lanes."""
+    if not entries:
+        return ""
+    start = min(entry.timestamp for entry in entries)
+    end = max(entry.timestamp for entry in entries)
+    duration = end - start
+    lanes: dict[str, list[str]] = {"message": [], "tool": [], "event": []}
+    for entry in entries:
+        kind = _entry_filter_kind(entry)
+        if kind not in lanes:
+            continue
+        position = 50.0 if duration <= 0 else ((entry.timestamp - start) / duration) * 100
+        title = _entry_title(entry)
+        marker = (
+            f'<a class="timeline-marker timeline-marker--{_attr(kind)}" '
+            f'data-timeline-kind="{_attr(kind)}" href="#entry-{_attr(entry.id)}" '
+            f'style="left: {position:.2f}%" title="{_attr(title)}" '
+            f'aria-label="{_attr(title)} at {_attr(_format_time_short(entry.timestamp))}"></a>'
+        )
+        lanes[kind].append(marker)
+    rendered_lanes = "".join(
+        f'<div class="timeline-lane"><span class="timeline-lane-label">{label}</span>'
+        f'<div class="timeline-track">{"".join(lanes[kind])}</div></div>'
+        for kind, label in (("message", "Messages"), ("tool", "Tools"), ("event", "Events"))
+        if lanes[kind]
+    )
+    return (
+        '<section class="timeline-overview" aria-label="Session timeline">'
+        '<div class="timeline-heading"><h2>Timeline</h2>'
+        f"<p>{_escape(_format_session_duration(entries))} elapsed · "
+        "select a marker to jump</p></div>"
+        f"{rendered_lanes}"
+        f'<div class="timeline-axis"><span>{_escape(_format_time_short(start))}</span>'
+        f"<span>{_escape(_format_time_short(end))}</span></div>"
+        "</section>"
+    )
 
 
 def _json_dump(value: dict[str, JSONValue]) -> str:

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -487,7 +487,8 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
         '<p class="usage-note">Costs use Tau\'s provider catalog rates. OAuth subscription '
         "estimates are API-rate equivalents, not actual subscription charges. Hover a request "
         "for exact values, select a legend item to hide a series, and use PNG to save a "
-        "chart. Event markers show compactions, model or thinking changes, and branch summaries."
+        "chart. This is a snapshot of the session at export time; re-export to include later "
+        "entries. Event markers show compactions, model or thinking changes, and branch summaries."
         "</p>"
         f'<div class="usage-charts">{charts_html}</div>'
         '<div class="usage-details">'

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -10,6 +10,7 @@ from tau_agent import (
     ModelChangeEntry,
     SessionInfoEntry,
     TextContent,
+    ThinkingContent,
     ToolCall,
     ToolResultMessage,
     UserMessage,
@@ -87,6 +88,27 @@ def test_render_session_html_uses_static_document_layout() -> None:
     assert 'id="themeToggle"' in html
     assert "<link" not in html.lower()
     assert "http://" not in html and "https://" not in html
+
+
+def test_render_session_html_includes_thinking_content_blocks() -> None:
+    entries = [
+        MessageEntry(
+            id="assistant-thinking",
+            message=AssistantMessage(
+                content=[
+                    ThinkingContent(
+                        thinking="Inspect the trace, then choose the smallest safe change."
+                    ),
+                    TextContent(text="I found the relevant path."),
+                ]
+            ),
+        )
+    ]
+
+    html = render_session_html(entries, title="Thinking Export")
+
+    assert "<span>Thinking</span>" in html
+    assert "Inspect the trace, then choose the smallest safe change." in html
 
 
 def test_render_session_html_includes_escaped_readable_system_prompt() -> None:
@@ -180,6 +202,65 @@ def test_render_session_html_includes_filter_bar_and_accordions() -> None:
     assert '<span class="node-type">read</span>' in html
     # The tool icon is a claw hammer.
     assert "m15 12-8.373" in html
+
+
+def test_render_session_html_includes_compact_session_summary() -> None:
+    entries = [
+        MessageEntry(id="user", timestamp=100.0, message=UserMessage(content="Hello")),
+        MessageEntry(
+            id="assistant",
+            parent_id="user",
+            timestamp=101.0,
+            message=AssistantMessage(
+                content=assistant_content(
+                    "Reading a file",
+                    [ToolCall(id="call-1", name="read", arguments={"path": "README.md"})],
+                )
+            ),
+        ),
+        MessageEntry(
+            id="tool",
+            parent_id="assistant",
+            timestamp=102.0,
+            message=ToolResultMessage(
+                tool_call_id="call-1",
+                tool_name="read",
+                content=[TextContent(text="File contents")],
+            ),
+        ),
+        ModelChangeEntry(id="model", parent_id="tool", timestamp=103.0, model="example/model"),
+    ]
+
+    html = render_session_html(entries, title="Summary Export")
+
+    assert '<section class="session-summary" aria-label="Session summary">' in html
+    assert "<strong>4</strong><span>Entries</span>" in html
+    assert "<strong>2</strong><span>Messages</span>" in html
+    assert "<strong>1</strong><span>Tools</span>" in html
+    assert "<strong>1</strong><span>Events</span>" in html
+    assert "<strong>3s</strong><span>Duration</span>" in html
+
+
+def test_render_session_html_includes_timestamp_timeline() -> None:
+    entries = [
+        MessageEntry(id="user", timestamp=100.0, message=UserMessage(content="Hello")),
+        MessageEntry(
+            id="assistant",
+            parent_id="user",
+            timestamp=110.0,
+            message=AssistantMessage(content="Done"),
+        ),
+        ModelChangeEntry(id="model", parent_id="assistant", timestamp=120.0, model="fake"),
+    ]
+
+    html = render_session_html(entries)
+
+    assert '<section class="timeline-overview" aria-label="Session timeline">' in html
+    assert "Timeline" in html
+    assert 'data-timeline-kind="message"' in html
+    assert 'data-timeline-kind="event"' in html
+    assert 'style="left: 0.00%"' in html
+    assert 'style="left: 100.00%"' in html
 
 
 def test_render_session_html_marks_tool_only_assistant_messages_as_tools() -> None:

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -123,6 +123,7 @@ def test_render_usage_dashboard_renders_charts_and_table() -> None:
     assert markup.count('class="usage-chart"') == 3
     assert markup.count('class="png-button"') == 3
     assert "Prompt input by request" in markup
+    assert "snapshot of the session at export time" in markup
     assert "Cache hit rate" in markup
     assert "claude-sonnet-4-5" in markup
 

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -115,9 +115,9 @@ This status is display-only: it is not saved to session history or sent to the
 model as context.
 
 HTML exports are self-contained and include two tabs: **Transcript** preserves
-the session tree and entries in storage order, while **Cache** summarizes the
+the session tree and entries in storage order, while **Usage** summarizes the
 active branch's model requests, prompt caching, output and reasoning tokens,
-estimated API-rate cost, tool calls, and compactions. Cache charts are
+estimated API-rate cost, tool calls, and compactions. Usage charts are
 interactive—hover for exact values and select a legend item to hide a
 series—and can be downloaded as static PNG images with white backgrounds. The
 export follows Tau's themes: tau-light in light mode and tau-dark in dark mode,
@@ -133,7 +133,10 @@ The system prompt is display-only export metadata, not a transcript entry.
 Direct JSONL exports and JSONL downloaded from the HTML remain entry-only and do
 not contain it.
 
-Every transcript entry is a compact accordion row
+The export header starts with a compact summary of total entries, messages,
+tools, session events, and elapsed duration. A timestamp timeline below the
+summary groups message, tool, and event markers into separate lanes; selecting
+a marker jumps to that entry. Every transcript entry is a compact accordion row
 (icon, title, one-line preview, timestamp) that expands to reveal the full
 content; thinking blocks, tool-call arguments, and tool-result details are
 nested accordions. The export header includes controls to:


### PR DESCRIPTION
## Motivation

Make session HTML exports easier to scan and compare during long coding sessions.

## Changes

- Add compact session summary cards for entries, messages, tools, events, and duration.
- Add a clickable timestamp timeline with message, tool, and event lanes.
- Preserve and test rendered ThinkingContent blocks.
- Clarify that Usage charts and cost estimates are export-time snapshots.
- Update the sessions guide and Phase 20.4 architecture notes.

## Validation

- `py -3.13 -m pytest tests/test_session_export.py tests/test_session_usage.py -q` — 26 passed
- `py -3.13 -m ruff check .`
- `py -3.13 -m ruff format --check .`
- `git diff --check`

The generated HTML previews were used for manual inspection and are intentionally not included in the commit. Hugo was unavailable locally, so the docs site build should be verified by CI.