### PR TITLE
TUI: accept completions with Tab only; Enter always submits

### DIFF
--- a/dev-notes/architecture/phase-17-tui-autocomplete.md
+++ b/dev-notes/architecture/phase-17-tui-autocomplete.md
@@ -60,7 +60,8 @@ Accepting a skill completion preserves the rest of the request:
 
 The prompt input handles:
 
-- `Tab` to accept the selected completion
+- `Tab` to accept the selected completion (Enter always submits the prompt as
+  typed, without applying a highlighted completion)
 - `Down` to select the next completion
 - `Up` to select the previous completion
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4156,16 +4156,11 @@ class TauTuiApp(App[None]):
         *,
         streaming_behavior: Literal["steer", "follow_up"],
     ) -> None:
+        # Enter always submits the prompt text as typed; accepting the
+        # selected completion is reserved for the accept-completion key
+        # (Tab by default).
         prompt = self.query_one("#prompt", PromptInput)
         raw_text = prompt.text_for_submission()
-        applied_completion = self._apply_selected_completion(raw_text)
-        if applied_completion is not None and applied_completion != raw_text:
-            prompt.text = applied_completion
-            prompt._clear_pending_paste()
-            prompt.move_cursor(_text_end_location(applied_completion))
-            self._completion_state = self._build_completion_state(applied_completion)
-            self._refresh_completions()
-            return
 
         text = raw_text.strip()
         if not text:
@@ -7284,7 +7279,7 @@ def _prompt_bindings(
                 keybindings.accept_completion,
                 "accept_completion",
                 "Complete",
-                key_display=f"{_key_hint(keybindings.accept_completion)}/Enter",
+                key_display=_key_hint(keybindings.accept_completion),
                 priority=True,
             ),
             Binding(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3114,7 +3114,7 @@ async def test_tui_app_footer_hints_update_for_completions() -> None:
 
         assert _visible_footer_bindings(app) == {
             "Choose": "Up/Down",
-            "Complete": "Tab/Enter",
+            "Complete": "Tab",
             "Close": "escape",
         }
 
@@ -5621,7 +5621,7 @@ async def test_tui_app_completes_registered_slash_command() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_enter_accepts_completion_without_submitting() -> None:
+async def test_tui_app_enter_submits_without_accepting_completion() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5631,13 +5631,14 @@ async def test_tui_app_enter_accepts_completion_without_submitting() -> None:
         app._refresh_completions()
 
         await pilot.press("enter")
+        await pilot.pause()
 
-        assert prompt.value == "/session"
-        assert app.state.items == []
+        assert prompt.value == ""
+        assert app.session.prompt_texts == ["/se"]
 
 
 @pytest.mark.anyio
-async def test_tui_app_enter_accepts_arrow_selected_completion() -> None:
+async def test_tui_app_enter_ignores_arrow_selected_completion() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5650,9 +5651,10 @@ async def test_tui_app_enter_accepts_arrow_selected_completion() -> None:
         assert selected is not None
 
         await pilot.press("enter")
+        await pilot.pause()
 
-        assert prompt.value == selected.replacement
-        assert app.state.items == []
+        assert prompt.value == ""
+        assert app.session.prompt_texts == ["/s"]
 
 
 @pytest.mark.anyio

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -11,7 +11,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 
 | Key | Action |
 | --- | --- |
-| `Enter` | Submit the prompt (or apply a highlighted completion) |
+| `Enter` | Submit the prompt |
 | `Shift+Enter` | Insert a newline |
 | `Esc` | Cancel the active run |
 | `Enter` (while running) | Queue text as steering for the current run |


### PR DESCRIPTION
## Description

In the TUI, pressing `Enter` while the autocomplete strip (file references, shell paths, slash commands) was open applied the highlighted completion instead of sending the message, requiring a second `Enter` to actually submit.

This PR makes `Enter` always submit the prompt text as typed. Accepting the selected completion is now reserved for the accept-completion key (`Tab` by default, remappable via `tui.json`).

Changes:

- `_submit_prompt_from_editor` no longer applies the selected completion before submitting; `Enter` submits directly.
- The completion-mode footer hint for "Complete" is now just the accept key (e.g. `Tab`) instead of `Tab/Enter`.
- Updated tests and docs (`website/content/reference/keybindings.md`, autocomplete dev-note).

## UX improvement

- `Enter` always does what users expect: send the message.
- No accidental half-submissions when typing a path or command with a completion popup open.
- `Tab` keeps its standard shell-like "accept suggestion" role; arrow keys still change selection.

## Manual validation

1. Run `uv run tau tui` in any repo.
2. Type `inspect @REA` — a file-reference completion appears; press `Enter`: the message `inspect @REA` is submitted as typed (prompt clears).
3. Type `inspect @REA` again and press `Tab`: the completion applies (`@README.md`) without submitting; press `Enter` to send.
4. Type `/se` and press `Enter`: `/se` is submitted as typed; with `/se`, `Tab` expands it to `/session`.
5. Confirm the footer hint shows `Complete Tab` (not `Tab/Enter`) when completions are visible.
