### PR TITLE
Explain OpenAI Codex TLS transport failures

### DIFF
--- a/dev-notes/codex-tls-transport-guidance.md
+++ b/dev-notes/codex-tls-transport-guidance.md
@@ -1,0 +1,22 @@
+# Codex TLS transport guidance
+
+## What changed
+
+OpenAI Codex TLS failures now show actionable provider-connection guidance instead of only an opaque OpenSSL message. The message explains that the failure can come from the upstream provider or a proxy/VPN, and suggests retrying, checking provider usage, and checking network settings.
+
+## Why it exists
+
+A Codex stream ended with `SSLV3_ALERT_BAD_RECORD_MAC`; the next request reported exhausted usage. A malformed TLS close cannot prove a quota failure, and it can also originate in an intermediary, so Tau must not misclassify it as an authentication or usage error. The previous raw OpenSSL text did not explain those possibilities.
+
+## Architecture
+
+The classification stays in `tau_ai.openai_codex`, alongside Codex transport retries. Recognized TLS exception chains and common TLS markers receive the friendly terminal message. Other HTTP transport errors retain their original message. The original TLS exception type and message remain in provider diagnostics, and `tau_coding.diagnostics` copies only their bounded scalar fields to `~/.tau/logs/agent-calls.jsonl`.
+
+## How to test
+
+```bash
+uv run pytest tests/test_tau_ai.py -k 'openai_codex_provider_explains_tls or openai_codex_provider_preserves_non_tls'
+uv run pytest tests/test_coding_session.py -k provider_transport_error
+```
+
+Manual validation requires a Codex TLS failure: the TUI should identify a TLS transport error, mention the provider/proxy/VPN possibilities, and retain the raw OpenSSL failure in `agent-calls.jsonl`.

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from json import JSONDecodeError, dumps, loads
 from platform import machine, release, system
+from ssl import SSLError
 from typing import Any
 
 import httpx
@@ -63,6 +64,7 @@ _TLS_ERROR_MARKERS = (
     "ssl error",
     "sslerror",
     "tls alert",
+    "tls handshake",
     "bad record mac",
 )
 
@@ -352,7 +354,9 @@ def _transport_error_message(exc: httpx.HTTPError) -> str:
     current: BaseException | None = exc
     while current is not None:
         normalized = str(current).lower()
-        if any(marker in normalized for marker in _TLS_ERROR_MARKERS):
+        if isinstance(current, SSLError) or any(
+            marker in normalized for marker in _TLS_ERROR_MARKERS
+        ):
             return _TLS_TRANSPORT_ERROR_MESSAGE
         current = current.__cause__ or current.__context__
     return str(exc)

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -53,6 +53,19 @@ from tau_ai.stream import canonicalize_provider_stream
 
 DEFAULT_OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api"
 
+_TLS_TRANSPORT_ERROR_MESSAGE = (
+    "Provider connection failed: TLS transport error. This may be caused by the upstream "
+    "provider or an intermediary such as a proxy or VPN. Retry the request; if it persists, "
+    "check provider usage and network settings."
+)
+_TLS_ERROR_MARKERS = (
+    "[ssl:",
+    "ssl error",
+    "sslerror",
+    "tls alert",
+    "bad record mac",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class OpenAICodexCredentials:
@@ -301,8 +314,14 @@ class OpenAICodexProvider:
                             return
                         continue
                     yield ProviderErrorEvent(
-                        message=str(exc),
-                        data={"attempts": attempt + 1},
+                        message=_transport_error_message(exc),
+                        data={
+                            "attempts": attempt + 1,
+                            "transport_error": {
+                                "type": type(exc).__name__,
+                                "message": str(exc),
+                            },
+                        },
                     )
                     return
                 except Exception as exc:  # noqa: BLE001 - provider errors are surfaced as events
@@ -326,6 +345,17 @@ class OpenAICodexProvider:
         if attempt >= self._config.max_retries:
             return False
         return status_code is None or _is_retryable_status(status_code, body)
+
+
+def _transport_error_message(exc: httpx.HTTPError) -> str:
+    """Add actionable context to opaque TLS failures while preserving other errors."""
+    current: BaseException | None = exc
+    while current is not None:
+        normalized = str(current).lower()
+        if any(marker in normalized for marker in _TLS_ERROR_MARKERS):
+            return _TLS_TRANSPORT_ERROR_MESSAGE
+        current = current.__cause__ or current.__context__
+    return str(exc)
 
 
 class _ToolCallBuilder:

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -87,6 +87,15 @@ A configured or extension-selected provider is fixed and never silently
 overridden. The external Hugging Face extension controls these modes with
 `/hf route`; core owns safe continuation, persistence, and reroute diagnostics.
 
+## Provider connection troubleshooting
+
+For recognized OpenAI Codex TLS failures, Tau explains that the connection may
+have failed at the upstream provider or an intermediary such as a proxy or VPN.
+Retry first. If the failure persists, check provider usage and network settings.
+Tau does not label a TLS failure as exhausted usage because the transport error
+cannot establish that cause; the raw exception remains in
+`~/.tau/logs/agent-calls.jsonl`.
+
 ## Changing the built-in catalog
 
 Tau follows Pi's build-time model-generation design. Provider transports,

--- a/src/tau_coding/diagnostics.py
+++ b/src/tau_coding/diagnostics.py
@@ -125,6 +125,9 @@ def _provider_error_details(message: AssistantMessage) -> dict[str, Any]:
         attempts = diagnostic.details.get("attempts")
         if isinstance(attempts, int) and not isinstance(attempts, bool):
             details["attempts"] = attempts
+        transport_error = _safe_transport_error(diagnostic.details.get("transport_error"))
+        if transport_error:
+            details["transport_error"] = transport_error
         event = diagnostic.details.get("event")
         if isinstance(event, dict):
             event_details = _safe_stream_event_details(event)
@@ -132,6 +135,17 @@ def _provider_error_details(message: AssistantMessage) -> dict[str, Any]:
                 details["event"] = event_details
         return details
     return {}
+
+
+def _safe_transport_error(value: object) -> dict[str, str]:
+    """Copy the bounded type and message from a provider transport failure."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: field[:2_000]
+        for key in ("type", "message")
+        if isinstance((field := value.get(key)), str) and field
+    }
 
 
 def _safe_stream_event_details(event: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -497,6 +497,53 @@ async def test_prompt_logs_safe_provider_stream_error_details(tmp_path: Path) ->
     assert "Hello" not in log_path.read_text(encoding="utf-8")
 
 
+@pytest.mark.anyio
+async def test_prompt_logs_safe_provider_transport_error_details(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    tau_paths = TauPaths(home=tmp_path / "tau-home", agents_home=tmp_path / "agents-home")
+    error = AssistantMessage(
+        stop_reason="error",
+        error_message="Provider connection failed: TLS transport error.",
+        diagnostics=[
+            AssistantMessageDiagnostic(
+                type="provider_error",
+                details={
+                    "attempts": 2,
+                    "transport_error": {
+                        "type": "ReadError",
+                        "message": "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] bad record mac",
+                        "ignored": "not copied",
+                    },
+                },
+            )
+        ],
+    )
+    provider = FakeProvider([[AssistantErrorEvent(reason="error", error=error)]])
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="fake",
+            system="You are Tau.",
+            storage=storage,
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            session_id="session-1",
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    await _collect_session_events(session.prompt("Hello"))
+
+    entry = json.loads(tau_paths.agent_calls_log_path.read_text().splitlines()[-1])
+    assert entry["error"]["provider"] == {
+        "attempts": 2,
+        "transport_error": {
+            "type": "ReadError",
+            "message": "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] bad record mac",
+        },
+    }
+
+
 class _CountingStorage:
     def __init__(self) -> None:
         self.entries: list[SessionEntry] = []

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1,3 +1,4 @@
+import ssl
 from collections.abc import AsyncIterator, Mapping
 from json import loads
 
@@ -1291,6 +1292,81 @@ async def test_openai_compatible_provider_includes_plain_http_error_body_in_mess
         "body": "bad request details",
         "attempts": 1,
     }
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_explains_tls_transport_error() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    raw_error = "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac (_ssl.c:2713)"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError(raw_error, request=request) from ssl.SSLError(1, raw_error)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=0,
+            ),
+            client=client,
+        )
+
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == (
+        "Provider connection failed: TLS transport error. This may be caused by the upstream "
+        "provider or an intermediary such as a proxy or VPN. Retry the request; if it persists, "
+        "check provider usage and network settings."
+    )
+    assert events[-1].error.diagnostics[0].details == {
+        "attempts": 1,
+        "transport_error": {
+            "type": "ReadError",
+            "message": "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac "
+            "(_ssl.c:2713)",
+        },
+    }
+
+
+@pytest.mark.anyio
+async def test_openai_codex_provider_preserves_non_tls_transport_error_message() -> None:
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError("stream dropped", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                max_retries=0,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="gpt-5.5",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say hello")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantErrorEvent)
+    assert events[-1].error.error_message == "stream dropped"
 
 
 @pytest.mark.anyio

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1295,14 +1295,29 @@ async def test_openai_compatible_provider_includes_plain_http_error_body_in_mess
 
 
 @pytest.mark.anyio
-async def test_openai_codex_provider_explains_tls_transport_error() -> None:
+@pytest.mark.parametrize(
+    ("raw_error", "cause"),
+    [
+        (
+            "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac (_ssl.c:2713)",
+            ssl.SSLError(1, "bad record mac"),
+        ),
+        ("connection failed", ssl.SSLError("handshake failed")),
+        ("TLS handshake failed", None),
+    ],
+)
+async def test_openai_codex_provider_explains_tls_transport_error(
+    raw_error: str,
+    cause: BaseException | None,
+) -> None:
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
 
-    raw_error = "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac (_ssl.c:2713)"
-
     def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ReadError(raw_error, request=request) from ssl.SSLError(1, raw_error)
+        error = httpx.ReadError(raw_error, request=request)
+        if cause is None:
+            raise error
+        raise error from cause
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICodexProvider(
@@ -1333,8 +1348,7 @@ async def test_openai_codex_provider_explains_tls_transport_error() -> None:
         "attempts": 1,
         "transport_error": {
             "type": "ReadError",
-            "message": "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac "
-            "(_ssl.c:2713)",
+            "message": raw_error,
         },
     }
 

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -280,6 +280,17 @@ Copilot Chat's model selector or ask your organization administrator;
 provider/model access varies by plan and policy.
 {{% /note %}}
 
+### Provider connection troubleshooting
+
+When OpenAI Codex encounters a recognized TLS failure, Tau identifies it as a
+provider connection error instead of showing only the opaque OpenSSL text. The
+failure may come from the upstream provider or an intermediary such as a proxy
+or VPN. Retry first; if it persists, check provider usage and network settings.
+
+A TLS failure cannot prove that usage is exhausted, even when the next request
+returns a quota error, so Tau does not guess that cause. The original exception
+type and message remain available in `~/.tau/logs/agent-calls.jsonl`.
+
 ## Choosing and switching models
 
 - **`/model`** — open the picker (lists models across configured providers;


### PR DESCRIPTION
## Description

- replace opaque OpenAI Codex TLS/OpenSSL failures with actionable provider-connection guidance
- explain that failures may originate at the upstream provider or a proxy/VPN without incorrectly claiming exhausted usage
- retain bounded raw transport details in `~/.tau/logs/agent-calls.jsonl`
- document troubleshooting behavior and add provider/diagnostic coverage

## User experience

Users now get a clear explanation and concrete next steps—retry, check provider usage, and inspect network settings—instead of only seeing errors such as `SSLV3_ALERT_BAD_RECORD_MAC`. Non-TLS transport errors keep their existing messages.

## Issue

No linked issue; addresses a Discord-reported OpenAI Codex TLS failure.

## Manual validation

1. Configure and select the `openai-codex` provider.
2. Trigger or simulate a TLS transport failure while streaming.
3. Confirm Tau says the provider connection failed and mentions upstream provider/proxy/VPN possibilities.
4. Confirm `~/.tau/logs/agent-calls.jsonl` retains the original transport exception type and message.
5. Confirm ordinary non-TLS transport errors retain their original message.

## Validation

- `uv run pytest` (1857 passed, 2 platform-specific skips)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` from `website/`

