### PR TITLE
Bound inline image request payloads

### DIFF
--- a/dev-notes/architecture/multimodal-read-results.md
+++ b/dev-notes/architecture/multimodal-read-results.md
@@ -33,11 +33,13 @@ prevents duplicate session storage and lets all frontends continue rendering the
 small text note without exposing base64 data.
 
 Tool images now share a 4 MB base64 budget between successful assistant
-responses. If a new attachment would exceed it, `read` returns an actionable
-text-only result asking the agent to resize or compress the file. Once an
-assistant successfully consumes pending images, future provider-context replays
-replace those image bytes with a short marker. Durable session history retains
-the original image blocks. Together these bounds prevent multiple individually
+responses. If a new attachment would exceed the remaining space, `read` first
+resizes and re-encodes it to fit. The model receives a transformation note. Only
+when safe automatic compression cannot fit the image does `read` return an
+actionable text-only result asking the agent to resize or compress the file. Once
+an assistant successfully consumes pending images, future provider-context
+replays replace those image bytes with a short marker. Durable session history
+retains the original image blocks. Together these bounds prevent multiple individually
 valid images from growing an OpenAI-compatible request until a backend rejects it
 with HTTP 413.
 

--- a/dev-notes/architecture/multimodal-read-results.md
+++ b/dev-notes/architecture/multimodal-read-results.md
@@ -32,6 +32,15 @@ The image base64 payload moved from tool-result `details` into `content`. This
 prevents duplicate session storage and lets all frontends continue rendering the
 small text note without exposing base64 data.
 
+Tool images now share a 4 MB base64 budget between successful assistant
+responses. If a new attachment would exceed it, `read` returns an actionable
+text-only result asking the agent to resize or compress the file. Once an
+assistant successfully consumes pending images, future provider-context replays
+replace those image bytes with a short marker. Durable session history retains
+the original image blocks. Together these bounds prevent multiple individually
+valid images from growing an OpenAI-compatible request until a backend rejects it
+with HTTP 413.
+
 ## Validation
 
 ```bash

--- a/dev-notes/architecture/read-image-processing.md
+++ b/dev-notes/architecture/read-image-processing.md
@@ -13,7 +13,8 @@ Processing has explicit ceilings:
 - source encoding: 50 MB
 - source dimensions: 40 million pixels
 - output dimensions: 2,000 by 2,000 maximum
-- output encoding: 5 MB
+- output encoding: 5 MB per processed image
+- cumulative base64 attachments: 4 MB between successful model responses
 - image header sniff: 64 KB before loading oversized local files
 - resize/encode attempts: 12
 
@@ -66,7 +67,12 @@ because tool-result image placement differs across APIs.
    to Pi's terminal-image protocol renderer, so the TUI continues to show the
    textual status. A custom widget or third-party integration can be evaluated
    separately without changing the tool-result contract.
-7. Keep live credential checks outside CI. `TODO.md` retains the provider/model
+7. Bound cumulative request payloads separately from per-image processing. If a
+   processed image would exceed the current turn's 4 MB base64 budget, return a
+   text-only tool result that tells the agent to resize or compress the file.
+   Images already consumed by a successful assistant response remain durable but
+   are omitted from later provider replays.
+8. Keep live credential checks outside CI. `TODO.md` retains the provider/model
    validation matrix follow-up.
 
 ## How to test

--- a/dev-notes/architecture/read-image-processing.md
+++ b/dev-notes/architecture/read-image-processing.md
@@ -68,10 +68,12 @@ because tool-result image placement differs across APIs.
    textual status. A custom widget or third-party integration can be evaluated
    separately without changing the tool-result contract.
 7. Bound cumulative request payloads separately from per-image processing. If a
-   processed image would exceed the current turn's 4 MB base64 budget, return a
-   text-only tool result that tells the agent to resize or compress the file.
-   Images already consumed by a successful assistant response remain durable but
-   are omitted from later provider replays.
+   processed image would exceed the remaining portion of the current turn's 4 MB
+   base64 budget, dynamically lower the processing byte target and resize or
+   re-encode the image to fit. Report that transformation to the model. Return a
+   text-only resize/compress instruction only when automatic processing cannot
+   fit safely. Images already consumed by a successful assistant response remain
+   durable but are omitted from later provider replays.
 8. Keep live credential checks outside CI. `TODO.md` retains the provider/model
    validation matrix follow-up.
 

--- a/dev-notes/hugging-face-automatic-route-failover.md
+++ b/dev-notes/hugging-face-automatic-route-failover.md
@@ -12,7 +12,9 @@ Tau now distinguishes two session-scoped Hugging Face routing modes:
 When a sticky automatic route exhausts its provider-level retries with HTTP 408,
 409, 425, 429, or 5xx before emitting content, the coding session clears the
 resolved suffix and continues the same agent run once through Hugging Face's
-unsuffixed automatic router. A successful response supplies the replacement
+unsuffixed automatic router. The same recovery applies to HTTP 413: although a
+payload rejection is not transient on one backend, another Hugging Face route
+may accept that model request. A successful response supplies the replacement
 route header, which becomes the new automatic session pin.
 
 ## Why core owns recovery
@@ -40,7 +42,7 @@ Failover happens only when all conditions hold:
 1. the logical Tau provider is `huggingface`;
 2. the session mode is `automatic`;
 3. a resolved route is currently pinned;
-4. provider diagnostics contain a retryable HTTP status; and
+4. provider diagnostics contain a retryable HTTP status or HTTP 413; and
 5. the failed assistant message has no text, thinking, or tool-call content.
 
 Only one automatic reroute is attempted per prompt. The fallback itself is not
@@ -76,7 +78,9 @@ renderers treat a successful retry as a successful command. The TUI removes the
 intermediate terminal error when retry progress begins.
 
 Failover may lose provider-local prefix cache state and require a cold prefill.
-It also cannot bypass account-wide or router-wide rate limits.
+It also cannot bypass account-wide or router-wide rate limits. A 413 from the
+unsuffixed fallback remains terminal after this single attempt, preventing retry
+loops.
 
 ## Validation
 

--- a/src/tau_agent/loop.py
+++ b/src/tau_agent/loop.py
@@ -22,6 +22,7 @@ from tau_agent.events import (
 from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
+    ImageContent,
     ResponseTiming,
     TextContent,
     ToolCall,
@@ -183,11 +184,15 @@ async def run_agent_loop(
 
 
 def _provider_context(messages: list[AgentMessage]) -> list[AgentMessage]:
-    """Return replayable messages while retaining failures in durable history.
+    """Return replayable messages while retaining full durable history.
 
     Providers cannot consistently accept an assistant turn with no content. Tau
     persists terminal failures for diagnostics, but an empty failed or aborted
     turn is not model context and must not poison the next request.
+
+    Inline tool images are needed until the model produces its next successful
+    response. Older image bytes have already been consumed and are replaced with
+    a text marker so long sessions do not resend an ever-growing base64 payload.
     """
     replayable = tuple(
         message
@@ -198,7 +203,34 @@ def _provider_context(messages: list[AgentMessage]) -> list[AgentMessage]:
             and not message.content
         )
     )
-    return list(repair_tool_history(replayable).messages)
+    latest_successful_assistant = max(
+        (
+            index
+            for index, message in enumerate(replayable)
+            if isinstance(message, AssistantMessage)
+            and message.stop_reason not in {"error", "aborted"}
+        ),
+        default=-1,
+    )
+    compacted_images = tuple(
+        _omit_consumed_tool_images(message) if index < latest_successful_assistant else message
+        for index, message in enumerate(replayable)
+    )
+    return list(repair_tool_history(compacted_images).messages)
+
+
+def _omit_consumed_tool_images(message: AgentMessage) -> AgentMessage:
+    if not isinstance(message, ToolResultMessage) or not any(
+        isinstance(block, ImageContent) for block in message.content
+    ):
+        return message
+    content = [
+        block.model_copy(deep=True)
+        for block in message.content
+        if not isinstance(block, ImageContent)
+    ]
+    content.append(TextContent(text="[image omitted from replay after the model processed it]"))
+    return message.model_copy(update={"content": content})
 
 
 async def _assistant_events(

--- a/src/tau_coding/__init__.py
+++ b/src/tau_coding/__init__.py
@@ -157,6 +157,7 @@ from tau_coding.thinking import (
     reasoning_effort_for_level,
 )
 from tau_coding.tools import (
+    ImageAttachmentBudgetState,
     ImageSupportState,
     ReadOperations,
     ToolDefinition,
@@ -191,6 +192,7 @@ __all__ = [
     "EventRenderer",
     "FinalTextRenderer",
     "JsonEventRenderer",
+    "ImageAttachmentBudgetState",
     "ImageSupportState",
     "ModelChoice",
     "SessionTreeBranchResult",

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -82,10 +82,11 @@ configure the built-in `llama.cpp` layer separately through `/local`.
 
 Hugging Face routing has two session modes. Automatic mode keeps the provider
 from the first successful response as a sticky route, but retries once through
-unsuffixed routing after that route exhausts retryable pre-output HTTP failures.
-A configured or extension-selected provider is fixed and never silently
-overridden. The external Hugging Face extension controls these modes with
-`/hf route`; core owns safe continuation, persistence, and reroute diagnostics.
+unsuffixed routing after that route exhausts retryable pre-output HTTP failures
+or rejects the request payload with HTTP 413. A configured or extension-selected
+provider is fixed and never silently overridden. The external Hugging Face
+extension controls these modes with `/hf route`; core owns safe continuation,
+persistence, and reroute diagnostics.
 
 ## Changing the built-in catalog
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -16,6 +16,8 @@ from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
     CustomMessage,
+    ImageContent,
+    ToolResultMessage,
     UserMessage,
     message_text,
 )
@@ -152,7 +154,12 @@ from tau_coding.thinking import (
     next_thinking_level,
     normalize_thinking_level,
 )
-from tau_coding.tools import ImageSupportState, create_bash_tool, create_coding_tools
+from tau_coding.tools import (
+    ImageAttachmentBudgetState,
+    ImageSupportState,
+    create_bash_tool,
+    create_coding_tools,
+)
 
 StreamingBehavior = Literal["steer", "follow_up"]
 SESSION_NAME_SYSTEM_PROMPT = (
@@ -399,6 +406,7 @@ class CodingSession:
         pending_initial_entries: tuple[SessionEntry, ...] = (),
         extension_runtime: ExtensionRuntime | None = None,
         image_support: ImageSupportState | None = None,
+        image_attachment_budget: ImageAttachmentBudgetState | None = None,
         project_trust_resolution: ProjectTrustResolution | None = None,
     ) -> None:
         self._config = config
@@ -407,6 +415,7 @@ class CodingSession:
         self._extension_runtime = extension_runtime or ExtensionRuntime()
         self._provider_registry = self._extension_runtime.provider_registry
         self._image_support = image_support or ImageSupportState()
+        self._image_attachment_budget = image_attachment_budget or ImageAttachmentBudgetState()
         self._session_start_pending = False
         self._last_parent_id = last_parent_id
         self._pending_initial_entries = pending_initial_entries
@@ -606,6 +615,9 @@ class CodingSession:
         image_support = ImageSupportState(
             supported=_configured_model_supports_images(config, active_model)
         )
+        image_attachment_budget = ImageAttachmentBudgetState(
+            used_encoded_bytes=_pending_tool_image_encoded_bytes(state.messages)
+        )
         base_tools = (
             config.tools
             if config.tools is not None
@@ -613,6 +625,7 @@ class CodingSession:
                 cwd=config.cwd,
                 shell_command_prefix=config.shell_command_prefix,
                 image_support=image_support,
+                image_attachment_budget=image_attachment_budget,
             )
         )
         tools = extension_runtime.compose_tools(base_tools)
@@ -668,6 +681,7 @@ class CodingSession:
             pending_initial_entries=pending_initial_entries,
             extension_runtime=extension_runtime,
             image_support=image_support,
+            image_attachment_budget=image_attachment_budget,
             project_trust_resolution=trust_resolution,
         )
         if config.owns_initial_provider:
@@ -2152,6 +2166,7 @@ class CodingSession:
                 cwd=self._config.cwd,
                 shell_command_prefix=self._config.shell_command_prefix,
                 image_support=self._image_support,
+                image_attachment_budget=self._image_attachment_budget,
             )
         )
         staged_tools = staged_runtime.compose_tools(base_tools)
@@ -2604,6 +2619,7 @@ class CodingSession:
         self._owned_providers.extend(replacement._owned_providers)
         replacement._owned_providers.clear()
         self._image_support = replacement._image_support
+        self._image_attachment_budget = replacement._image_attachment_budget
         self._project_trust_resolution = replacement._project_trust_resolution
         self._project_trust_commit_pending = False
         self._session_start_pending = False
@@ -3259,6 +3275,9 @@ class CodingSession:
     async def _refresh_persisted_state(self, *, leaf_id: str | None) -> None:
         entries = await self._read_session_entries()
         self._state = SessionState.from_entries(entries, leaf_id=leaf_id)
+        self._image_attachment_budget.reset(
+            used_encoded_bytes=_pending_tool_image_encoded_bytes(self._state.messages)
+        )
         if self._config.session_id is not None and self._config.session_manager is not None:
             self._config.session_manager.touch_session(
                 self._config.session_id,
@@ -3667,6 +3686,26 @@ def _next_user_message_index(
     return None
 
 
+def _pending_tool_image_encoded_bytes(messages: Sequence[AgentMessage]) -> int:
+    """Count tool images produced since the latest successful assistant response."""
+    latest_successful_assistant = max(
+        (
+            index
+            for index, message in enumerate(messages)
+            if isinstance(message, AssistantMessage)
+            and message.stop_reason not in {"error", "aborted"}
+        ),
+        default=-1,
+    )
+    return sum(
+        len(block.data)
+        for message in messages[latest_successful_assistant + 1 :]
+        if isinstance(message, ToolResultMessage)
+        for block in message.content
+        if isinstance(block, ImageContent)
+    )
+
+
 def is_context_overflow_error(message: AssistantMessage) -> bool:
     """Return True when an assistant error looks like a context overflow."""
     text = message.error_message or ""
@@ -3697,7 +3736,10 @@ def is_retryable_huggingface_route_error(message: AssistantMessage) -> bool:
             continue
         status_code = diagnostic.details.get("status_code")
         if isinstance(status_code, int) and not isinstance(status_code, bool):
-            return status_code in {408, 409, 425, 429} or status_code >= 500
+            # A 413 is not transient on the pinned backend, but another Hugging
+            # Face route may accept the same payload. Automatic mode can safely
+            # ask the router to choose again before any output was emitted.
+            return status_code in {408, 409, 413, 425, 429} or status_code >= 500
     return False
 
 

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -40,6 +40,7 @@ from tau_coding.image_processing import (
 
 DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024
 DEFAULT_MAX_OUTPUT_LINES = 2_000
+DEFAULT_MAX_TURN_IMAGE_ENCODED_BYTES = 4 * 1024 * 1024
 IMAGE_SNIFF_BYTES = 64 * 1024
 UTF8_BOM = "\ufeff"
 
@@ -53,6 +54,29 @@ class ImageSupportState:
     """Mutable active-model image capability shared with built-in tools."""
 
     supported: bool | None = None
+
+
+@dataclass(slots=True)
+class ImageAttachmentBudgetState:
+    """Mutable base64 payload budget for images attached during one model turn."""
+
+    max_encoded_bytes: int = DEFAULT_MAX_TURN_IMAGE_ENCODED_BYTES
+    used_encoded_bytes: int = 0
+
+    def reserve(self, encoded_bytes: int) -> bool:
+        """Reserve encoded payload bytes, returning False when the turn is full."""
+        if encoded_bytes < 0:
+            raise ValueError("encoded_bytes must be non-negative")
+        if self.used_encoded_bytes + encoded_bytes > self.max_encoded_bytes:
+            return False
+        self.used_encoded_bytes += encoded_bytes
+        return True
+
+    def reset(self, *, used_encoded_bytes: int = 0) -> None:
+        """Start a new turn or synchronize the budget to restored context."""
+        if used_encoded_bytes < 0:
+            raise ValueError("used_encoded_bytes must be non-negative")
+        self.used_encoded_bytes = used_encoded_bytes
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,6 +190,7 @@ def create_coding_tools(
     cwd: str | Path | None = None,
     shell_command_prefix: str | None = None,
     image_support: ImageSupportState | None = None,
+    image_attachment_budget: ImageAttachmentBudgetState | None = None,
 ) -> list[AgentTool]:
     """Create the default coding-tool set for a local project.
 
@@ -178,7 +203,11 @@ def create_coding_tools(
     """
     root = Path.cwd() if cwd is None else Path(cwd)
     return [
-        create_read_tool(cwd=root, image_support=image_support),
+        create_read_tool(
+            cwd=root,
+            image_support=image_support,
+            image_attachment_budget=image_attachment_budget,
+        ),
         create_write_tool(cwd=root),
         create_edit_tool(cwd=root),
         create_bash_tool(cwd=root, shell_command_prefix=shell_command_prefix),
@@ -190,6 +219,7 @@ def create_read_tool_definition(
     cwd: str | Path | None = None,
     operations: ReadOperations | None = None,
     image_support: ImageSupportState | None = None,
+    image_attachment_budget: ImageAttachmentBudgetState | None = None,
 ) -> ToolDefinition:
     """Create a definition for the `read` tool.
 
@@ -285,6 +315,21 @@ def create_read_tool_definition(
                     details=image_details,
                 )
 
+            encoded = _base64_text(processed.data)
+            if image_attachment_budget is not None and not image_attachment_budget.reserve(
+                len(encoded)
+            ):
+                return _omitted_image_result(
+                    path=path,
+                    source_mime_type=source_mime_type,
+                    source_bytes=len(data),
+                    reason=(
+                        "inline image attachments for this turn would exceed the "
+                        f"{format_size(image_attachment_budget.max_encoded_bytes)} request "
+                        "budget. Resize or compress the image to a smaller file, then read "
+                        "that file. Do not retry the unchanged file"
+                    ),
+                )
             image_details.update(
                 {
                     "mime_type": processed.mime_type,
@@ -297,7 +342,7 @@ def create_read_tool_definition(
             return AgentToolResult(
                 content=[
                     TextContent(text=f"Read image file [{processed.mime_type}]{note_lines}"),
-                    ImageContent(data=_base64_text(processed.data), mime_type=processed.mime_type),
+                    ImageContent(data=encoded, mime_type=processed.mime_type),
                 ],
                 details=image_details,
             )
@@ -364,8 +409,9 @@ def create_read_tool_definition(
         description=(
             "Read the contents of a file. Supports text files and images "
             "(jpg, png, gif, webp, bmp). "
-            "Images are sent to vision-capable models as attachments. For text files, output is "
-            "truncated to "
+            "Images are sent to vision-capable models as attachments and share a 4MB encoded "
+            "request budget per turn; resize or compress an image when the returned omission "
+            "notice says that budget is exhausted. For text files, output is truncated to "
             f"{DEFAULT_MAX_OUTPUT_LINES} lines or {DEFAULT_MAX_OUTPUT_BYTES // 1024}KB "
             "(whichever is hit first). Use offset/limit for large files. When you need the "
             "full file, continue with offset until complete."
@@ -409,12 +455,14 @@ def create_read_tool(
     cwd: str | Path | None = None,
     operations: ReadOperations | None = None,
     image_support: ImageSupportState | None = None,
+    image_attachment_budget: ImageAttachmentBudgetState | None = None,
 ) -> AgentTool:
     """Create an `AgentTool` for reading UTF-8 text files and supported images."""
     return create_read_tool_definition(
         cwd=cwd,
         operations=operations,
         image_support=image_support,
+        image_attachment_budget=image_attachment_budget,
     ).to_agent_tool()
 
 

--- a/src/tau_coding/tools.py
+++ b/src/tau_coding/tools.py
@@ -30,6 +30,7 @@ from tau_agent.tools import (
 )
 from tau_agent.types import JSONValue
 from tau_coding.image_processing import (
+    DEFAULT_MAX_IMAGE_BYTES,
     DEFAULT_MAX_SOURCE_IMAGE_BYTES,
     ImageProcessingFailure,
     detect_image_family_mime_type,
@@ -63,11 +64,16 @@ class ImageAttachmentBudgetState:
     max_encoded_bytes: int = DEFAULT_MAX_TURN_IMAGE_ENCODED_BYTES
     used_encoded_bytes: int = 0
 
+    @property
+    def remaining_encoded_bytes(self) -> int:
+        """Return encoded bytes still available in the current turn."""
+        return max(0, self.max_encoded_bytes - self.used_encoded_bytes)
+
     def reserve(self, encoded_bytes: int) -> bool:
         """Reserve encoded payload bytes, returning False when the turn is full."""
         if encoded_bytes < 0:
             raise ValueError("encoded_bytes must be non-negative")
-        if self.used_encoded_bytes + encoded_bytes > self.max_encoded_bytes:
+        if encoded_bytes > self.remaining_encoded_bytes:
             return False
         self.used_encoded_bytes += encoded_bytes
         return True
@@ -296,13 +302,43 @@ def create_read_tool_definition(
                         "to a vision-capable model"
                     ),
                 )
-            processed = await asyncio.to_thread(process_image, data, source_mime_type)
+            max_processed_bytes = DEFAULT_MAX_IMAGE_BYTES
+            compacted_for_turn_budget = False
+            if image_attachment_budget is not None:
+                max_processed_bytes = min(
+                    max_processed_bytes,
+                    _max_binary_bytes_for_base64_budget(
+                        image_attachment_budget.remaining_encoded_bytes
+                    ),
+                )
+                if max_processed_bytes < 1:
+                    return _turn_image_budget_omission(
+                        path=path,
+                        source_mime_type=source_mime_type,
+                        source_bytes=len(data),
+                        budget=image_attachment_budget,
+                    )
+                compacted_for_turn_budget = len(data) > max_processed_bytes
+
+            processed = await asyncio.to_thread(
+                process_image,
+                data,
+                source_mime_type,
+                max_bytes=max_processed_bytes,
+            )
             image_details: dict[str, JSONValue] = {
                 "path": str(path),
                 "source_mime_type": source_mime_type,
                 "bytes": len(data),
             }
             if isinstance(processed, ImageProcessingFailure):
+                if compacted_for_turn_budget and image_attachment_budget is not None:
+                    return _turn_image_budget_omission(
+                        path=path,
+                        source_mime_type=source_mime_type,
+                        source_bytes=len(data),
+                        budget=image_attachment_budget,
+                    )
                 return AgentToolResult(
                     content=[
                         TextContent(
@@ -319,16 +355,11 @@ def create_read_tool_definition(
             if image_attachment_budget is not None and not image_attachment_budget.reserve(
                 len(encoded)
             ):
-                return _omitted_image_result(
+                return _turn_image_budget_omission(
                     path=path,
                     source_mime_type=source_mime_type,
                     source_bytes=len(data),
-                    reason=(
-                        "inline image attachments for this turn would exceed the "
-                        f"{format_size(image_attachment_budget.max_encoded_bytes)} request "
-                        "budget. Resize or compress the image to a smaller file, then read "
-                        "that file. Do not retry the unchanged file"
-                    ),
+                    budget=image_attachment_budget,
                 )
             image_details.update(
                 {
@@ -338,7 +369,12 @@ def create_read_tool_definition(
                     "height": processed.height,
                 }
             )
-            note_lines = "".join(f"\n[{note}]" for note in processed.notes)
+            notes = list(processed.notes)
+            if compacted_for_turn_budget:
+                notes.append(
+                    "Image automatically compressed to fit the remaining turn request budget."
+                )
+            note_lines = "".join(f"\n[{note}]" for note in notes)
             return AgentToolResult(
                 content=[
                     TextContent(text=f"Read image file [{processed.mime_type}]{note_lines}"),
@@ -410,8 +446,9 @@ def create_read_tool_definition(
             "Read the contents of a file. Supports text files and images "
             "(jpg, png, gif, webp, bmp). "
             "Images are sent to vision-capable models as attachments and share a 4MB encoded "
-            "request budget per turn; resize or compress an image when the returned omission "
-            "notice says that budget is exhausted. For text files, output is truncated to "
+            "request budget per turn. Images are automatically compressed to fit remaining "
+            "space; resize or compress the file yourself only when an omission notice says "
+            "automatic compression could not fit it. For text files, output is truncated to "
             f"{DEFAULT_MAX_OUTPUT_LINES} lines or {DEFAULT_MAX_OUTPUT_BYTES // 1024}KB "
             "(whichever is hit first). Use offset/limit for large files. When you need the "
             "full file, continue with offset until complete."
@@ -428,6 +465,32 @@ def create_read_tool_definition(
             "required": ["path"],
         },
         executor=execute,
+    )
+
+
+def _max_binary_bytes_for_base64_budget(encoded_bytes: int) -> int:
+    """Return the largest raw payload whose base64 fits in encoded_bytes."""
+    return max(0, encoded_bytes // 4 * 3)
+
+
+def _turn_image_budget_omission(
+    *,
+    path: Path,
+    source_mime_type: str,
+    source_bytes: int,
+    budget: ImageAttachmentBudgetState,
+) -> AgentToolResult:
+    return _omitted_image_result(
+        path=path,
+        source_mime_type=source_mime_type,
+        source_bytes=source_bytes,
+        reason=(
+            "inline image attachments for this turn would exceed the "
+            f"{format_size(budget.max_encoded_bytes)} request budget. Automatic "
+            "compression could not fit the image in the remaining "
+            f"{format_size(budget.remaining_encoded_bytes)}. Resize or compress the image "
+            "to a smaller file, then read that file. Do not retry the unchanged file"
+        ),
     )
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -19,6 +19,7 @@ from tau_agent import (
     AgentTool,
     AgentToolResult,
     AssistantMessage,
+    ImageContent,
     MessageEndEvent,
     MessageUpdateEvent,
     SimpleCancellationToken,
@@ -335,6 +336,44 @@ async def test_agent_loop_converts_provider_error_to_assistant_error_message() -
     assert isinstance(error, AssistantMessage)
     assert error.stop_reason == "error"
     assert error.error_message == "provider failed"
+
+
+def test_provider_context_omits_images_already_consumed_by_assistant() -> None:
+    old_call = ToolCall(id="call-old", name="read", arguments={"path": "old.png"})
+    current_call = ToolCall(id="call-current", name="read", arguments={"path": "current.png"})
+    old_result = ToolResultMessage(
+        tool_call_id=old_call.id,
+        tool_name="read",
+        content=[TextContent(text="old"), ImageContent(data="b2xk", mime_type="image/png")],
+    )
+    current_result = ToolResultMessage(
+        tool_call_id=current_call.id,
+        tool_name="read",
+        content=[TextContent(text="current"), ImageContent(data="bmV3", mime_type="image/png")],
+    )
+    messages: list[AgentMessage] = [
+        AssistantMessage(content=[old_call]),
+        old_result,
+        AssistantMessage(content=[current_call]),
+        current_result,
+    ]
+
+    context = loop_module._provider_context(messages)
+
+    replayed_old = next(
+        message
+        for message in context
+        if isinstance(message, ToolResultMessage) and message.tool_call_id == old_call.id
+    )
+    replayed_current = next(
+        message
+        for message in context
+        if isinstance(message, ToolResultMessage) and message.tool_call_id == current_call.id
+    )
+    assert not any(isinstance(block, ImageContent) for block in replayed_old.content)
+    assert "image omitted from replay after the model processed it" in replayed_old.text
+    assert any(isinstance(block, ImageContent) for block in replayed_current.content)
+    assert any(isinstance(block, ImageContent) for block in old_result.content)
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -4018,6 +4018,7 @@ async def test_huggingface_session_pins_successful_automatic_route(
     [
         (429, [], True),
         (503, [], True),
+        (413, [], True),
         (400, [], False),
         (429, [TextContent(text="partial")], False),
     ],
@@ -4042,8 +4043,11 @@ def test_huggingface_route_failover_requires_retryable_pre_output_error(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("failure_status", [413, 429])
 async def test_huggingface_automatic_pin_fails_over_and_repins(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_status: int,
 ) -> None:
     model = "moonshotai/Kimi-K3"
     created: list[tuple[str | None, FakeProvider]] = []
@@ -4059,7 +4063,7 @@ async def test_huggingface_automatic_pin_fails_over_and_repins(
     ) -> FakeProvider:
         del provider_config, credential_store, model, thinking_level
         if inference_provider == "deepinfra":
-            provider: FakeProvider = FakeProvider([[_provider_http_error(429)]])
+            provider: FakeProvider = FakeProvider([[_provider_http_error(failure_status)]])
         elif inference_provider is None:
             provider = HeaderObservingFakeProvider(
                 [

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -38,6 +38,12 @@ def animated_png_bytes() -> bytes:
     return png[:idat_offset] + animated_chunk + png[idat_offset:]
 
 
+def noisy_png_bytes(*, size: tuple[int, int] = (400, 400)) -> bytes:
+    output = BytesIO()
+    Image.effect_noise(size, 100).convert("RGB").save(output, format="PNG")
+    return output.getvalue()
+
+
 class FakeCancellationToken:
     def __init__(self) -> None:
         self.cancelled = False
@@ -171,6 +177,24 @@ async def test_read_tool_explicitly_omits_images_for_text_only_model(tmp_path: P
 
 
 @pytest.mark.anyio
+async def test_read_tool_automatically_compacts_image_to_remaining_turn_budget(
+    tmp_path: Path,
+) -> None:
+    image_data = noisy_png_bytes()
+    path = tmp_path / "large.png"
+    path.write_bytes(image_data)
+    budget = ImageAttachmentBudgetState(max_encoded_bytes=50 * 1024)
+    tool = create_read_tool(cwd=tmp_path, image_attachment_budget=budget)
+
+    result = await tool.execute("call-1", {"path": "large.png"})
+
+    image = next(block for block in result.content if isinstance(block, ImageContent))
+    assert len(image.data) <= budget.max_encoded_bytes
+    assert len(base64.b64decode(image.data)) < len(image_data)
+    assert "automatically compressed to fit the remaining turn request budget" in result.text
+
+
+@pytest.mark.anyio
 async def test_read_tool_omits_image_when_turn_attachment_budget_is_exhausted(
     tmp_path: Path,
 ) -> None:
@@ -187,6 +211,8 @@ async def test_read_tool_omits_image_when_turn_attachment_budget_is_exhausted(
 
     assert any(isinstance(block, ImageContent) for block in attached.content)
     assert "Image omitted: inline image attachments for this turn would exceed" in omitted.text
+    assert f"{encoded_size}B request budget" in omitted.text
+    assert "remaining 0B" in omitted.text
     assert "Resize or compress the image to a smaller file" in omitted.text
     assert "Do not retry the unchanged file" in omitted.text
     assert not any(isinstance(block, ImageContent) for block in omitted.content)

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -10,6 +10,7 @@ from PIL import Image
 
 from tau_agent import ImageContent
 from tau_coding import (
+    ImageAttachmentBudgetState,
     ImageSupportState,
     ReadOperations,
     create_bash_tool,
@@ -167,6 +168,45 @@ async def test_read_tool_explicitly_omits_images_for_text_only_model(tmp_path: P
     attached = await tool.execute("test-call", {"path": "galaxy.png"})
 
     assert any(isinstance(block, ImageContent) for block in attached.content)
+
+
+@pytest.mark.anyio
+async def test_read_tool_omits_image_when_turn_attachment_budget_is_exhausted(
+    tmp_path: Path,
+) -> None:
+    first_data = image_bytes(size=(20, 20))
+    second_data = image_bytes(size=(20, 20))
+    (tmp_path / "first.png").write_bytes(first_data)
+    (tmp_path / "second.png").write_bytes(second_data)
+    encoded_size = len(base64.b64encode(first_data))
+    budget = ImageAttachmentBudgetState(max_encoded_bytes=encoded_size)
+    tool = create_read_tool(cwd=tmp_path, image_attachment_budget=budget)
+
+    attached = await tool.execute("call-1", {"path": "first.png"})
+    omitted = await tool.execute("call-2", {"path": "second.png"})
+
+    assert any(isinstance(block, ImageContent) for block in attached.content)
+    assert "Image omitted: inline image attachments for this turn would exceed" in omitted.text
+    assert "Resize or compress the image to a smaller file" in omitted.text
+    assert "Do not retry the unchanged file" in omitted.text
+    assert not any(isinstance(block, ImageContent) for block in omitted.content)
+
+
+@pytest.mark.anyio
+async def test_read_tool_attachment_budget_can_be_reset_after_model_response(
+    tmp_path: Path,
+) -> None:
+    image_data = image_bytes(size=(20, 20))
+    (tmp_path / "frame.png").write_bytes(image_data)
+    budget = ImageAttachmentBudgetState(max_encoded_bytes=len(base64.b64encode(image_data)))
+    tool = create_read_tool(cwd=tmp_path, image_attachment_budget=budget)
+
+    first = await tool.execute("call-1", {"path": "frame.png"})
+    budget.reset()
+    second = await tool.execute("call-2", {"path": "frame.png"})
+
+    assert any(isinstance(block, ImageContent) for block in first.content)
+    assert any(isinstance(block, ImageContent) for block in second.content)
 
 
 @pytest.mark.anyio

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -163,10 +163,11 @@ For a new session without an explicit preference, Hugging Face initially routes
 the model automatically. After the first successful response, Tau reads Hugging
 Face's `x-inference-provider` response header and keeps that backing provider as
 a sticky automatic route. If that route later exhausts its normal retries with a
-retryable HTTP failure before producing output, Tau retries the interrupted turn
-once through unsuffixed automatic routing and makes the successful replacement
-the new sticky route. To choose a fixed provider instead, add a per-model
-`inference_providers` preference to `~/.tau/providers.json`:
+retryable HTTP failure before producing output, or rejects the request payload
+with HTTP 413, Tau retries the interrupted turn once through unsuffixed automatic
+routing and makes the successful replacement the new sticky route. To choose a
+fixed provider instead, add a per-model `inference_providers` preference to
+`~/.tau/providers.json`:
 
 ```json
 {
@@ -203,9 +204,11 @@ configured fixed route or starts automatic resolution again. `/session` reports
 `automatic (currently <provider>)` for a sticky automatic route and
 `<provider> (fixed)` for an explicit route.
 
-Transient failures first retry on the same wire model, and stream failures are
-not retried or rerouted after model output has started. After those retries are
-exhausted, only sticky routes selected in automatic mode fail over; routes chosen
+Transient failures first retry on the same wire model. An HTTP 413 from a sticky
+automatic route skips futile same-route retries and lets the Hugging Face router
+choose another backend. Stream failures are not retried or rerouted after model
+output has started. After those retries are exhausted, only sticky routes
+selected in automatic mode fail over; routes chosen
 through `/hf route <provider>` or the `inference_providers` preference remain
 fixed so Tau never overrides explicit user intent. Automatic failover emits
 visible retry progress and durable provider diagnostics. Pinning can reduce cold

--- a/website/content/reference/tools.md
+++ b/website/content/reference/tools.md
@@ -42,6 +42,13 @@ upscaling or changing their aspect ratio. The processed attachment is limited to
 unsupported-format notices. If decoding, conversion, or resizing cannot produce
 a safe attachment, Tau returns a clear omission notice.
 
+Image attachments produced between model responses share a 4 MB base64 request
+budget. If another image would exceed that budget, `read` returns a regular
+text-only tool result telling the agent to resize or compress the file instead
+of allowing the next provider request to fail. After a successful model response,
+Tau omits the already-consumed image bytes from later request replays while
+retaining the complete attachment in durable session history.
+
 When the active model does not accept images, `read` returns an explicit
 text-only notice that says the image contents are unavailable and recommends
 switching to a vision-capable model. It does not attach or process the image.

--- a/website/content/reference/tools.md
+++ b/website/content/reference/tools.md
@@ -43,11 +43,13 @@ unsupported-format notices. If decoding, conversion, or resizing cannot produce
 a safe attachment, Tau returns a clear omission notice.
 
 Image attachments produced between model responses share a 4 MB base64 request
-budget. If another image would exceed that budget, `read` returns a regular
-text-only tool result telling the agent to resize or compress the file instead
-of allowing the next provider request to fail. After a successful model response,
-Tau omits the already-consumed image bytes from later request replays while
-retaining the complete attachment in durable session history.
+budget. If an image would exceed the remaining space, `read` automatically
+resizes and re-encodes it to fit and reports that transformation to the agent.
+Only when safe automatic compression cannot fit the image does `read` return a
+text-only result telling the agent to resize or compress the file. After a
+successful model response, Tau omits the already-consumed image bytes from later
+request replays while retaining the complete attachment in durable session
+history.
 
 When the active model does not accept images, `read` returns an explicit
 text-only notice that says the image contents are unavailable and recommends


### PR DESCRIPTION
## Summary

- cap `read`-generated inline image payloads at 4 MB of base64 per assistant turn
- automatically resize and re-encode images to fit the remaining turn budget
- return an actionable text-only tool result only when safe automatic compression cannot fit
- omit image bytes already consumed by a successful assistant from later provider replays while preserving durable session history
- allow sticky automatic Hugging Face routes to reroute once after a pre-output HTTP 413

## User experience

Multiple individually valid screenshots can no longer accumulate until the next model request fails with `request entity too large`. Tau first compresses an image to fit the request and tells the agent what happened. If the image still cannot fit safely, the agent receives a normal tool result with the total limit, remaining space, and instructions to resize or compress the source. Existing sessions also stop replaying already-consumed image bytes.

## Validation

- `uv run pytest -q` — 1858 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`

## Manual validation

1. Ask a vision-capable model to read enough screenshots in one turn to approach the 4 MB encoded-image budget.
2. Confirm the next large image is automatically resized/re-encoded to fit and the tool result reports the transformation.
3. Exhaust the remaining budget and confirm `read` returns an omission result containing the total limit, remaining space, and resize/compress guidance.
4. Continue after a successful image response and confirm old image bytes are not resent while session history remains intact.
