### PR TITLE
Prepare Tau 0.4.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.4.1",
+    "date": "2026-08-28",
+    "sections": {
+      "New": [
+        "Set the startup thinking level with a new --thinking/-t CLI flag; it overrides remembered per-model defaults and resumed transcript state without being persisted, and validates against the selected model's supported levels.",
+        "See per-response performance in the TUI sidebar: average tokens per second and average time to first output, measured from provider stream timing and persisted on assistant messages."
+      ],
+      "Changed": [
+        "Accept autocomplete completions with Tab only; Enter now always submits the prompt unchanged.",
+        "Cycle backward through scoped (favorite) models with Shift+Ctrl+P (remappable via model_cycle_reverse), complementing the existing Ctrl+P forward cycling."
+      ]
+    }
+  },
+  {
     "version": "0.4.0",
     "date": "2026-08-24",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -848,7 +848,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.4.0" in console.export_text()
+    assert "τ = 2π  0.4.1" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Prepare Tau 0.4.1 release

Bumps the package version from `0.4.0` to `0.4.1` and adds release notes for the patch release.

## Changes

- Bump `[project].version` in `pyproject.toml` to `0.4.1` (and refresh `uv.lock`)
- Add a `0.4.1` entry to `src/tau_coding/data/release-notes/releases.json`
- Update the TUI sidebar version test to `0.4.1`

## Release notes summary

- **New:** `--thinking/-t` CLI flag to set the startup thinking level; per-response timing with average tokens per second and time-to-first-output in the TUI sidebar
- **Changed:** completions accepted with Tab only (Enter always submits); backward scoped-model cycling via `Shift+Ctrl+P`

## Checks

- [x] `uv run mypy` — passed
- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run pytest` — 1852 passed, 2 skipped
