### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ tau
 ```
 
 Tau ships with support for OpenAI, Anthropic, OpenAI Codex subscription auth,
-OpenRouter, Hugging Face, and custom OpenAI-compatible endpoints, including local
+OpenRouter, OrcaRouter, Hugging Face, and custom OpenAI-compatible endpoints, including local
 models. See the [providers guide](https://twotimespi.dev/guides/providers-and-models/).
 
 The built-in catalog lives in `src/tau_coding/data/catalog.toml`; add your own

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3357,6 +3357,1054 @@ max_tokens = 128000
 cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
 
 [[providers]]
+name = "orcarouter"
+display_name = "OrcaRouter"
+kind = "openai-compatible"
+base_url = "https://api.orcarouter.ai/v1"
+api_key_env = "ORCAROUTER_API_KEY"
+credential_name = "orcarouter"
+models = [
+    "anthropic/claude-fable-5", "anthropic/claude-haiku-4.5", "anthropic/claude-opus-4.5", "anthropic/claude-opus-4.6", "anthropic/claude-opus-4.7", "anthropic/claude-opus-4.8", "anthropic/claude-opus-5", "anthropic/claude-sonnet-4.5",
+    "anthropic/claude-sonnet-4.6", "anthropic/claude-sonnet-5", "deepseek/deepseek-chat", "deepseek/deepseek-reasoner", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash-0731", "deepseek/deepseek-v4-flash-vision-exp", "deepseek/deepseek-v4-pro",
+    "deepseek/deepseek-v4-pro-0813", "google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.5-pro", "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-pro-preview", "google/gemini-3.1-pro-preview-customtools",
+    "google/gemini-3.5-flash", "google/gemini-3.5-flash-lite", "google/gemini-3.6-flash", "kimi/kimi-k2.5", "kimi/kimi-k2.6", "kimi/kimi-k2.7-code", "minimax/minimax-m2.5", "minimax/minimax-m2.5-highspeed",
+    "minimax/minimax-m2.7", "minimax/minimax-m2.7-highspeed", "minimax/minimax-m3", "openai/gpt-3.5-turbo", "openai/gpt-3.5-turbo-16k", "openai/gpt-4", "openai/gpt-4-turbo", "openai/gpt-4-turbo-2024-04-09",
+    "openai/gpt-4.1", "openai/gpt-4.1-2025-04-14", "openai/gpt-4.1-mini", "openai/gpt-4.1-mini-2025-04-14", "openai/gpt-4.1-nano", "openai/gpt-4.1-nano-2025-04-14", "openai/gpt-4o", "openai/gpt-4o-2024-05-13",
+    "openai/gpt-4o-2024-08-06", "openai/gpt-4o-2024-11-20", "openai/gpt-4o-mini", "openai/gpt-4o-mini-2024-07-18", "openai/gpt-5", "openai/gpt-5-2025-08-07", "openai/gpt-5-mini", "openai/gpt-5-mini-2025-08-07",
+    "openai/gpt-5-nano", "openai/gpt-5-nano-2025-08-07", "openai/gpt-5-pro", "openai/gpt-5-pro-2025-10-06", "openai/gpt-5.1", "openai/gpt-5.1-2025-11-13", "openai/gpt-5.1-codex", "openai/gpt-5.1-codex-mini",
+    "openai/gpt-5.2", "openai/gpt-5.2-2025-12-11", "openai/gpt-5.2-codex", "openai/gpt-5.2-pro", "openai/gpt-5.2-pro-2025-12-11", "openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-2026-03-05",
+    "openai/gpt-5.4-mini", "openai/gpt-5.4-nano", "openai/gpt-5.4-pro", "openai/gpt-5.4-pro-2026-03-05", "openai/gpt-5.6-luna", "openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "orcarouter/auto",
+    "orcarouter/free", "qwen/qwen3-max", "qwen/qwen3-max-preview", "qwen/qwen3-vl-235b-a22b-thinking", "qwen/qwen3-vl-8b-instruct", "qwen/qwen3-vl-8b-thinking", "qwen/qwen3.5-122b-a10b", "qwen/qwen3.5-27b",
+    "qwen/qwen3.5-35b-a3b", "qwen/qwen3.5-397b-a17b", "qwen/qwen3.5-flash", "qwen/qwen3.5-flash-2026-02-23", "qwen/qwen3.5-plus", "qwen/qwen3.5-plus-2026-02-15", "qwen/qwen3.6-35b-a3b", "qwen/qwen3.6-flash",
+    "qwen/qwen3.6-flash-2026-04-16", "qwen/qwen3.6-plus", "qwen/qwen3.6-plus-2026-04-02", "qwen/qwen3.7-flash", "qwen/qwen3.7-max", "qwen/qwen3.7-max-2026-05-20", "qwen/qwen3.7-plus", "qwen/qwen3.8-flash",
+    "z-ai/glm-4.5", "z-ai/glm-4.5-air", "z-ai/glm-4.6", "z-ai/glm-4.7", "z-ai/glm-5", "z-ai/glm-5.1", "z-ai/glm-5.2", "z-ai/glm-5.3",
+    "z-ai/glm-5.3-flash"
+]
+default_model = "openai/gpt-5.4"
+docs_url = "https://docs.orcarouter.ai"
+api = "openai-completions"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"anthropic/claude-fable-5" = 1000000
+"anthropic/claude-haiku-4.5" = 200000
+"anthropic/claude-opus-4.5" = 200000
+"anthropic/claude-opus-4.6" = 1000000
+"anthropic/claude-opus-4.7" = 1000000
+"anthropic/claude-opus-4.8" = 1000000
+"anthropic/claude-opus-5" = 1000000
+"anthropic/claude-sonnet-4.5" = 1000000
+"anthropic/claude-sonnet-4.6" = 1000000
+"anthropic/claude-sonnet-5" = 1000000
+"deepseek/deepseek-chat" = 1048576
+"deepseek/deepseek-reasoner" = 1048576
+"deepseek/deepseek-v4-flash" = 1048576
+"deepseek/deepseek-v4-flash-0731" = 1048576
+"deepseek/deepseek-v4-flash-vision-exp" = 1048576
+"deepseek/deepseek-v4-pro" = 1048576
+"deepseek/deepseek-v4-pro-0813" = 1048576
+"google/gemini-2.5-flash" = 1048576
+"google/gemini-2.5-flash-lite" = 1048576
+"google/gemini-2.5-pro" = 1048576
+"google/gemini-3-flash-preview" = 1048576
+"google/gemini-3.1-flash-lite-preview" = 1048576
+"google/gemini-3.1-pro-preview" = 1048576
+"google/gemini-3.1-pro-preview-customtools" = 1048576
+"google/gemini-3.5-flash" = 1048576
+"google/gemini-3.5-flash-lite" = 1048576
+"google/gemini-3.6-flash" = 1048576
+"kimi/kimi-k2.5" = 262144
+"kimi/kimi-k2.6" = 262144
+"kimi/kimi-k2.7-code" = 262144
+"minimax/minimax-m2.5" = 204800
+"minimax/minimax-m2.5-highspeed" = 204800
+"minimax/minimax-m2.7" = 204800
+"minimax/minimax-m2.7-highspeed" = 204800
+"minimax/minimax-m3" = 1048576
+"openai/gpt-3.5-turbo" = 16385
+"openai/gpt-3.5-turbo-16k" = 16385
+"openai/gpt-4" = 8191
+"openai/gpt-4-turbo" = 128000
+"openai/gpt-4-turbo-2024-04-09" = 128000
+"openai/gpt-4.1" = 1047576
+"openai/gpt-4.1-2025-04-14" = 1047576
+"openai/gpt-4.1-mini" = 1047576
+"openai/gpt-4.1-mini-2025-04-14" = 1047576
+"openai/gpt-4.1-nano" = 1047576
+"openai/gpt-4.1-nano-2025-04-14" = 1047576
+"openai/gpt-4o" = 128000
+"openai/gpt-4o-2024-05-13" = 128000
+"openai/gpt-4o-2024-08-06" = 128000
+"openai/gpt-4o-2024-11-20" = 128000
+"openai/gpt-4o-mini" = 128000
+"openai/gpt-4o-mini-2024-07-18" = 128000
+"openai/gpt-5" = 400000
+"openai/gpt-5-2025-08-07" = 400000
+"openai/gpt-5-mini" = 400000
+"openai/gpt-5-mini-2025-08-07" = 400000
+"openai/gpt-5-nano" = 400000
+"openai/gpt-5-nano-2025-08-07" = 400000
+"openai/gpt-5-pro" = 400000
+"openai/gpt-5-pro-2025-10-06" = 400000
+"openai/gpt-5.1" = 400000
+"openai/gpt-5.1-2025-11-13" = 400000
+"openai/gpt-5.1-codex" = 400000
+"openai/gpt-5.1-codex-mini" = 400000
+"openai/gpt-5.2" = 400000
+"openai/gpt-5.2-2025-12-11" = 400000
+"openai/gpt-5.2-codex" = 400000
+"openai/gpt-5.2-pro" = 400000
+"openai/gpt-5.2-pro-2025-12-11" = 400000
+"openai/gpt-5.3-codex" = 400000
+"openai/gpt-5.4" = 1050000
+"openai/gpt-5.4-2026-03-05" = 1050000
+"openai/gpt-5.4-mini" = 400000
+"openai/gpt-5.4-nano" = 400000
+"openai/gpt-5.4-pro" = 1050000
+"openai/gpt-5.4-pro-2026-03-05" = 1050000
+"openai/gpt-5.6-luna" = 1050000
+"openai/gpt-5.6-sol" = 1050000
+"openai/gpt-5.6-terra" = 1050000
+"qwen/qwen3-max" = 262144
+"qwen/qwen3-max-preview" = 262144
+"qwen/qwen3-vl-235b-a22b-thinking" = 131072
+"qwen/qwen3-vl-8b-instruct" = 131072
+"qwen/qwen3-vl-8b-thinking" = 131072
+"qwen/qwen3.5-122b-a10b" = 32768
+"qwen/qwen3.5-27b" = 32768
+"qwen/qwen3.5-35b-a3b" = 32768
+"qwen/qwen3.5-397b-a17b" = 32768
+"qwen/qwen3.5-flash" = 1048576
+"qwen/qwen3.5-flash-2026-02-23" = 1048576
+"qwen/qwen3.5-plus" = 1048576
+"qwen/qwen3.5-plus-2026-02-15" = 1048576
+"qwen/qwen3.6-35b-a3b" = 262144
+"qwen/qwen3.6-flash" = 1048576
+"qwen/qwen3.6-flash-2026-04-16" = 1048576
+"qwen/qwen3.6-plus" = 1048576
+"qwen/qwen3.6-plus-2026-04-02" = 1048576
+"qwen/qwen3.7-flash" = 1000000
+"qwen/qwen3.7-max" = 1000000
+"qwen/qwen3.7-max-2026-05-20" = 1000000
+"qwen/qwen3.7-plus" = 1000000
+"qwen/qwen3.8-flash" = 1000000
+"z-ai/glm-4.5" = 128000
+"z-ai/glm-4.5-air" = 128000
+"z-ai/glm-4.6" = 200000
+"z-ai/glm-4.7" = 200000
+"z-ai/glm-5" = 200000
+"z-ai/glm-5.1" = 200000
+"z-ai/glm-5.2" = 1000000
+"z-ai/glm-5.3" = 1000000
+"z-ai/glm-5.3-flash" = 1000000
+
+[providers.model_metadata."anthropic/claude-fable-5"]
+name = "Anthropic: Claude Fable 5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 10.0, output = 50.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-haiku-4.5"]
+name = "Anthropic: Claude Haiku 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1.0, output = 5.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-opus-4.5"]
+name = "Anthropic: Claude Opus 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 5.0, output = 25.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-opus-4.6"]
+name = "Anthropic: Claude Opus 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5.0, output = 25.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-opus-4.7"]
+name = "Anthropic: Claude Opus 4.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5.0, output = 25.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-opus-4.8"]
+name = "Anthropic: Claude Opus 4.8"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5.0, output = 25.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-opus-5"]
+name = "Anthropic: Claude Opus 5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5.0, output = 25.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.5"]
+name = "Anthropic: Claude Sonnet 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3.0, output = 15.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4.6"]
+name = "Anthropic: Claude Sonnet 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3.0, output = 15.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."anthropic/claude-sonnet-5"]
+name = "Anthropic: Claude Sonnet 5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 2.0, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-chat"]
+name = "DeepSeek: DeepSeek V3"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.147, output = 0.295, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-reasoner"]
+name = "deepseek/deepseek-reasoner"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.147, output = 0.295, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-flash"]
+name = "DeepSeek: DeepSeek V4 Flash"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.147, output = 0.295, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-flash-0731"]
+name = "DeepSeek: DeepSeek V4 Flash 0731"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.147, output = 0.295, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-flash-vision-exp"]
+name = "DeepSeek: DeepSeek V4 Flash Vision (Exp)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.147, output = 0.295, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-pro"]
+name = "DeepSeek: DeepSeek V4 Pro"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.442, output = 0.884, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-v4-pro-0813"]
+name = "DeepSeek: DeepSeek V4 Pro 0813"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 384000
+cost = { input = 0.442, output = 0.884, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash"]
+name = "Google: Gemini 2.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash-lite"]
+name = "Google: Gemini 2.5 Flash Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.1, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-pro"]
+name = "Google: Gemini 2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2.5, output = 15.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3-flash-preview"]
+name = "Google: Gemini 3 Flash Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.5, output = 3.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-flash-lite-preview"]
+name = "Google: Gemini 3.1 Flash Lite Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-pro-preview"]
+name = "Google: Gemini 3.1 Pro Preview"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 2.0, output = 12.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.1-pro-preview-customtools"]
+name = "Google: Gemini 3.1 Pro Preview Custom Tools"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 4.0, output = 18.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.5-flash"]
+name = "Gemini 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.5, output = 9.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.5-flash-lite"]
+name = "Google: Gemini 3.5 Flash-Lite"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.3, output = 2.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-3.6-flash"]
+name = "Google: Gemini 3.6 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 1.5, output = 7.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."kimi/kimi-k2.5"]
+name = "kimi/kimi-k2.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.6, output = 3.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."kimi/kimi-k2.6"]
+name = "kimi/kimi-k2.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 32768
+cost = { input = 0.95, output = 4.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."kimi/kimi-k2.7-code"]
+name = "MoonshotAI: Kimi K2.7 Code"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 262144
+cost = { input = 0.95, output = 4.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.5"]
+name = "MiniMax: MiniMax M2.5"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 2048
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.5-highspeed"]
+name = "MiniMax M2.5 highspeed"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 2048
+cost = { input = 0.6, output = 2.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.7"]
+name = "MiniMax: MiniMax M2.7"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 2048
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m2.7-highspeed"]
+name = "MiniMax M2.7 highspeed"
+reasoning = true
+input = ["text"]
+context_window = 204800
+max_tokens = 2048
+cost = { input = 0.6, output = 2.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."minimax/minimax-m3"]
+name = "MiniMax: MiniMax M3"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 512000
+cost = { input = 0.3, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-3.5-turbo"]
+name = "OpenAI: GPT-3.5 Turbo"
+reasoning = false
+input = ["text"]
+context_window = 16385
+max_tokens = 4096
+cost = { input = 0.5, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-3.5-turbo-16k"]
+name = "OpenAI: GPT-3.5 Turbo 16k"
+reasoning = false
+input = ["text"]
+context_window = 16385
+max_tokens = 4096
+cost = { input = 3.0, output = 4.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4"]
+name = "OpenAI: GPT-4"
+reasoning = false
+input = ["text"]
+context_window = 8191
+max_tokens = 8192
+cost = { input = 30.0, output = 60.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-turbo"]
+name = "OpenAI: GPT-4 Turbo"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10.0, output = 30.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4-turbo-2024-04-09"]
+name = "openai/gpt-4-turbo-2024-04-09"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 4096
+cost = { input = 10.0, output = 30.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1"]
+name = "OpenAI: GPT-4.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 2.0, output = 8.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-2025-04-14"]
+name = "openai/gpt-4.1-2025-04-14"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 2.0, output = 8.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-mini"]
+name = "OpenAI: GPT-4.1 Mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.4, output = 1.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-mini-2025-04-14"]
+name = "openai/gpt-4.1-mini-2025-04-14"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.4, output = 1.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-nano"]
+name = "OpenAI: GPT-4.1 Nano"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.1, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-nano-2025-04-14"]
+name = "openai/gpt-4.1-nano-2025-04-14"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.1, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o"]
+name = "OpenAI: GPT-4o"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-05-13"]
+name = "OpenAI: GPT-4o (2024-05-13)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 5.0, output = 15.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-08-06"]
+name = "OpenAI: GPT-4o (2024-08-06)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-2024-11-20"]
+name = "OpenAI: GPT-4o (2024-11-20)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 2.5, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini"]
+name = "OpenAI: GPT-4o-mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini-2024-07-18"]
+name = "OpenAI: GPT-4o-mini (2024-07-18)"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5"]
+name = "OpenAI: GPT-5"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-2025-08-07"]
+name = "openai/gpt-5-2025-08-07"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-mini"]
+name = "OpenAI: GPT-5 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-mini-2025-08-07"]
+name = "openai/gpt-5-mini-2025-08-07"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-nano"]
+name = "OpenAI: GPT-5 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.05, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-nano-2025-08-07"]
+name = "openai/gpt-5-nano-2025-08-07"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.05, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-pro"]
+name = "OpenAI: GPT-5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 272000
+cost = { input = 15.0, output = 120.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-pro-2025-10-06"]
+name = "openai/gpt-5-pro-2025-10-06"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 272000
+cost = { input = 15.0, output = 120.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1"]
+name = "OpenAI: GPT-5.1"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-2025-11-13"]
+name = "openai/gpt-5.1-2025-11-13"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex"]
+name = "OpenAI: GPT-5.1-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.1-codex-mini"]
+name = "OpenAI: GPT-5.1-Codex-Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2"]
+name = "OpenAI: GPT-5.2"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2-2025-12-11"]
+name = "openai/gpt-5.2-2025-12-11"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2-codex"]
+name = "OpenAI: GPT-5.2-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2-pro"]
+name = "OpenAI: GPT-5.2 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 21.0, output = 168.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.2-pro-2025-12-11"]
+name = "openai/gpt-5.2-pro-2025-12-11"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 21.0, output = 168.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.3-codex"]
+name = "OpenAI: GPT-5.3-Codex"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.75, output = 14.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4"]
+name = "OpenAI: GPT-5.4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5.0, output = 22.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-2026-03-05"]
+name = "openai/gpt-5.4-2026-03-05"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5.0, output = 22.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-mini"]
+name = "OpenAI: GPT-5.4 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-nano"]
+name = "OpenAI: GPT-5.4 Nano"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.2, output = 1.25, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-pro"]
+name = "OpenAI: GPT-5.4 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 60.0, output = 270.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-pro-2026-03-05"]
+name = "openai/gpt-5.4-pro-2026-03-05"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 60.0, output = 270.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.6-luna"]
+name = "OpenAI: GPT-5.6 Luna"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 0.2, output = 1.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.6-sol"]
+name = "OpenAI: GPT-5.6 Sol"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 4.0, output = 20.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.6-terra"]
+name = "OpenAI: GPT-5.6 Terra"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.0, output = 12.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."orcarouter/auto"]
+name = "OrcaRouter Auto"
+reasoning = true
+input = ["text", "image"]
+context_window = 2000000
+max_tokens = 30000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."orcarouter/free"]
+name = "OrcaRouter Free"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 30000
+cost = { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-max"]
+name = "Qwen: Qwen3 Max"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.359, output = 1.434, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-max-preview"]
+name = "qwen/qwen3-max-preview"
+reasoning = true
+input = ["text"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.861, output = 3.441, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-235b-a22b-thinking"]
+name = "Qwen: Qwen3 VL 235B A22B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 40960
+cost = { input = 0.4, output = 4.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-8b-instruct"]
+name = "Qwen: Qwen3 VL 8B Instruct"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 32768
+cost = { input = 0.18, output = 0.7, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3-vl-8b-thinking"]
+name = "Qwen: Qwen3 VL 8B Thinking"
+reasoning = true
+input = ["text", "image"]
+context_window = 131072
+max_tokens = 40960
+cost = { input = 0.18, output = 2.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-122b-a10b"]
+name = "Qwen: Qwen3.5-122B-A10B"
+reasoning = true
+input = ["text", "image"]
+context_window = 32768
+max_tokens = 65536
+cost = { input = 0.115, output = 0.917, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-27b"]
+name = "Qwen: Qwen3.5-27B"
+reasoning = true
+input = ["text", "image"]
+context_window = 32768
+max_tokens = 65536
+cost = { input = 0.086, output = 0.688, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-35b-a3b"]
+name = "Qwen: Qwen3.5-35B-A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 32768
+max_tokens = 65536
+cost = { input = 0.057, output = 0.459, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-397b-a17b"]
+name = "Qwen: Qwen3.5 397B A17B"
+reasoning = true
+input = ["text", "image"]
+context_window = 32768
+max_tokens = 65536
+cost = { input = 0.172, output = 1.032, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-flash"]
+name = "qwen/qwen3.5-flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.1, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-flash-2026-02-23"]
+name = "qwen/qwen3.5-flash-2026-02-23"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.1, output = 0.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-plus"]
+name = "qwen/qwen3.5-plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.115, output = 0.688, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.5-plus-2026-02-15"]
+name = "qwen/qwen3.5-plus-2026-02-15"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.115, output = 0.688, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-35b-a3b"]
+name = "Qwen: Qwen3.6 35B A3B"
+reasoning = true
+input = ["text", "image"]
+context_window = 262144
+max_tokens = 65536
+cost = { input = 0.248, output = 1.485, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-flash"]
+name = "Qwen: Qwen3.6 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-flash-2026-04-16"]
+name = "qwen/qwen3.6-flash-2026-04-16"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.25, output = 1.5, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-plus"]
+name = "Qwen: Qwen3.6 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.5, output = 3.0, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.6-plus-2026-04-02"]
+name = "qwen/qwen3.6-plus-2026-04-02"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65536
+cost = { input = 0.276, output = 1.651, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.7-flash"]
+name = "Qwen: Qwen3.7 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.03, output = 0.13, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.7-max"]
+name = "Qwen3.7 Max"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 1.25, output = 3.75, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.7-max-2026-05-20"]
+name = "Qwen3.7 Max (2026-05-20)"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 1.25, output = 3.75, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.7-plus"]
+name = "Qwen: Qwen3.7 Plus"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 65536
+cost = { input = 0.35, output = 1.42, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."qwen/qwen3.8-flash"]
+name = "Qwen: Qwen3.8 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 131072
+cost = { input = 0.15, output = 0.47, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5"]
+name = "Z.ai: GLM 4.5"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 96000
+cost = { input = 0.6, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.5-air"]
+name = "Z.ai: GLM 4.5 Air"
+reasoning = true
+input = ["text"]
+context_window = 128000
+max_tokens = 96000
+cost = { input = 0.2, output = 1.1, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.6"]
+name = "Z.ai: GLM 4.6"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 0.6, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-4.7"]
+name = "Z.ai: GLM 4.7"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 0.6, output = 2.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5"]
+name = "Z.ai: GLM 5"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 1.0, output = 3.2, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5.1"]
+name = "Z.ai: GLM 5.1"
+reasoning = true
+input = ["text"]
+context_window = 200000
+max_tokens = 128000
+cost = { input = 1.4, output = 4.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5.2"]
+name = "Z.ai: GLM 5.2"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 1.4, output = 4.4, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5.3"]
+name = "Z.ai: GLM 5.3"
+reasoning = true
+input = ["text"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 1.26, output = 3.96, cacheRead = 0, cacheWrite = 0 }
+
+[providers.model_metadata."z-ai/glm-5.3-flash"]
+name = "Z.ai: GLM 5.3 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 0.075, output = 0.25, cacheRead = 0, cacheWrite = 0 }
+
+[[providers]]
 name = "zai"
 display_name = "ZAI"
 kind = "openai-compatible"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1842,6 +1842,7 @@ def test_providers_command_lists_default_provider(
     assert " \topenai-codex\topenai-codex\tgpt-5.5" in result.stdout
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
     assert " \topenrouter\topenai-compatible\tqwen/qwen3.7-max" in result.stdout
+    assert " \torcarouter\topenai-compatible\topenai/gpt-5.4" in result.stdout
     assert " \thuggingface\topenai-compatible\tmoonshotai/Kimi-K2.6" in result.stdout
 
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -63,6 +63,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "cerebras",
         "nvidia",
         "openrouter",
+        "orcarouter",
         "zai",
         "mistral",
         "minimax",

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -105,6 +105,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "cerebras",
         "nvidia",
         "openrouter",
+        "orcarouter",
         "zai",
         "mistral",
         "minimax",
@@ -151,6 +152,7 @@ def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:
     settings = ProviderSettings()
     openai = settings.get_provider("openai")
     openrouter = settings.get_provider("openrouter")
+    orcarouter = settings.get_provider("orcarouter")
     huggingface = settings.get_provider("huggingface")
     codex = settings.get_provider("openai-codex")
     anthropic = settings.get_provider("anthropic")
@@ -189,6 +191,26 @@ def test_builtin_openai_declares_model_scoped_thinking_capabilities() -> None:
     )
     assert (
         provider_thinking_unavailable_reason(openrouter, model="anthropic/claude-sonnet-4.6")
+        is None
+    )
+    assert orcarouter.context_windows["openai/gpt-5.4"] == 1_050_000
+    assert provider_thinking_levels(orcarouter, model="openai/gpt-5.4") == (
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+    )
+    assert provider_thinking_unavailable_reason(orcarouter, model="openai/gpt-5.4") is None
+    assert provider_thinking_levels(orcarouter, model="anthropic/claude-sonnet-4.6") == (
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+    )
+    assert (
+        provider_thinking_unavailable_reason(orcarouter, model="anthropic/claude-sonnet-4.6")
         is None
     )
     assert provider_thinking_levels(huggingface, model="MiniMaxAI/MiniMax-M2.7") == (

--- a/website/content/concepts.md
+++ b/website/content/concepts.md
@@ -18,7 +18,7 @@ model has nothing left to do. That loop is the heart of every coding agent.
 ## Providers and models
 
 A **provider** is the service that hosts AI models (OpenAI, Anthropic, OpenAI
-Codex, OpenRouter, Hugging Face, or any OpenAI-compatible endpoint). A **model**
+Codex, OpenRouter, OrcaRouter, Hugging Face, or any OpenAI-compatible endpoint). A **model**
 is the specific brain you're talking to (e.g. `gpt-5.5`, `claude-sonnet-4-6`).
 You pick a provider + model; you can switch either mid-session.
 → [Providers & models]({{< relref "./guides/providers-and-models.md" >}})

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -30,8 +30,8 @@ tau
 
 Built-in providers include **OpenAI**, **Anthropic**, **OpenAI Codex**
 (subscription), **GitHub Copilot**, **OpenCode Go**, **OpenCode Zen**,
-**Moonshot AI (Kimi)**, **Kimi Code** (subscription), **OpenRouter**, **Hugging Face**,
-and **NVIDIA NIM**.
+**Moonshot AI (Kimi)**, **Kimi Code** (subscription), **OpenRouter**, **OrcaRouter**,
+**Hugging Face**, and **NVIDIA NIM**.
 
 ### OAuth subscriptions
 

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -86,7 +86,7 @@ Then run one of these inside Tau:
 ```
 
 Tau ships with built-in entries for OpenAI, Anthropic, OpenAI Codex,
-OpenRouter, and Hugging Face. See [Providers & models]({{< relref "./guides/providers-and-models.md" >}})
+OpenRouter, OrcaRouter, and Hugging Face. See [Providers & models]({{< relref "./guides/providers-and-models.md" >}})
 for switching models or adding a custom/local OpenAI-compatible endpoint.
 
 ## 3. Start a session

--- a/website/content/what-is-tau.md
+++ b/website/content/what-is-tau.md
@@ -29,7 +29,7 @@ The name is a small joke about picking the *right* foundation. See
   **running shell commands** in your project.
 - Work in an **interactive TUI** or as a **one-shot command** for scripts and
   pipes.
-- Talk to **OpenAI, Anthropic, OpenAI Codex, OpenRouter, Hugging Face**, or any
+- Talk to **OpenAI, Anthropic, OpenAI Codex, OpenRouter, OrcaRouter, Hugging Face**, or any
   OpenAI-compatible endpoint (including local models).
 - **Remember** every session, let you **resume** it later, and **branch** from
   any earlier point to explore a different path.


### PR DESCRIPTION
## Why

Tau describes itself as *"a coding agent that lives in your terminal"* and a
*teaching project for understanding the shape of a coding-agent system*. For
that to stay true, the built-in provider list in `/login` should keep up with
the gateways people actually run agents through. Tau already ships an
OpenRouter entry as a first-class provider; this PR adds the same treatment
for [OrcaRouter](https://www.orcarouter.ai).

OrcaRouter is an OpenAI-compatible AI gateway built for both models and
agents. Like OpenRouter, it exposes a provider/model namespace across many
models — but it also combines adaptive routing, automatic failover,
zero-markup inference, observability, guardrails, and agent-tool governance
behind the same endpoint. Adding `orcarouter` as a first-class provider means
Tau users can use that stack directly, without treating OrcaRouter as an
anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

## What changed

The built-in catalog is data, not code: I added an `orcarouter` entry to
`src/tau_coding/data/catalog.toml`, following the exact shape of the existing
`openrouter` entry:

- `kind = "openai-compatible"`, `api = "openai-completions"`, base URL
  `https://api.orcarouter.ai/v1`, credential env `ORCAROUTER_API_KEY`.
- 113 chat-capable models across Anthropic, DeepSeek, Google, Kimi, MiniMax,
  OpenAI, Qwen, xAI, and Z.AI, plus the `orcarouter/auto` adaptive-router and
  `orcarouter/free` aliases. Model IDs use OrcaRouter's `vendor/model`
  namespace, matching how Tau already presents OpenRouter.
- Per-model `context_windows`, `max_tokens`, and `cost` rates were pulled from
  OrcaRouter's live `/v1/models/<id>` metadata endpoint (verified today).
- Thinking levels use `reasoning_effort`, so the existing OpenAI-compatible
  transport handles reasoning without any provider-specific code.

Because provider configuration flows through Tau's normal catalog → settings →
runtime path, no Python changes were needed — this mirrors how CONTRIBUTING.md
describes adding a provider: *"The built-in provider catalog is data, not
code: edit `src/tau_coding/data/catalog.toml` and open a PR."*

## Checks

- `uv run pytest` — 1852 passed, 3 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — passed
- Live test: `tau --provider orcarouter --model openai/gpt-5.4 -p "Say OK"`
  returned `OK` through Tau's orcarouter provider path (HTTP 200).

## Docs

Updated the providers guide, quickstart, concepts, what-is-tau, and README to
list OrcaRouter alongside OpenRouter.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
