### PR TITLE
Improve API protocol setup for custom providers

### DIFF
--- a/dev-notes/README.md
+++ b/dev-notes/README.md
@@ -26,6 +26,8 @@ User-facing documentation lives in `website/content/` and is published at
 - `catalog-model-safety.md` — checklist for adding providers and models to the built-in catalog safely.
 - `google-stream-completion.md` — why native Google streams require an explicit
   `finishReason` before Tau reports successful completion.
+- `openai-compatible-protocol-selection.md` documents custom-provider API
+  selection, the Pi mapping, and compatibility for existing catalog entries.
 - `startup-thinking-level-fallback.md` — why startup resolves a valid thinking
   level per model instead of assuming the global `medium` default.
 - `models-dev-catalog.md` — Pi-compatible build-time models.dev catalog

--- a/dev-notes/openai-compatible-protocol-selection.md
+++ b/dev-notes/openai-compatible-protocol-selection.md
@@ -1,10 +1,24 @@
 # OpenAI-compatible protocol selection
 
-Issue #546 ports Pi's explicit custom-model API selection into Tau. The upstream
-reference used for this implementation is Pi v0.74.0 (`1eee081`), specifically
-`packages/ai/src/types.ts`, `packages/coding-agent/src/core/model-config.ts`,
-`packages/coding-agent/src/core/provider-composer.ts`, and
-`packages/coding-agent/docs/models.md`.
+## Context
+
+Custom-provider setup accepted a base URL and model without asking which OpenAI
+API the server supports. The provider adapter could then use the model name to
+choose between Chat Completions and Responses. Proxy names and local model names
+made that behavior hard to predict.
+
+Issue #546 adds the API choice to `tau setup` and `/login custom`. Tau saves the
+selection with the existing provider metadata in `catalog.toml` and uses it for
+every request.
+
+## What changed
+
+`openai-completions` selects `/chat/completions`, while `openai-responses`
+selects `/responses`. A model-level setting overrides its provider setting. The
+model ID remains unchanged in the request payload.
+
+New providers created through either setup flow always save an API value.
+`providers.json` remains preference-only, and session JSONL remains unchanged.
 
 ## Pi to Tau mapping
 
@@ -17,18 +31,17 @@ reference used for this implementation is Pi v0.74.0 (`1eee081`), specifically
 | `getApiProvider(model.api)` | exact OpenAI-compatible transport branch |
 | `models.json` | `~/.tau/catalog.toml` |
 
-Pi treats the API as model capability metadata. Tau now follows the same rule:
-`openai-completions` always uses `/chat/completions`, and `openai-responses`
-always uses `/responses`. The model ID is request data, not routing policy.
+The upstream reference is Pi v0.74.0 at `1eee081`. The relevant sources are
+`packages/ai/src/types.ts`, `packages/coding-agent/src/core/model-config.ts`,
+`packages/coding-agent/src/core/provider-composer.ts`, and
+`packages/coding-agent/docs/models.md`.
 
-`/login custom` and `tau setup --api` save the provider default in
-`catalog.toml`. A model-level `api` in `model_metadata` overrides it.
-`providers.json` remains preference-only and session JSONL remains unchanged.
+## Compatibility
 
 API-less legacy OpenAI-compatible entries resolve to `openai-completions`. This
-is a deterministic compatibility default, not inference. Existing entries that
-depended on a `gpt-5` or `codex` model name to reach Responses must add
-`api = "openai-responses"`; Tau does not rewrite them by guessing from names.
+preserves providers configured before the API field was available. Entries that
+depended on a `gpt-5` or `codex` model name to reach Responses should add
+`api = "openai-responses"`.
 
 ## Verification
 
@@ -39,6 +52,7 @@ uv run ruff check src/tau_coding/cli.py src/tau_coding/tui/app.py \
   tests/test_provider_catalog.py tests/test_cli.py tests/test_tui_app.py
 ```
 
-For manual verification, configure a misleading model name once with each API:
-`company/openai/gpt-5.6` plus `openai-responses` must use `/responses`, while
-`gpt-5.5-proxy` plus `openai-completions` must use `/chat/completions`.
+For a manual check, configure `company/openai/gpt-5.6` with
+`openai-responses` and confirm that Tau uses `/responses`. Then configure
+`gpt-5.5-proxy` with `openai-completions` and confirm that Tau uses
+`/chat/completions`.

--- a/dev-notes/openai-compatible-protocol-selection.md
+++ b/dev-notes/openai-compatible-protocol-selection.md
@@ -1,0 +1,44 @@
+# OpenAI-compatible protocol selection
+
+Issue #546 ports Pi's explicit custom-model API selection into Tau. The upstream
+reference used for this implementation is Pi v0.74.0 (`1eee081`), specifically
+`packages/ai/src/types.ts`, `packages/coding-agent/src/core/model-config.ts`,
+`packages/coding-agent/src/core/provider-composer.ts`, and
+`packages/coding-agent/docs/models.md`.
+
+## Pi to Tau mapping
+
+| Pi | Tau |
+| --- | --- |
+| resolved `Model.api` | resolved provider/model catalog API |
+| provider `api` | `ProviderCatalogEntry.api` |
+| custom-model `api` | `ModelCatalogMetadata.api` |
+| `definition.api ?? provider.api` | model metadata, then provider metadata |
+| `getApiProvider(model.api)` | exact OpenAI-compatible transport branch |
+| `models.json` | `~/.tau/catalog.toml` |
+
+Pi treats the API as model capability metadata. Tau now follows the same rule:
+`openai-completions` always uses `/chat/completions`, and `openai-responses`
+always uses `/responses`. The model ID is request data, not routing policy.
+
+`/login custom` and `tau setup --api` save the provider default in
+`catalog.toml`. A model-level `api` in `model_metadata` overrides it.
+`providers.json` remains preference-only and session JSONL remains unchanged.
+
+API-less legacy OpenAI-compatible entries resolve to `openai-completions`. This
+is a deterministic compatibility default, not inference. Existing entries that
+depended on a `gpt-5` or `codex` model name to reach Responses must add
+`api = "openai-responses"`; Tau does not rewrite them by guessing from names.
+
+## Verification
+
+```bash
+uv run pytest tests/test_tau_ai.py tests/test_provider_config.py \
+  tests/test_provider_catalog.py tests/test_cli.py tests/test_tui_app.py
+uv run ruff check src/tau_coding/cli.py src/tau_coding/tui/app.py \
+  tests/test_provider_catalog.py tests/test_cli.py tests/test_tui_app.py
+```
+
+For manual verification, configure a misleading model name once with each API:
+`company/openai/gpt-5.6` plus `openai-responses` must use `/responses`, while
+`gpt-5.5-proxy` plus `openai-completions` must use `/chat/completions`.

--- a/plans/546-openai-compatible-api-protocol-selection.md
+++ b/plans/546-openai-compatible-api-protocol-selection.md
@@ -1,143 +1,106 @@
-# Issue 546: expose API protocol selection for custom OpenAI-compatible providers
+# Issue 546 custom-provider API selection
 
-Issue: https://github.com/huggingface/tau/issues/546
+Issue [#546](https://github.com/huggingface/tau/issues/546)
 
-Pi reference: https://github.com/badlogic/pi-mono
+Pi reference [badlogic/pi-mono](https://github.com/badlogic/pi-mono)
 
 ## Goal
 
-Implement custom-provider API selection as a direct port of Pi's API-selection
-model. Make catalog metadata authoritative throughout Tau's application path,
-remove model-name routing from the OpenAI-compatible adapter, and do not add a
-durable `infer_api_from_model` or equivalent Tau-only configuration concept.
+Give users a clear way to choose the OpenAI API supported by a custom provider.
+The choice must be available through `tau setup`, `/login custom`, and catalog
+metadata. Tau must use the saved value consistently for every model request.
+
+The implementation should follow Pi's resolved-model API behavior and preserve
+Tau's existing package boundaries.
 
 ## Intuition
 
-Tau already implements both OpenAI wire protocols. The bug is that the model
-name can currently override catalog intent:
+Tau already supports Chat Completions and Responses. Custom-provider setup
+previously collected a URL and model without asking which API the server uses.
+The provider adapter could then choose an API from the model name, which made
+proxy names and local model names hard to predict.
+
+The desired flow is explicit.
 
 ```text
-Current Tau
+provider API ────────────┐
+                        ├──► resolved model API ──► request endpoint
+model API override ─────┘
 
-catalog api ─────────────┐
-                        ├──► model-name heuristic ──► endpoint
-model id ────────────────┘
+model ID ───────────────────► request payload
 ```
 
-The Pi-faithful flow is simpler:
+These examples show the expected result.
 
 ```text
-Desired Tau, matching Pi
-
-provider api ────────────┐
-                        ├──► resolved model api ──► exact transport
-model-level api ─────────┘
-
-model id ───────────────────► request payload only
-```
-
-For the issue's two counterexamples:
-
-```text
-company/openai/gpt-5.6 + openai-responses
+company/openai/gpt-5.6 with openai-responses
     └──► POST /responses
 
-gpt-5.5-proxy + openai-completions
+gpt-5.5-proxy with openai-completions
     └──► POST /chat/completions
 ```
 
-Neither result depends on the spelling of the model ID.
+## Pi mapping
 
-## Pi reference behavior
+Pi stores `api` on each resolved model. Custom-model composition checks the
+model setting first and then the provider setting. Streaming dispatch uses the
+resolved value.
 
-Pi makes `api` part of the resolved model. It resolves a custom model's API in
-this order:
+The implementation should use Pi v0.74.0 at `1eee081` as its reference.
 
-```text
-model.api  ??  provider.api  ??  inherited model api
-```
-
-It then dispatches through the provider registered for that exact `model.api`.
-The model ID never selects an API protocol.
-
-Use these upstream sources as the normative references, and record the Pi
-revision used during implementation in the development note:
-
-- `packages/ai/src/types.ts`: Pi's resolved `Model` has a required `api` field.
-- `packages/coding-agent/src/core/model-config.ts`: `api` is accepted at both
-  provider and custom-model level.
-- `packages/coding-agent/src/core/provider-composer.ts`: custom model
-  composition resolves `definition.api ?? providerConfig.api ?? defaults?.api`
-  and errors if no API can be resolved.
-- `packages/coding-agent/src/core/provider-composer.ts`: streaming dispatches
-  with `getApiProvider(model.api)`.
-- `packages/coding-agent/docs/models.md`: documents provider-level defaults and
-  model-level API overrides, including `openai-completions` and
-  `openai-responses`.
-
-Canonical links:
-
-- https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/types.ts
-- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/model-config.ts
-- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/provider-composer.ts
-- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md
-
-### Pi to Tau mapping
-
-| Pi concept | Tau equivalent | Required behavior |
+| Pi concept | Tau equivalent | Behavior |
 | --- | --- | --- |
-| `Model.api` | `provider_api(provider, model)` and `OpenAICompatibleConfig.api` | One concrete protocol is resolved before streaming |
-| Provider `api` | `ProviderCatalogEntry.api` / `OpenAICompatibleProviderConfig.api` | Default API for the provider's models |
-| Custom-model `api` | `ModelCatalogMetadata.api` / `ProviderModelMetadata.api` | Overrides the provider API for that model |
-| `model.api ?? provider.api ?? default` | `provider_api()` plus the provider-kind compatibility default | Model metadata wins, then provider metadata |
-| `getApiProvider(model.api)` | `create_model_provider()` plus exact branching inside `OpenAICompatibleProvider` | Dispatch by API metadata, never by model ID |
-| `models.json` | `~/.tau/catalog.toml` | Durable provider/model capability metadata |
+| Resolved `Model.api` | `provider_api()` and `OpenAICompatibleConfig.api` | One API is resolved before streaming |
+| Provider `api` | `ProviderCatalogEntry.api` and `OpenAICompatibleProviderConfig.api` | Default API for the provider |
+| Model `api` | `ModelCatalogMetadata.api` and `ProviderModelMetadata.api` | Override for one model |
+| `getApiProvider(model.api)` | Exact branch inside `OpenAICompatibleProvider` | Select the matching endpoint |
+| `models.json` | `~/.tau/catalog.toml` | Store provider and model capabilities |
 
-Tau uses one Python `OpenAICompatibleProvider` class with two internal
-transports, whereas Pi registers separate API implementations. That is an
-acceptable language-level difference only if dispatch remains behaviorally
-equivalent: the resolved `api` value alone chooses the transport.
+Relevant Pi sources include
 
-## Architectural fit
+- `packages/ai/src/types.ts`
+- `packages/coding-agent/src/core/model-config.ts`
+- `packages/coding-agent/src/core/provider-composer.ts`
+- `packages/coding-agent/docs/models.md`
 
-Tau's dependency direction remains:
+Tau uses one Python provider class with two internal transports. Pi registers
+separate API implementations. Both designs select the transport from the
+resolved API value.
+
+## Architecture
+
+The existing dependency direction stays in place.
 
 ```text
 tau_coding  ─────►  tau_agent  ─────►  tau_ai
  application        portable brain     provider streams
 ```
 
-For this feature:
+This feature touches the application and provider layers.
 
 ```text
 tau_coding
-├── CLI `tau setup`
-├── TUI `/login custom`
+├── `tau setup`
+├── `/login custom`
 ├── catalog composition
-└── resolved runtime configuration
+└── runtime provider configuration
           │
           ▼
 tau_ai.OpenAICompatibleProvider
-├── api == openai-completions ──► /chat/completions
-└── api == openai-responses ────► /responses
+├── openai-completions ──► /chat/completions
+└── openai-responses ────► /responses
 ```
 
-No change belongs in `tau_agent`, `AgentHarness`, the agent loop, tools, event
-types, or session storage. Pi also hands its agent core an already resolved
-model/provider; provider configuration and composition stay in the coding
-application and AI-provider layers.
+`tau_agent`, the harness, tools, events, and session storage keep their current
+interfaces. Provider capability metadata remains in `catalog.toml`.
 
-The custom setup screens are Tau-specific frontend conveniences—Pi primarily
-uses `models.json` for this configuration—but they must produce the same
-provider/model metadata Pi would consume. UI differences are acceptable;
-configuration and dispatch semantics are not.
+## Implementation
 
-## Detailed implementation plan
+### 1. Route from the configured API
 
-### 1. Make the API value the sole routing authority
-
-Update `src/tau_ai/openai_compatible.py` so `_stream_provider_events()` selects
-the endpoint only from `self._config.api`:
+Update `src/tau_ai/openai_compatible.py` so
+`OpenAICompatibleProvider._stream_provider_events()` branches only on
+`self._config.api`.
 
 ```python
 if self._config.api == "openai-responses":
@@ -145,321 +108,142 @@ if self._config.api == "openai-responses":
 return self._stream_chat_completions(...)
 ```
 
-Remove the Tau-specific routing policy:
+Remove the model-name routing helpers and prefixes. Remove
+`infer_api_from_model` from `OpenAICompatibleConfig` in `src/tau_ai/env.py`.
 
-- `_RESPONSES_ONLY_PREFIXES`
-- `_use_responses_api()`
-- the `"codex"` substring check
-- the model-prefix branch inside `_stream_provider_events()`
-
-Update `src/tau_ai/env.py` to remove `infer_api_from_model` from
-`OpenAICompatibleConfig`. Once routing matches Pi, there is nothing left to
-infer.
-
-Also remove now-obsolete `infer_api_from_model=False` arguments and assertions
-from:
+Remove the obsolete flag from dynamic providers and llama.cpp in
 
 - `src/tau_coding/provider_runtime.py`
 - `src/tau_coding/extensions/builtins/llama_cpp/service.py`
-- `tests/test_llama_cpp_extension.py`
 
-Dynamic providers and llama.cpp remain deterministic because their configured
-`api="openai-completions"` directly selects Chat Completions.
+Both paths already configure `openai-completions` explicitly.
 
-### 2. Centralize Pi's provider/model precedence in Tau's provider composition
+### 2. Resolve model and provider metadata in one place
 
-Tau already has the right durable-provider resolution logic in the private
-`src/tau_coding/provider_config.py::_provider_api()` helper. Promote it to a
-module-level application helper named `provider_api()` and use it everywhere
-that needs the resolved API:
+Promote `_provider_api()` in `src/tau_coding/provider_config.py` to the public
+application helper `provider_api()`.
 
-```python
-def provider_api(provider: ProviderConfig, model: str | None = None):
-    metadata = _metadata_for_model(provider, selected_model)
-    if metadata is not None and metadata.api is not None:
-        return metadata.api
-    return provider.api
-```
-
-Preserve and test this mapping explicitly:
+The resolver follows this order.
 
 ```text
-ProviderCatalogEntry.api
+model metadata API
         │
-        ├───────────────┐
-        ▼               │
-provider.api            │
-                        ▼
-model_metadata.api ──► resolved api ──► OpenAICompatibleConfig.api
-     (override)
+        ▼
+provider API
+        │
+        ▼
+openai-completions compatibility value
 ```
 
-Keep this resolver in `tau_coding`: protocol composition is application/model
-metadata policy. Do not move provider catalog knowledge into `tau_ai` or
-`tau_agent`. Leave the existing session and RPC projection logic unchanged;
-persisted provider/model metadata already uses the same precedence there, and
-refactoring extension runtime fallbacks is outside issue #546.
+Use the helper when building `OpenAICompatibleConfig`. Keep this policy in
+`tau_coding`, where provider catalogs and model metadata are composed.
 
-Do not add `infer_api_from_model` or an `api_was_explicit` field to
-`OpenAICompatibleProviderConfig`; neither has a Pi counterpart.
+Leave session and RPC code unchanged. Their existing durable-provider
+projection already applies model metadata before provider metadata.
 
-For legacy Tau catalog entries that omit provider and model `api`, keep the
-existing provider-kind compatibility default of `openai-completions`. This is a
-deterministic configuration migration fallback, not runtime model-name
-inference:
+### 3. Add the CLI choice
+
+Update `src/tau_coding/cli.py` with an `--api` option for `tau setup`.
+
+Accepted values include
+
+- `openai-completions`
+- `openai-responses`
+
+Use `openai-completions` when the option is omitted. Save the chosen value into
+the existing provider definition in `catalog.toml` and preserve its display and
+documentation metadata. Save provider preferences through the existing
+`providers.json` path.
+
+The CLI save path must materialize the API field when updating an older catalog
+entry that lacks it.
+
+### 4. Add the TUI choice
+
+Update `src/tau_coding/tui/app.py` and `CustomProviderLoginResult` with the
+selected API.
+
+Place a selector after the base URL with these labels.
+
+- OpenAI Chat Completions (`/chat/completions`)
+- OpenAI Responses (`/responses`)
+
+Use Chat Completions as the initial value. Enter should accept the current
+value. Space should open the choices. Selecting another value should advance to
+the API-key environment field. The implementation should use Textual's public
+bindings and messages.
+
+Save the value into both runtime configuration and `ProviderCatalogEntry`.
+
+### 5. Preserve configuration ownership
+
+Continue using the existing persistence split.
 
 ```text
-missing api on legacy openai-compatible entry
-    └──► openai-completions
+catalog.toml   provider and model capabilities, including API
+providers.json provider preferences and ordering
+session JSONL  selected provider, model, and messages
 ```
 
-This fallback should be documented. It should not inspect the model ID, and it
-should not silently choose Responses. A later explicit save may materialize the
-resolved provider API in `catalog.toml`, matching Pi's documented requirement
-that custom models resolve an API from provider or model metadata.
+Older OpenAI-compatible catalog entries may omit `api`. Resolve those entries
+to `openai-completions` so existing custom providers continue to work. New
+entries created through either setup flow always save an explicit value.
 
-Preserve Tau's existing persistence split:
+## Tests
 
-```text
-catalog.toml   = provider/model capabilities, including api
-providers.json = user preferences and provider ordering; no api ownership
-session JSONL  = selected provider/model and messages; no new api field
-```
+### Provider routing
 
-Verify catalog load, merge, save, and reload rather than introducing another
-configuration location. In particular, account for
-`_provider_definition_differs_from_catalog()`: the TUI must create its initial
-`ProviderCatalogEntry` with `api` populated because a pre-existing entry whose
-API is absent is intentionally not treated as an override during settings
-merge/save.
+Update `tests/test_tau_ai.py` with misleading model names in both directions.
 
-### 3. Add protocol selection to `tau setup`
-
-Update `src/tau_coding/cli.py`:
-
-- Add an `api` argument to `setup_command()`.
-- Add a `--api` option to the root callback, scoped in help text to `tau setup`.
-- Accept the exact Pi/Tau protocol identifiers:
-
-  ```text
-  openai-completions
-  openai-responses
-  ```
-
-- Default to `openai-completions`, Pi's documented choice for most compatible
-  custom servers.
-- Pass the selected value into `OpenAICompatibleProviderConfig.api`.
-- Let the existing catalog serialization write the same value to the provider's
-  `api` field.
-
-Example:
-
-```bash
-tau --provider company \
-  --base-url https://ai.company.example/v1 \
-  --model company/openai/gpt-5.6 \
-  --api openai-responses \
-  setup
-```
-
-Invalid values should fail as CLI usage errors before any files are written.
-
-The option and persisted values intentionally use Pi's API names rather than a
-new Tau-specific enum or aliases.
-
-### 4. Add protocol selection to `/login custom`
-
-Update `src/tau_coding/tui/app.py`:
-
-```python
-@dataclass(frozen=True, slots=True)
-class CustomProviderLoginResult:
-    ...
-    api: Literal["openai-completions", "openai-responses"]
-```
-
-In `CustomProviderLoginScreen`:
-
-- Add a Textual `Select` after the base URL.
-- Present friendly labels while retaining the exact Pi protocol values:
-
-  ```text
-  OpenAI Chat Completions (/chat/completions)
-  OpenAI Responses (/responses)
-  ```
-
-- Default to Chat Completions.
-- Follow the existing mixed `Input`/`Select` form pattern in
-  `src/tau_coding/tui/local_backends.py::LocalConfigureScreen`: query the next
-  field without assuming it is an `Input`, and use `cast(Select[str],
-  widget).value` when collecting the choice.
-- Rename `_INPUT_ORDER` to a field-oriented name and insert the selector after
-  `custom-provider-base-url`. Submitting the base-URL input must focus the
-  selector, and leaving the selector must continue to the API-key-environment
-  field without breaking keyboard-only entry.
-- Advance after the user accepts either protocol, including accepting the
-  unchanged default with Enter. Do not let the selector's mount-time default
-  event move focus.
-- Validate the selection when collecting the result.
-- Extend the existing custom-provider CSS so the selector matches the form.
-
-When saving, put the value into both representations:
-
-```python
-provider = OpenAICompatibleProviderConfig(
-    ...,
-    api=result.api,
-)
-
-catalog_entry = ProviderCatalogEntry(
-    ...,
-    api=result.api,
-)
-```
-
-Writing the API directly into `ProviderCatalogEntry` ensures
-`~/.tau/catalog.toml` remains the capability source of truth, analogous to Pi's
-`models.json`; `providers.json` remains preferences-only.
-
-### 5. Add Pi-parity regression tests
-
-#### API dispatch contract
-
-Replace the heuristic-oriented tests in `tests/test_tau_ai.py` with a table that
-proves model names are irrelevant:
-
-| Configured API | Model ID | Expected endpoint |
+| Configured API | Model ID | Endpoint |
 | --- | --- | --- |
 | `openai-completions` | `gpt-5.5-proxy` | `/chat/completions` |
-| `openai-completions` | `company/openai/gpt-5.6` | `/chat/completions` |
-| `openai-responses` | `gpt-4o` | `/responses` |
 | `openai-responses` | `company/openai/gpt-5.6` | `/responses` |
 
-The important invariant is:
+Keep request-shape and stream-parser tests for both APIs. Give each Responses
+test an explicit `api="openai-responses"` configuration.
 
-```python
-endpoint = endpoint_for(config.api)
-# never endpoint_for(model_id)
-```
+### Catalog composition
 
-Keep the existing request-shape and SSE parser tests for both transports; only
-make their API selection explicit in every `OpenAICompatibleConfig`
-construction. Add a direct environment-config regression proving that an
-unset API remains `openai-completions`.
+Cover these behaviors in `tests/test_provider_config.py` and
+`tests/test_provider_catalog.py`.
 
-#### Provider/model composition contract
+- Model metadata overrides provider metadata
+- Provider and model API values survive catalog round trips
+- API-less OpenAI-compatible entries resolve to Chat Completions
+- Provider preferences stay free of capability metadata
 
-Extend `tests/test_provider_config.py`, `tests/test_provider_catalog.py`, and
-`tests/test_provider_runtime.py`:
+### CLI and TUI setup
 
-- Provider-level `openai-completions` reaches the completions runtime path.
-- Provider-level `openai-responses` reaches the Responses runtime path.
-- Model-level `api` overrides the provider-level default.
-- A legacy OpenAI-compatible catalog entry with no `api` resolves
-  deterministically to `openai-completions`.
-- Misleading model IDs do not alter any of those results.
-- The final assistant message records the resolved API, matching Pi's model API
-  metadata rather than an inferred transport.
-- Catalog serialization round-trips provider-level and model-level APIs, while
-  provider preferences remain API-free.
+Cover these behaviors in `tests/test_cli.py` and `tests/test_tui_app.py`.
 
-Name or document the precedence test as a Pi-parity contract so future changes
-do not reintroduce model-name routing.
+- Both API choices save and reload correctly
+- The CLI default saves Chat Completions
+- Updating an API-less entry materializes the chosen API
+- Invalid CLI values fail before files are written
+- TUI focus moves through the selector with the keyboard
+- Accepting the initial TUI value works with Enter
+- The saved catalog includes the chosen API
 
-#### CLI setup
+Keep dynamic-provider and llama.cpp regression tests focused on explicit Chat
+Completions routing.
 
-Extend `tests/test_cli.py`:
+## Documentation
 
-- `--api openai-responses` appears in the saved catalog and loaded provider.
-- Explicit/default Chat Completions is saved as `openai-completions`.
-- Unsupported API values fail without writing configuration.
-- Existing timeout, retry, default-provider, and missing-key behavior remains
-  intact.
+Update the user-facing provider and configuration guides in
 
-#### TUI setup
+- `website/content/guides/providers-and-models.md`
+- `website/content/reference/configuration.md`
+- `src/tau_coding/data/docs/models.md`
+- `src/tau_coding/data/docs/cli.md`
 
-Extend `tests/test_tui_app.py`:
-
-- The custom-provider screen exposes both friendly protocol choices.
-- The chosen exact API value reaches `CustomProviderLoginResult`.
-- Enter/focus traversal crosses the new `Select` and continues to the next
-  field; keyboard-only submission still saves.
-- Saving includes `api = "openai-responses"` or
-  `api = "openai-completions"` in `catalog.toml`.
-- Existing credential, reload, and provider-selection behavior remains
-  unchanged.
-
-#### Dynamic provider regression
-
-Update `tests/test_extension_providers.py` and
-`tests/test_llama_cpp_extension.py` as needed to prove that explicit
-`openai-completions` still routes misleading names such as `gpt-5.4-local` to
-Chat Completions after the inference flag is removed.
-
-### 6. Document the Pi mapping and compatibility decision
-
-Update:
-
-- `website/content/guides/providers-and-models.md` with `tau setup --api` and
-  `/login custom` behavior.
-- `website/content/reference/configuration.md` with provider-level defaults,
-  model-level overrides, and exact supported API names.
-- `src/tau_coding/data/docs/models.md` so Tau's bundled self-documentation
-  explains the same model as Pi's `docs/models.md`.
-- `src/tau_coding/data/docs/cli.md` with the `tau setup` option.
-- `src/tau_ai/openai_compatible.py` module/class documentation so it no longer
-  claims model names select the Responses API.
-- Add `dev-notes/openai-compatible-protocol-selection.md` with:
-  - the upstream Pi revision used;
-  - the Pi-to-Tau mapping table;
-  - why model-name inference was removed;
-  - the deterministic legacy fallback to Chat Completions;
-  - test and manual verification instructions.
-
-Suggested catalog example:
-
-```toml
-[[providers]]
-name = "company-ai"
-display_name = "Company AI"
-kind = "openai-compatible"
-base_url = "https://ai.company.example/v1"
-api = "openai-responses"
-models = ["company/openai/gpt-5.6"]
-default_model = "company/openai/gpt-5.6"
-```
-
-Also document the override form that corresponds to Pi's per-model `api`:
-
-```toml
-api = "openai-completions"
-
-[providers.model_metadata."responses-only-model"]
-api = "openai-responses"
-```
-
-## Compatibility policy
-
-The Pi-faithful behavior intentionally changes Tau's old heuristic:
-
-| Existing Tau configuration | Revised behavior |
-| --- | --- |
-| Explicit `api = "openai-completions"` | Always Chat Completions |
-| Explicit `api = "openai-responses"` | Always Responses |
-| Model metadata contains `api` | Model API overrides provider API |
-| No API anywhere on an OpenAI-compatible entry | Deterministic legacy default: Chat Completions |
-
-An old API-less custom provider that relied on a `gpt-5.4`, `gpt-5.5`, or
-`*codex*` name to reach Responses will need `api = "openai-responses"` added.
-That is preferable to preserving an undocumented inference mechanism that can
-also route proxy model IDs incorrectly and has no Pi equivalent.
-
-Call this out in the release note or migration documentation. Do not attempt to
-guess and rewrite old configurations from their model names.
+Explain how users choose an API, where Tau saves it, how model overrides work,
+and how older entries behave. Keep Pi-specific implementation detail in
+`dev-notes/openai-compatible-protocol-selection.md`.
 
 ## Validation
 
-Run focused checks first:
+Run the focused suite.
 
 ```bash
 uv run pytest \
@@ -467,15 +251,13 @@ uv run pytest \
   tests/test_provider_config.py \
   tests/test_provider_catalog.py \
   tests/test_provider_runtime.py \
-  tests/test_coding_session.py \
-  tests/test_rpc.py \
   tests/test_extension_providers.py \
   tests/test_llama_cpp_extension.py \
   tests/test_cli.py \
   tests/test_tui_app.py
 ```
 
-Then the repository's standard suite:
+Run the repository checks.
 
 ```bash
 uv run pytest
@@ -484,54 +266,24 @@ uv run ruff format --check .
 uv run mypy
 ```
 
-If published documentation changes, also build the Hugo website.
+Complete two manual checks against a mock or compatible server.
 
-Manual acceptance checks:
+1. Configure `company/openai/gpt-5.6` with `openai-responses` and confirm a
+   request to `/responses`.
+2. Configure `gpt-5.5-proxy` with `openai-completions` and confirm a request to
+   `/chat/completions`.
 
-```text
-1. Configure company/openai/gpt-5.6 with openai-responses.
-   Expected: POST <base-url>/responses.
+## Change surface
 
-2. Configure gpt-5.5-proxy with openai-completions.
-   Expected: POST <base-url>/chat/completions.
+Expected source changes include
 
-3. Configure one provider with a completions default and a model-level
-   responses override.
-   Expected: each model uses its resolved metadata API, matching Pi.
-```
+- `src/tau_ai/env.py`
+- `src/tau_ai/openai_compatible.py`
+- `src/tau_coding/cli.py`
+- `src/tau_coding/provider_config.py`
+- `src/tau_coding/provider_runtime.py`
+- `src/tau_coding/tui/app.py`
+- `src/tau_coding/extensions/builtins/llama_cpp/service.py`
 
-## Expected change surface
-
-No new provider implementation is needed, but the existing combined adapter's
-selection policy changes to match Pi.
-
-```text
-Updated
-├── src/tau_ai/env.py
-├── src/tau_ai/openai_compatible.py
-├── src/tau_coding/cli.py
-├── src/tau_coding/tui/app.py
-├── src/tau_coding/provider_config.py
-├── src/tau_coding/provider_runtime.py
-├── src/tau_coding/extensions/builtins/llama_cpp/service.py
-├── tests/test_tau_ai.py
-├── tests/test_provider_config.py
-├── tests/test_provider_catalog.py
-├── tests/test_provider_runtime.py
-├── tests/test_llama_cpp_extension.py
-├── tests/test_cli.py
-├── tests/test_tui_app.py
-├── website/content/guides/providers-and-models.md
-├── website/content/reference/configuration.md
-├── src/tau_coding/data/docs/models.md
-└── src/tau_coding/data/docs/cli.md
-
-Added
-└── dev-notes/openai-compatible-protocol-selection.md
-
-Unchanged
-├── src/tau_agent/*
-├── agent/session event formats
-├── Chat Completions request/parser implementation
-└── Responses request/parser implementation
-```
+Expected test and documentation changes stay within the files listed above.
+The implementation adds no provider, session format, dependency, or framework.

--- a/plans/546-openai-compatible-api-protocol-selection.md
+++ b/plans/546-openai-compatible-api-protocol-selection.md
@@ -1,0 +1,537 @@
+# Issue 546: expose API protocol selection for custom OpenAI-compatible providers
+
+Issue: https://github.com/huggingface/tau/issues/546
+
+Pi reference: https://github.com/badlogic/pi-mono
+
+## Goal
+
+Implement custom-provider API selection as a direct port of Pi's API-selection
+model. Make catalog metadata authoritative throughout Tau's application path,
+remove model-name routing from the OpenAI-compatible adapter, and do not add a
+durable `infer_api_from_model` or equivalent Tau-only configuration concept.
+
+## Intuition
+
+Tau already implements both OpenAI wire protocols. The bug is that the model
+name can currently override catalog intent:
+
+```text
+Current Tau
+
+catalog api ─────────────┐
+                        ├──► model-name heuristic ──► endpoint
+model id ────────────────┘
+```
+
+The Pi-faithful flow is simpler:
+
+```text
+Desired Tau, matching Pi
+
+provider api ────────────┐
+                        ├──► resolved model api ──► exact transport
+model-level api ─────────┘
+
+model id ───────────────────► request payload only
+```
+
+For the issue's two counterexamples:
+
+```text
+company/openai/gpt-5.6 + openai-responses
+    └──► POST /responses
+
+gpt-5.5-proxy + openai-completions
+    └──► POST /chat/completions
+```
+
+Neither result depends on the spelling of the model ID.
+
+## Pi reference behavior
+
+Pi makes `api` part of the resolved model. It resolves a custom model's API in
+this order:
+
+```text
+model.api  ??  provider.api  ??  inherited model api
+```
+
+It then dispatches through the provider registered for that exact `model.api`.
+The model ID never selects an API protocol.
+
+Use these upstream sources as the normative references, and record the Pi
+revision used during implementation in the development note:
+
+- `packages/ai/src/types.ts`: Pi's resolved `Model` has a required `api` field.
+- `packages/coding-agent/src/core/model-config.ts`: `api` is accepted at both
+  provider and custom-model level.
+- `packages/coding-agent/src/core/provider-composer.ts`: custom model
+  composition resolves `definition.api ?? providerConfig.api ?? defaults?.api`
+  and errors if no API can be resolved.
+- `packages/coding-agent/src/core/provider-composer.ts`: streaming dispatches
+  with `getApiProvider(model.api)`.
+- `packages/coding-agent/docs/models.md`: documents provider-level defaults and
+  model-level API overrides, including `openai-completions` and
+  `openai-responses`.
+
+Canonical links:
+
+- https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/types.ts
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/model-config.ts
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/provider-composer.ts
+- https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md
+
+### Pi to Tau mapping
+
+| Pi concept | Tau equivalent | Required behavior |
+| --- | --- | --- |
+| `Model.api` | `provider_api(provider, model)` and `OpenAICompatibleConfig.api` | One concrete protocol is resolved before streaming |
+| Provider `api` | `ProviderCatalogEntry.api` / `OpenAICompatibleProviderConfig.api` | Default API for the provider's models |
+| Custom-model `api` | `ModelCatalogMetadata.api` / `ProviderModelMetadata.api` | Overrides the provider API for that model |
+| `model.api ?? provider.api ?? default` | `provider_api()` plus the provider-kind compatibility default | Model metadata wins, then provider metadata |
+| `getApiProvider(model.api)` | `create_model_provider()` plus exact branching inside `OpenAICompatibleProvider` | Dispatch by API metadata, never by model ID |
+| `models.json` | `~/.tau/catalog.toml` | Durable provider/model capability metadata |
+
+Tau uses one Python `OpenAICompatibleProvider` class with two internal
+transports, whereas Pi registers separate API implementations. That is an
+acceptable language-level difference only if dispatch remains behaviorally
+equivalent: the resolved `api` value alone chooses the transport.
+
+## Architectural fit
+
+Tau's dependency direction remains:
+
+```text
+tau_coding  ─────►  tau_agent  ─────►  tau_ai
+ application        portable brain     provider streams
+```
+
+For this feature:
+
+```text
+tau_coding
+├── CLI `tau setup`
+├── TUI `/login custom`
+├── catalog composition
+└── resolved runtime configuration
+          │
+          ▼
+tau_ai.OpenAICompatibleProvider
+├── api == openai-completions ──► /chat/completions
+└── api == openai-responses ────► /responses
+```
+
+No change belongs in `tau_agent`, `AgentHarness`, the agent loop, tools, event
+types, or session storage. Pi also hands its agent core an already resolved
+model/provider; provider configuration and composition stay in the coding
+application and AI-provider layers.
+
+The custom setup screens are Tau-specific frontend conveniences—Pi primarily
+uses `models.json` for this configuration—but they must produce the same
+provider/model metadata Pi would consume. UI differences are acceptable;
+configuration and dispatch semantics are not.
+
+## Detailed implementation plan
+
+### 1. Make the API value the sole routing authority
+
+Update `src/tau_ai/openai_compatible.py` so `_stream_provider_events()` selects
+the endpoint only from `self._config.api`:
+
+```python
+if self._config.api == "openai-responses":
+    return self._stream_responses(...)
+return self._stream_chat_completions(...)
+```
+
+Remove the Tau-specific routing policy:
+
+- `_RESPONSES_ONLY_PREFIXES`
+- `_use_responses_api()`
+- the `"codex"` substring check
+- the model-prefix branch inside `_stream_provider_events()`
+
+Update `src/tau_ai/env.py` to remove `infer_api_from_model` from
+`OpenAICompatibleConfig`. Once routing matches Pi, there is nothing left to
+infer.
+
+Also remove now-obsolete `infer_api_from_model=False` arguments and assertions
+from:
+
+- `src/tau_coding/provider_runtime.py`
+- `src/tau_coding/extensions/builtins/llama_cpp/service.py`
+- `tests/test_llama_cpp_extension.py`
+
+Dynamic providers and llama.cpp remain deterministic because their configured
+`api="openai-completions"` directly selects Chat Completions.
+
+### 2. Centralize Pi's provider/model precedence in Tau's provider composition
+
+Tau already has the right durable-provider resolution logic in the private
+`src/tau_coding/provider_config.py::_provider_api()` helper. Promote it to a
+module-level application helper named `provider_api()` and use it everywhere
+that needs the resolved API:
+
+```python
+def provider_api(provider: ProviderConfig, model: str | None = None):
+    metadata = _metadata_for_model(provider, selected_model)
+    if metadata is not None and metadata.api is not None:
+        return metadata.api
+    return provider.api
+```
+
+Preserve and test this mapping explicitly:
+
+```text
+ProviderCatalogEntry.api
+        │
+        ├───────────────┐
+        ▼               │
+provider.api            │
+                        ▼
+model_metadata.api ──► resolved api ──► OpenAICompatibleConfig.api
+     (override)
+```
+
+Keep this resolver in `tau_coding`: protocol composition is application/model
+metadata policy. Do not move provider catalog knowledge into `tau_ai` or
+`tau_agent`. Leave the existing session and RPC projection logic unchanged;
+persisted provider/model metadata already uses the same precedence there, and
+refactoring extension runtime fallbacks is outside issue #546.
+
+Do not add `infer_api_from_model` or an `api_was_explicit` field to
+`OpenAICompatibleProviderConfig`; neither has a Pi counterpart.
+
+For legacy Tau catalog entries that omit provider and model `api`, keep the
+existing provider-kind compatibility default of `openai-completions`. This is a
+deterministic configuration migration fallback, not runtime model-name
+inference:
+
+```text
+missing api on legacy openai-compatible entry
+    └──► openai-completions
+```
+
+This fallback should be documented. It should not inspect the model ID, and it
+should not silently choose Responses. A later explicit save may materialize the
+resolved provider API in `catalog.toml`, matching Pi's documented requirement
+that custom models resolve an API from provider or model metadata.
+
+Preserve Tau's existing persistence split:
+
+```text
+catalog.toml   = provider/model capabilities, including api
+providers.json = user preferences and provider ordering; no api ownership
+session JSONL  = selected provider/model and messages; no new api field
+```
+
+Verify catalog load, merge, save, and reload rather than introducing another
+configuration location. In particular, account for
+`_provider_definition_differs_from_catalog()`: the TUI must create its initial
+`ProviderCatalogEntry` with `api` populated because a pre-existing entry whose
+API is absent is intentionally not treated as an override during settings
+merge/save.
+
+### 3. Add protocol selection to `tau setup`
+
+Update `src/tau_coding/cli.py`:
+
+- Add an `api` argument to `setup_command()`.
+- Add a `--api` option to the root callback, scoped in help text to `tau setup`.
+- Accept the exact Pi/Tau protocol identifiers:
+
+  ```text
+  openai-completions
+  openai-responses
+  ```
+
+- Default to `openai-completions`, Pi's documented choice for most compatible
+  custom servers.
+- Pass the selected value into `OpenAICompatibleProviderConfig.api`.
+- Let the existing catalog serialization write the same value to the provider's
+  `api` field.
+
+Example:
+
+```bash
+tau --provider company \
+  --base-url https://ai.company.example/v1 \
+  --model company/openai/gpt-5.6 \
+  --api openai-responses \
+  setup
+```
+
+Invalid values should fail as CLI usage errors before any files are written.
+
+The option and persisted values intentionally use Pi's API names rather than a
+new Tau-specific enum or aliases.
+
+### 4. Add protocol selection to `/login custom`
+
+Update `src/tau_coding/tui/app.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CustomProviderLoginResult:
+    ...
+    api: Literal["openai-completions", "openai-responses"]
+```
+
+In `CustomProviderLoginScreen`:
+
+- Add a Textual `Select` after the base URL.
+- Present friendly labels while retaining the exact Pi protocol values:
+
+  ```text
+  OpenAI Chat Completions (/chat/completions)
+  OpenAI Responses (/responses)
+  ```
+
+- Default to Chat Completions.
+- Follow the existing mixed `Input`/`Select` form pattern in
+  `src/tau_coding/tui/local_backends.py::LocalConfigureScreen`: query the next
+  field without assuming it is an `Input`, and use `cast(Select[str],
+  widget).value` when collecting the choice.
+- Rename `_INPUT_ORDER` to a field-oriented name and insert the selector after
+  `custom-provider-base-url`. Submitting the base-URL input must focus the
+  selector, and leaving the selector must continue to the API-key-environment
+  field without breaking keyboard-only entry.
+- Advance after the user accepts either protocol, including accepting the
+  unchanged default with Enter. Do not let the selector's mount-time default
+  event move focus.
+- Validate the selection when collecting the result.
+- Extend the existing custom-provider CSS so the selector matches the form.
+
+When saving, put the value into both representations:
+
+```python
+provider = OpenAICompatibleProviderConfig(
+    ...,
+    api=result.api,
+)
+
+catalog_entry = ProviderCatalogEntry(
+    ...,
+    api=result.api,
+)
+```
+
+Writing the API directly into `ProviderCatalogEntry` ensures
+`~/.tau/catalog.toml` remains the capability source of truth, analogous to Pi's
+`models.json`; `providers.json` remains preferences-only.
+
+### 5. Add Pi-parity regression tests
+
+#### API dispatch contract
+
+Replace the heuristic-oriented tests in `tests/test_tau_ai.py` with a table that
+proves model names are irrelevant:
+
+| Configured API | Model ID | Expected endpoint |
+| --- | --- | --- |
+| `openai-completions` | `gpt-5.5-proxy` | `/chat/completions` |
+| `openai-completions` | `company/openai/gpt-5.6` | `/chat/completions` |
+| `openai-responses` | `gpt-4o` | `/responses` |
+| `openai-responses` | `company/openai/gpt-5.6` | `/responses` |
+
+The important invariant is:
+
+```python
+endpoint = endpoint_for(config.api)
+# never endpoint_for(model_id)
+```
+
+Keep the existing request-shape and SSE parser tests for both transports; only
+make their API selection explicit in every `OpenAICompatibleConfig`
+construction. Add a direct environment-config regression proving that an
+unset API remains `openai-completions`.
+
+#### Provider/model composition contract
+
+Extend `tests/test_provider_config.py`, `tests/test_provider_catalog.py`, and
+`tests/test_provider_runtime.py`:
+
+- Provider-level `openai-completions` reaches the completions runtime path.
+- Provider-level `openai-responses` reaches the Responses runtime path.
+- Model-level `api` overrides the provider-level default.
+- A legacy OpenAI-compatible catalog entry with no `api` resolves
+  deterministically to `openai-completions`.
+- Misleading model IDs do not alter any of those results.
+- The final assistant message records the resolved API, matching Pi's model API
+  metadata rather than an inferred transport.
+- Catalog serialization round-trips provider-level and model-level APIs, while
+  provider preferences remain API-free.
+
+Name or document the precedence test as a Pi-parity contract so future changes
+do not reintroduce model-name routing.
+
+#### CLI setup
+
+Extend `tests/test_cli.py`:
+
+- `--api openai-responses` appears in the saved catalog and loaded provider.
+- Explicit/default Chat Completions is saved as `openai-completions`.
+- Unsupported API values fail without writing configuration.
+- Existing timeout, retry, default-provider, and missing-key behavior remains
+  intact.
+
+#### TUI setup
+
+Extend `tests/test_tui_app.py`:
+
+- The custom-provider screen exposes both friendly protocol choices.
+- The chosen exact API value reaches `CustomProviderLoginResult`.
+- Enter/focus traversal crosses the new `Select` and continues to the next
+  field; keyboard-only submission still saves.
+- Saving includes `api = "openai-responses"` or
+  `api = "openai-completions"` in `catalog.toml`.
+- Existing credential, reload, and provider-selection behavior remains
+  unchanged.
+
+#### Dynamic provider regression
+
+Update `tests/test_extension_providers.py` and
+`tests/test_llama_cpp_extension.py` as needed to prove that explicit
+`openai-completions` still routes misleading names such as `gpt-5.4-local` to
+Chat Completions after the inference flag is removed.
+
+### 6. Document the Pi mapping and compatibility decision
+
+Update:
+
+- `website/content/guides/providers-and-models.md` with `tau setup --api` and
+  `/login custom` behavior.
+- `website/content/reference/configuration.md` with provider-level defaults,
+  model-level overrides, and exact supported API names.
+- `src/tau_coding/data/docs/models.md` so Tau's bundled self-documentation
+  explains the same model as Pi's `docs/models.md`.
+- `src/tau_coding/data/docs/cli.md` with the `tau setup` option.
+- `src/tau_ai/openai_compatible.py` module/class documentation so it no longer
+  claims model names select the Responses API.
+- Add `dev-notes/openai-compatible-protocol-selection.md` with:
+  - the upstream Pi revision used;
+  - the Pi-to-Tau mapping table;
+  - why model-name inference was removed;
+  - the deterministic legacy fallback to Chat Completions;
+  - test and manual verification instructions.
+
+Suggested catalog example:
+
+```toml
+[[providers]]
+name = "company-ai"
+display_name = "Company AI"
+kind = "openai-compatible"
+base_url = "https://ai.company.example/v1"
+api = "openai-responses"
+models = ["company/openai/gpt-5.6"]
+default_model = "company/openai/gpt-5.6"
+```
+
+Also document the override form that corresponds to Pi's per-model `api`:
+
+```toml
+api = "openai-completions"
+
+[providers.model_metadata."responses-only-model"]
+api = "openai-responses"
+```
+
+## Compatibility policy
+
+The Pi-faithful behavior intentionally changes Tau's old heuristic:
+
+| Existing Tau configuration | Revised behavior |
+| --- | --- |
+| Explicit `api = "openai-completions"` | Always Chat Completions |
+| Explicit `api = "openai-responses"` | Always Responses |
+| Model metadata contains `api` | Model API overrides provider API |
+| No API anywhere on an OpenAI-compatible entry | Deterministic legacy default: Chat Completions |
+
+An old API-less custom provider that relied on a `gpt-5.4`, `gpt-5.5`, or
+`*codex*` name to reach Responses will need `api = "openai-responses"` added.
+That is preferable to preserving an undocumented inference mechanism that can
+also route proxy model IDs incorrectly and has no Pi equivalent.
+
+Call this out in the release note or migration documentation. Do not attempt to
+guess and rewrite old configurations from their model names.
+
+## Validation
+
+Run focused checks first:
+
+```bash
+uv run pytest \
+  tests/test_tau_ai.py \
+  tests/test_provider_config.py \
+  tests/test_provider_catalog.py \
+  tests/test_provider_runtime.py \
+  tests/test_coding_session.py \
+  tests/test_rpc.py \
+  tests/test_extension_providers.py \
+  tests/test_llama_cpp_extension.py \
+  tests/test_cli.py \
+  tests/test_tui_app.py
+```
+
+Then the repository's standard suite:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```
+
+If published documentation changes, also build the Hugo website.
+
+Manual acceptance checks:
+
+```text
+1. Configure company/openai/gpt-5.6 with openai-responses.
+   Expected: POST <base-url>/responses.
+
+2. Configure gpt-5.5-proxy with openai-completions.
+   Expected: POST <base-url>/chat/completions.
+
+3. Configure one provider with a completions default and a model-level
+   responses override.
+   Expected: each model uses its resolved metadata API, matching Pi.
+```
+
+## Expected change surface
+
+No new provider implementation is needed, but the existing combined adapter's
+selection policy changes to match Pi.
+
+```text
+Updated
+├── src/tau_ai/env.py
+├── src/tau_ai/openai_compatible.py
+├── src/tau_coding/cli.py
+├── src/tau_coding/tui/app.py
+├── src/tau_coding/provider_config.py
+├── src/tau_coding/provider_runtime.py
+├── src/tau_coding/extensions/builtins/llama_cpp/service.py
+├── tests/test_tau_ai.py
+├── tests/test_provider_config.py
+├── tests/test_provider_catalog.py
+├── tests/test_provider_runtime.py
+├── tests/test_llama_cpp_extension.py
+├── tests/test_cli.py
+├── tests/test_tui_app.py
+├── website/content/guides/providers-and-models.md
+├── website/content/reference/configuration.md
+├── src/tau_coding/data/docs/models.md
+└── src/tau_coding/data/docs/cli.md
+
+Added
+└── dev-notes/openai-compatible-protocol-selection.md
+
+Unchanged
+├── src/tau_agent/*
+├── agent/session event formats
+├── Chat Completions request/parser implementation
+└── Responses request/parser implementation
+```

--- a/src/tau_ai/env.py
+++ b/src/tau_ai/env.py
@@ -62,7 +62,6 @@ class OpenAICompatibleConfig:
     omit_authorization_header: bool = False
     credential_resolver: RuntimeProviderAuthResolver | None = None
     response_headers_observer: RuntimeResponseHeadersObserver | None = None
-    infer_api_from_model: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -1,12 +1,4 @@
-"""OpenAI-compatible chat completions provider.
-
-Most OpenAI-compatible models are served over `/chat/completions`. Newer
-reasoning models (e.g. ``gpt-5.5``/``gpt-5.4`` and the ``*-codex`` family)
-reject the combination of function tools and ``reasoning_effort`` on that
-endpoint and require ``/v1/responses`` instead. This adapter routes those
-models to the Responses API at request time while leaving every other model on
-the original chat-completions path unchanged.
-"""
+"""OpenAI-compatible chat completions and Responses provider."""
 
 from __future__ import annotations
 
@@ -56,24 +48,9 @@ from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_ret
 from tau_ai.stream import canonicalize_provider_stream
 from tau_ai.tool_call_ids import portable_tool_call_id
 
-# Models that reject function tools + reasoning_effort on /chat/completions and
-# must use the /v1/responses endpoint instead.
-_RESPONSES_ONLY_PREFIXES: tuple[str, ...] = ("gpt-5.5", "gpt-5.4")
-
-
-def _use_responses_api(model: str) -> bool:
-    """Return whether ``model`` must be served over the Responses API."""
-    normalized = model.strip().lower()
-    if "codex" in normalized:
-        return True
-    return any(normalized.startswith(prefix) for prefix in _RESPONSES_ONLY_PREFIXES)
-
 
 class OpenAICompatibleProvider:
-    """Provider adapter for OpenAI-compatible `/chat/completions` APIs.
-
-    Models that require it are transparently served over `/v1/responses`.
-    """
+    """Provider adapter for explicitly configured OpenAI-compatible APIs."""
 
     def __init__(
         self,
@@ -128,9 +105,7 @@ class OpenAICompatibleProvider:
         session_id: str | None = None,
     ) -> AsyncIterator[ProviderEvent]:
         """Stream one model response as provider-neutral events."""
-        if self._config.api == "openai-responses" or (
-            self._config.infer_api_from_model and _use_responses_api(model)
-        ):
+        if self._config.api == "openai-responses":
             return self._stream_responses(
                 model=model,
                 system=system,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -171,11 +171,20 @@ def setup_command(
 ) -> None:
     """Create or update an OpenAI-compatible provider entry."""
     settings = load_provider_settings()
+    existing = next(
+        (item for item in settings.providers if item.name == provider_name),
+        None,
+    )
     provider = OpenAICompatibleProviderConfig(
         name=provider_name,
         base_url=base_url.rstrip("/"),
         api_key_env=api_key_env,
         api=api,
+        credential_name=(
+            existing.credential_name
+            if isinstance(existing, OpenAICompatibleProviderConfig)
+            else None
+        ),
         models=(model,),
         default_model=model,
         timeout_seconds=timeout_seconds,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -162,6 +162,7 @@ def setup_command(
     base_url: str = DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
     api_key_env: str = "OPENAI_API_KEY",
     model: str = DEFAULT_MODEL,
+    api: Literal["openai-completions", "openai-responses"] = "openai-completions",
     timeout_seconds: float = DEFAULT_OPENAI_COMPATIBLE_TIMEOUT_SECONDS,
     max_retries: int = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRIES,
     max_retry_delay_seconds: float = DEFAULT_OPENAI_COMPATIBLE_MAX_RETRY_DELAY_SECONDS,
@@ -173,6 +174,7 @@ def setup_command(
         name=provider_name,
         base_url=base_url.rstrip("/"),
         api_key_env=api_key_env,
+        api=api,
         models=(model,),
         default_model=model,
         timeout_seconds=timeout_seconds,
@@ -239,6 +241,10 @@ def main(
         str,
         typer.Option("--api-key-env", help="API key environment variable for `tau setup`."),
     ] = "OPENAI_API_KEY",
+    setup_api: Annotated[
+        Literal["openai-completions", "openai-responses"],
+        typer.Option("--api", help="OpenAI API protocol for `tau setup`."),
+    ] = "openai-completions",
     setup_timeout_seconds: Annotated[
         float,
         typer.Option(
@@ -501,6 +507,7 @@ def main(
             base_url=setup_base_url,
             api_key_env=setup_api_key_env,
             model=model or DEFAULT_MODEL,
+            api=setup_api,
             timeout_seconds=setup_timeout_seconds,
             max_retries=setup_max_retries,
             max_retry_delay_seconds=setup_max_retry_delay_seconds,

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -44,6 +44,7 @@ from tau_coding.provider_config import (
     provider_kind,
     resolve_provider_selection,
     resolve_startup_thinking_level,
+    save_provider_definition,
     save_provider_settings,
     upsert_openai_compatible_provider,
 )
@@ -182,6 +183,7 @@ def setup_command(
         max_retry_delay_seconds=max_retry_delay_seconds,
     )
     updated = upsert_openai_compatible_provider(settings, provider, set_default=set_default)
+    save_provider_definition(provider)
     path = save_provider_settings(updated)
     typer.echo(
         f"Saved provider '{provider.name}' to {user_catalog_path()} and preferences to {path}"

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -51,6 +51,21 @@ Explicit `--provider` and `--model` overrides take precedence over a resumed
 provider-aware transcript entry. Print mode reports actionable errors instead of
 opening an interactive login or local setup flow.
 
+## Custom provider setup
+
+```bash
+tau --provider company-ai \
+  --base-url https://ai.company.example/v1 \
+  --model company/openai/gpt-5.6 \
+  --api openai-responses \
+  setup
+```
+
+`--api` accepts the exact protocol names `openai-completions` (the default) and
+`openai-responses`. Setup saves the capability to `~/.tau/catalog.toml`;
+`~/.tau/providers.json` remains preference-only. `/login custom` exposes the
+same choice interactively.
+
 ## Model catalog refresh
 
 ```bash

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -62,6 +62,13 @@ Ollama, gateways, and older manually configured local providers. An existing
 provider named `llama-cpp` remains distinct from the built-in `llama.cpp`; Tau
 does not migrate or overwrite it.
 
+Custom providers choose one exact Pi-compatible API protocol:
+`openai-completions` for `/chat/completions` (the setup default), or
+`openai-responses` for `/responses`. The provider-level `api` is the default and
+`model_metadata.<model>.api` overrides it for one model. Tau dispatches from that
+resolved metadata only; a model name containing `gpt-5` or `codex` has no routing
+meaning. API-less legacy entries use `openai-completions` deterministically.
+
 ## Metadata and selection rules
 
 Use exact provider/model IDs. Tau does not infer context windows, output limits,

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -62,12 +62,12 @@ Ollama, gateways, and older manually configured local providers. An existing
 provider named `llama-cpp` remains distinct from the built-in `llama.cpp`; Tau
 does not migrate or overwrite it.
 
-Custom providers choose one exact Pi-compatible API protocol:
-`openai-completions` for `/chat/completions` (the setup default), or
-`openai-responses` for `/responses`. The provider-level `api` is the default and
-`model_metadata.<model>.api` overrides it for one model. Tau dispatches from that
-resolved metadata only; a model name containing `gpt-5` or `codex` has no routing
-meaning. API-less legacy entries use `openai-completions` deterministically.
+Choose the API used by each custom OpenAI-compatible provider.
+`openai-completions` selects `/chat/completions` and is the setup default.
+`openai-responses` selects `/responses`. The provider-level `api` is the default,
+and `model_metadata.<model>.api` can override it for one model. Model names do not
+change the selected API. Existing entries without the field use
+`openai-completions`.
 
 ## Metadata and selection rules
 

--- a/src/tau_coding/extensions/builtins/llama_cpp/service.py
+++ b/src/tau_coding/extensions/builtins/llama_cpp/service.py
@@ -1342,7 +1342,6 @@ class LlamaCppService:
                 timeout_seconds=self.timeout_seconds,
                 max_retries=0,
                 omit_authorization_header=auth.omit_authorization_header,
-                infer_api_from_model=False,
             ),
             client=client,
         )
@@ -1397,7 +1396,6 @@ class LlamaCppService:
                 timeout_seconds=self.timeout_seconds,
                 max_retries=0,
                 omit_authorization_header=auth.omit_authorization_header,
-                infer_api_from_model=False,
             ),
             client=client,
         )

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -532,6 +532,16 @@ def save_provider_settings(settings: ProviderSettings, paths: TauPaths | None = 
     return path
 
 
+def save_provider_definition(provider: ProviderConfig, paths: TauPaths | None = None) -> Path:
+    """Write one complete provider definition to the user catalog."""
+    existing = next(
+        (entry for entry in effective_catalog(paths) if entry.name == provider.name),
+        None,
+    )
+    entry = _catalog_entry_from_provider(provider, existing=existing)
+    return save_user_catalog_entries((entry,), paths=paths)
+
+
 def save_default_provider_model(
     *,
     provider_name: str,

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1161,11 +1161,7 @@ def _catalog_entry_from_provider(
         base_url=provider.base_url,
         api_key_env=provider.api_key_env,
         api=getattr(provider, "api", None),
-        credential_name=(
-            existing.credential_name
-            if existing is not None and provider.credential_name is None
-            else provider.credential_name
-        ),
+        credential_name=provider.credential_name,
         models=provider.models,
         default_model=(
             existing.default_model

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1539,7 +1539,8 @@ def _metadata_for_model(provider: ProviderConfig, model: str) -> ProviderModelMe
     return getattr(provider, "model_metadata", {}).get(model)
 
 
-def _provider_api(provider: ProviderConfig, model: str | None = None) -> ProviderApi | str:
+def provider_api(provider: ProviderConfig, model: str | None = None) -> ProviderApi | str:
+    """Resolve the API for a model, with model metadata taking precedence."""
     selected_model = model or provider.default_model
     metadata = _metadata_for_model(provider, selected_model)
     if metadata is not None and metadata.api is not None:
@@ -1583,7 +1584,7 @@ def _detected_compat(provider: ProviderConfig, model: str) -> dict[str, Any]:
     is_openai_api = (
         urlsplit(base_url).hostname == urlsplit(DEFAULT_OPENAI_COMPATIBLE_BASE_URL).hostname
     )
-    is_openai_responses = _provider_api(provider, model) == "openai-responses"
+    is_openai_responses = provider_api(provider, model) == "openai-responses"
     is_nonstandard = is_cerebras or is_grok or is_together or is_deepseek or is_zai or is_moonshot
     use_max_tokens = is_moonshot or is_together
     is_anthropic_api = urlsplit(base_url).hostname == urlsplit(DEFAULT_ANTHROPIC_BASE_URL).hostname
@@ -1714,7 +1715,7 @@ def openai_compatible_config_from_provider(
     return OpenAICompatibleConfig(
         api_key=api_key,
         provider_name=provider.name,
-        api=str(_provider_api(provider, selected_model)),
+        api=str(provider_api(provider, selected_model)),
         base_url=base_url.rstrip("/"),
         headers=_model_headers(provider, selected_model),
         timeout_seconds=provider.timeout_seconds,

--- a/src/tau_coding/provider_config.py
+++ b/src/tau_coding/provider_config.py
@@ -1161,7 +1161,11 @@ def _catalog_entry_from_provider(
         base_url=provider.base_url,
         api_key_env=provider.api_key_env,
         api=getattr(provider, "api", None),
-        credential_name=provider.credential_name,
+        credential_name=(
+            existing.credential_name
+            if existing is not None and provider.credential_name is None
+            else provider.credential_name
+        ),
         models=provider.models,
         default_model=(
             existing.default_model

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -148,9 +148,6 @@ async def create_dynamic_model_provider(
         compat=json_compatible_mapping(selected_model.compat),
         provider_name=provider.id,
         omit_authorization_header=auth.omit_authorization_header,
-        # Dynamic providers explicitly own their API choice. A local model id
-        # resembling gpt-* or *codex* must not reroute to /responses.
-        infer_api_from_model=False,
     )
     return OpenAICompatibleProvider(config, client=transport.client)
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -34,6 +34,7 @@ from textual.widgets import (
     Label,
     ListItem,
     ListView,
+    OptionList,
     Select,
     Static,
     TextArea,
@@ -2823,6 +2824,18 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
     def _focus_next(self, field_id: str) -> None:
         index = self._FIELD_ORDER.index(field_id)
         self.query_one(f"#{self._FIELD_ORDER[index + 1]}").focus()
+
+    def action_cursor_down(self) -> None:
+        """Move down through the open protocol choices."""
+        protocol = self.query_one("#custom-provider-api", Select)
+        if protocol.expanded:
+            protocol.query_one(OptionList).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move up through the open protocol choices."""
+        protocol = self.query_one("#custom-provider-api", Select)
+        if protocol.expanded:
+            protocol.query_one(OptionList).action_cursor_up()
 
     def _collect_result(self) -> CustomProviderLoginResult | None:
         provider_name = self._field("custom-provider-name", "Provider name")
@@ -5654,7 +5667,8 @@ class TauTuiApp(App[None]):
             | LocalChoiceConfirmScreen
             | LocalConfirmScreen
             | LocalSearchResultsScreen
-            | ProjectTrustScreen,
+            | ProjectTrustScreen
+            | CustomProviderLoginScreen,
         ):
             self.screen.action_cursor_down()
             return
@@ -5690,7 +5704,8 @@ class TauTuiApp(App[None]):
             | LocalChoiceConfirmScreen
             | LocalConfirmScreen
             | LocalSearchResultsScreen
-            | ProjectTrustScreen,
+            | ProjectTrustScreen
+            | CustomProviderLoginScreen,
         ):
             self.screen.action_cursor_up()
             return

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -23,6 +23,7 @@ from textual.binding import Binding, BindingsMap
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.events import Key, Resize
+from textual.message import Message
 from textual.screen import ModalScreen
 from textual.strip import Strip
 from textual.timer import Timer
@@ -33,9 +34,11 @@ from textual.widgets import (
     Label,
     ListItem,
     ListView,
+    Select,
     Static,
     TextArea,
 )
+from textual.widgets._select import SelectOverlay
 from textual.worker import Worker
 
 from tau_agent.events import (
@@ -2194,10 +2197,23 @@ class CustomProviderLoginResult:
     provider_name: str
     display_name: str
     base_url: str
+    api: Literal["openai-completions", "openai-responses"]
     api_key_env: str
     models: tuple[str, ...]
     default_model: str
     api_key: str
+
+
+class _CustomProviderApiSelect(Select[str]):
+    """Protocol select that reports accepting an unchanged default value."""
+
+    class Accepted(Message):
+        """A protocol choice was accepted from the open overlay."""
+
+    @on(SelectOverlay.UpdateSelection)
+    def _update_selection(self, event: SelectOverlay.UpdateSelection) -> None:
+        super()._update_selection(event)
+        self.post_message(self.Accepted())
 
 
 class LoginMethodPickerScreen(ModalScreen[str | None]):
@@ -2702,10 +2718,11 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
         Binding("ctrl+d", "close", "Close", priority=True),
     ]
 
-    _INPUT_ORDER: ClassVar[tuple[str, ...]] = (
+    _FIELD_ORDER: ClassVar[tuple[str, ...]] = (
         "custom-provider-name",
         "custom-provider-display-name",
         "custom-provider-base-url",
+        "custom-provider-api",
         "custom-provider-api-key-env",
         "custom-provider-models",
         "custom-provider-default-model",
@@ -2732,6 +2749,18 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
             yield Input(
                 placeholder="OpenAI-compatible base URL, e.g. https://api.studio.nebius.ai/v1",
                 id="custom-provider-base-url",
+            )
+            yield _CustomProviderApiSelect(
+                (
+                    (
+                        "OpenAI Chat Completions (/chat/completions)",
+                        "openai-completions",
+                    ),
+                    ("OpenAI Responses (/responses)", "openai-responses"),
+                ),
+                value="openai-completions",
+                allow_blank=False,
+                id="custom-provider-api",
             )
             yield Input(
                 placeholder="API key environment variable fallback, e.g. NEBIUS_API_KEY",
@@ -2762,19 +2791,25 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Advance through fields, then dismiss with provider details."""
         input_id = event.input.id
-        if input_id not in self._INPUT_ORDER:
+        if input_id not in self._FIELD_ORDER:
             return
         event.stop()
-        if input_id != self._INPUT_ORDER[-1]:
+        if input_id != self._FIELD_ORDER[-1]:
             self._focus_next(input_id)
             return
         result = self._collect_result()
         if result is not None:
             self.dismiss(result)
 
-    def _focus_next(self, input_id: str) -> None:
-        index = self._INPUT_ORDER.index(input_id)
-        self.query_one(f"#{self._INPUT_ORDER[index + 1]}", Input).focus()
+    @on(_CustomProviderApiSelect.Accepted)
+    def on_custom_provider_api_accepted(self, event: _CustomProviderApiSelect.Accepted) -> None:
+        """Advance after accepting either the default or alternate protocol."""
+        event.stop()
+        self._focus_next("custom-provider-api")
+
+    def _focus_next(self, field_id: str) -> None:
+        index = self._FIELD_ORDER.index(field_id)
+        self.query_one(f"#{self._FIELD_ORDER[index + 1]}").focus()
 
     def _collect_result(self) -> CustomProviderLoginResult | None:
         provider_name = self._field("custom-provider-name", "Provider name")
@@ -2783,6 +2818,14 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
         base_url = self._field("custom-provider-base-url", "Base URL")
         if base_url is None:
             return None
+        selected_api = cast(Select[str], self.query_one("#custom-provider-api")).value
+        if selected_api not in {"openai-completions", "openai-responses"}:
+            self.query_one("#custom-provider-help", Static).update(
+                "An OpenAI API protocol is required."
+            )
+            self.query_one("#custom-provider-api", Select).focus()
+            return None
+        api = cast(Literal["openai-completions", "openai-responses"], selected_api)
         api_key_env = self._field("custom-provider-api-key-env", "API key environment variable")
         if api_key_env is None:
             return None
@@ -2815,6 +2858,7 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
             provider_name=provider_name,
             display_name=display_name or provider_name,
             base_url=base_url,
+            api=api,
             api_key_env=api_key_env,
             models=models,
             default_model=default_model,
@@ -3760,6 +3804,7 @@ class TauTuiApp(App[None]):
     #custom-provider-name,
     #custom-provider-display-name,
     #custom-provider-base-url,
+    #custom-provider-api,
     #custom-provider-api-key-env,
     #custom-provider-models,
     #custom-provider-default-model,
@@ -6046,6 +6091,7 @@ class TauTuiApp(App[None]):
             name=result.provider_name,
             base_url=result.base_url.rstrip("/"),
             api_key_env=result.api_key_env,
+            api=result.api,
             credential_name=result.provider_name,
             models=result.models,
             default_model=result.default_model,
@@ -6060,6 +6106,7 @@ class TauTuiApp(App[None]):
             models=provider.models,
             default_model=provider.default_model,
             docs_url=provider.base_url,
+            api=result.api,
         )
         try:
             save_user_catalog_entries((catalog_entry,))

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -38,7 +38,6 @@ from textual.widgets import (
     Static,
     TextArea,
 )
-from textual.widgets._select import SelectOverlay
 from textual.worker import Worker
 
 from tau_agent.events import (
@@ -2205,14 +2204,17 @@ class CustomProviderLoginResult:
 
 
 class _CustomProviderApiSelect(Select[str]):
-    """Protocol select that reports accepting an unchanged default value."""
+    """Protocol selector whose current value can be accepted with Enter."""
+
+    BINDINGS = [
+        Binding("enter", "accept_value", "Accept", show=False),
+        Binding("space", "show_overlay", "Show menu", show=False),
+    ]
 
     class Accepted(Message):
-        """A protocol choice was accepted from the open overlay."""
+        """The current protocol value was accepted."""
 
-    @on(SelectOverlay.UpdateSelection)
-    def _update_selection(self, event: SelectOverlay.UpdateSelection) -> None:
-        super()._update_selection(event)
+    def action_accept_value(self) -> None:
         self.post_message(self.Accepted())
 
 
@@ -2732,6 +2734,7 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
     def __init__(self, *, theme: TuiTheme) -> None:
         super().__init__()
         self.theme = theme
+        self._api_selection_ready = False
 
     def compose(self) -> ComposeResult:
         """Compose the custom provider prompt."""
@@ -2787,6 +2790,10 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
     def on_mount(self) -> None:
         """Focus the first provider-detail field."""
         self.query_one("#custom-provider-name", Input).focus()
+        self.call_after_refresh(self._enable_api_selection_events)
+
+    def _enable_api_selection_events(self) -> None:
+        self._api_selection_ready = True
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Advance through fields, then dismiss with provider details."""
@@ -2801,9 +2808,15 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
         if result is not None:
             self.dismiss(result)
 
+    @on(Select.Changed, "#custom-provider-api")
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Advance after choosing a different protocol."""
+        if self._api_selection_ready:
+            self._focus_next("custom-provider-api")
+
     @on(_CustomProviderApiSelect.Accepted)
     def on_custom_provider_api_accepted(self, event: _CustomProviderApiSelect.Accepted) -> None:
-        """Advance after accepting either the default or alternate protocol."""
+        """Advance after accepting the current protocol."""
         event.stop()
         self._focus_next("custom-provider-api")
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -2783,7 +2783,7 @@ class CustomProviderLoginScreen(ModalScreen[CustomProviderLoginResult | _LoginFl
                 id="custom-provider-api-key",
             )
             yield Static(
-                "Enter advances/saves - Escape goes back - Ctrl+D closes",
+                "Enter advances/saves - Space opens API choices - Escape goes back - Ctrl+D closes",
                 id="login-footer",
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1969,7 +1969,7 @@ def test_setup_command_materializes_api_for_existing_api_less_provider(
                 kind="openai-compatible",
                 base_url="https://api.openai.com/v1",
                 api_key_env="OPENAI_API_KEY",
-                credential_name=None,
+                credential_name="local-credential",
                 models=("gpt-5.4",),
                 default_model="gpt-5.4",
                 docs_url="https://example.test/local",
@@ -1987,6 +1987,8 @@ def test_setup_command_materializes_api_for_existing_api_less_provider(
     assert f'api = "{api}"' in catalog
     assert 'display_name = "Local gateway"' in catalog
     assert 'docs_url = "https://example.test/local"' in catalog
+    assert 'credential_name = "local-credential"' in catalog
+    assert provider.credential_name == "local-credential"
 
 
 def test_setup_command_rejects_unsupported_api_without_writing_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,10 @@ from tau_ai import (
     FakeProvider,
 )
 from tau_coding import CodingSessionRecord, SessionManager, cli
+from tau_coding.catalog_loader import save_user_catalog_entries
 from tau_coding.cli import app, run_print_mode
 from tau_coding.paths import TauPaths
+from tau_coding.provider_catalog import ProviderCatalogEntry
 from tau_coding.provider_config import (
     OpenAICompatibleProviderConfig,
     ProviderSettings,
@@ -1949,6 +1951,42 @@ def test_setup_command_defaults_to_chat_completions(
     assert 'api = "openai-completions"' in (tmp_path / ".tau" / "catalog.toml").read_text(
         encoding="utf-8"
     )
+
+
+@pytest.mark.parametrize("api", ["openai-completions", "openai-responses"])
+def test_setup_command_materializes_api_for_existing_api_less_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    api: str,
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+    paths = TauPaths(home=tmp_path / ".tau")
+    save_user_catalog_entries(
+        (
+            ProviderCatalogEntry(
+                name="local",
+                display_name="Local gateway",
+                kind="openai-compatible",
+                base_url="https://api.openai.com/v1",
+                api_key_env="OPENAI_API_KEY",
+                credential_name=None,
+                models=("gpt-5.4",),
+                default_model="gpt-5.4",
+                docs_url="https://example.test/local",
+            ),
+        ),
+        paths,
+    )
+
+    result = CliRunner().invoke(app, ["--provider", "local", "--api", api, "setup"])
+
+    assert result.exit_code == 0
+    provider = load_provider_settings(paths).get_provider("local")
+    assert provider.api == api
+    catalog = (paths.home / "catalog.toml").read_text(encoding="utf-8")
+    assert f'api = "{api}"' in catalog
+    assert 'display_name = "Local gateway"' in catalog
+    assert 'docs_url = "https://example.test/local"' in catalog
 
 
 def test_setup_command_rejects_unsupported_api_without_writing_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -1902,6 +1903,8 @@ def test_setup_command_writes_provider_settings(
             "http://localhost:11434/v1/",
             "--api-key-env",
             "LOCAL_API_KEY",
+            "--api",
+            "openai-responses",
             "--timeout-seconds",
             "120",
             "--max-retries",
@@ -1921,10 +1924,45 @@ def test_setup_command_writes_provider_settings(
     assert settings.default_provider == "local"
     assert provider.base_url == "http://localhost:11434/v1"
     assert provider.api_key_env == "LOCAL_API_KEY"
+    assert provider.api == "openai-responses"
     assert provider.default_model == "qwen"
     assert provider.timeout_seconds == 120
     assert provider.max_retries == 2
     assert provider.max_retry_delay_seconds == 0.5
+    catalog = (tmp_path / ".tau" / "catalog.toml").read_text(encoding="utf-8")
+    preferences = json.loads((tmp_path / ".tau" / "providers.json").read_text(encoding="utf-8"))
+    assert 'api = "openai-responses"' in catalog
+    assert "api" not in preferences["provider_preferences"]["local"]
+
+
+def test_setup_command_defaults_to_chat_completions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(app, ["--provider", "local", "setup"])
+
+    assert result.exit_code == 0
+    provider = load_provider_settings(TauPaths(home=tmp_path / ".tau")).get_provider("local")
+    assert provider.api == "openai-completions"
+    assert 'api = "openai-completions"' in (tmp_path / ".tau" / "catalog.toml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_setup_command_rejects_unsupported_api_without_writing_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    isolate_home(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(app, ["--api", "automatic", "setup"])
+
+    assert result.exit_code == 2
+    assert "Invalid value" in result.stderr
+    assert not (tmp_path / ".tau" / "catalog.toml").exists()
+    assert not (tmp_path / ".tau" / "providers.json").exists()
 
 
 def test_setup_command_warns_when_api_key_env_is_missing(

--- a/tests/test_llama_cpp_extension.py
+++ b/tests/test_llama_cpp_extension.py
@@ -496,7 +496,6 @@ async def test_gpt_and_codex_model_ids_use_local_chat_transport(tmp_path: Path) 
             environment={},
         )
         assert runtime._config.api == "openai-completions"
-        assert runtime._config.infer_api_from_model is False
         await runtime.aclose()
     await client.aclose()
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -17,6 +17,8 @@ from tau_coding.catalog_loader import (
 from tau_coding.paths import TauPaths
 from tau_coding.provider_catalog import (
     BUILTIN_PROVIDER_CATALOG,
+    ModelCatalogMetadata,
+    ProviderCatalogEntry,
     builtin_provider_entry,
     model_cost_for_input_tokens,
 )
@@ -530,6 +532,33 @@ def test_user_catalog_adds_new_provider(tmp_path: Path) -> None:
     assert entry.default_model == "deepseek-ai/DeepSeek-V4-Pro"
     assert entry.context_windows == {"deepseek-ai/DeepSeek-V4-Pro": 163_840}
     assert entry.thinking_levels == ("off", "low", "medium", "high")
+
+
+def test_user_catalog_round_trips_provider_and_model_api_metadata(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau")
+    entry = ProviderCatalogEntry(
+        name="company-ai",
+        display_name="Company AI",
+        kind="openai-compatible",
+        base_url="https://ai.company.example/v1",
+        api_key_env="COMPANY_AI_API_KEY",
+        credential_name="company-ai",
+        models=("chat-proxy", "responses-only"),
+        default_model="chat-proxy",
+        docs_url="https://ai.company.example/docs",
+        api="openai-completions",
+        model_metadata={"responses-only": ModelCatalogMetadata(api="openai-responses")},
+    )
+
+    save_user_catalog_entries((entry,), paths)
+    reloaded = next(item for item in effective_catalog(paths) if item.name == "company-ai")
+
+    assert reloaded.api == "openai-completions"
+    assert reloaded.model_metadata["responses-only"].api == "openai-responses"
+    serialized = user_catalog_path(paths).read_text(encoding="utf-8")
+    assert 'api = "openai-completions"' in serialized
+    assert "[providers.model_metadata.responses-only]" in serialized
+    assert 'api = "openai-responses"' in serialized
 
 
 def test_user_catalog_overlays_builtin_provider(tmp_path: Path) -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -19,6 +19,7 @@ from tau_coding.provider_config import (
     anthropic_config_from_provider,
     load_provider_settings,
     openai_compatible_config_from_provider,
+    provider_api,
     provider_default_thinking_level,
     provider_has_usable_credentials,
     provider_model_max_tokens,
@@ -34,6 +35,22 @@ from tau_coding.provider_config import (
     upsert_openai_compatible_provider,
 )
 from tau_coding.thinking import ThinkingLevel
+
+
+def test_provider_api_prefers_model_metadata() -> None:
+    provider = OpenAICompatibleProviderConfig(
+        name="local",
+        api="openai-completions",
+        models=("chat", "reasoning"),
+        default_model="chat",
+        model_metadata={
+            "reasoning": ProviderModelMetadata(api="openai-responses"),
+        },
+    )
+
+    assert provider_api(provider, "chat") == "openai-completions"
+    assert provider_api(provider, "reasoning") == "openai-responses"
+    assert provider_api(OpenAICodexProviderConfig()) == "openai-codex-responses"
 
 
 def test_stale_preferences_cannot_restore_removed_codex_alias(tmp_path: Path) -> None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -106,6 +106,54 @@ def test_openai_compatible_config_from_env(monkeypatch: pytest.MonkeyPatch) -> N
     assert config.timeout_seconds == 12.5
     assert config.max_retries == 2
     assert config.max_retry_delay_seconds == 0.25
+    assert config.api == "openai-completions"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("api", "model", "endpoint"),
+    [
+        ("openai-completions", "gpt-5.5-proxy", "/chat/completions"),
+        ("openai-responses", "company/openai/gpt-5.6", "/responses"),
+    ],
+)
+async def test_openai_compatible_routes_only_from_configured_api(
+    api: str,
+    model: str,
+    endpoint: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = (
+            'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+            if endpoint == "/responses"
+            else 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+        )
+        return httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api=api,
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model=model,
+                system="You are Tau.",
+                messages=[UserMessage(content="hi")],
+                tools=[],
+            )
+        )
+
+    assert requests[0].url.path == f"/v1{endpoint}"
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].message.api == api
 
 
 def test_openai_compatible_config_from_env_rejects_invalid_timeout(
@@ -2685,20 +2733,6 @@ def _weather_tool() -> AgentTool:
     )
 
 
-def test_use_responses_api_routes_only_restricted_models() -> None:
-    from tau_ai.openai_compatible import _use_responses_api
-
-    assert _use_responses_api("gpt-5.5") is True
-    assert _use_responses_api("gpt-5.5-pro") is True
-    assert _use_responses_api("gpt-5.4") is True
-    assert _use_responses_api("gpt-5.3-codex") is True
-    assert _use_responses_api("GPT-5.5") is True
-    assert _use_responses_api("gpt-5.1") is False
-    assert _use_responses_api("gpt-5") is False
-    assert _use_responses_api("gpt-4o") is False
-    assert _use_responses_api("test-model") is False
-
-
 @pytest.mark.anyio
 async def test_responses_api_formats_request_for_restricted_model() -> None:
     requests: list[httpx.Request] = []
@@ -2735,6 +2769,7 @@ async def test_responses_api_formats_request_for_restricted_model() -> None:
             OpenAICompatibleConfig(
                 api_key="test-key",
                 base_url="https://example.test/v1",
+                api="openai-responses",
                 reasoning_effort="medium",
             ),
             client=client,
@@ -2822,7 +2857,11 @@ async def test_responses_api_parses_streamed_tool_call() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -2866,7 +2905,11 @@ async def test_responses_api_streams_refusal_as_text() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -2914,6 +2957,7 @@ async def test_responses_api_streams_reasoning_summary_as_thinking() -> None:
             OpenAICompatibleConfig(
                 api_key="test-key",
                 base_url="https://example.test/v1",
+                api="openai-responses",
                 reasoning_effort="high",
             ),
             client=client,
@@ -2965,6 +3009,7 @@ async def test_responses_api_preserves_reasoning_summary_part_boundaries() -> No
             OpenAICompatibleConfig(
                 api_key="test-key",
                 base_url="https://example.test/v1",
+                api="openai-responses",
                 reasoning_effort="high",
             ),
             client=client,
@@ -3010,6 +3055,7 @@ async def test_responses_api_omits_reasoning_when_effort_is_none() -> None:
             OpenAICompatibleConfig(
                 api_key="test-key",
                 base_url="https://example.test/v1",
+                api="openai-responses",
                 reasoning_effort="none",
             ),
             client=client,
@@ -3045,7 +3091,11 @@ async def test_responses_api_surfaces_stream_failure() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -3092,7 +3142,11 @@ async def test_responses_api_orders_parallel_tool_calls_by_output_index() -> Non
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -3122,7 +3176,11 @@ async def test_responses_api_surfaces_top_level_error_event() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -3154,7 +3212,11 @@ async def test_responses_api_maps_incomplete_status_to_length() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         provider = OpenAICompatibleProvider(
-            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                api="openai-responses",
+            ),
             client=client,
         )
 
@@ -3303,6 +3365,7 @@ async def test_openai_compatible_responses_reports_usage_and_sends_cache_affinit
             OpenAICompatibleConfig(
                 api_key="test-key",
                 base_url="https://api.openai.com/v1",
+                api="openai-responses",
             ),
             client=client,
         )

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7164,8 +7164,10 @@ async def test_tui_login_custom_provider_protocol_field_supports_keyboard_traver
 
         protocol = app.screen.query_one("#custom-provider-api", Select)
         assert protocol.has_focus
-        protocol.value = "openai-responses"
-        await pilot.press("enter", "enter")
+        await pilot.press("space")
+        await pilot.pause()
+        assert protocol.expanded
+        await pilot.press("r", "enter")
         await pilot.pause()
 
         assert protocol.value == "openai-responses"
@@ -7206,7 +7208,7 @@ async def test_tui_login_custom_provider_accepts_default_protocol_with_enter() -
         protocol = app.screen.query_one("#custom-provider-api", Select)
         assert protocol.has_focus
         assert protocol.value == "openai-completions"
-        await pilot.press("enter", "enter")
+        await pilot.press("enter")
         await pilot.pause()
 
         assert protocol.value == "openai-completions"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -17,7 +17,7 @@ from textual.content import Content
 from textual.content import Style as TextualStyle
 from textual.geometry import Offset
 from textual.selection import SELECT_ALL, Selection
-from textual.widgets import Collapsible, Input, Label, ListItem, ListView, Static, TextArea
+from textual.widgets import Collapsible, Input, Label, ListItem, ListView, Select, Static, TextArea
 from textual.widgets import Markdown as TextualMarkdown
 from textual.widgets.markdown import MarkdownStream
 
@@ -7104,6 +7104,7 @@ async def test_tui_login_custom_provider_writes_catalog_and_preferences(
                 provider_name="nebius",
                 display_name="Nebius AI Studio",
                 base_url="https://api.studio.nebius.ai/v1/",
+                api="openai-responses",
                 api_key_env="NEBIUS_API_KEY",
                 models=("deepseek-ai/DeepSeek-V4-Pro", "Qwen/Qwen3-Coder"),
                 default_model="deepseek-ai/DeepSeek-V4-Pro",
@@ -7118,8 +7119,10 @@ async def test_tui_login_custom_provider_writes_catalog_and_preferences(
     assert 'name = "nebius"' in catalog
     assert 'display_name = "Nebius AI Studio"' in catalog
     assert 'base_url = "https://api.studio.nebius.ai/v1"' in catalog
+    assert 'api = "openai-responses"' in catalog
     assert 'models = ["deepseek-ai/DeepSeek-V4-Pro", "Qwen/Qwen3-Coder"]' in catalog
     assert settings.get_provider("nebius").default_model == "deepseek-ai/DeepSeek-V4-Pro"
+    assert settings.get_provider("nebius").api == "openai-responses"
     assert FileCredentialStore(tmp_path / ".tau" / "credentials.json").get("nebius") == (
         "stored-nebius-key"
     )
@@ -7139,6 +7142,75 @@ async def test_tui_login_custom_provider_opens_from_slash_command() -> None:
 
         assert isinstance(app.screen, CustomProviderLoginScreen)
         assert app.screen.query_one("#custom-provider-name", Input).has_focus
+        protocol = app.screen.query_one("#custom-provider-api", Select)
+        assert protocol.value == "openai-completions"
+
+
+@pytest.mark.anyio
+async def test_tui_login_custom_provider_protocol_field_supports_keyboard_traversal() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login custom"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CustomProviderLoginScreen)
+        base_url = app.screen.query_one("#custom-provider-base-url", Input)
+        base_url.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        protocol = app.screen.query_one("#custom-provider-api", Select)
+        assert protocol.has_focus
+        protocol.value = "openai-responses"
+        await pilot.press("enter", "enter")
+        await pilot.pause()
+
+        assert protocol.value == "openai-responses"
+        assert app.screen.query_one("#custom-provider-api-key-env", Input).has_focus
+        values = {
+            "custom-provider-name": "company-ai",
+            "custom-provider-display-name": "Company AI",
+            "custom-provider-base-url": "https://ai.company.example/v1",
+            "custom-provider-api-key-env": "COMPANY_AI_API_KEY",
+            "custom-provider-models": "company/openai/gpt-5.6",
+            "custom-provider-default-model": "company/openai/gpt-5.6",
+            "custom-provider-api-key": "secret",
+        }
+        for field_id, value in values.items():
+            app.screen.query_one(f"#{field_id}", Input).value = value
+
+        result = app.screen._collect_result()
+        assert result is not None
+        assert result.api == "openai-responses"
+
+
+@pytest.mark.anyio
+async def test_tui_login_custom_provider_accepts_default_protocol_with_enter() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/login custom"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CustomProviderLoginScreen)
+        base_url = app.screen.query_one("#custom-provider-base-url", Input)
+        base_url.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        protocol = app.screen.query_one("#custom-provider-api", Select)
+        assert protocol.has_focus
+        assert protocol.value == "openai-completions"
+        await pilot.press("enter", "enter")
+        await pilot.pause()
+
+        assert protocol.value == "openai-completions"
+        assert app.screen.query_one("#custom-provider-api-key-env", Input).has_focus
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7167,7 +7167,9 @@ async def test_tui_login_custom_provider_protocol_field_supports_keyboard_traver
         await pilot.press("space")
         await pilot.pause()
         assert protocol.expanded
-        await pilot.press("r", "enter")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
         await pilot.pause()
 
         assert protocol.value == "openai-responses"

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -357,8 +357,8 @@ Ollama. The easiest interactive path is:
 Tau prompts for the provider details, saves the API key, writes the provider
 metadata to `~/.tau/catalog.toml`, and makes the provider available immediately.
 Choose **OpenAI Chat Completions** for `/chat/completions` servers (the default),
-or **OpenAI Responses** for `/responses` servers. The model ID does not select
-the protocol.
+or **OpenAI Responses** for `/responses` servers. The selected option controls
+the protocol for every model ID.
 
 ### Built-in llama.cpp backend
 
@@ -452,7 +452,7 @@ The exact supported OpenAI-compatible protocol names are
 `openai-completions` and `openai-responses`. A model can override its provider:
 
 ```toml
-[providers.model_metadata."responses-only-model"]
+[providers.model_metadata."qwen-coder"]
 api = "openai-responses"
 ```
 

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -356,6 +356,9 @@ Ollama. The easiest interactive path is:
 
 Tau prompts for the provider details, saves the API key, writes the provider
 metadata to `~/.tau/catalog.toml`, and makes the provider available immediately.
+Choose **OpenAI Chat Completions** for `/chat/completions` servers (the default),
+or **OpenAI Responses** for `/responses` servers. The model ID does not select
+the protocol.
 
 ### Built-in llama.cpp backend
 
@@ -415,6 +418,7 @@ tau --provider local \
   --base-url http://localhost:11434/v1 \
   --api-key-env LOCAL_API_KEY \
   --model qwen \
+  --api openai-completions \
   setup
 ```
 
@@ -438,10 +442,24 @@ credential_name = "local-gateway"
 models = ["qwen-coder"]
 default_model = "qwen-coder"
 docs_url = "https://example.test/local-gateway"
+api = "openai-completions"
 
 [providers.context_windows]
 qwen-coder = 64000
 ```
+
+The exact supported OpenAI-compatible protocol names are
+`openai-completions` and `openai-responses`. A model can override its provider:
+
+```toml
+[providers.model_metadata."responses-only-model"]
+api = "openai-responses"
+```
+
+Tau resolves the model override first, then the provider default. Legacy custom
+entries with neither value use `openai-completions`; Tau never guesses from the
+model name. If an older entry relied on a `gpt-5` or `codex` name to reach the
+Responses endpoint, add `api = "openai-responses"` explicitly.
 
 Tau loads its bundled `src/tau_coding/data/catalog.toml` first, then overlays
 `~/.tau/catalog.toml`. A user entry with the same `name` can extend or override a

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -449,17 +449,18 @@ qwen-coder = 64000
 ```
 
 The exact supported OpenAI-compatible protocol names are
-`openai-completions` and `openai-responses`. A model can override its provider:
+`openai-completions` and `openai-responses`. A model can override its provider.
+The example below changes `qwen-coder`.
 
 ```toml
 [providers.model_metadata."qwen-coder"]
 api = "openai-responses"
 ```
 
-Tau resolves the model override first, then the provider default. Legacy custom
-entries with neither value use `openai-completions`; Tau never guesses from the
-model name. If an older entry relied on a `gpt-5` or `codex` name to reach the
-Responses endpoint, add `api = "openai-responses"` explicitly.
+Tau resolves the model override first, then the provider default. Older custom
+entries with neither value use `openai-completions`. If an older entry relied on
+a `gpt-5` or `codex` name to reach the Responses endpoint, add
+`api = "openai-responses"` explicitly.
 
 Tau loads its bundled `src/tau_coding/data/catalog.toml` first, then overlays
 `~/.tau/catalog.toml`. A user entry with the same `name` can extend or override a

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -156,11 +156,9 @@ qwen-coder = 64000
 
 OpenAI-compatible entries accept `api = "openai-completions"` or
 `api = "openai-responses"`. The provider value is the default for every model;
-model metadata can override it:
+model metadata can override it. The example below changes `qwen-coder`.
 
 ```toml
-api = "openai-completions"
-
 [providers.model_metadata."qwen-coder"]
 api = "openai-responses"
 ```

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -161,13 +161,13 @@ model metadata can override it:
 ```toml
 api = "openai-completions"
 
-[providers.model_metadata."responses-only-model"]
+[providers.model_metadata."qwen-coder"]
 api = "openai-responses"
 ```
 
-This matches Pi's resolved-model rule: model API, then provider API. Model IDs
-never choose a wire protocol. API-less legacy OpenAI-compatible entries resolve
-to `openai-completions`; configure Responses explicitly when required.
+Tau checks the model-level API first and then the provider-level API. Existing
+OpenAI-compatible entries without either field use `openai-completions`.
+Configure `openai-responses` explicitly when the server requires it.
 
 Catalog entries support `kind` values of `openai-compatible`, `anthropic`, and
 `openai-codex`. For most custom services, start with `openai-compatible`.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -148,10 +148,26 @@ credential_name = "local-gateway"
 models = ["qwen-coder"]
 default_model = "qwen-coder"
 docs_url = "https://example.test/local-gateway"
+api = "openai-completions"
 
 [providers.context_windows]
 qwen-coder = 64000
 ```
+
+OpenAI-compatible entries accept `api = "openai-completions"` or
+`api = "openai-responses"`. The provider value is the default for every model;
+model metadata can override it:
+
+```toml
+api = "openai-completions"
+
+[providers.model_metadata."responses-only-model"]
+api = "openai-responses"
+```
+
+This matches Pi's resolved-model rule: model API, then provider API. Model IDs
+never choose a wire protocol. API-less legacy OpenAI-compatible entries resolve
+to `openai-completions`; configure Responses explicitly when required.
 
 Catalog entries support `kind` values of `openai-compatible`, `anthropic`, and
 `openai-codex`. For most custom services, start with `openai-compatible`.


### PR DESCRIPTION
## Overview

When users add a custom OpenAI-compatible provider, Tau currently gives them no
way to choose between Chat Completions and the Responses API. This PR adds that
choice to both custom-provider setup flows and uses it consistently when sending
requests.

Users can select the API through `tau setup` or `/login custom`. Tau stores the
selection alongside the existing provider metadata and uses it regardless of how
the model is named. The routing follows Pi's resolved-model API behavior, where
provider and model metadata determine which transport is used.

## User experience

The CLI accepts an `--api` option during setup.

```bash
tau --provider company-ai \
  --model company/openai/gpt-5.6 \
  --api openai-responses \
  setup
```

The `/login custom` flow presents the same choice with friendly labels.

- OpenAI Chat Completions
- OpenAI Responses

The selector defaults to Chat Completions and supports keyboard-only navigation,
including accepting the default selection with Enter.

The supported configuration values are

- `openai-completions`
- `openai-responses`

Tau stores the selection alongside the existing provider metadata in
`~/.tau/catalog.toml`. Individual models can override the provider-level choice
through model metadata. Provider preferences remain in `providers.json`, and
session JSONL remains unchanged.

## Protocol resolution

Tau resolves the API in this order

1. Model-level API metadata
2. Provider-level API metadata
3. Chat Completions for existing entries without API metadata

The resolved value directly selects `/chat/completions` or `/responses`. Model
IDs are passed through as request data and do not affect that decision.

This matches Pi's behavior, where the resolved model API selects the registered
transport. Tau continues to use one OpenAI-compatible provider class with two
internal transports while preserving the same selection behavior.

## Compatibility

New providers configured through `tau setup` or `/login custom` always receive
an explicit API value. Existing catalog entries without the field continue to
use Chat Completions, preserving compatibility with providers configured before
this option was available.

Configurations that previously depended on names such as `gpt-5` or `codex` to
reach the Responses API should add the following setting.

```toml
api = "openai-responses"
```

Tau leaves existing configuration files intact and applies the Chat Completions
compatibility behavior when API metadata is unavailable.

## Documentation

The updated documentation covers

- CLI and TUI setup
- Provider-level defaults
- Model-level overrides
- Existing configuration behavior
- The mapping between Pi and Tau

A development note records the Pi revision used during implementation and the
architectural mapping behind the change.

## Validation

- `uv run pytest` with 1,861 passing tests and 3 platform-specific skips
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`

Closes #546.
