### PR TITLE
Fix empty Anthropic SSE data frames

### DIFF
--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -700,9 +700,11 @@ def _anthropic_tool(
 
 
 def _parse_sse_line(line: str) -> str | None:
-    if not line.startswith("data:"):
+    line = line.strip()
+    if not line or not line.startswith("data:"):
         return None
-    return line.removeprefix("data:").strip()
+    data = line.removeprefix("data:").strip()
+    return data or None
 
 
 def _loads_object(text: str) -> dict[str, Any] | None:

--- a/tests/test_anthropic_sse.py
+++ b/tests/test_anthropic_sse.py
@@ -1,0 +1,49 @@
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from tau_agent import UserMessage
+from tau_ai import AnthropicConfig, AnthropicProvider, AssistantDoneEvent
+
+
+async def _collect(stream: AsyncIterator[object]) -> list[object]:
+    return [event async for event in stream]
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_ignores_empty_data_frames() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"message_start","message":{"usage":{}}}\n\n'
+                "data:\n\n"
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+                '"usage":{"output_tokens":1}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].message.text == "ok"


### PR DESCRIPTION
## Motivation

GitHub Copilot can emit empty SSE `data:` frames on the Anthropic Messages API path. Tau currently turns those frames into an empty string and passes them to the JSON decoder, which surfaces `Provider returned invalid JSON chunk`.

Partially addresses #679.

## Changes

- ignore blank SSE lines and empty `data:` payloads in `tau_ai.anthropic._parse_sse_line`
- add a focused regression test using `httpx.MockTransport` that keeps streaming successfully across an empty `data:` frame

This keeps the change limited to the provider streaming layer, consistent with Tau's architecture.

The separate empty `tool_use.name` error reported in #679 is not addressed by this patch.