### PR TITLE
Discover Codex subscription model catalogs

### DIFF
--- a/dev-notes/codex-live-model-catalog.md
+++ b/dev-notes/codex-live-model-catalog.md
@@ -1,0 +1,64 @@
+# Codex live model catalog
+
+## What changed
+
+Tau now uses the authenticated ChatGPT Codex `/models` response as both a model
+inventory and a source of runtime model limits. Previously Tau parsed context
+and compaction values from this response but kept the selectable
+`openai-codex` inventory entirely in `src/tau_coding/data/catalog.toml`.
+Consequently, a newly rolled-out subscription model could be usable by an
+account but remain unselectable until Tau released a static catalog update.
+
+`tau_ai` now exposes an optional `ModelCatalogProvider` capability. The Codex
+adapter implements it and defensively parses rows that the official schema
+marks with `visibility = "list"`. It intentionally does not filter on
+`supported_in_api`: the official client applies that field to API-key mode but
+keeps subscription-visible rows in ChatGPT mode. Tau preserves provider priority
+order and reads verified names, text/image modalities,
+reasoning efforts, defaults, and limits. One in-memory fetch serves both model
+inventory and limit discovery.
+
+`tau_coding` publishes a successful snapshot as a process-local overlay on the
+durable `openai-codex` configuration. Active Codex sessions discover during
+load. Opening `/model` also discovers Codex while another provider is active by
+creating and closing a model-less provider. The picker initially renders its
+static snapshot and updates after background refresh, preserving its existing
+non-blocking behavior.
+
+## Safety and persistence
+
+The authenticated catalog is account- and rollout-specific. Tau therefore does
+not write it into `catalog.toml`, `providers.json`, session JSONL, or the
+models.dev cache. The checked-in Codex rows remain the offline and failure
+fallback. Empty, malformed, unauthorized, or unavailable responses do not erase
+the fallback. `TAU_OFFLINE=1` skips authenticated discovery.
+
+A live inventory is authoritative for picker visibility after successful
+discovery. The active session model is not silently changed when absent from a
+new snapshot. Scoped references may store only their provider/model pair; they
+do not persist discovered metadata.
+
+This preserves Tau's package boundary: `tau_ai` owns authenticated transport and
+wire parsing, while `tau_coding` owns model selection and the ephemeral catalog
+overlay. `tau_agent` remains independent of provider catalogs and OAuth.
+
+## Validation
+
+Automated tests cover:
+
+- authenticated catalog parsing and one-request caching with runtime limits;
+- filtering hidden rows while retaining subscription-visible, non-public-API rows;
+- live names, modalities, reasoning levels, and context limits;
+- publication while Codex is active;
+- model-less discovery and provider cleanup while another provider is active;
+- existing static fallback behavior for discovery failures.
+
+Manual validation:
+
+1. Authenticate with `/login openai-codex`.
+2. Open `/model`; observe the checked-in list immediately.
+3. Wait for background refresh and confirm it updates to models visible to the
+   authenticated account.
+4. Select a live-only model and send a tool-using prompt.
+5. Run `/session` and confirm live context-limit reporting.
+6. Repeat with `TAU_OFFLINE=1` and confirm the static list remains available.

--- a/dev-notes/codex-live-model-catalog.md
+++ b/dev-notes/codex-live-model-catalog.md
@@ -49,6 +49,21 @@ This preserves Tau's package boundary: `tau_ai` owns authenticated transport and
 wire parsing, while `tau_coding` owns model selection and the ephemeral catalog
 overlay. `tau_agent` remains independent of provider catalogs and OAuth.
 
+## Lifecycle validation
+
+Explicit startup and transcript resume now discover live-only Codex IDs before
+static selection validation, including when a frontend supplied a fallback
+provider. Discovery uses a temporary, closed provider and never mutates durable
+settings. Failed/offline discovery leaves unknown IDs rejected, rather than
+silently substituting a static model. RPC startup also defers live-only validation
+to this session boundary.
+
+Picker visibility is separate from active-runtime validity: when discovery drops
+the active model, runtime rebuilds retain its previously selected Codex metadata.
+Repeated settings refresh therefore cannot invalidate an otherwise usable session.
+Regression tests cover explicit/resumed startup with and without preconstructed
+providers and repeated settings reload after the active model disappears.
+
 ## Validation
 
 Automated tests cover:
@@ -68,5 +83,6 @@ Manual validation:
 3. Wait for background refresh and confirm it updates to models visible to the
    authenticated account.
 4. Select a live-only model and send a tool-using prompt.
-5. Run `/session` and confirm live context-limit reporting.
-6. Repeat with `TAU_OFFLINE=1` and confirm the static list remains available.
+5. Restart and resume that session; confirm the exact live-only model is retained.
+6. Run `/session` and confirm live context-limit reporting.
+7. Repeat with `TAU_OFFLINE=1` and confirm the static list remains available.

--- a/dev-notes/codex-live-model-catalog.md
+++ b/dev-notes/codex-live-model-catalog.md
@@ -11,7 +11,13 @@ account but remain unselectable until Tau released a static catalog update.
 
 `tau_ai` now exposes an optional `ModelCatalogProvider` capability. The Codex
 adapter implements it and defensively parses rows that the official schema
-marks with `visibility = "list"`. It intentionally does not filter on
+marks with `visibility = "list"`. Before discovery, `tau_coding` resolves the
+current stable `@openai/codex` version from npm because the backend suppresses
+models newer than the supplied `client_version`. The safe version string is
+cached for four hours with ETag revalidation; stale cache and the bundled known
+version are fallbacks, so newly client-gated models need no Tau release.
+
+The adapter intentionally does not filter on
 `supported_in_api`: the official client applies that field to API-key mode but
 keeps subscription-visible rows in ChatGPT mode. Tau preserves provider priority
 order and reads verified names, text/image modalities,
@@ -36,7 +42,8 @@ the fallback. `TAU_OFFLINE=1` skips authenticated discovery.
 A live inventory is authoritative for picker visibility after successful
 discovery. The active session model is not silently changed when absent from a
 new snapshot. Scoped references may store only their provider/model pair; they
-do not persist discovered metadata.
+do not persist discovered metadata. `~/.tau/codex-version-store.json` contains
+only public npm release metadata, never account-specific model data or secrets.
 
 This preserves Tau's package boundary: `tau_ai` owns authenticated transport and
 wire parsing, while `tau_coding` owns model selection and the ephemeral catalog
@@ -46,6 +53,7 @@ overlay. `tau_agent` remains independent of provider catalogs and OAuth.
 
 Automated tests cover:
 
+- latest stable Codex-version lookup, validation, ETag caching, and fallbacks;
 - authenticated catalog parsing and one-request caching with runtime limits;
 - filtering hidden rows while retaining subscription-visible, non-public-API rows;
 - live names, modalities, reasoning levels, and context limits;

--- a/dev-notes/codex-live-model-catalog.md
+++ b/dev-notes/codex-live-model-catalog.md
@@ -64,6 +64,19 @@ Repeated settings refresh therefore cannot invalidate an otherwise usable sessio
 Regression tests cover explicit/resumed startup with and without preconstructed
 providers and repeated settings reload after the active model disappears.
 
+A follow-up exercises full TUI startup, picker highlighting, and indexed `/resume`,
+including a source session that has not discovered Astra and a stale session
+index. Provider-aware replacement keeps the destination loader's resolved model;
+it neither restores the source session's model nor revalidates against the
+source's stale catalog. Newly staged model metadata is replayed after discovery
+so the active runtime and initial transcript agree.
+
+Older sessions may already contain a mismatch: the index and assistant metadata
+name Astra but the authoritative model-change entry still names Sol. No automatic
+migration guesses a selection from assistant metadata (providers can report
+routed model aliases). Resume and explicitly select Astra in `/model` to append
+the correct model-change entry.
+
 ## Validation
 
 Automated tests cover:

--- a/src/tau_ai/__init__.py
+++ b/src/tau_ai/__init__.py
@@ -31,6 +31,7 @@ from tau_ai.events import (
 from tau_ai.fake import FakeProvider
 from tau_ai.google import GoogleGenerativeAIProvider
 from tau_ai.mistral import MistralConversationsProvider
+from tau_ai.model_catalog import ModelCatalogProvider, RuntimeModel, RuntimeModelCatalog
 from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
 from tau_ai.openai_codex import (
     DEFAULT_OPENAI_CODEX_BASE_URL,

--- a/src/tau_ai/model_catalog.py
+++ b/src/tau_ai/model_catalog.py
@@ -1,0 +1,53 @@
+"""Optional runtime model-catalog discovery contracts for provider adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+from tau_ai.model_limits import RuntimeModelLimits
+
+RuntimeInputModality = Literal["text", "image"]
+RuntimeThinkingLevel = Literal["off", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeModel:
+    """One model advertised by an authenticated provider catalog."""
+
+    id: str
+    name: str | None = None
+    limits: RuntimeModelLimits | None = None
+    input_modalities: tuple[RuntimeInputModality, ...] = ("text",)
+    thinking_levels: tuple[RuntimeThinkingLevel, ...] = ()
+    default_thinking_level: RuntimeThinkingLevel | None = None
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("model id must be non-empty")
+        if not self.input_modalities:
+            raise ValueError("input_modalities must be non-empty")
+        if self.default_thinking_level is not None and (
+            self.default_thinking_level not in self.thinking_levels
+        ):
+            raise ValueError("default_thinking_level must be advertised in thinking_levels")
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeModelCatalog:
+    """Complete account-specific model snapshot from a provider."""
+
+    models: tuple[RuntimeModel, ...]
+
+    def model(self, model_id: str) -> RuntimeModel | None:
+        """Return one advertised model by exact ID."""
+        return next((model for model in self.models if model.id == model_id), None)
+
+
+@runtime_checkable
+class ModelCatalogProvider(Protocol):
+    """Optional provider capability for authenticated model discovery."""
+
+    async def discover_models(self) -> RuntimeModelCatalog:
+        """Return the complete model inventory available to the active account."""
+        ...

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from json import JSONDecodeError, dumps, loads
 from platform import machine, release, system
-from typing import Any
+from typing import Any, Literal, cast
 
 import httpx
 
@@ -45,6 +45,7 @@ from tau_ai.env import (
 from tau_ai.events import AssistantMessageEvent
 from tau_ai.http import create_async_client
 from tau_ai.http_errors import provider_http_error_message
+from tau_ai.model_catalog import RuntimeModel, RuntimeModelCatalog, RuntimeThinkingLevel
 from tau_ai.model_limits import RuntimeModelLimits
 from tau_ai.openai_cache import openai_prompt_cache_key
 from tau_ai.provider import CancellationToken
@@ -98,6 +99,7 @@ class OpenAICodexProvider:
         self._config = config
         self._client = client
         self._owns_client = client is None
+        self._discovered_model_catalog: RuntimeModelCatalog | None = None
         self._discovered_model_limits: dict[str, RuntimeModelLimits] | None = None
 
     async def aclose(self) -> None:
@@ -106,13 +108,26 @@ class OpenAICodexProvider:
             await self._client.aclose()
             self._client = None
 
+    async def discover_models(self) -> RuntimeModelCatalog:
+        """Discover the authenticated account's selectable Codex models."""
+        await self._ensure_model_catalog()
+        assert self._discovered_model_catalog is not None
+        return self._discovered_model_catalog
+
     async def discover_model_limits(self, model: str) -> RuntimeModelLimits | None:
         """Discover model limits from the authenticated Codex model catalog."""
-        if self._discovered_model_limits is None:
-            self._discovered_model_limits = await self._fetch_model_limits()
+        await self._ensure_model_catalog()
+        assert self._discovered_model_limits is not None
         return self._discovered_model_limits.get(model)
 
-    async def _fetch_model_limits(self) -> dict[str, RuntimeModelLimits]:
+    async def _ensure_model_catalog(self) -> None:
+        if self._discovered_model_catalog is not None:
+            return
+        payload = await self._fetch_model_catalog()
+        self._discovered_model_catalog = _parse_codex_model_catalog(payload)
+        self._discovered_model_limits = _parse_codex_model_limits(payload)
+
+    async def _fetch_model_catalog(self) -> object:
         client = self._get_client()
         credentials = await self._config.credential_resolver()
         headers = _build_codex_headers(
@@ -130,7 +145,7 @@ class OpenAICodexProvider:
             timeout=self._config.model_catalog_timeout_seconds,
         )
         response.raise_for_status()
-        return _parse_codex_model_limits(response.json())
+        return response.json()
 
     def stream_response(
         self,
@@ -1007,6 +1022,88 @@ def _resolve_codex_models_url(base_url: str) -> str:
     return f"{normalized}/codex/models"
 
 
+def _parse_codex_model_catalog(payload: object) -> RuntimeModelCatalog:
+    """Parse models the Codex backend marks visible to ChatGPT accounts."""
+    if not isinstance(payload, Mapping):
+        return RuntimeModelCatalog(())
+    items = payload.get("models")
+    if not isinstance(items, list):
+        return RuntimeModelCatalog(())
+
+    candidates: list[tuple[int, int, RuntimeModel]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(items):
+        if not isinstance(item, Mapping):
+            continue
+        model_id = item.get("slug")
+        if (
+            not isinstance(model_id, str)
+            or not model_id
+            or model_id in seen
+            or item.get("visibility") != "list"
+        ):
+            continue
+        seen.add(model_id)
+        limits = _runtime_model_limits(item)
+        modalities = _codex_input_modalities(item.get("input_modalities"))
+        thinking_levels = _codex_thinking_levels(item.get("supported_reasoning_levels"))
+        default_thinking = _codex_thinking_level(item.get("default_reasoning_level"))
+        if default_thinking not in thinking_levels:
+            default_thinking = None
+        priority = item.get("priority")
+        candidates.append(
+            (
+                priority if isinstance(priority, int) and not isinstance(priority, bool) else 0,
+                index,
+                RuntimeModel(
+                    id=model_id,
+                    name=(
+                        item.get("display_name")
+                        if isinstance(item.get("display_name"), str) and item.get("display_name")
+                        else None
+                    ),
+                    limits=limits,
+                    input_modalities=modalities,
+                    thinking_levels=thinking_levels,
+                    default_thinking_level=default_thinking,
+                ),
+            )
+        )
+    candidates.sort(key=lambda candidate: (-candidate[0], candidate[1]))
+    return RuntimeModelCatalog(tuple(candidate[2] for candidate in candidates))
+
+
+def _codex_input_modalities(value: object) -> tuple[Literal["text", "image"], ...]:
+    # Official Codex clients treat an omitted field as legacy text+image support.
+    if value is None:
+        return ("text", "image")
+    if not isinstance(value, list):
+        return ("text",)
+    known: tuple[Literal["text", "image"], ...] = ("text", "image")
+    modalities = tuple(item for item in known if item in value)
+    return modalities or ("text",)
+
+
+def _codex_thinking_levels(value: object) -> tuple[RuntimeThinkingLevel, ...]:
+    if not isinstance(value, list):
+        return ()
+    levels: list[RuntimeThinkingLevel] = []
+    for item in value:
+        raw = item.get("effort") if isinstance(item, Mapping) else None
+        level = _codex_thinking_level(raw)
+        if level is not None and level not in levels:
+            levels.append(level)
+    return tuple(levels)
+
+
+def _codex_thinking_level(value: object) -> RuntimeThinkingLevel | None:
+    if value == "none":
+        return "off"
+    if value in {"minimal", "low", "medium", "high", "xhigh", "max"}:
+        return cast(RuntimeThinkingLevel, value)
+    return None
+
+
 def _parse_codex_model_limits(payload: object) -> dict[str, RuntimeModelLimits]:
     if not isinstance(payload, Mapping):
         return {}
@@ -1019,21 +1116,28 @@ def _parse_codex_model_limits(payload: object) -> dict[str, RuntimeModelLimits]:
         if not isinstance(item, Mapping):
             continue
         model = item.get("slug")
-        context_window = _positive_int(item.get("context_window")) or _positive_int(
-            item.get("max_context_window")
-        )
-        if not isinstance(model, str) or not model or context_window is None:
+        limits = _runtime_model_limits(item)
+        if not isinstance(model, str) or not model or limits is None:
             continue
-        effective_percent = _positive_int(item.get("effective_context_window_percent")) or 100
-        if effective_percent > 100:
-            continue
-        parsed[model] = RuntimeModelLimits(
-            context_window=context_window,
-            max_output_tokens=_positive_int(item.get("max_output_tokens")),
-            effective_context_window_percent=effective_percent,
-            auto_compact_token_limit=_positive_int(item.get("auto_compact_token_limit")),
-        )
+        parsed[model] = limits
     return parsed
+
+
+def _runtime_model_limits(item: Mapping[object, object]) -> RuntimeModelLimits | None:
+    context_window = _positive_int(item.get("context_window")) or _positive_int(
+        item.get("max_context_window")
+    )
+    if context_window is None:
+        return None
+    effective_percent = _positive_int(item.get("effective_context_window_percent")) or 100
+    if effective_percent > 100:
+        return None
+    return RuntimeModelLimits(
+        context_window=context_window,
+        max_output_tokens=_positive_int(item.get("max_output_tokens")),
+        effective_context_window_percent=effective_percent,
+        auto_compact_token_limit=_positive_int(item.get("auto_compact_token_limit")),
+    )
 
 
 def _positive_int(value: object) -> int | None:

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -53,6 +53,7 @@ from tau_ai.retry import provider_retry_event, retry_delay_seconds, wait_for_ret
 from tau_ai.stream import canonicalize_provider_stream
 
 DEFAULT_OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api"
+DEFAULT_OPENAI_CODEX_CLIENT_VERSION = "0.153.4"
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,6 +65,7 @@ class OpenAICodexCredentials:
 
 
 type OpenAICodexCredentialResolver = Callable[[], Awaitable[OpenAICodexCredentials]]
+type OpenAICodexClientVersionResolver = Callable[[], Awaitable[str]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,9 +83,11 @@ class OpenAICodexConfig:
     reasoning_summary: str = "auto"
     supports_images: bool = False
     provider_name: str = "OpenAI Codex"
-    # The Codex catalog filters models by the official client's compatibility
-    # version. This is the oldest known version that advertises GPT-5.6.
-    client_version: str = "0.144.3"
+    # The endpoint requires an official Codex compatibility version and filters
+    # newer models from older clients. Tau resolves the latest release at runtime;
+    # this bundled value remains the offline/error fallback.
+    client_version: str = DEFAULT_OPENAI_CODEX_CLIENT_VERSION
+    client_version_resolver: OpenAICodexClientVersionResolver | None = None
     model_catalog_timeout_seconds: float = 5.0
 
 
@@ -138,9 +142,14 @@ class OpenAICodexProvider:
         )
         headers["accept"] = "application/json"
         headers.pop("content-type", None)
+        client_version = (
+            await self._config.client_version_resolver()
+            if self._config.client_version_resolver is not None
+            else self._config.client_version
+        )
         response = await client.get(
             _resolve_codex_models_url(self._config.base_url),
-            params={"client_version": self._config.client_version},
+            params={"client_version": client_version},
             headers=headers,
             timeout=self._config.model_catalog_timeout_seconds,
         )

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -951,11 +951,18 @@ async def run_openai_rpc_mode(
         session_id=None,
     )
     explicit_selection = provider_name is not None or model is not None
-    selection = resolve_provider_selection(
-        settings,
-        provider_name=provider_name if explicit_selection else record.provider_name,
-        model=model if explicit_selection else record.model,
-    )
+    selected_provider = provider_name if explicit_selection else record.provider_name
+    selected_model = model if explicit_selection else record.model
+    try:
+        selection = resolve_provider_selection(
+            settings, provider_name=selected_provider, model=selected_model
+        )
+    except ProviderConfigError:
+        if (selected_provider or settings.default_provider) != "openai-codex":
+            raise
+        # Bootstrap with the static default; the staged loader discovers and
+        # validates the requested/resumed live-only model before activating it.
+        selection = resolve_provider_selection(settings, provider_name="openai-codex")
     inference_provider = (
         record.inference_provider
         if resume_session_id is not None
@@ -990,7 +997,10 @@ async def run_openai_rpc_mode(
     session = await CodingSession.load(
         CodingSessionConfig(
             provider=provider,
-            model=selection.model,
+            model=selected_model or selection.model,
+            requested_provider=selected_provider if explicit_selection else None,
+            requested_model=selected_model if explicit_selection else None,
+            session_provider_name=record.provider_name,
             thinking_level_override=thinking_level_override,
             cwd=record.cwd,
             storage=jsonl_session_storage(record.path),

--- a/src/tau_coding/codex_version.py
+++ b/src/tau_coding/codex_version.py
@@ -1,0 +1,146 @@
+"""Runtime resolution and caching of the latest released Codex client version."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from os import environ
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+import httpx
+
+from tau_ai.openai_codex import DEFAULT_OPENAI_CODEX_CLIENT_VERSION
+from tau_coding.paths import TauPaths
+
+CODEX_NPM_LATEST_URL = "https://registry.npmjs.org/@openai%2Fcodex/latest"
+CODEX_VERSION_STORE_SCHEMA_VERSION = 1
+CODEX_VERSION_REFRESH_INTERVAL_SECONDS = 4 * 60 * 60
+CODEX_VERSION_REFRESH_TIMEOUT_SECONDS = 5.0
+_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+class CodexClientVersionResolver:
+    """Resolve a real released Codex version, retaining safe cached fallbacks."""
+
+    def __init__(
+        self,
+        *,
+        paths: TauPaths | None = None,
+        client: httpx.AsyncClient | None = None,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self._paths = paths or TauPaths()
+        self._client = client
+        self._now = now
+
+    async def __call__(self) -> str:
+        """Return the latest known stable Codex version without making discovery fatal."""
+        cache = _read_cache(self._paths.codex_version_store_path)
+        if environ.get("TAU_OFFLINE") is not None:
+            return _latest_known_version(_cached_version(cache))
+
+        current_time = self._now()
+        if (
+            cache is not None
+            and current_time - cache["checked_at"] < CODEX_VERSION_REFRESH_INTERVAL_SECONDS
+        ):
+            return _latest_known_version(cache["version"])
+
+        owned_client = self._client is None
+        client = self._client or httpx.AsyncClient(timeout=CODEX_VERSION_REFRESH_TIMEOUT_SECONDS)
+        try:
+            headers = {"Accept": "application/json", "User-Agent": "tau-codex-version-refresh"}
+            if cache is not None and cache.get("etag"):
+                headers["If-None-Match"] = cache["etag"]
+            response = await client.get(CODEX_NPM_LATEST_URL, headers=headers)
+            if response.status_code == 304 and cache is not None:
+                cache["checked_at"] = current_time
+                _try_write_cache(self._paths.codex_version_store_path, cache)
+                return _latest_known_version(cache["version"])
+            response.raise_for_status()
+            payload = response.json()
+            version = _latest_known_version(_parse_version(payload))
+            document: dict[str, Any] = {
+                "schema_version": CODEX_VERSION_STORE_SCHEMA_VERSION,
+                "checked_at": current_time,
+                "etag": response.headers.get("etag"),
+                "version": version,
+            }
+            _try_write_cache(self._paths.codex_version_store_path, document)
+            return version
+        except (httpx.HTTPError, TypeError, ValueError, json.JSONDecodeError):
+            return _latest_known_version(_cached_version(cache))
+        finally:
+            if owned_client:
+                await client.aclose()
+
+
+def _parse_version(payload: object) -> str:
+    if not isinstance(payload, dict):
+        raise ValueError("Codex package metadata must be an object")
+    version = payload.get("version")
+    if not isinstance(version, str) or _VERSION_PATTERN.fullmatch(version) is None:
+        raise ValueError("Codex package metadata has an invalid stable version")
+    return version
+
+
+def _read_cache(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(value, dict)
+            or value.get("schema_version") != CODEX_VERSION_STORE_SCHEMA_VERSION
+            or not isinstance(value.get("checked_at"), int | float)
+            or not isinstance(value.get("version"), str)
+            or _VERSION_PATTERN.fullmatch(value["version"]) is None
+            or (value.get("etag") is not None and not isinstance(value.get("etag"), str))
+        ):
+            return None
+        return value
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _cached_version(cache: dict[str, Any] | None) -> str | None:
+    return cache["version"] if cache is not None else None
+
+
+def _latest_known_version(candidate: str | None) -> str:
+    if candidate is None:
+        return DEFAULT_OPENAI_CODEX_CLIENT_VERSION
+    return max(candidate, DEFAULT_OPENAI_CODEX_CLIENT_VERSION, key=_version_key)
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    major, minor, patch = version.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def _try_write_cache(path: Path, value: dict[str, Any]) -> None:
+    with suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path: Path | None = None
+        try:
+            with NamedTemporaryFile(
+                "w",
+                dir=path.parent,
+                encoding="utf-8",
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temp_file:
+                temp_path = Path(temp_file.name)
+                json.dump(value, temp_file, indent=2, sort_keys=True)
+                temp_file.write("\n")
+                temp_file.flush()
+            temp_path.replace(path)
+        except OSError:
+            if temp_path is not None:
+                with suppress(OSError):
+                    temp_path.unlink()
+            raise

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -115,8 +115,17 @@ immediately and refreshes in the background. `tau update --models` forces a
 refresh. Results are ETag-revalidated, throttled to four hours, and cached at
 `~/.tau/models-store.json`; a cache applies only when newer than the bundled
 snapshot. Since Tau has no hosted catalog service, it fetches models.dev and
-NVIDIA directly and transforms them locally. `TAU_OFFLINE=1` disables catalog
-network access.
+NVIDIA directly and transforms them locally.
+
+The `openai-codex` provider is different: its inventory is account-specific.
+When Codex OAuth is configured, Tau fetches the authenticated Codex `/models`
+catalog at session startup and whenever `/model` refreshes. A successful live
+snapshot replaces the checked-in Codex inventory for that process and supplies
+model names, input modalities, reasoning efforts, and runtime limits. The
+snapshot is memory-only and never enters `catalog.toml`, `providers.json`, or
+the models.dev cache. Missing credentials, malformed data, or network failures
+retain the static Codex fallback. `TAU_OFFLINE=1` disables all catalog network
+access.
 
 Startup never requires network. Missing, invalid, or incompatible generated or
 cached data falls back silently to `catalog.toml`. User `~/.tau/catalog.toml`

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -134,7 +134,13 @@ malformed data, or network failures retain the static Codex fallback.
 `TAU_OFFLINE=1` disables all catalog network access and permits only the cached
 or bundled client version.
 
-Startup never requires network. Missing, invalid, or incompatible generated or
+Explicit startup and resume of a Codex model absent from the static catalog
+perform authenticated discovery before model validation. Such live-only selections
+require successful discovery; offline startup still supports static models.
+If a refreshed inventory omits the active model, its existing runtime metadata
+remains usable without restoring that model to the picker.
+
+Static-model startup never requires network. Missing, invalid, or incompatible generated or
 cached data falls back silently to `catalog.toml`. User `~/.tau/catalog.toml`
 overlays are applied last. When withdrawing one provider's model, add it to that
 provider's `removed_models` list so stale user overlays cannot restore it.

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -119,13 +119,20 @@ NVIDIA directly and transforms them locally.
 
 The `openai-codex` provider is different: its inventory is account-specific.
 When Codex OAuth is configured, Tau fetches the authenticated Codex `/models`
-catalog at session startup and whenever `/model` refreshes. A successful live
-snapshot replaces the checked-in Codex inventory for that process and supplies
-model names, input modalities, reasoning efforts, and runtime limits. The
-snapshot is memory-only and never enters `catalog.toml`, `providers.json`, or
-the models.dev cache. Missing credentials, malformed data, or network failures
-retain the static Codex fallback. `TAU_OFFLINE=1` disables all catalog network
-access.
+catalog at session startup and whenever `/model` refreshes. Because that endpoint
+filters models by official-client version, Tau first resolves the current stable
+`@openai/codex` release from the npm registry. The version lookup is
+ETag-revalidated, throttled to four hours, and cached at
+`~/.tau/codex-version-store.json`; a stale cached or bundled version is the
+non-fatal fallback. This lets newly gated models appear without a Tau release.
+
+A successful live snapshot replaces the checked-in Codex inventory for that
+process and supplies model names, input modalities, reasoning efforts, and
+runtime limits. The account-specific snapshot is memory-only and never enters
+`catalog.toml`, `providers.json`, or either model cache. Missing credentials,
+malformed data, or network failures retain the static Codex fallback.
+`TAU_OFFLINE=1` disables all catalog network access and permits only the cached
+or bundled client version.
 
 Startup never requires network. Missing, invalid, or incompatible generated or
 cached data falls back silently to `catalog.toml`. User `~/.tau/catalog.toml`

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -138,7 +138,10 @@ Explicit startup and resume of a Codex model absent from the static catalog
 perform authenticated discovery before model validation. Such live-only selections
 require successful discovery; offline startup still supports static models.
 If a refreshed inventory omits the active model, its existing runtime metadata
-remains usable without restoring that model to the picker.
+remains usable without restoring that model to the picker. Resume restores the
+transcript's model selection, not the model from the session being left. If an
+older session has a stale saved selection, resume it and explicitly select the
+intended model in `/model` to record the correction.
 
 Static-model startup never requires network. Missing, invalid, or incompatible generated or
 cached data falls back silently to `catalog.toml`. User `~/.tau/catalog.toml`

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -40,6 +40,11 @@ class TauPaths:
         return self.home / "models-store.json"
 
     @property
+    def codex_version_store_path(self) -> Path:
+        """Return the latest released Codex-version cache path."""
+        return self.home / "codex-version-store.json"
+
+    @property
     def extension_state_dir(self) -> Path:
         """Return the user-level state directory owned by built-in extensions."""
         return self.home / "state" / "extensions"

--- a/src/tau_coding/provider_runtime.py
+++ b/src/tau_coding/provider_runtime.py
@@ -22,6 +22,7 @@ from tau_ai.openai_codex import (
     OpenAICodexProvider,
 )
 from tau_ai.openai_compatible import OpenAICompatibleProvider
+from tau_coding.codex_version import CodexClientVersionResolver
 from tau_coding.credentials import FileCredentialStore, OAuthCredential
 from tau_coding.extensions.providers import (
     CredentialReader,
@@ -43,6 +44,7 @@ from tau_coding.oauth import (
 )
 from tau_coding.oauth_registry import get_oauth_provider
 from tau_coding.oauth_types import OAuthProvider
+from tau_coding.paths import TauPaths
 from tau_coding.provider_config import (
     AnthropicProviderConfig,
     OpenAICodexProviderConfig,
@@ -269,6 +271,9 @@ def create_model_provider(
                     thinking_level=thinking_level,
                 ),
                 supports_images=provider_model_supports_images(provider, model),
+                client_version_resolver=CodexClientVersionResolver(
+                    paths=TauPaths(home=credentials.path.parent)
+                ),
             )
         )
     if isinstance(provider, OpenAICompatibleProviderConfig):

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -7,6 +7,7 @@ import string
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, replace
+from os import environ
 from pathlib import Path
 from typing import Literal
 
@@ -41,6 +42,7 @@ from tau_agent.session.tree import SessionTreeError, path_to_entry
 from tau_agent.tool_history import ToolHistoryRepair, repair_tool_history
 from tau_agent.tools import AgentTool
 from tau_agent.types import JSONValue
+from tau_ai.model_catalog import ModelCatalogProvider, RuntimeModel, RuntimeModelCatalog
 from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
 from tau_coding.branch_summary import summarize_branch_messages_with_model
 from tau_coding.commands import CommandRegistry, CommandResult, create_default_command_registry
@@ -95,9 +97,11 @@ from tau_coding.prompt_templates import (
     load_prompt_templates_with_diagnostics,
 )
 from tau_coding.provider_config import (
+    OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfig,
     ProviderConfigError,
+    ProviderModelMetadata,
     ProviderSettings,
     load_provider_settings,
     provider_default_thinking_level,
@@ -426,6 +430,9 @@ class CodingSession:
             "fixed" if config.inference_provider is not None else "automatic"
         )
         self._provider_settings = config.provider_settings
+        self._durable_provider_settings = config.provider_settings
+        self._runtime_model_catalogs: dict[str, RuntimeModelCatalog] = {}
+        self._model_catalog_discovery_errors: dict[str, str] = {}
         self._runtime_provider_config = config.runtime_provider_config
         self._resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
         self._auto_compact_token_threshold = config.auto_compact_token_threshold
@@ -1582,6 +1589,7 @@ class CodingSession:
             raise ProviderConfigError("Provider settings are not available for this session")
         available = set(self.available_model_choices)
         existing = choice in self.scoped_model_choices
+        durable_settings = getattr(self, "_durable_provider_settings", self._provider_settings)
         effective = self._provider_registry.effective(choice.provider_name)
         if effective is not None and isinstance(effective.definition, DynamicProvider):
             if not (
@@ -1601,14 +1609,28 @@ class CodingSession:
                 raise ProviderConfigError(
                     f"Model is not available: {choice.provider_name}:{choice.model}"
                 )
-            toggle = toggle_saved_scoped_model
+            durable_provider = (
+                durable_settings.get_provider(choice.provider_name)
+                if durable_settings is not None
+                else None
+            )
+            toggle = (
+                toggle_saved_scoped_model
+                if durable_provider is not None and choice.model in durable_provider.models
+                else toggle_saved_stable_scoped_model
+            )
 
-        self._provider_settings = toggle(
+        updated_settings = toggle(
             provider_name=choice.provider_name,
             model=choice.model,
             paths=self._resource_paths.paths,
-            fallback_settings=self._provider_settings,
+            fallback_settings=durable_settings,
         )
+        if hasattr(self, "_durable_provider_settings"):
+            self._durable_provider_settings = updated_settings
+            self._apply_runtime_model_catalogs()
+        else:  # narrowly supports lightweight host/test session doubles
+            self._provider_settings = updated_settings
         self._sync_thinking_level_to_active_model()
         return self.scoped_model_choices
 
@@ -1803,14 +1825,19 @@ class CodingSession:
         )
 
     def _persist_default_model_choice(self) -> None:
-        if self._provider_settings is None:
+        if self._durable_provider_settings is None:
             return
-        self._provider_settings = save_default_provider_model(
+        durable_provider = self._durable_provider_settings.get_provider(self.provider_name)
+        if self.model not in durable_provider.models:
+            # Account-specific inventory is deliberately not written into catalog.toml.
+            return
+        self._durable_provider_settings = save_default_provider_model(
             provider_name=self.provider_name,
             model=self.model,
             paths=self._resource_paths.paths,
-            fallback_settings=self._provider_settings,
+            fallback_settings=self._durable_provider_settings,
         )
+        self._apply_runtime_model_catalogs()
         self._sync_thinking_level_to_active_model()
 
     def _persist_thinking_level_choice(self) -> None:
@@ -1823,13 +1850,14 @@ class CodingSession:
         ):
             return
         try:
-            self._provider_settings = save_provider_thinking_level(
+            self._durable_provider_settings = save_provider_thinking_level(
                 provider_name=self.provider_name,
                 model=self.model,
                 thinking_level=self._thinking_level,
                 paths=self._resource_paths.paths,
-                fallback_settings=self._provider_settings,
+                fallback_settings=self._durable_provider_settings,
             )
+            self._apply_runtime_model_catalogs()
         except ProviderConfigError:
             return
 
@@ -2037,12 +2065,23 @@ class CodingSession:
         self._runtime_model_limits_key = key
         self._model_limits_discovery_error = None
         provider = self._harness.config.provider
-        if not isinstance(provider, ModelLimitsProvider):
+        if (
+            self.provider_name == "openai-codex"
+            and isinstance(provider, ModelCatalogProvider)
+            and environ.get("TAU_OFFLINE") is not None
+        ):
             return
         try:
-            self._runtime_model_limits = await provider.discover_model_limits(self.model)
+            if isinstance(provider, ModelCatalogProvider):
+                catalog = await provider.discover_models()
+                self._publish_runtime_model_catalog(self.provider_name, catalog)
+            if isinstance(provider, ModelLimitsProvider):
+                self._runtime_model_limits = await provider.discover_model_limits(self.model)
         except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
-            self._model_limits_discovery_error = f"{type(exc).__name__}: {exc}"
+            error = f"{type(exc).__name__}: {exc}"
+            self._model_limits_discovery_error = error
+            if isinstance(provider, ModelCatalogProvider):
+                self._model_catalog_discovery_errors[self.provider_name] = error
 
     async def reload(self) -> CodingReloadSummary:
         """Stage and atomically publish a complete replacement snapshot."""
@@ -2257,27 +2296,98 @@ class CodingSession:
         )
 
     async def refresh_model_catalogs(self, *, force: bool = False) -> ModelsDevRefreshResult:
-        """Refresh the persisted remote catalog and publish it to this session."""
+        """Refresh public and authenticated catalogs and publish them to this session."""
         result = await refresh_models_dev_catalog(
             paths=self._resource_paths.paths,
             force=force,
         )
         self.reload_provider_settings()
+        await self._refresh_codex_model_catalog()
         return result
+
+    async def _refresh_codex_model_catalog(self) -> None:
+        """Refresh the account-specific Codex inventory without making it durable."""
+        if environ.get("TAU_OFFLINE") is not None or self._durable_provider_settings is None:
+            return
+        try:
+            provider_config = self._durable_provider_settings.get_provider("openai-codex")
+        except ProviderConfigError:
+            return
+        if not isinstance(provider_config, OpenAICodexProviderConfig):
+            return
+        if not self._provider_is_usable(provider_config):
+            return
+
+        active_provider = self._harness.config.provider
+        catalog_provider: ModelCatalogProvider
+        temporary_provider: ClosableModelProvider | None = None
+        if self.provider_name == provider_config.name and isinstance(
+            active_provider, ModelCatalogProvider
+        ):
+            catalog_provider = active_provider
+        else:
+            temporary_provider = create_model_provider(
+                provider_config,
+                credential_store=self._credential_store,
+                model=None,
+                thinking_level=None,
+            )
+            if not isinstance(temporary_provider, ModelCatalogProvider):
+                await temporary_provider.aclose()
+                return
+            catalog_provider = temporary_provider
+        try:
+            catalog = await catalog_provider.discover_models()
+            self._publish_runtime_model_catalog(provider_config.name, catalog)
+        except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
+            self._model_catalog_discovery_errors[provider_config.name] = (
+                f"{type(exc).__name__}: {exc}"
+            )
+        finally:
+            if temporary_provider is not None:
+                await temporary_provider.aclose()
+
+    def _publish_runtime_model_catalog(
+        self,
+        provider_name: str,
+        catalog: RuntimeModelCatalog,
+    ) -> None:
+        if not catalog.models:
+            raise ValueError("provider returned an empty model catalog")
+        self._runtime_model_catalogs[provider_name] = catalog
+        self._model_catalog_discovery_errors.pop(provider_name, None)
+        self._apply_runtime_model_catalogs()
+
+    def _apply_runtime_model_catalogs(self) -> None:
+        settings = self._durable_provider_settings
+        if settings is None:
+            self._provider_settings = None
+            return
+        providers = tuple(
+            _provider_with_runtime_model_catalog(
+                provider,
+                self._runtime_model_catalogs.get(provider.name),
+            )
+            for provider in settings.providers
+        )
+        self._provider_settings = replace(settings, providers=providers)
 
     def reload_provider_settings(self) -> None:
         """Reload provider settings for login and model-selection flows."""
         if self._provider_settings is None:
             return
         previous_settings = self._provider_settings
+        previous_durable_settings = self._durable_provider_settings
         previous_thinking_level = self._thinking_level
-        self._provider_settings = load_provider_settings(self._resource_paths.paths)
+        self._durable_provider_settings = load_provider_settings(self._resource_paths.paths)
+        self._apply_runtime_model_catalogs()
         try:
             self._sync_thinking_level_to_active_model()
             self._refresh_runtime_provider()
             self._sync_image_support()
         except ProviderConfigError:
             self._provider_settings = previous_settings
+            self._durable_provider_settings = previous_durable_settings
             self._thinking_level = previous_thinking_level
             raise
 
@@ -2351,7 +2461,7 @@ class CodingSession:
                 requested_provider=provider_name if dynamic_resume else None,
                 requested_model=model if dynamic_resume else None,
                 session_provider_name=record.provider_name,
-                provider_settings=self._provider_settings,
+                provider_settings=self._durable_provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 auto_compact_token_threshold=self._auto_compact_token_threshold,
                 auto_compact_enabled=self._auto_compact_enabled,
@@ -2509,7 +2619,7 @@ class CodingSession:
                 requested_provider=provider_name if dynamic_provider is not None else None,
                 requested_model=model if dynamic_provider is not None else None,
                 session_provider_name=provider_name,
-                provider_settings=self._provider_settings,
+                provider_settings=self._durable_provider_settings,
                 runtime_provider_config=runtime_provider_config,
                 dynamic_provider=dynamic_provider,
                 owns_initial_provider=dynamic_provider is not None,
@@ -2586,6 +2696,9 @@ class CodingSession:
         self._inference_provider = replacement._inference_provider
         self._inference_provider_mode = replacement._inference_provider_mode
         self._provider_settings = replacement._provider_settings
+        self._durable_provider_settings = replacement._durable_provider_settings
+        self._runtime_model_catalogs = replacement._runtime_model_catalogs
+        self._model_catalog_discovery_errors = replacement._model_catalog_discovery_errors
         self._runtime_provider_config = replacement._runtime_provider_config
         self._resource_paths = replacement._resource_paths
         self._auto_compact_token_threshold = replacement._auto_compact_token_threshold
@@ -4380,6 +4493,77 @@ def _system_prompt_resource_signatures(
         str(custom_system_prompt_path) if custom_system_prompt_path is not None else None,
         append_system_prompt,
         tuple(str(path) for path in append_system_prompt_paths),
+    )
+
+
+def _provider_with_runtime_model_catalog(
+    provider: ProviderConfig,
+    catalog: RuntimeModelCatalog | None,
+) -> ProviderConfig:
+    """Overlay one account-specific catalog without changing durable settings."""
+    if catalog is None or not isinstance(provider, OpenAICodexProviderConfig):
+        return provider
+
+    models = tuple(model.id for model in catalog.models)
+    metadata = {
+        model.id: _runtime_provider_model_metadata(provider, model) for model in catalog.models
+    }
+    context_windows = {
+        model.id: (
+            model.limits.context_window
+            if model.limits is not None
+            else provider.context_windows[model.id]
+        )
+        for model in catalog.models
+        if model.limits is not None or model.id in provider.context_windows
+    }
+    return replace(
+        provider,
+        models=models,
+        default_model=(provider.default_model if provider.default_model in models else models[0]),
+        context_windows=context_windows,
+        model_metadata=metadata,
+        thinking_models=tuple(model.id for model in catalog.models if model.thinking_levels),
+        thinking_defaults=_runtime_model_thinking_defaults(provider, catalog),
+    )
+
+
+def _runtime_model_thinking_defaults(
+    provider: OpenAICodexProviderConfig,
+    catalog: RuntimeModelCatalog,
+) -> dict[str, ThinkingLevel]:
+    defaults: dict[str, ThinkingLevel] = {}
+    for model in catalog.models:
+        default = provider.thinking_defaults.get(model.id) or model.default_thinking_level
+        if default is not None:
+            defaults[model.id] = default
+    return defaults
+
+
+def _runtime_provider_model_metadata(
+    provider: OpenAICodexProviderConfig,
+    model: RuntimeModel,
+) -> ProviderModelMetadata:
+    existing = provider.model_metadata.get(model.id, ProviderModelMetadata())
+    supported = set(model.thinking_levels)
+    thinking_level_map = {
+        level: ("none" if level == "off" else level) if level in supported else None
+        for level in THINKING_LEVELS
+    }
+    return replace(
+        existing,
+        name=model.name or existing.name,
+        reasoning=True if model.thinking_levels else existing.reasoning,
+        input=model.input_modalities,
+        context_window=(
+            model.limits.context_window if model.limits is not None else existing.context_window
+        ),
+        max_tokens=(
+            model.limits.max_output_tokens
+            if model.limits is not None and model.limits.max_output_tokens is not None
+            else existing.max_tokens
+        ),
+        thinking_level_map=thinking_level_map,
     )
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -581,13 +581,30 @@ class CodingSession:
                 include_user_dir=False,
             )
 
-        if config.provider is None:
+        selected_provider_name = (
+            config.requested_provider or state.provider or config.session_provider_name
+        )
+        selected_model = config.requested_model or state.model
+        rediscover_codex = False
+        if selected_provider_name == "openai-codex" and config.provider_settings is not None:
+            selected_config = config.provider_settings.get_provider(selected_provider_name)
+            rediscover_codex = (
+                isinstance(selected_config, OpenAICodexProviderConfig)
+                and selected_model not in selected_config.models
+            )
+        if config.provider is None or rediscover_codex:
             prepared = await _prepare_provider_selection(
                 config,
                 state=state,
                 provider_registry=extension_runtime.provider_registry,
                 credential_store=credential_store,
             )
+            if config.provider is not None and config.owns_initial_provider:
+                try:
+                    await config.provider.aclose()  # type: ignore[attr-defined]
+                except BaseException:
+                    await prepared.provider.aclose()
+                    raise
             config = replace(
                 config,
                 provider=prepared.provider,
@@ -1767,9 +1784,20 @@ class CodingSession:
         if self._provider_settings is None:
             return None
         try:
-            return self._provider_settings.get_provider(self._provider_name)
+            provider = self._provider_settings.get_provider(self._provider_name)
         except ProviderConfigError:
             return None
+        runtime = self._runtime_provider_config
+        if (
+            isinstance(provider, OpenAICodexProviderConfig)
+            and self.model not in provider.models
+            and runtime is not None
+            and runtime.name == provider.name
+            and self.model in runtime.models
+        ):
+            # Picker visibility must not invalidate an already selected runtime.
+            return runtime
+        return provider
 
     def _apply_thinking_level_override(self) -> None:
         """Apply the one-shot startup thinking override to the loaded session.
@@ -2432,7 +2460,15 @@ class CodingSession:
                         dynamic_resume = True
                         runtime_provider_config = None
                     else:
-                        validate_provider_model(runtime_provider_config, model)
+                        if (
+                            isinstance(runtime_provider_config, OpenAICodexProviderConfig)
+                            and model not in runtime_provider_config.models
+                        ):
+                            # Re-discover a live-only destination model before validation.
+                            dynamic_resume = True
+                            runtime_provider_config = None
+                        else:
+                            validate_provider_model(runtime_provider_config, model)
 
         replacement = await type(self).load(
             CodingSessionConfig(
@@ -4097,10 +4133,43 @@ async def _prepare_provider_selection(
             f"Provider is not available after trusted extension loading: "
             f"{provider_name or config.model}"
         )
+    selected_model = requested_model or (state.model if state.provider == provider_name else None)
+    selected_provider = settings.get_provider(provider_name or settings.default_provider)
+    if (
+        isinstance(selected_provider, OpenAICodexProviderConfig)
+        and selected_model is not None
+        and selected_model not in selected_provider.models
+        and environ.get("TAU_OFFLINE") is None
+    ):
+        # Live-only explicit/resumed models need discovery before static validation.
+        discovery_provider = None
+        try:
+            discovery_provider = create_model_provider(
+                selected_provider,
+                credential_store=credential_store,
+                model=None,
+                thinking_level=None,
+            )
+            if isinstance(discovery_provider, ModelCatalogProvider):
+                catalog = await discovery_provider.discover_models()
+                if catalog.models:
+                    live_provider = _provider_with_runtime_model_catalog(selected_provider, catalog)
+                    settings = replace(
+                        settings,
+                        providers=tuple(
+                            live_provider if item.name == selected_provider.name else item
+                            for item in settings.providers
+                        ),
+                    )
+        except Exception:  # noqa: BLE001 - retain ordinary static validation on failure
+            pass
+        finally:
+            if discovery_provider is not None:
+                await discovery_provider.aclose()
     selection = resolve_provider_selection(
         settings,
         provider_name=provider_name,
-        model=(requested_model or (state.model if state.provider == provider_name else None)),
+        model=selected_model,
     )
     inference_provider = _session_inference_provider(
         config,
@@ -4248,6 +4317,11 @@ def _provider_config_for_name(
     config: CodingSessionConfig,
     provider_name: str,
 ) -> ProviderConfig | None:
+    if (
+        isinstance(config.runtime_provider_config, OpenAICodexProviderConfig)
+        and config.runtime_provider_config.name == provider_name
+    ):
+        return config.runtime_provider_config
     if config.provider_settings is not None:
         try:
             return config.provider_settings.get_provider(provider_name)

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -2318,34 +2318,27 @@ class CodingSession:
         if not self._provider_is_usable(provider_config):
             return
 
-        active_provider = self._harness.config.provider
-        catalog_provider: ModelCatalogProvider
-        temporary_provider: ClosableModelProvider | None = None
-        if self.provider_name == provider_config.name and isinstance(
-            active_provider, ModelCatalogProvider
-        ):
-            catalog_provider = active_provider
-        else:
-            temporary_provider = create_model_provider(
-                provider_config,
-                credential_store=self._credential_store,
-                model=None,
-                thinking_level=None,
-            )
-            if not isinstance(temporary_provider, ModelCatalogProvider):
-                await temporary_provider.aclose()
-                return
-            catalog_provider = temporary_provider
+        # Use a fresh provider even when Codex is active. The active provider caches
+        # its startup snapshot so reusing it would make `/model` unable to discover
+        # versions or models released during a long-running Tau process.
+        temporary_provider = create_model_provider(
+            provider_config,
+            credential_store=self._credential_store,
+            model=None,
+            thinking_level=None,
+        )
+        if not isinstance(temporary_provider, ModelCatalogProvider):
+            await temporary_provider.aclose()
+            return
         try:
-            catalog = await catalog_provider.discover_models()
+            catalog = await temporary_provider.discover_models()
             self._publish_runtime_model_catalog(provider_config.name, catalog)
         except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
             self._model_catalog_discovery_errors[provider_config.name] = (
                 f"{type(exc).__name__}: {exc}"
             )
         finally:
-            if temporary_provider is not None:
-                await temporary_provider.aclose()
+            await temporary_provider.aclose()
 
     def _publish_runtime_model_catalog(
         self,

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -625,6 +625,9 @@ class CodingSession:
                     else entry
                     for entry in pending_initial_entries
                 )
+                # Initial fallback metadata was created before live discovery.
+                # Replay the corrected entries so runtime and durable selection agree.
+                state = SessionState.from_entries(list(pending_initial_entries))
         assert config.provider is not None
         active_model = _runtime_model_for_state(config, state)
         image_support = ImageSupportState(
@@ -2511,9 +2514,10 @@ class CodingSession:
             )
         )
         try:
-            if restore_record_model and runtime_provider_config is not None:
-                validate_provider_model(runtime_provider_config, replacement.model)
-            else:
+            if not restore_record_model:
+                # Only provider-less legacy records inherit the source model.
+                # The staged loader has already resolved provider-aware records
+                # against the destination's (possibly freshly discovered) catalog.
                 replacement._harness.config.model = self.model
                 replacement._sync_thinking_level_to_active_model()
                 replacement._refresh_runtime_provider()

--- a/tests/test_codex_resume.py
+++ b/tests/test_codex_resume.py
@@ -1,0 +1,176 @@
+"""End-to-end Codex resume regressions with real session loading and fake transport."""
+
+from pathlib import Path
+
+import pytest
+from textual.widgets import ListView
+
+from tau_agent.session import JsonlSessionStorage, ModelChangeEntry, SessionInfoEntry
+from tau_ai import FakeProvider, RuntimeModel, RuntimeModelCatalog
+from tau_coding import (
+    CodingSession,
+    CodingSessionConfig,
+    FileCredentialStore,
+    OAuthCredential,
+    OpenAICodexProviderConfig,
+    ProviderSettings,
+)
+from tau_coding import session as session_module
+from tau_coding.paths import TauPaths
+from tau_coding.session_manager import SessionManager
+from tau_coding.tui import app as tui_app
+
+
+class CatalogProvider(FakeProvider):
+    def __init__(self, *, include_astra: bool = True) -> None:
+        super().__init__([])
+        self.include_astra = include_astra
+
+    async def discover_models(self) -> RuntimeModelCatalog:
+        models = (RuntimeModel(id="gpt-5.6-sol"),)
+        if self.include_astra:
+            models += (RuntimeModel(id="gpt-6-astra"),)
+        return RuntimeModelCatalog(models)
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.anyio
+async def test_initial_live_selection_replays_corrected_fallback_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("TAU_OFFLINE", raising=False)
+    static = OpenAICodexProviderConfig(models=("gpt-5.6-sol",), default_model="gpt-5.6-sol")
+    settings = ProviderSettings(default_provider="openai-codex", providers=(static,))
+    monkeypatch.setattr(session_module, "create_model_provider", lambda *a, **k: CatalogProvider())
+    storage = JsonlSessionStorage(tmp_path / "new.jsonl")
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=None,
+            model="gpt-5.6-sol",
+            provider_name="openai-codex",
+            requested_provider="openai-codex",
+            requested_model="gpt-6-astra",
+            provider_settings=settings,
+            cwd=tmp_path,
+            storage=storage,
+            system="Test",
+            extensions_enabled=False,
+            defer_authoritative_writes=True,
+        )
+    )
+    try:
+        assert session.model == "gpt-6-astra"
+        assert session._state.model == "gpt-6-astra"
+        await session._commit_prepared_entries()
+        entries = await storage.read_all()
+        selections = [entry.model for entry in entries if isinstance(entry, ModelChangeEntry)]
+        assert selections == ["gpt-6-astra"]
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("flow", ["startup", "resume"])
+@pytest.mark.parametrize("stale_index", [False, True])
+async def test_codex_resume_restores_astra_through_real_frontend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, flow: str, stale_index: bool
+) -> None:
+    monkeypatch.delenv("TAU_OFFLINE", raising=False)
+    paths = TauPaths()
+    manager = SessionManager(paths)
+    static = OpenAICodexProviderConfig(models=("gpt-5.6-sol",), default_model="gpt-5.6-sol")
+    settings = ProviderSettings(default_provider="openai-codex", providers=(static,))
+    FileCredentialStore(paths.home / "credentials.json").set_oauth(
+        "openai-codex",
+        OAuthCredential(access="test", refresh="test", expires=4_000_000_000, account_id="test"),
+    )
+    record = manager.create_session(
+        cwd=tmp_path,
+        model="gpt-5.6-sol" if stale_index else "gpt-6-astra",
+        provider_name="openai-codex",
+    )
+    storage = JsonlSessionStorage(record.path)
+    info = SessionInfoEntry(cwd=str(tmp_path))
+    previous = ModelChangeEntry(parent_id=info.id, model="gpt-5.6-sol", provider="openai-codex")
+    astra = ModelChangeEntry(parent_id=previous.id, model="gpt-6-astra", provider="openai-codex")
+    await storage.append_batch((info, previous, astra))
+
+    monkeypatch.setattr(tui_app, "load_provider_settings", lambda: settings)
+    monkeypatch.setattr(session_module, "load_provider_settings", lambda *a: settings)
+    monkeypatch.setattr(tui_app, "create_model_provider", lambda *a, **k: CatalogProvider())
+    monkeypatch.setattr(session_module, "create_model_provider", lambda *a, **k: CatalogProvider())
+
+    real_app = tui_app.TauTuiApp
+
+    async def inspect_picker(session: CodingSession) -> None:
+        async def refresh() -> None:
+            session.reload_provider_settings()
+
+        monkeypatch.setattr(session, "refresh_model_catalogs", refresh)
+        app = real_app(session)
+        async with app.run_test() as pilot:
+            assert session.model == "gpt-6-astra"
+            app._open_model_picker()
+            await pilot.pause()
+            picker = app.screen
+            assert isinstance(picker, tui_app.ModelPickerScreen)
+            index = picker.query_one("#model-picker-list", ListView).index
+            assert index is not None
+            assert picker.visible_choices[index].model == "gpt-6-astra"
+
+    if flow == "startup":
+
+        class InspectApp:
+            def __init__(self, session: CodingSession, **kwargs: object) -> None:
+                self.session = session
+
+            async def run_async(self) -> None:
+                assert self.session.provider_name == "openai-codex"
+                assert self.session.model == "gpt-6-astra"
+                await inspect_picker(self.session)
+
+        monkeypatch.setattr(tui_app, "TauTuiApp", InspectApp)
+        await tui_app.run_tui_app(
+            model=None,
+            cwd=tmp_path,
+            session_id=record.id,
+            session_manager=manager,
+            extensions_enabled=False,
+            trust_override="trust",
+        )
+    else:
+        source = manager.create_session(
+            cwd=tmp_path, model="gpt-5.6-sol", provider_name="openai-codex"
+        )
+        monkeypatch.setattr(
+            session_module,
+            "create_model_provider",
+            lambda *a, **k: CatalogProvider(include_astra=False),
+        )
+        session = await CodingSession.load(
+            CodingSessionConfig(
+                provider=CatalogProvider(),
+                model="gpt-5.6-sol",
+                provider_name="openai-codex",
+                provider_settings=settings,
+                runtime_provider_config=static,
+                cwd=tmp_path,
+                storage=JsonlSessionStorage(source.path),
+                session_id=source.id,
+                session_manager=manager,
+                system="Test",
+                extensions_enabled=False,
+            )
+        )
+        monkeypatch.setattr(
+            session_module, "create_model_provider", lambda *a, **k: CatalogProvider()
+        )
+        try:
+            await session.resume(record.id)
+            assert session.provider_name == "openai-codex"
+            assert session.model == "gpt-6-astra"
+            await inspect_picker(session)
+        finally:
+            await session.aclose()

--- a/tests/test_codex_version.py
+++ b/tests/test_codex_version.py
@@ -1,0 +1,127 @@
+import json
+
+import httpx
+import pytest
+
+from tau_ai.openai_codex import DEFAULT_OPENAI_CODEX_CLIENT_VERSION
+from tau_coding.codex_version import (
+    CODEX_NPM_LATEST_URL,
+    CodexClientVersionResolver,
+)
+from tau_coding.paths import TauPaths
+
+
+@pytest.mark.anyio
+async def test_codex_version_resolver_fetches_and_caches_latest_release(tmp_path) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"version": "0.153.4"}, headers={"etag": '"latest"'})
+
+    paths = TauPaths(home=tmp_path / ".tau")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        resolver = CodexClientVersionResolver(paths=paths, client=client, now=lambda: 1_000)
+        assert await resolver() == "0.153.4"
+        assert await resolver() == "0.153.4"
+
+    assert len(requests) == 1
+    assert str(requests[0].url) == CODEX_NPM_LATEST_URL
+    assert json.loads(paths.codex_version_store_path.read_text(encoding="utf-8")) == {
+        "checked_at": 1_000,
+        "etag": '"latest"',
+        "schema_version": 1,
+        "version": "0.153.4",
+    }
+
+
+@pytest.mark.anyio
+async def test_codex_version_resolver_revalidates_stale_cache(tmp_path) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(304)
+
+    paths = TauPaths(home=tmp_path / ".tau")
+    paths.home.mkdir(parents=True)
+    paths.codex_version_store_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "checked_at": 1,
+                "etag": '"cached"',
+                "version": "0.154.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        resolver = CodexClientVersionResolver(paths=paths, client=client, now=lambda: 20_000)
+        assert await resolver() == "0.154.0"
+
+    assert requests[0].headers["if-none-match"] == '"cached"'
+    cache = json.loads(paths.codex_version_store_path.read_text(encoding="utf-8"))
+    assert cache["checked_at"] == 20_000
+
+
+@pytest.mark.anyio
+async def test_codex_version_resolver_uses_stale_cache_on_failure(tmp_path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau")
+    paths.home.mkdir(parents=True)
+    paths.codex_version_store_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "checked_at": 1,
+                "etag": None,
+                "version": "0.154.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        resolver = CodexClientVersionResolver(paths=paths, client=client, now=lambda: 20_000)
+        assert await resolver() == "0.154.0"
+
+
+@pytest.mark.anyio
+async def test_codex_version_resolver_rejects_malformed_version(tmp_path) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"version": "999.999.999-next.1"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        resolver = CodexClientVersionResolver(paths=TauPaths(home=tmp_path / ".tau"), client=client)
+        assert await resolver() == DEFAULT_OPENAI_CODEX_CLIENT_VERSION
+
+
+@pytest.mark.anyio
+async def test_codex_version_resolver_offline_uses_cache_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("TAU_OFFLINE", "1")
+    paths = TauPaths(home=tmp_path / ".tau")
+    paths.home.mkdir(parents=True)
+    paths.codex_version_store_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "checked_at": 1,
+                "etag": None,
+                "version": "0.154.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("offline resolution must not use the network")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        resolver = CodexClientVersionResolver(paths=paths, client=client)
+        assert await resolver() == "0.154.0"

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -37,13 +37,21 @@ from tau_agent.session import (
     SessionInfoEntry,
     ThinkingLevelChangeEntry,
 )
-from tau_ai import CancellationToken, FakeProvider, ModelProvider, RuntimeModelLimits
+from tau_ai import (
+    CancellationToken,
+    FakeProvider,
+    ModelProvider,
+    RuntimeModel,
+    RuntimeModelCatalog,
+    RuntimeModelLimits,
+)
 from tau_ai.events import AssistantMessageEvent
 from tau_coding import (
     CodingSession,
     CodingSessionConfig,
     FileCredentialStore,
     ModelChoice,
+    OAuthCredential,
     OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderConfigError,
@@ -66,7 +74,7 @@ from tau_coding.extensions import (
 )
 from tau_coding.extensions.runtime import InputHookOutcome
 from tau_coding.prompt_templates import PromptTemplate
-from tau_coding.provider_config import ProviderModelMetadata
+from tau_coding.provider_config import ProviderModelMetadata, provider_thinking_levels
 from tau_coding.session import (
     _ordered_tree_entries,
     is_retryable_huggingface_route_error,
@@ -205,6 +213,27 @@ class ModelLimitsFakeProvider(FakeProvider):
         if self.error is not None:
             raise self.error
         return self.limits
+
+
+class ModelCatalogFakeProvider(ModelLimitsFakeProvider):
+    def __init__(
+        self,
+        scripts: list[list[AssistantMessageEvent]],
+        *,
+        catalog: RuntimeModelCatalog,
+        limits: RuntimeModelLimits | None = None,
+    ) -> None:
+        super().__init__(scripts, limits=limits)
+        self.catalog = catalog
+        self.catalog_calls = 0
+        self.closed = False
+
+    async def discover_models(self) -> RuntimeModelCatalog:
+        self.catalog_calls += 1
+        return self.catalog
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 class RaisingProvider:
@@ -3831,6 +3860,164 @@ async def test_session_uses_live_provider_limits_for_compaction_threshold(
     assert session.auto_compact_token_threshold == 334_800
     assert session.context_window_source == "provider live catalog"
     assert session.model_limits_discovery_error is None
+
+
+@pytest.mark.anyio
+async def test_session_publishes_authenticated_codex_model_inventory(tmp_path: Path) -> None:
+    tau_paths = TauPaths(home=tmp_path / ".tau")
+    FileCredentialStore(tau_paths.home / "credentials.json").set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="access-token",
+            refresh="refresh-token",
+            expires=4_000_000_000,
+            account_id="account-1",
+        ),
+    )
+    limits = RuntimeModelLimits(context_window=500_000, max_output_tokens=100_000)
+    provider = ModelCatalogFakeProvider(
+        [],
+        catalog=RuntimeModelCatalog(
+            (
+                RuntimeModel(
+                    id="astra",
+                    name="Astra",
+                    limits=limits,
+                    input_modalities=("text", "image"),
+                    thinking_levels=("low", "high"),
+                    default_thinking_level="high",
+                ),
+            )
+        ),
+    )
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=("static-model",),
+                default_model="static-model",
+                context_windows={"static-model": 272_000},
+                thinking_levels=("off", "low", "medium", "high"),
+                thinking_models=("static-model",),
+                thinking_default="medium",
+                thinking_parameter="reasoning.effort",
+            ),
+        ),
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="static-model",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    assert provider.catalog_calls == 1
+    assert session.available_models == ("astra",)
+    live = session.provider_config("openai-codex")
+    assert live is not None
+    assert live.context_windows == {"astra": 500_000}
+    assert live.model_metadata["astra"].name == "Astra"
+    assert live.model_metadata["astra"].input == ("text", "image")
+    assert provider_thinking_levels(live, model="astra") == ("low", "high")
+
+
+@pytest.mark.anyio
+async def test_session_skips_codex_catalog_discovery_offline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("TAU_OFFLINE", "1")
+    provider = ModelCatalogFakeProvider(
+        [],
+        catalog=RuntimeModelCatalog((RuntimeModel(id="astra"),)),
+    )
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=("static-model",),
+                default_model="static-model",
+                context_windows={"static-model": 272_000},
+            ),
+        ),
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="static-model",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+        )
+    )
+
+    assert provider.catalog_calls == 0
+    assert provider.discovery_calls == []
+    assert session.context_window_tokens == 272_000
+    assert session.provider_config("openai-codex") == settings.providers[0]
+
+
+@pytest.mark.anyio
+async def test_session_discovers_codex_inventory_while_another_provider_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tau_paths = TauPaths(home=tmp_path / ".tau")
+    FileCredentialStore(tau_paths.home / "credentials.json").set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="access-token",
+            refresh="refresh-token",
+            expires=4_000_000_000,
+            account_id="account-1",
+        ),
+    )
+    discovered = ModelCatalogFakeProvider(
+        [],
+        catalog=RuntimeModelCatalog((RuntimeModel(id="astra", name="Astra"),)),
+    )
+    monkeypatch.setattr(
+        coding_session_module, "create_model_provider", lambda *args, **kwargs: discovered
+    )
+    settings = ProviderSettings(
+        default_provider="local",
+        providers=(
+            OpenAICompatibleProviderConfig(
+                name="local",
+                models=("local-model",),
+                default_model="local-model",
+            ),
+            OpenAICodexProviderConfig(models=("static-model",), default_model="static-model"),
+        ),
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model="local-model",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="local",
+            provider_settings=settings,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    await session._refresh_codex_model_catalog()
+
+    assert ModelChoice("openai-codex", "astra") in session.available_model_choices
+    assert discovered.catalog_calls == 1
+    assert discovered.closed is True
 
 
 @pytest.mark.anyio

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3946,6 +3946,128 @@ async def test_session_publishes_authenticated_codex_model_inventory(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("resume", [False, True])
+@pytest.mark.parametrize("preconstructed", [False, True])
+async def test_codex_live_only_model_is_discovered_before_startup_validation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resume: bool, preconstructed: bool
+) -> None:
+    monkeypatch.delenv("TAU_OFFLINE", raising=False)
+    static = OpenAICodexProviderConfig(models=("static-model",), default_model="static-model")
+    settings = ProviderSettings(default_provider="openai-codex", providers=(static,))
+    providers: list[ModelCatalogFakeProvider] = []
+    initial_provider = ModelCatalogFakeProvider([], catalog=RuntimeModelCatalog(()))
+
+    def create(*args: object, **kwargs: object) -> ModelCatalogFakeProvider:
+        provider = ModelCatalogFakeProvider(
+            [], catalog=RuntimeModelCatalog((RuntimeModel(id="live-model"),))
+        )
+        providers.append(provider)
+        return provider
+
+    monkeypatch.setattr(coding_session_module, "create_model_provider", create)
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    if resume:
+        info = SessionInfoEntry(cwd=str(tmp_path))
+        await storage.append(info)
+        await storage.append(
+            ModelChangeEntry(parent_id=info.id, provider="openai-codex", model="live-model")
+        )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=initial_provider if preconstructed else None,
+            owns_initial_provider=preconstructed,
+            runtime_provider_config=static if preconstructed else None,
+            model="static-model" if resume else "live-model",
+            requested_provider=None if resume else "openai-codex",
+            requested_model=None if resume else "live-model",
+            provider_name="openai-codex",
+            provider_settings=settings,
+            system="Test",
+            cwd=tmp_path,
+            storage=storage,
+            extensions_enabled=False,
+        )
+    )
+    try:
+        assert session.model == "live-model"
+        assert session._durable_provider_settings == settings
+        assert providers[0].closed
+        assert initial_provider.closed is preconstructed
+        assert session._active_provider_config() is not None
+        assert "live-model" in session._active_provider_config().models
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("offline", [False, True])
+async def test_codex_unknown_startup_model_is_not_silently_substituted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, offline: bool
+) -> None:
+    if offline:
+        monkeypatch.setenv("TAU_OFFLINE", "1")
+    else:
+        monkeypatch.delenv("TAU_OFFLINE", raising=False)
+    discovery = ModelCatalogFakeProvider([], catalog=RuntimeModelCatalog(()))
+    monkeypatch.setattr(coding_session_module, "create_model_provider", lambda *a, **k: discovery)
+    static = OpenAICodexProviderConfig(models=("static-model",), default_model="static-model")
+    with pytest.raises(ProviderConfigError, match="live-model"):
+        await CodingSession.load(
+            CodingSessionConfig(
+                provider=None,
+                model="live-model",
+                requested_provider="openai-codex",
+                requested_model="live-model",
+                provider_name="openai-codex",
+                provider_settings=ProviderSettings(
+                    default_provider="openai-codex", providers=(static,)
+                ),
+                system="Test",
+                cwd=tmp_path,
+                storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+                extensions_enabled=False,
+            )
+        )
+    assert discovery.catalog_calls == (0 if offline else 1)
+    assert discovery.closed is not offline
+
+
+@pytest.mark.anyio
+async def test_codex_missing_active_model_survives_settings_refresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    static = OpenAICodexProviderConfig(models=("static-model",), default_model="static-model")
+    settings = ProviderSettings(default_provider="openai-codex", providers=(static,))
+    provider = ModelCatalogFakeProvider(
+        [], catalog=RuntimeModelCatalog((RuntimeModel(id="live-model"),))
+    )
+    monkeypatch.setattr(coding_session_module, "create_model_provider", lambda *a, **k: provider)
+    monkeypatch.setattr(coding_session_module, "load_provider_settings", lambda *a: settings)
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="static-model",
+            provider_name="openai-codex",
+            provider_settings=settings,
+            runtime_provider_config=static,
+            system="Test",
+            cwd=tmp_path,
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            extensions_enabled=False,
+        )
+    )
+    try:
+        assert session.provider_config("openai-codex").models == ("live-model",)
+        session.reload_provider_settings()
+        session.reload_provider_settings()
+        assert session.model == "static-model"
+        assert session._active_provider_config() == static
+        assert session.provider_config("openai-codex").models == ("live-model",)
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.anyio
 async def test_session_skips_codex_catalog_discovery_offline(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3863,7 +3863,10 @@ async def test_session_uses_live_provider_limits_for_compaction_threshold(
 
 
 @pytest.mark.anyio
-async def test_session_publishes_authenticated_codex_model_inventory(tmp_path: Path) -> None:
+async def test_session_publishes_authenticated_codex_model_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     tau_paths = TauPaths(home=tmp_path / ".tau")
     FileCredentialStore(tau_paths.home / "credentials.json").set_oauth(
         "openai-codex",
@@ -3926,6 +3929,20 @@ async def test_session_publishes_authenticated_codex_model_inventory(tmp_path: P
     assert live.model_metadata["astra"].name == "Astra"
     assert live.model_metadata["astra"].input == ("text", "image")
     assert provider_thinking_levels(live, model="astra") == ("low", "high")
+
+    refreshed = ModelCatalogFakeProvider(
+        [],
+        catalog=RuntimeModelCatalog((RuntimeModel(id="nova", name="Nova"),)),
+    )
+    monkeypatch.setattr(
+        coding_session_module, "create_model_provider", lambda *args, **kwargs: refreshed
+    )
+    await session._refresh_codex_model_catalog()
+
+    assert session.available_models == ("nova",)
+    assert provider.catalog_calls == 1
+    assert refreshed.catalog_calls == 1
+    assert refreshed.closed is True
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -26,6 +26,7 @@ def test_create_model_provider_returns_openai_codex_provider(tmp_path) -> None:
     )
 
     assert isinstance(provider, OpenAICodexProvider)
+    assert provider._config.client_version_resolver is not None
 
 
 def test_create_model_provider_uses_codex_model_image_capability(tmp_path) -> None:

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -32,6 +32,8 @@ from tau_ai import (
     OpenAICodexProvider,
     OpenAICompatibleConfig,
     OpenAICompatibleProvider,
+    RuntimeModel,
+    RuntimeModelCatalog,
     RuntimeModelLimits,
     TextDeltaEvent,
     ThinkingDeltaEvent,
@@ -1294,7 +1296,7 @@ async def test_openai_compatible_provider_includes_plain_http_error_body_in_mess
 
 
 @pytest.mark.anyio
-async def test_openai_codex_provider_discovers_and_caches_live_model_limits() -> None:
+async def test_openai_codex_provider_discovers_and_caches_live_model_catalog() -> None:
     requests: list[httpx.Request] = []
 
     async def credentials() -> OpenAICodexCredentials:
@@ -1308,11 +1310,35 @@ async def test_openai_codex_provider_discovers_and_caches_live_model_limits() ->
                 "models": [
                     {
                         "slug": "gpt-5.6-sol",
+                        "display_name": "GPT-5.6 Sol",
+                        "visibility": "list",
+                        "supported_in_api": True,
+                        "priority": 10,
                         "context_window": 372_000,
                         "max_context_window": 372_000,
                         "effective_context_window_percent": 95,
                         "auto_compact_token_limit": 330_000,
                         "max_output_tokens": 128_000,
+                        "input_modalities": ["text", "image"],
+                        "default_reasoning_level": "high",
+                        "supported_reasoning_levels": [
+                            {"effort": "low", "description": "Fast"},
+                            {"effort": "high", "description": "Deep"},
+                        ],
+                    },
+                    {
+                        "slug": "subscription-only",
+                        "display_name": "Subscription only",
+                        "visibility": "list",
+                        "supported_in_api": False,
+                        "priority": 5,
+                        "supported_reasoning_levels": [],
+                    },
+                    {
+                        "slug": "hidden",
+                        "visibility": "hide",
+                        "supported_in_api": True,
+                        "context_window": 100_000,
                     },
                     {"slug": "invalid", "context_window": -1},
                 ]
@@ -1329,16 +1355,41 @@ async def test_openai_codex_provider_discovers_and_caches_live_model_limits() ->
             client=client,
         )
 
+        catalog = await provider.discover_models()
+        cached_catalog = await provider.discover_models()
         limits = await provider.discover_model_limits("gpt-5.6-sol")
-        cached = await provider.discover_model_limits("gpt-5.6-sol")
 
+    expected_limits = RuntimeModelLimits(
+        context_window=372_000,
+        max_output_tokens=128_000,
+        effective_context_window_percent=95,
+        auto_compact_token_limit=330_000,
+    )
+    assert catalog == RuntimeModelCatalog(
+        (
+            RuntimeModel(
+                id="gpt-5.6-sol",
+                name="GPT-5.6 Sol",
+                limits=expected_limits,
+                input_modalities=("text", "image"),
+                thinking_levels=("low", "high"),
+                default_thinking_level="high",
+            ),
+            RuntimeModel(
+                id="subscription-only",
+                name="Subscription only",
+                input_modalities=("text", "image"),
+            ),
+        )
+    )
+    assert cached_catalog == catalog
+    assert limits == expected_limits
     assert limits == RuntimeModelLimits(
         context_window=372_000,
         max_output_tokens=128_000,
         effective_context_window_percent=95,
         auto_compact_token_limit=330_000,
     )
-    assert cached == limits
     assert len(requests) == 1
     assert str(requests[0].url) == (
         "https://chatgpt.test/backend-api/codex/models?client_version=0.2.0"

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1400,6 +1400,46 @@ async def test_openai_codex_provider_discovers_and_caches_live_model_catalog() -
 
 
 @pytest.mark.anyio
+async def test_openai_codex_provider_uses_resolved_latest_client_version() -> None:
+    requests: list[httpx.Request] = []
+    version_calls = 0
+
+    async def credentials() -> OpenAICodexCredentials:
+        return OpenAICodexCredentials(access_token="access-token", account_id="account-1")
+
+    async def client_version() -> str:
+        nonlocal version_calls
+        version_calls += 1
+        return "0.153.4"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"models": [{"slug": "new-model", "visibility": "list"}]},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICodexProvider(
+            OpenAICodexConfig(
+                credential_resolver=credentials,
+                base_url="https://chatgpt.test/backend-api",
+                client_version="0.144.3",
+                client_version_resolver=client_version,
+            ),
+            client=client,
+        )
+        catalog = await provider.discover_models()
+        await provider.discover_model_limits("new-model")
+
+    assert [model.id for model in catalog.models] == ["new-model"]
+    assert version_calls == 1
+    assert str(requests[0].url) == (
+        "https://chatgpt.test/backend-api/codex/models?client_version=0.153.4"
+    )
+
+
+@pytest.mark.anyio
 async def test_openai_codex_provider_includes_http_error_detail_in_message() -> None:
     async def credentials() -> OpenAICodexCredentials:
         return OpenAICodexCredentials(access_token="access-token", account_id="account-1")

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -103,12 +103,19 @@ window through Codex OAuth than through an API key. For example, the public
 GPT-5.6 Sol API advertises a 1.05M-token window, while Codex has advertised
 substantially smaller limits through its authenticated model catalog.
 
-Tau queries that catalog when a Codex session starts and uses the returned
-context window and automatic-compaction threshold for the session. If discovery
-is unavailable, Tau falls back to conservative Codex-specific values from its
-built-in catalog; it does not reuse the public API limit. `/session` reports both
-the active value and whether it came from the live provider catalog or Tau's
-configured fallback.
+Tau queries that catalog when a Codex session starts and whenever `/model`
+refreshes. The authenticated result replaces the Codex model picker inventory
+for the current process, so newly enabled models appear without a Tau release
+and unavailable models are not copied from the separate public API catalog. Tau
+also uses reported context windows, compaction thresholds, input modalities, and
+reasoning efforts when present.
+
+If discovery is unavailable or invalid, Tau retains the checked-in Codex model
+list and its conservative Codex-specific limits; it does not reuse the public
+API inventory or limits. `/session` reports whether the active context value
+came from the live provider catalog or Tau's configured fallback. Live snapshots
+are account-specific and memory-only; Tau does not write them to `catalog.toml`,
+`providers.json`, or its models.dev cache.
 
 Live limits can vary by account or rollout and may change independently of Tau.
 A discovery failure is non-fatal: Tau reports it in `/session` and continues with

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -104,11 +104,15 @@ GPT-5.6 Sol API advertises a 1.05M-token window, while Codex has advertised
 substantially smaller limits through its authenticated model catalog.
 
 Tau queries that catalog when a Codex session starts and whenever `/model`
-refreshes. The authenticated result replaces the Codex model picker inventory
-for the current process, so newly enabled models appear without a Tau release
-and unavailable models are not copied from the separate public API catalog. Tau
-also uses reported context windows, compaction thresholds, input modalities, and
-reasoning efforts when present.
+refreshes. Since OpenAI filters the response by official-client version, Tau
+resolves the current stable `@openai/codex` release from the npm registry and
+caches that safe, non-secret version for four hours at
+`~/.tau/codex-version-store.json`. Failed lookups use the stale cached version or
+Tau's bundled fallback. The authenticated result replaces the Codex model picker
+inventory for the current process, so newly enabled and newly client-gated models
+appear without a Tau release. Models unavailable to the account are not copied
+from the separate public API catalog. Tau also uses reported context windows,
+compaction thresholds, input modalities, and reasoning efforts when present.
 
 If discovery is unavailable or invalid, Tau retains the checked-in Codex model
 list and its conservative Codex-specific limits; it does not reuse the public

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -125,6 +125,9 @@ Starting or resuming a live-only Codex model discovers the account inventory
 before validating the selection. This requires successful discovery; offline
 startup remains available for static models. If a later refresh omits the active
 model, Tau preserves its runtime metadata without adding it back to the picker.
+Resume restores the transcript's saved model selection. If an older session
+restores a stale selection, resume it and explicitly choose the intended model
+in `/model` once to record the correction.
 
 Live limits can vary by account or rollout and may change independently of Tau.
 A discovery failure is non-fatal: Tau reports it in `/session` and continues with

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -121,6 +121,11 @@ came from the live provider catalog or Tau's configured fallback. Live snapshots
 are account-specific and memory-only; Tau does not write them to `catalog.toml`,
 `providers.json`, or its models.dev cache.
 
+Starting or resuming a live-only Codex model discovers the account inventory
+before validating the selection. This requires successful discovery; offline
+startup remains available for static models. If a later refresh omits the active
+model, Tau preserves its runtime metadata without adding it back to the picker.
+
 Live limits can vary by account or rollout and may change independently of Tau.
 A discovery failure is non-fatal: Tau reports it in `/session` and continues with
 the fallback. Direct OpenAI API sessions retain the context limits documented on


### PR DESCRIPTION
## Description

- add a provider-neutral runtime model-catalog discovery capability to `tau_ai`
- parse and cache the authenticated ChatGPT Codex `/models` response alongside runtime limits
- publish the account-specific Codex inventory as a process-local `tau_coding` overlay
- refresh Codex models at session startup and in the `/model` background refresh, including while another provider is active
- retain the checked-in Codex catalog on offline, empty, malformed, unauthorized, or unavailable discovery
- document the runtime/static catalog relationship and safety model

## User experience

New Codex subscription models become selectable as soon as OpenAI exposes them to the authenticated account. Users no longer need to wait for a Tau release that updates the static `openai-codex` list, and Tau avoids copying potentially unavailable models from the separate public OpenAI API inventory.

The picker still opens immediately with the static fallback and updates in place after discovery. Account-specific metadata remains memory-only.

## Issue

No linked issue. Addresses the delay between Codex subscription rollouts and Tau's checked-in model inventory.

## Manual validation

1. Run `/login openai-codex` with a supported ChatGPT/Codex subscription.
2. Open `/model` and observe the static inventory immediately.
3. Wait for background refresh and confirm the Codex entries update to the authenticated account's visible models.
4. Select a model that is absent from Tau's checked-in Codex list and send a tool-using prompt.
5. Run `/session` and confirm provider-live context limits are reported.
6. Restart with `TAU_OFFLINE=1`, open `/model`, and confirm the static Codex fallback remains available.

## Checks

- `uv run pytest` (1856 passed, 2 skipped: Windows-only updater tests)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `cd website && hugo --minify`
- `cd website && npx --yes pagefind@latest --site public`
