### PR TITLE
TUI: cycled tool display with compact Worked-for summaries by default

### DIFF
--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -11,11 +11,12 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
 
 1. **Summary** — while the agent works, tool rows render as live compact call
    lines so progress stays visible; when the turn settles, each contiguous burst
-   of tool rows collapses into one line: `Worked for 1m 23s · 5 tool calls`. A
-   burst left pending (e.g. after a cancel) shows `Running… 2/5 tool calls`
-   instead, and failures are counted (`· 1 failed`). Assistant text, thinking,
-   user messages, terminal `!` commands, and extension-rendered tool cards are
-   never collapsed. Starting a new turn expands the rows again.
+   representing two or more calls collapses into one line: `Worked for 1m 23s ·
+   5 tool calls`. A single tool call keeps its own row. A burst left pending
+   (e.g. after a cancel) shows `Running… 2/5 tool calls` instead, and failures
+   are counted (`· 1 failed`). Assistant text, thinking, user messages, terminal
+   `!` commands, and extension-rendered tool cards are never collapsed. Starting
+   a new turn expands the rows again.
 2. **Calls** — the previous default: compact per-call lines and batch groups
    without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.
@@ -42,12 +43,14 @@ activity stays in place.
 - `TranscriptView` owns collapse rendering. `_display_rows()` projects the
   windowed items, replacing runs of collapsible tool items with one synthetic
   `ChatItem` (the hidden-thinking-placeholder pattern) — but only when the turn
-  has settled (`_collapsing()` requires `not state.running`), so summary mode
-  keeps live call rows visible while the agent works. `_item_widgets` maps
-  every member to the summary widget, so live `update_item` calls (tool
-  results, the 1s elapsed timer, extension updates) recompute the summary line
-  in place with no remount. `append_item` folds new tool rows into the
-  previous row's summary, starting a new one only after a non-tool item.
+  has settled (`_collapsing()` requires `not state.running`) and only when the
+  run represents two or more calls (`tool_run_leaves()` counts batch/group
+  members); a single tool call keeps its own row. `_item_widgets` maps every
+  member to the summary widget, so live `update_item` calls (tool results, the
+  1s elapsed timer, extension updates) recompute the summary line in place with
+  no remount. `append_item` folds new tool rows into the previous row's summary
+  — converting a lone row into a summary when a second call arrives — starting
+  a new one only after a non-tool item.
 - Turn boundaries drive the collapse/expand transitions in summary mode:
   `AgentStartEvent` rebuilds the window expanded, and `AgentEndEvent` /
   `AgentSettledEvent` rebuild it collapsed; `_refresh()` paths pick the right

--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -16,7 +16,9 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
    (e.g. after a cancel) shows `Running… 2/5 tool calls` instead, and failures
    are counted (`· 1 failed`). Assistant text, thinking, user messages, terminal
    `!` commands, and extension-rendered tool cards are never collapsed. Starting
-   a new turn expands the rows again.
+   a new turn expands the rows again. Thinking blocks interleaved with a
+   summarized burst are swallowed into its summary line; standalone thinking
+   stays under Ctrl+T control.
 2. **Calls** — the previous default: compact per-call lines and batch groups
    without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.

--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -9,11 +9,13 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
 
 `Ctrl+O` now cycles through three modes, announced in a toast:
 
-1. **Summary** — each contiguous burst of tool rows collapses into one line:
-   `Worked for 1m 23s · 5 tool calls`. While tools are still executing the line
-   shows live progress instead: `Running… 2/5 tool calls`. Failures are counted
-   (`· 1 failed`). Assistant text, thinking, user messages, terminal `!`
-   commands, and extension-rendered tool cards are never collapsed.
+1. **Summary** — while the agent works, tool rows render as live compact call
+   lines so progress stays visible; when the turn settles, each contiguous burst
+   of tool rows collapses into one line: `Worked for 1m 23s · 5 tool calls`. A
+   burst left pending (e.g. after a cancel) shows `Running… 2/5 tool calls`
+   instead, and failures are counted (`· 1 failed`). Assistant text, thinking,
+   user messages, terminal `!` commands, and extension-rendered tool cards are
+   never collapsed. Starting a new turn expands the rows again.
 2. **Calls** — the previous default: compact per-call lines and batch groups
    without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.
@@ -39,11 +41,17 @@ activity stays in place.
   elapsed is suppressed (same 1s threshold as the per-row timer).
 - `TranscriptView` owns collapse rendering. `_display_rows()` projects the
   windowed items, replacing runs of collapsible tool items with one synthetic
-  `ChatItem` (the hidden-thinking-placeholder pattern). `_item_widgets` maps
+  `ChatItem` (the hidden-thinking-placeholder pattern) — but only when the turn
+  has settled (`_collapsing()` requires `not state.running`), so summary mode
+  keeps live call rows visible while the agent works. `_item_widgets` maps
   every member to the summary widget, so live `update_item` calls (tool
   results, the 1s elapsed timer, extension updates) recompute the summary line
   in place with no remount. `append_item` folds new tool rows into the
   previous row's summary, starting a new one only after a non-tool item.
+- Turn boundaries drive the collapse/expand transitions in summary mode:
+  `AgentStartEvent` rebuilds the window expanded, and `AgentEndEvent` /
+  `AgentSettledEvent` rebuild it collapsed; `_refresh()` paths pick the right
+  shape automatically from `state.running`.
 - Entering or leaving summary mode rebuilds the mounted window
   (`set_tool_display`); `calls` ↔ `expanded` still update rows in place via
   `update_tool_results_visibility`, preserving widget identity for tests and

--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -7,7 +7,9 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
 
 ## What changed
 
-`Ctrl+O` now cycles through three modes, announced in a toast:
+`Ctrl+O` now cycles through three modes, announced in a toast. **Summary is
+the default**; the preference is per-session display state, not persisted
+settings.
 
 1. **Summary** — while the agent works, tool rows render as live compact call
    lines so progress stays visible; when the turn settles, each contiguous burst
@@ -20,8 +22,7 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
    loads interleaved with a summarized burst are swallowed into its summary line
    (skill loads count toward the call total); standalone thinking and
    user-invoked skill rows stay under their own controls.
-2. **Calls** — the previous default: compact per-call lines and batch groups
-   without result contents.
+2. **Calls** — compact per-call lines and batch groups without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.
 
 Cycling is global; every burst in the visible transcript collapses together.

--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -1,0 +1,69 @@
+# Cycled tool display in the TUI (summary / calls / expanded)
+
+Long agent turns can produce dozens of tool rows. Even with batching and file
+grouping, a scrolled-back transcript is mostly tool plumbing when all you want
+is the narrative: what the model said and what it accomplished. This phase adds
+a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
+
+## What changed
+
+`Ctrl+O` now cycles through three modes, announced in a toast:
+
+1. **Summary** — each contiguous burst of tool rows collapses into one line:
+   `Worked for 1m 23s · 5 tool calls`. While tools are still executing the line
+   shows live progress instead: `Running… 2/5 tool calls`. Failures are counted
+   (`· 1 failed`). Assistant text, thinking, user messages, terminal `!`
+   commands, and extension-rendered tool cards are never collapsed.
+2. **Calls** — the previous default: compact per-call lines and batch groups
+   without result contents.
+3. **Expanded** — call lines plus exact commands and result previews.
+
+Cycling is global; every burst in the visible transcript collapses together.
+Burst boundaries are any non-tool item, so assistant prose between tool
+activity stays in place.
+
+## How it works
+
+- `TuiState.tool_display` (`summary | calls | expanded`) replaces the old
+  `show_tool_results` bool. The bool survives as a property (`expanded` iff
+  mode is `expanded`) so the roughly twenty per-row rendering call sites in
+  `app.py`/`widgets.py` keep working unchanged. `cycle_tool_display()` advances
+  the mode.
+- Tool rows record `finished_at` when their result arrives (`started_at` is no
+  longer cleared on completion; `_refresh_tool_batch` now detects pending rows
+  via `tool_result_text is None`). Restored sessions set `_restoring` while
+  projecting history, so restored rows carry no invented timing and their
+  summaries show the call count only.
+- `format_tool_run_summary()` flattens batch heads, grouped file calls, and
+  standalone rows into "leaves" and renders one line. Sub-second running
+  elapsed is suppressed (same 1s threshold as the per-row timer).
+- `TranscriptView` owns collapse rendering. `_display_rows()` projects the
+  windowed items, replacing runs of collapsible tool items with one synthetic
+  `ChatItem` (the hidden-thinking-placeholder pattern). `_item_widgets` maps
+  every member to the summary widget, so live `update_item` calls (tool
+  results, the 1s elapsed timer, extension updates) recompute the summary line
+  in place with no remount. `append_item` folds new tool rows into the
+  previous row's summary, starting a new one only after a non-tool item.
+- Entering or leaving summary mode rebuilds the mounted window
+  (`set_tool_display`); `calls` ↔ `expanded` still update rows in place via
+  `update_tool_results_visibility`, preserving widget identity for tests and
+  avoiding flicker.
+- Collapsibility is decided by `_is_collapsible_tool`: `role == "tool"`, not
+  `always_show_tool_result`, and no extension `render_call` for the tool (or
+  any of its batch/group members). Custom-rendered tools keep their dedicated
+  widgets in every mode.
+
+## Testing
+
+- Unit tests cover `cycle_tool_display`, the `show_tool_results` property,
+  custom-render detection, and `format_tool_run_summary` (durations, failures,
+  running progress, batch leaves, restored rows without timing).
+- Pilot tests cover the keybinding cycle, restored-history collapse, and live
+  streaming through `Running…` to `Worked for …` with exactly one summary
+  widget per run.
+
+## Docs
+
+`website/content/guides/tui.md` documents the three modes and the
+never-collapsed exceptions; `website/content/reference/keybindings.md` updates
+the `Ctrl+O` entry.

--- a/dev-notes/tui-tool-display-cycle.md
+++ b/dev-notes/tui-tool-display-cycle.md
@@ -16,9 +16,10 @@ a third, most-compact display mode and turns `Ctrl+O` into a three-way cycle.
    (e.g. after a cancel) shows `Running… 2/5 tool calls` instead, and failures
    are counted (`· 1 failed`). Assistant text, thinking, user messages, terminal
    `!` commands, and extension-rendered tool cards are never collapsed. Starting
-   a new turn expands the rows again. Thinking blocks interleaved with a
-   summarized burst are swallowed into its summary line; standalone thinking
-   stays under Ctrl+T control.
+   a new turn expands the rows again. Thinking blocks and tool-driven skill
+   loads interleaved with a summarized burst are swallowed into its summary line
+   (skill loads count toward the call total); standalone thinking and
+   user-invoked skill rows stay under their own controls.
 2. **Calls** — the previous default: compact per-call lines and batch groups
    without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -507,7 +507,7 @@ def _hotkeys_command(context: CommandContext) -> CommandResult:
         "- Ctrl+P / Shift+Ctrl+P: cycle scoped models forward / backward",
         "- Shift+Tab: cycle thinking mode",
         "- Ctrl+T: toggle thinking tokens",
-        "- Ctrl+O: collapse or expand tool output",
+        "- Ctrl+O: cycle tool display (summary / calls / results)",
         "- Ctrl+C: clear prompt input",
         "- Ctrl+D: quit",
     ]

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5344,10 +5344,15 @@ class TauTuiApp(App[None]):
             self._refresh()
             return
         if isinstance(event, AgentStartEvent):
+            # Summary mode shows live tool rows while the agent works.
+            if self.state.tool_display == "summary":
+                await transcript.set_tool_display(self.state, theme=theme)
             self._refresh_chrome()
             return
         if isinstance(event, AgentEndEvent):
             await transcript.finish_assistant_message()
+            if self.state.tool_display == "summary" and not self.state.running:
+                await transcript.set_tool_display(self.state, theme=theme)
             self._refresh_chrome()
             return
         if isinstance(event, MessageStartEvent):
@@ -5470,6 +5475,12 @@ class TauTuiApp(App[None]):
                     invocation=self.state.resolve_tool_invocation(updated_item, expanded=expanded),
                     result_markup=self.state.resolve_tool_result(updated_item, expanded=expanded),
                 )
+            self._refresh_chrome()
+            return
+        if isinstance(event, AgentSettledEvent):
+            # The turn is over: summary mode compacts completed tool runs.
+            if self.state.tool_display == "summary":
+                await transcript.set_tool_display(self.state, theme=theme)
             self._refresh_chrome()
             return
         if isinstance(event, QueueUpdateEvent):

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -5815,12 +5815,27 @@ class TauTuiApp(App[None]):
         self.run_worker(self._cycle_scoped_model(reverse=reverse), exclusive=False)
 
     def action_toggle_tool_results(self) -> None:
-        """Toggle inline tool result details without rebuilding unrelated history."""
-        self.state.toggle_tool_results()
-        self.run_worker(self._update_tool_results_visibility(), exclusive=False)
+        """Cycle collapsed summaries, call lines, and expanded tool results."""
+        mode = self.state.cycle_tool_display()
+        self._notify(f"Tool display: {mode}")
+        self.run_worker(self._apply_tool_display_mode(), exclusive=False)
 
-    async def _update_tool_results_visibility(self) -> None:
+    async def _apply_tool_display_mode(self) -> None:
         transcript = self.query_one("#transcript", TranscriptView)
+        needs_rebuild = "summary" in (
+            self.state.tool_display,
+            transcript.tool_display,
+        )
+        if needs_rebuild:
+            # Entering or leaving summary mode changes the row structure, so
+            # the mounted window rebuilds.
+            await transcript.set_tool_display(
+                self.state,
+                theme=self.tui_settings.resolved_theme,
+            )
+            return
+        # Calls/expanded only change per-row rendering; update rows in place to
+        # avoid remounting unrelated history.
         await transcript.update_tool_results_visibility(
             self.state,
             theme=self.tui_settings.resolved_theme,

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -798,11 +798,16 @@ def format_elapsed(seconds: float) -> str:
 def tool_run_leaves(items: Sequence[ChatItem]) -> list[ChatItem | GroupedToolCall]:
     """Flatten batch heads and grouped file calls into the calls a run represents.
 
-    Non-tool members (e.g. thinking blocks swallowed by a run) contribute no
-    leaves: only actual tool calls are counted and timed.
+    Tool-driven skill loads (``role == "skill"`` rows backed by a tool call id)
+    count as calls since they are re-labeled reads; thinking blocks and
+    user-invoked skill rows contribute no leaves.
     """
     leaves: list[ChatItem | GroupedToolCall] = []
     for item in items:
+        if item.role == "skill":
+            if item.tool_call_id is not None:
+                leaves.append(item)
+            continue
         if item.role != "tool":
             continue
         if item.tool_batch_items is not None:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -796,9 +796,15 @@ def format_elapsed(seconds: float) -> str:
 
 
 def tool_run_leaves(items: Sequence[ChatItem]) -> list[ChatItem | GroupedToolCall]:
-    """Flatten batch heads and grouped file calls into the calls a run represents."""
+    """Flatten batch heads and grouped file calls into the calls a run represents.
+
+    Non-tool members (e.g. thinking blocks swallowed by a run) contribute no
+    leaves: only actual tool calls are counted and timed.
+    """
     leaves: list[ChatItem | GroupedToolCall] = []
     for item in items:
+        if item.role != "tool":
+            continue
         if item.tool_batch_items is not None:
             for row in item.tool_batch_items:
                 if row.grouped_tool_calls is not None:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -26,6 +26,8 @@ from tau_coding.skills import Skill, parse_skill_invocation
 from tau_coding.tui.themes import TranscriptRole
 
 ChatItemRole = TranscriptRole
+ToolDisplayMode = Literal["summary", "calls", "expanded"]
+TOOL_DISPLAY_MODES: tuple[ToolDisplayMode, ...] = ("summary", "calls", "expanded")
 TOOL_RESULT_PREVIEW_LINES = 8
 TOOL_PATCH_PREVIEW_LINES = 32
 TOOL_RESULT_PREVIEW_CHARS = 2_000
@@ -50,6 +52,7 @@ class GroupedToolCall:
     tool_result: AgentToolResult | None = None
     update_text: str | None = None
     started_at: float | None = None
+    finished_at: float | None = None
 
 
 @dataclass(slots=True)
@@ -67,6 +70,7 @@ class ChatItem:
     tool_name: str | None = None
     tool_arguments: dict[str, JSONValue] | None = None
     started_at: float | None = None
+    finished_at: float | None = None
     tool_batch_id: int | None = None
     allows_file_mutation_continuation: bool = False
     grouped_tool_calls: list[GroupedToolCall] | None = None
@@ -86,7 +90,7 @@ class TuiState:
     assistant_buffer: str = ""
     running: bool = False
     error: str | None = None
-    show_tool_results: bool = False
+    tool_display: ToolDisplayMode = "calls"
     show_thinking: bool = False
     queued_steering: tuple[str, ...] = ()
     queued_follow_up: tuple[str, ...] = ()
@@ -113,6 +117,9 @@ class TuiState:
         compare=False,
     )
     _next_tool_batch_id: int = field(default=0, init=False, repr=False, compare=False)
+    # Set while projecting restored session history: restored tool rows have no
+    # real timing data, so they must not invent wall-clock durations.
+    _restoring: bool = field(default=False, init=False, repr=False, compare=False)
 
     def add_item(
         self,
@@ -284,7 +291,7 @@ class TuiState:
             tool_call_id=tool_call.id,
             tool_name=tool_call.name,
             tool_arguments=tool_call.arguments,
-            started_at=time.monotonic(),
+            started_at=None if self._restoring else time.monotonic(),
             tool_batch_id=batch_id,
             allows_file_mutation_continuation=allows_file_mutation_continuation,
         )
@@ -426,7 +433,7 @@ class TuiState:
     def _refresh_tool_batch(self, item: ChatItem) -> None:
         rows = item.tool_batch_items or []
         item.text = "\n".join(row.text for row in rows)
-        pending = [row for row in rows if row.started_at is not None]
+        pending = [row for row in rows if row.tool_result_text is None]
         failures = [
             row
             for row in rows
@@ -575,13 +582,15 @@ class TuiState:
                 member.tool_result_text = result_text
                 member.tool_result = result
                 member.update_text = None
-                member.started_at = None
+                if member.started_at is not None:
+                    member.finished_at = time.monotonic()
                 self._refresh_tool_group(row)
             else:
                 row.tool_result_text = result_text
                 row.tool_result = result
                 row.update_text = None
-                row.started_at = None
+                if row.started_at is not None:
+                    row.finished_at = time.monotonic()
             if item.tool_batch_items is not None:
                 self._refresh_tool_batch(item)
             return
@@ -595,10 +604,39 @@ class TuiState:
         self.items.append(item)
         self._tool_items_by_call_id[tool_call_id] = item
 
-    def toggle_tool_results(self) -> bool:
-        """Toggle expanded display for tool results and return the new state."""
-        self.show_tool_results = not self.show_tool_results
-        return self.show_tool_results
+    @property
+    def show_tool_results(self) -> bool:
+        """Return whether expanded tool result details should render."""
+        return self.tool_display == "expanded"
+
+    @show_tool_results.setter
+    def show_tool_results(self, value: bool) -> None:
+        self.tool_display = "expanded" if value else "calls"
+
+    def cycle_tool_display(self) -> ToolDisplayMode:
+        """Advance summary -> calls -> expanded -> summary and return the new mode."""
+        index = TOOL_DISPLAY_MODES.index(self.tool_display)
+        self.tool_display = TOOL_DISPLAY_MODES[(index + 1) % len(TOOL_DISPLAY_MODES)]
+        return self.tool_display
+
+    def has_custom_tool_rendering(self, item: ChatItem) -> bool:
+        """Return whether an extension renders this tool call itself.
+
+        Custom-rendered tool rows keep their dedicated widgets in every display
+        mode; collapsing them into a run summary would hide extension UI.
+        """
+        if item.role != "tool" or item.tool_name is None:
+            return False
+        if item.tool_batch_items is not None:
+            return any(self.has_custom_tool_rendering(row) for row in item.tool_batch_items)
+        if item.grouped_tool_calls is not None:
+            if self.tool_call_renderer is None:
+                return False
+            return any(
+                self.tool_call_renderer(member.tool_name, member.tool_arguments) is not None
+                for member in item.grouped_tool_calls
+            )
+        return self._has_custom_call_rendering(item.tool_name, item.tool_arguments or {})
 
     def toggle_thinking(self) -> bool:
         """Toggle thinking-token display and return the new state."""
@@ -630,6 +668,13 @@ class TuiState:
 
     def load_messages(self, messages: Iterable[AgentMessage]) -> None:
         """Populate the transcript from restored canonical session messages."""
+        self._restoring = True
+        try:
+            self._load_messages_inner(messages)
+        finally:
+            self._restoring = False
+
+    def _load_messages_inner(self, messages: Iterable[AgentMessage]) -> None:
         for message in messages:
             if isinstance(message, UserMessage):
                 self.add_user_message(message.text)
@@ -745,6 +790,53 @@ def format_elapsed(seconds: float) -> str:
         return f"{minutes}m {secs}s"
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h {minutes}m"
+
+
+def format_tool_run_summary(items: Sequence[ChatItem], *, now: float | None = None) -> str:
+    """Summarize a contiguous run of collapsed tool rows into one line.
+
+    Completed runs report total wall time and call count, e.g. ``Worked for
+    1m 23s · 5 tool calls``; a run with pending calls reports live progress
+    instead. Runs restored from session history without timing data fall back
+    to the call count alone.
+    """
+    leaves: list[ChatItem | GroupedToolCall] = []
+    for item in items:
+        if item.tool_batch_items is not None:
+            for row in item.tool_batch_items:
+                if row.grouped_tool_calls is not None:
+                    leaves.extend(row.grouped_tool_calls)
+                else:
+                    leaves.append(row)
+        elif item.grouped_tool_calls is not None:
+            leaves.extend(item.grouped_tool_calls)
+        else:
+            leaves.append(item)
+    total = len(leaves)
+    completed = [leaf for leaf in leaves if leaf.tool_result_text is not None]
+    failures = [leaf for leaf in completed if (leaf.tool_result_text or "").startswith("✗")]
+    running = len(completed) < total
+    # Running leaves carry `started_at`; completed leaves carry both it and
+    # `finished_at`, so wall time survives completion for run summaries.
+    starts = [leaf.started_at for leaf in leaves if leaf.started_at is not None]
+    ends = [leaf.finished_at for leaf in leaves if leaf.finished_at is not None]
+    duration: float | None = None
+    if starts:
+        started_at = min(starts)
+        if running:
+            duration = (now if now is not None else time.monotonic()) - started_at
+        elif ends:
+            duration = max(ends) - started_at
+    noun = "tool call" if total == 1 else "tool calls"
+    failure_suffix = f" · {len(failures)} failed" if failures else ""
+    if running:
+        done = len(completed)
+        if duration is not None and duration >= TOOL_TIMER_MIN_SECONDS:
+            return f"→ Running… {done}/{total} {noun} · {format_elapsed(duration)}"
+        return f"→ Running… {done}/{total} {noun}"
+    if duration is not None:
+        return f"→ Worked for {format_elapsed(duration)} · {total} {noun}{failure_suffix}"
+    return f"→ {total} {noun}{failure_suffix}"
 
 
 def format_tool_call_block(tool_call: ToolCall, *, compact: bool = True) -> str:

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -93,7 +93,7 @@ class TuiState:
     assistant_buffer: str = ""
     running: bool = False
     error: str | None = None
-    tool_display: ToolDisplayMode = "calls"
+    tool_display: ToolDisplayMode = "summary"
     show_thinking: bool = False
     queued_steering: tuple[str, ...] = ()
     queued_follow_up: tuple[str, ...] = ()

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -76,6 +76,9 @@ class ChatItem:
     grouped_tool_calls: list[GroupedToolCall] | None = None
     tool_batch_items: list[ChatItem] | None = None
     always_show_tool_result: bool = False
+    # Marks the synthetic one-line summary that replaces a collapsed run of
+    # tool rows in summary display mode.
+    tool_run_summary: bool = False
     custom_type: str | None = None
     details: dict[str, JSONValue] | None = None
     system_prompt: bool = False

--- a/src/tau_coding/tui/state.py
+++ b/src/tau_coding/tui/state.py
@@ -792,14 +792,8 @@ def format_elapsed(seconds: float) -> str:
     return f"{hours}h {minutes}m"
 
 
-def format_tool_run_summary(items: Sequence[ChatItem], *, now: float | None = None) -> str:
-    """Summarize a contiguous run of collapsed tool rows into one line.
-
-    Completed runs report total wall time and call count, e.g. ``Worked for
-    1m 23s · 5 tool calls``; a run with pending calls reports live progress
-    instead. Runs restored from session history without timing data fall back
-    to the call count alone.
-    """
+def tool_run_leaves(items: Sequence[ChatItem]) -> list[ChatItem | GroupedToolCall]:
+    """Flatten batch heads and grouped file calls into the calls a run represents."""
     leaves: list[ChatItem | GroupedToolCall] = []
     for item in items:
         if item.tool_batch_items is not None:
@@ -812,6 +806,18 @@ def format_tool_run_summary(items: Sequence[ChatItem], *, now: float | None = No
             leaves.extend(item.grouped_tool_calls)
         else:
             leaves.append(item)
+    return leaves
+
+
+def format_tool_run_summary(items: Sequence[ChatItem], *, now: float | None = None) -> str:
+    """Summarize a contiguous run of collapsed tool rows into one line.
+
+    Completed runs report total wall time and call count, e.g. ``Worked for
+    1m 23s · 5 tool calls``; a run with pending calls reports live progress
+    instead. Runs restored from session history without timing data fall back
+    to the call count alone.
+    """
+    leaves = tool_run_leaves(items)
     total = len(leaves)
     completed = [leaf for leaf in leaves if leaf.tool_result_text is not None]
     failures = [leaf for leaf in completed if (leaf.tool_result_text or "").startswith("✗")]

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -45,9 +45,11 @@ from tau_coding.tui.state import (
     RESULTFUL_FILE_GROUP_NAMES,
     TOOL_TIMER_MIN_SECONDS,
     ChatItem,
+    ToolDisplayMode,
     TuiState,
     format_elapsed,
     format_tool_call_invocation,
+    format_tool_run_summary,
 )
 from tau_coding.version import current_version
 
@@ -603,6 +605,27 @@ class TranscriptMessageWidget(Horizontal):
             body.styles.background = background
         return True
 
+    def update_tool_run_text(self, text: str) -> bool:
+        """Rewrite a collapsed tool-run summary row in place; False when unsupported."""
+        if not _use_plain_transcript_body(self.item):
+            return False
+        self.item.text = text
+        self.selection_text = text
+        self._markdown_text = text
+        try:
+            body = self.query_one(".transcript-plain-body", Static)
+        except NoMatches:
+            return False
+        body.update(
+            _transcript_plain_body_text(
+                self.item,
+                text=text,
+                body_style=self._role_style.body,
+                theme=self._theme,
+            )
+        )
+        return True
+
 
 class StreamingTranscriptMessageWidget(ThemedMarkdownWidget):
     """One assistant or thinking Markdown block that accepts streamed fragments."""
@@ -725,6 +748,10 @@ class TranscriptView(VerticalScroll):
         self._item_widgets: dict[
             int, TranscriptMessageWidget | StreamingTranscriptMessageWidget
         ] = {}
+        self._tool_display: ToolDisplayMode = "calls"
+        # Widgets that summarize a collapsed run of tool rows, keyed by widget
+        # id, mapped to the transcript items the run replaces.
+        self._summary_members: dict[int, list[ChatItem]] = {}
         self._top_boundary: TranscriptWindowBoundary | None = None
         self._bottom_boundary: TranscriptWindowBoundary | None = None
 
@@ -856,6 +883,7 @@ class TranscriptView(VerticalScroll):
         retained_projection = same_state and any(
             id(item) in self._item_widgets for item in state.items
         )
+        self._tool_display = state.tool_display
         should_follow = self._should_follow_output
         if not retained_projection:
             self._follow_output = True
@@ -957,6 +985,105 @@ class TranscriptView(VerticalScroll):
                 lambda: self.scroll_to(y=previous_scroll_y, animate=False, immediate=True)
             )
 
+    @property
+    def tool_display(self) -> ToolDisplayMode:
+        """Return the tool display mode the mounted transcript was built with."""
+        return self._tool_display
+
+    def _is_collapsible_tool(self, item: ChatItem, state: TuiState) -> bool:
+        """Return whether summary mode collapses this row into its tool run."""
+        return (
+            item.role == "tool"
+            and not item.always_show_tool_result
+            and not state.has_custom_tool_rendering(item)
+        )
+
+    def _display_rows(self, state: TuiState) -> list[ChatItem | list[ChatItem]]:
+        """Project window items into widget rows, collapsing tool runs in summary mode.
+
+        Each row is either a transcript item or, only in summary mode, the list
+        of contiguous collapsible tool items that one run summary replaces.
+        """
+        window = state.items[self._window_start : self._window_end]
+        if self._tool_display != "summary":
+            return list(window)
+        rows: list[ChatItem | list[ChatItem]] = []
+        run: list[ChatItem] = []
+        for item in window:
+            if self._is_collapsible_tool(item, state):
+                run.append(item)
+                continue
+            if run:
+                rows.append(run)
+                run = []
+            rows.append(item)
+        if run:
+            rows.append(run)
+        return rows
+
+    def _run_summary_widget(self, item: ChatItem) -> TranscriptMessageWidget | None:
+        """Return the collapsed run summary widget covering this item, if any."""
+        widget = self._item_widgets.get(id(item))
+        if isinstance(widget, TranscriptMessageWidget) and id(widget) in self._summary_members:
+            return widget
+        return None
+
+    def _refresh_run_summary(self, widget: TranscriptMessageWidget) -> None:
+        """Recompute a collapsed run summary line from its member items."""
+        members = self._summary_members.get(id(widget))
+        if members:
+            widget.update_tool_run_text(format_tool_run_summary(members))
+
+    async def _append_run_member(
+        self,
+        item: ChatItem,
+        *,
+        item_index: int,
+        state: TuiState,
+        theme: TuiTheme,
+    ) -> TranscriptMessageWidget:
+        """Fold a new tool item into its run summary, starting one when needed."""
+        previous = state.items[item_index - 1] if item_index > 0 else None
+        widget = self._run_summary_widget(previous) if previous is not None else None
+        if widget is not None:
+            self._summary_members[id(widget)].append(item)
+            self._item_widgets[id(item)] = widget
+            self._refresh_run_summary(widget)
+            return widget
+        widget = TranscriptMessageWidget(
+            ChatItem(role="tool", text=format_tool_run_summary([item])),
+            theme=theme,
+            show_tool_results=False,
+        )
+        self._summary_members[id(widget)] = [item]
+        self._item_widgets[id(item)] = widget
+        await self.mount(widget, before=self._bottom_boundary)
+        self._active_assistant_widget = None
+        self._active_thinking_widget = None
+        self._active_message_widgets = []
+        self._hidden_thinking_placeholder_visible = False
+        return widget
+
+    async def set_tool_display(
+        self,
+        state: TuiState,
+        *,
+        theme: TuiTheme = TAU_DARK_THEME,
+    ) -> None:
+        """Switch tool display mode and rebuild the mounted transcript window."""
+        self._render_state = state
+        self._render_theme = theme
+        self._tool_display = state.tool_display
+        should_follow = self._should_follow_output
+        previous_scroll_y = self.scroll_y
+        self._redraw(scroll_end=should_follow, preserve_window=True)
+        if should_follow:
+            self._request_follow_scroll()
+        else:
+            self.call_after_refresh(
+                lambda: self.scroll_to(y=previous_scroll_y, animate=False, immediate=True)
+            )
+
     def _redraw(self, *, scroll_end: bool, preserve_window: bool = False) -> None:
         state = self._render_state
         if state is None:
@@ -989,6 +1116,7 @@ class TranscriptView(VerticalScroll):
         self._active_message_widgets = []
         self._hidden_thinking_placeholder_visible = False
         self._item_widgets.clear()
+        self._summary_members.clear()
         self._top_boundary = None
         self._bottom_boundary = None
 
@@ -998,7 +1126,19 @@ class TranscriptView(VerticalScroll):
             widgets.append(self._top_boundary)
 
         hidden_thinking_widget: TranscriptMessageWidget | None = None
-        for item in state.items[self._window_start : self._window_end]:
+        for row in self._display_rows(state):
+            if isinstance(row, list):
+                summary_widget = TranscriptMessageWidget(
+                    ChatItem(role="tool", text=format_tool_run_summary(row)),
+                    theme=theme,
+                    show_tool_results=False,
+                )
+                self._summary_members[id(summary_widget)] = row
+                for member in row:
+                    self._item_widgets[id(member)] = summary_widget
+                widgets.append(summary_widget)
+                continue
+            item = row
             if item.role == "thinking" and not state.show_thinking:
                 if hidden_thinking_widget is None:
                     hidden_thinking_widget = TranscriptMessageWidget(
@@ -1094,6 +1234,18 @@ class TranscriptView(VerticalScroll):
             return widget
         if state is not None and item_index is not None:
             self._window_end = max(self._window_end, item_index + 1)
+        if (
+            self._tool_display == "summary"
+            and state is not None
+            and item_index is not None
+            and self._is_collapsible_tool(item, state)
+        ):
+            return await self._append_run_member(
+                item,
+                item_index=item_index,
+                state=state,
+                theme=theme,
+            )
         await self.mount(widget, before=self._bottom_boundary)
         self._item_widgets[id(item)] = widget
         self._active_assistant_widget = None
@@ -1149,6 +1301,17 @@ class TranscriptView(VerticalScroll):
         result_markup: str | None = None,
     ) -> bool:
         """Update a mounted item in O(1); off-screen state is rendered when paged in."""
+        state = self._render_state
+        if (
+            self._tool_display == "summary"
+            and state is not None
+            and self._is_collapsible_tool(item, state)
+        ):
+            widget = self._run_summary_widget(item)
+            if widget is None:
+                return False
+            self._refresh_run_summary(widget)
+            return True
         child = self._item_widgets.get(id(item))
         if not isinstance(child, TranscriptMessageWidget) or child.item is not item:
             return False

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -749,7 +749,7 @@ class TranscriptView(VerticalScroll):
         self._item_widgets: dict[
             int, TranscriptMessageWidget | StreamingTranscriptMessageWidget
         ] = {}
-        self._tool_display: ToolDisplayMode = "calls"
+        self._tool_display: ToolDisplayMode = "summary"
         # Widgets that summarize a collapsed run of tool rows, keyed by widget
         # id, mapped to the transcript items the run replaces.
         self._summary_members: dict[int, list[ChatItem]] = {}

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -50,6 +50,7 @@ from tau_coding.tui.state import (
     format_elapsed,
     format_tool_call_invocation,
     format_tool_run_summary,
+    tool_run_leaves,
 )
 from tau_coding.version import current_version
 
@@ -1017,16 +1018,26 @@ class TranscriptView(VerticalScroll):
             return list(window)
         rows: list[ChatItem | list[ChatItem]] = []
         run: list[ChatItem] = []
+
+        def flush_run() -> None:
+            nonlocal run
+            if not run:
+                return
+            if len(tool_run_leaves(run)) > 1:
+                # Only multi-call runs compact; a single tool call keeps its
+                # own row.
+                rows.append(run)
+            else:
+                rows.extend(run)
+            run = []
+
         for item in window:
             if self._is_collapsible_tool(item, state):
                 run.append(item)
                 continue
-            if run:
-                rows.append(run)
-                run = []
+            flush_run()
             rows.append(item)
-        if run:
-            rows.append(run)
+        flush_run()
         return rows
 
     def _run_summary_widget(self, item: ChatItem) -> TranscriptMessageWidget | None:
@@ -1049,28 +1060,39 @@ class TranscriptView(VerticalScroll):
         item_index: int,
         state: TuiState,
         theme: TuiTheme,
-    ) -> TranscriptMessageWidget:
-        """Fold a new tool item into its run summary, starting one when needed."""
+    ) -> TranscriptMessageWidget | None:
+        """Fold a tool item into its run summary when one exists or is now needed.
+
+        Returns ``None`` when the item starts a single-call run, which renders
+        as its own row instead of a summary.
+        """
         previous = state.items[item_index - 1] if item_index > 0 else None
-        widget = self._run_summary_widget(previous) if previous is not None else None
+        if previous is None or not self._is_collapsible_tool(previous, state):
+            return None
+        widget = self._run_summary_widget(previous)
         if widget is not None:
             self._summary_members[id(widget)].append(item)
             self._item_widgets[id(item)] = widget
             self._refresh_run_summary(widget)
             return widget
-        widget = TranscriptMessageWidget(
-            ChatItem(role="tool", text=format_tool_run_summary([item])),
+        # The previous call was rendered as its own row (a single-call run):
+        # a second call turns the run into a summary.
+        members = [previous, item]
+        summary = TranscriptMessageWidget(
+            ChatItem(role="tool", text=format_tool_run_summary(members)),
             theme=theme,
             show_tool_results=False,
         )
-        self._summary_members[id(widget)] = [item]
-        self._item_widgets[id(item)] = widget
-        await self.mount(widget, before=self._bottom_boundary)
-        self._active_assistant_widget = None
-        self._active_thinking_widget = None
-        self._active_message_widgets = []
-        self._hidden_thinking_placeholder_visible = False
-        return widget
+        previous_widget = self._item_widgets.get(id(previous))
+        self._summary_members[id(summary)] = members
+        for member in members:
+            self._item_widgets[id(member)] = summary
+        if isinstance(previous_widget, TranscriptMessageWidget):
+            await self.mount(summary, before=previous_widget)
+            await previous_widget.remove()
+        else:
+            await self.mount(summary, before=self._bottom_boundary)
+        return summary
 
     async def set_tool_display(
         self,
@@ -1248,12 +1270,16 @@ class TranscriptView(VerticalScroll):
             and self._collapsing(state)
             and self._is_collapsible_tool(item, state)
         ):
-            return await self._append_run_member(
+            joined = await self._append_run_member(
                 item,
                 item_index=item_index,
                 state=state,
                 theme=theme,
             )
+            if joined is not None:
+                return joined
+            # A single-call run renders as its own row: fall through to the
+            # normal mount below.
         await self.mount(widget, before=self._bottom_boundary)
         self._item_widgets[id(item)] = widget
         self._active_assistant_widget = None
@@ -1315,16 +1341,16 @@ class TranscriptView(VerticalScroll):
             and self._tool_display == "summary"
             and self._is_collapsible_tool(item, state)
         ):
-            if not self._collapsing(state):
-                # The turn is running: rows render normally, and any stale
-                # collapsed widget from the settled view is replaced through
-                # append_item on the next render request.
-                return False
             widget = self._run_summary_widget(item)
-            if widget is None:
-                return False
-            self._refresh_run_summary(widget)
-            return True
+            if widget is not None:
+                if not self._collapsing(state):
+                    # The turn is running: rows render normally, and any stale
+                    # collapsed widget from the settled view is replaced
+                    # through append_item on the next render request.
+                    return False
+                self._refresh_run_summary(widget)
+                return True
+            # No summary widget: single-call rows use the normal path below.
         child = self._item_widgets.get(id(item))
         if not isinstance(child, TranscriptMessageWidget) or child.item is not item:
             return False

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1051,7 +1051,9 @@ class TranscriptView(VerticalScroll):
         """Recompute a collapsed run summary line from its member items."""
         members = self._summary_members.get(id(widget))
         if members:
-            widget.update_tool_run_text(format_tool_run_summary(members))
+            fresh = _tool_run_summary_item(members)
+            widget.item.tool_result_text = fresh.tool_result_text
+            widget.update_tool_run_text(fresh.text)
 
     async def _append_run_member(
         self,
@@ -1079,7 +1081,7 @@ class TranscriptView(VerticalScroll):
         # a second call turns the run into a summary.
         members = [previous, item]
         summary = TranscriptMessageWidget(
-            ChatItem(role="tool", text=format_tool_run_summary(members)),
+            _tool_run_summary_item(members),
             theme=theme,
             show_tool_results=False,
         )
@@ -1159,7 +1161,7 @@ class TranscriptView(VerticalScroll):
         for row in self._display_rows(state):
             if isinstance(row, list):
                 summary_widget = TranscriptMessageWidget(
-                    ChatItem(role="tool", text=format_tool_run_summary(row)),
+                    _tool_run_summary_item(row),
                     theme=theme,
                     show_tool_results=False,
                 )
@@ -1590,6 +1592,27 @@ def _last_transcript_child_is_hidden_thinking_placeholder(children: Sequence[Wid
     return False
 
 
+def _tool_run_summary_item(members: list[ChatItem]) -> ChatItem:
+    """Build the synthetic one-line summary item for a collapsed tool run.
+
+    The status marker colors the line like any tool row: green when every call
+    succeeded, red when any failed, and neutral while calls are pending.
+    """
+    leaves = tool_run_leaves(members)
+    if any((leaf.tool_result_text or "").startswith("✗") for leaf in leaves):
+        marker = "✗"
+    elif any(leaf.tool_result_text is None for leaf in leaves):
+        marker = "…"
+    else:
+        marker = "✓"
+    return ChatItem(
+        role="tool",
+        text=format_tool_run_summary(members),
+        tool_result_text=marker,
+        tool_run_summary=True,
+    )
+
+
 def _transcript_widget(
     item: ChatItem,
     *,
@@ -1693,6 +1716,14 @@ def _transcript_plain_body_text(
     """Return styled transcript text for selectable plain rows."""
     if item.role != "tool":
         return Text(text, style=body_style, overflow="fold", no_wrap=False)
+    if item.tool_run_summary:
+        # Collapsed run summaries render fully in the tool status color.
+        status_style = (
+            theme.tool_error_text
+            if (item.tool_result_text or "").startswith("✗")
+            else theme.tool_success_text
+        )
+        return Text(text, style=status_style, overflow="fold", no_wrap=False)
     if item.tool_batch_items is not None:
         return _render_transcript_tool_batch(
             item,

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -939,6 +939,9 @@ class TranscriptView(VerticalScroll):
 
         for item in window_items:
             if item.role == "thinking":
+                if self._tool_display == "summary" and self._run_summary_widget(item) is not None:
+                    # Swallowed by a collapsed tool run in summary mode.
+                    continue
                 if state.show_thinking:
                     pending.append(
                         (
@@ -1023,15 +1026,22 @@ class TranscriptView(VerticalScroll):
             nonlocal run
             if not run:
                 return
-            if len(tool_run_leaves(run)) > 1:
-                # Only multi-call runs compact; a single tool call keeps its
-                # own row.
+            tools = [item for item in run if item.role == "tool"]
+            if tools and len(tool_run_leaves(tools)) > 1:
+                # Multi-call runs compact into one summary line that also
+                # swallows the thinking blocks interleaved with the calls; a
+                # single tool call keeps its own row (and its thinking).
                 rows.append(run)
             else:
                 rows.extend(run)
             run = []
 
         for item in window:
+            if item.role == "thinking":
+                # Held inside the open run: swallowed when tools follow,
+                # rendered normally when the run ends without a summary.
+                run.append(item)
+                continue
             if self._is_collapsible_tool(item, state):
                 run.append(item)
                 continue

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -1026,20 +1026,20 @@ class TranscriptView(VerticalScroll):
             nonlocal run
             if not run:
                 return
-            tools = [item for item in run if item.role == "tool"]
-            if tools and len(tool_run_leaves(tools)) > 1:
+            if len(tool_run_leaves(run)) > 1:
                 # Multi-call runs compact into one summary line that also
-                # swallows the thinking blocks interleaved with the calls; a
-                # single tool call keeps its own row (and its thinking).
+                # swallows the thinking blocks and skill loads interleaved
+                # with the calls; a single tool call keeps its own row (and
+                # its thinking).
                 rows.append(run)
             else:
                 rows.extend(run)
             run = []
 
         for item in window:
-            if item.role == "thinking":
-                # Held inside the open run: swallowed when tools follow,
-                # rendered normally when the run ends without a summary.
+            if item.role == "thinking" or (item.role == "skill" and item.tool_call_id is not None):
+                # Held inside the open run: swallowed when the run compacts,
+                # rendered normally when it ends without a summary.
                 run.append(item)
                 continue
             if self._is_collapsible_tool(item, state):
@@ -1348,19 +1348,18 @@ class TranscriptView(VerticalScroll):
     ) -> bool:
         """Update a mounted item in O(1); off-screen state is rendered when paged in."""
         state = self._render_state
-        if (
-            state is not None
-            and self._tool_display == "summary"
-            and self._is_collapsible_tool(item, state)
-        ):
+        if state is not None and self._tool_display == "summary":
             widget = self._run_summary_widget(item)
             if widget is not None:
-                if not self._collapsing(state):
-                    # The turn is running: rows render normally, and any stale
-                    # collapsed widget from the settled view is replaced
-                    # through append_item on the next render request.
-                    return False
-                self._refresh_run_summary(widget)
+                if self._is_collapsible_tool(item, state):
+                    if not self._collapsing(state):
+                        # The turn is running: rows render normally, and any
+                        # stale collapsed widget from the settled view is
+                        # replaced through append_item on the next request.
+                        return False
+                    self._refresh_run_summary(widget)
+                    return True
+                # Thinking/skill members are represented by the summary line.
                 return True
             # No summary widget: single-call rows use the normal path below.
         child = self._item_widgets.get(id(item))

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -990,6 +990,14 @@ class TranscriptView(VerticalScroll):
         """Return the tool display mode the mounted transcript was built with."""
         return self._tool_display
 
+    def _collapsing(self, state: TuiState) -> bool:
+        """Return whether summary mode is currently collapsing tool runs.
+
+        Summary mode shows live tool rows while the agent works so progress
+        stays visible; runs collapse into summary lines once the turn settles.
+        """
+        return self._tool_display == "summary" and not state.running
+
     def _is_collapsible_tool(self, item: ChatItem, state: TuiState) -> bool:
         """Return whether summary mode collapses this row into its tool run."""
         return (
@@ -1005,7 +1013,7 @@ class TranscriptView(VerticalScroll):
         of contiguous collapsible tool items that one run summary replaces.
         """
         window = state.items[self._window_start : self._window_end]
-        if self._tool_display != "summary":
+        if not self._collapsing(state):
             return list(window)
         rows: list[ChatItem | list[ChatItem]] = []
         run: list[ChatItem] = []
@@ -1235,9 +1243,9 @@ class TranscriptView(VerticalScroll):
         if state is not None and item_index is not None:
             self._window_end = max(self._window_end, item_index + 1)
         if (
-            self._tool_display == "summary"
-            and state is not None
+            state is not None
             and item_index is not None
+            and self._collapsing(state)
             and self._is_collapsible_tool(item, state)
         ):
             return await self._append_run_member(
@@ -1303,10 +1311,15 @@ class TranscriptView(VerticalScroll):
         """Update a mounted item in O(1); off-screen state is rendered when paged in."""
         state = self._render_state
         if (
-            self._tool_display == "summary"
-            and state is not None
+            state is not None
+            and self._tool_display == "summary"
             and self._is_collapsible_tool(item, state)
         ):
+            if not self._collapsing(state):
+                # The turn is running: rows render normally, and any stale
+                # collapsed widget from the settled view is replaced through
+                # append_item on the next render request.
+                return False
             widget = self._run_summary_widget(item)
             if widget is None:
                 return False

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8003,6 +8003,99 @@ async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
 
 
 @pytest.mark.anyio
+async def test_summary_mode_keeps_single_tool_call_rows() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="call-1",
+                            name="bash",
+                            arguments={"command": "seq 3", "description": "Counting"},
+                        )
+                    ]
+                ),
+                ToolResultMessage(tool_call_id="call-1", tool_name="bash", content="1\n2\n3"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.tool_display = "summary"
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+        await pilot.pause()
+
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("Counting" in text for text in texts)
+        assert not any("tool call" in text for text in texts)
+
+        # A second call turns the run into a summary line.
+        app.state.add_tool_call(ToolCall(id="call-2", name="read", arguments={"path": "b.py"}))
+        app.state.record_tool_result(
+            "call-2",
+            "read",
+            AgentToolResult(content="contents"),
+            False,
+        )
+        await transcript.append_item(
+            app.state.items[-1],
+            theme=app.tui_settings.resolved_theme,
+        )
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("2 tool calls" in text for text in texts)
+        assert not any("Counting" in text for text in texts)
+        assert not any("→ read b.py" in text for text in texts)
+
+
+@pytest.mark.anyio
+async def test_summary_mode_keeps_single_live_call_after_settle() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async def stream(event: AgentEvent) -> None:
+        app.adapter.apply(event)
+        await app._apply_streaming_transcript_event(event)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.tool_display = "summary"
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+
+        await stream(AgentStartEvent())
+        await stream(
+            MessageEndEvent(
+                message=AssistantMessage(
+                    content=[ToolCall(id="call-1", name="read", arguments={"path": "a.py"})]
+                )
+            )
+        )
+        await stream(
+            ToolExecutionStartEvent(tool_call_id="call-1", tool_name="read", args={"path": "a.py"})
+        )
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-1",
+                tool_name="read",
+                result=AgentToolResult(content="done"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("→ read a.py" in text for text in texts)
+
+        await stream(AgentSettledEvent())
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("→ read a.py" in text for text in texts)
+        assert not any("tool call" in text for text in texts)
+
+
+@pytest.mark.anyio
 async def test_summary_mode_shows_live_rows_then_compacts_on_settle() -> None:
     app = TauTuiApp(FakeSession())
 
@@ -8059,7 +8152,7 @@ async def test_summary_mode_shows_live_rows_then_compacts_on_settle() -> None:
             )
         )
         await pilot.pause()
-        assert any("→ Reading 2 files" in text for text in widget_texts())
+        assert any("→ Read 2 files" in text for text in widget_texts())
 
         # The turn settles: the run compacts into one summary line.
         await stream(AgentSettledEvent())

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8028,6 +8028,41 @@ def test_tool_run_summary_item_renders_in_status_color() -> None:
 
 
 @pytest.mark.anyio
+async def test_summary_mode_swallows_skill_loads_into_run_summaries() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        state = app.state
+        state.add_item("skill", "Using skill: delivery")
+        state.add_item("skill", "Loading skill: explore", tool_call_id="call-skill")
+        state.record_tool_result("call-skill", "read", AgentToolResult(content="skill"), False)
+        state.add_tool_call(ToolCall(id="call-1", name="read", arguments={"path": "a.py"}))
+        state.record_tool_result("call-1", "read", AgentToolResult(content="one"), False)
+        state.add_tool_call(ToolCall(id="call-2", name="read", arguments={"path": "b.py"}))
+        state.record_tool_result("call-2", "read", AgentToolResult(content="two"), False)
+
+        state.tool_display = "summary"
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.set_tool_display(state, theme=app.tui_settings.resolved_theme)
+        await pilot.pause()
+
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("3 tool calls" in text for text in texts)
+        assert any("Using skill: delivery" in text for text in texts)
+        assert not any("Loading skill" in text for text in texts)
+        assert not any("→ read a.py" in text for text in texts)
+
+        # Calls mode restores the skill rows.
+        state.tool_display = "calls"
+        await transcript.set_tool_display(state, theme=app.tui_settings.resolved_theme)
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("Loading skill: explore" in text for text in texts)
+        assert any("→ read a.py" in text for text in texts)
+
+
+@pytest.mark.anyio
 async def test_summary_mode_swallows_thinking_into_run_summaries() -> None:
     app = TauTuiApp(
         FakeSession(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8028,6 +8028,45 @@ def test_tool_run_summary_item_renders_in_status_color() -> None:
 
 
 @pytest.mark.anyio
+async def test_summary_mode_swallows_thinking_into_run_summaries() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content=[
+                        ThinkingContent(thinking="weighing options"),
+                        ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                        ToolCall(id="call-2", name="read", arguments={"path": "b.py"}),
+                    ]
+                ),
+                ToolResultMessage(tool_call_id="call-1", tool_name="read", content="one"),
+                ToolResultMessage(tool_call_id="call-2", tool_name="read", content="two"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.show_thinking = True
+        app.state.tool_display = "summary"
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+        await pilot.pause()
+
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("2 tool calls" in text for text in texts)
+        assert not any("weighing options" in text for text in texts)
+        assert not any("Thinking" in text for text in texts)
+
+        # Calls mode restores the thinking block under Ctrl+T control.
+        app.state.tool_display = "calls"
+        await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("weighing options" in text for text in texts)
+
+
+@pytest.mark.anyio
 async def test_summary_mode_keeps_single_tool_call_rows() -> None:
     app = TauTuiApp(
         FakeSession(

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -158,6 +158,7 @@ from tau_coding.tui.widgets import (
     _styled_cwd,
     _syntax_language,
     _system_prompt_markdown,
+    _tool_run_summary_item,
     _transcript_plain_body_text,
     render_chat_item,
     render_compact_session_info,
@@ -8002,6 +8003,30 @@ async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
         assert not any("tool calls" in text for text in texts)
 
 
+def test_tool_run_summary_item_renders_in_status_color() -> None:
+    ok = _tool_run_summary_item(
+        [ChatItem(role="tool", text="→ read a.py", tool_name="read", tool_result_text="✓ read")]
+    )
+    assert ok.tool_run_summary is True
+    assert ok.tool_result_text == "✓"
+    rendered = _transcript_plain_body_text(ok, text=ok.text, body_style="", theme=TAU_DARK_THEME)
+    assert isinstance(rendered, Text)
+    assert rendered.style == TAU_DARK_THEME.tool_success_text
+
+    failed = _tool_run_summary_item(
+        [ChatItem(role="tool", text="→ bash", tool_name="bash", tool_result_text="✗ bash")]
+    )
+    assert failed.tool_result_text == "✗"
+    rendered = _transcript_plain_body_text(
+        failed, text=failed.text, body_style="", theme=TAU_DARK_THEME
+    )
+    assert isinstance(rendered, Text)
+    assert rendered.style == TAU_DARK_THEME.tool_error_text
+
+    pending = _tool_run_summary_item([ChatItem(role="tool", text="→ bash", tool_name="bash")])
+    assert pending.tool_result_text == "…"
+
+
 @pytest.mark.anyio
 async def test_summary_mode_keeps_single_tool_call_rows() -> None:
     app = TauTuiApp(
@@ -8157,7 +8182,13 @@ async def test_summary_mode_shows_live_rows_then_compacts_on_settle() -> None:
         # The turn settles: the run compacts into one summary line.
         await stream(AgentSettledEvent())
         await pilot.pause()
-        assert any("→ Worked for 0s · 2 tool calls" in text for text in widget_texts())
+        summaries = [
+            w
+            for w in app.query(TranscriptMessageWidget)
+            if w.item.tool_run_summary and "Worked for" in w.selection_text
+        ]
+        assert len(summaries) == 1
+        assert summaries[0].item.tool_result_text == "✓"
         assert not any("→ Reading 2 files" in text for text in widget_texts())
 
         # The next turn expands the rows again.

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from rich.console import Console
@@ -135,7 +136,7 @@ from tau_coding.tui.config import (
     tui_settings_path,
 )
 from tau_coding.tui.local_backends import LocalBackendScreen, LocalConfirmScreen
-from tau_coding.tui.state import ChatItem, TuiState, format_tool_run_summary
+from tau_coding.tui.state import ChatItem, ToolDisplayMode, TuiState, format_tool_run_summary
 from tau_coding.tui.terminal_notification import TerminalNotificationController
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
@@ -1366,7 +1367,7 @@ def test_tui_state_indexes_tool_items_and_clears_index() -> None:
 
 def test_state_cycles_tool_display_and_maps_show_tool_results() -> None:
     state = TuiState()
-    assert state.tool_display == "calls"
+    assert state.tool_display == "summary"
     assert state.show_tool_results is False
 
     state.show_tool_results = True
@@ -2165,6 +2166,15 @@ async def test_tool_execution_updates_render_in_place() -> None:
         assert "turn 2 done" not in tool_widgets[0].selection_text
 
 
+async def _set_tool_display_mode(app: TauTuiApp, mode: ToolDisplayMode, pilot: Any) -> None:
+    """Pin the tool display mode for tests exercising per-row rendering."""
+    app.state.tool_display = mode
+    transcript = app.query_one("#transcript", TranscriptView)
+    await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+    # Let Textual finish the async removal of replaced widgets before queries.
+    await pilot.pause()
+
+
 @pytest.mark.anyio
 async def test_batched_reads_share_one_live_transcript_row() -> None:
     app = TauTuiApp(FakeSession())
@@ -2175,6 +2185,7 @@ async def test_batched_reads_share_one_live_transcript_row() -> None:
 
     async with app.run_test(size=(120, 30)) as pilot:
         await pilot.pause()
+        await _set_tool_display_mode(app, "calls", pilot)
         await stream(
             MessageEndEvent(
                 message=AssistantMessage(
@@ -2258,6 +2269,7 @@ async def test_mixed_tool_batch_uses_one_widget_and_expands_each_row() -> None:
     )
 
     async with app.run_test(size=(120, 30)) as pilot:
+        await _set_tool_display_mode(app, "calls", pilot)
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert len([w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool"]) == 1
         assert widget.selection_text == (
@@ -2785,6 +2797,7 @@ async def test_tui_streaming_deltas_update_active_message_without_full_refresh()
 
     try:
         async with app.run_test(size=(120, 30)) as pilot:
+            await _set_tool_display_mode(app, "calls", pilot)
             await app._run_prompt("stream")
             await pilot.pause()
 
@@ -4533,6 +4546,7 @@ async def test_tool_result_renders_via_render_result() -> None:
 
     async with app.run_test(size=(120, 30)) as pilot:
         await pilot.pause()
+        await _set_tool_display_mode(app, "calls", pilot)
         await stream(
             ToolExecutionStartEvent(
                 tool_call_id="call-1",
@@ -5486,6 +5500,7 @@ async def test_structured_assistant_finalization_preserves_existing_widget_ident
 
     async with app.run_test(size=(120, 30)) as pilot:
         await pilot.pause()
+        await _set_tool_display_mode(app, "calls", pilot)
         custom_widget = next(
             widget for widget in app.query(TranscriptMessageWidget) if widget.item.role == "custom"
         )
@@ -5523,6 +5538,7 @@ async def test_structured_assistant_ignores_empty_final_content_blocks() -> None
     app = TauTuiApp(session)
 
     async with app.run_test(size=(120, 30)) as pilot:
+        await _set_tool_display_mode(app, "calls", pilot)
         await app._run_prompt("run")
         await pilot.pause()
 
@@ -7937,6 +7953,10 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
+        assert app.state.tool_display == "summary"
+        assert app.state.show_tool_results is False
+        await pilot.press("ctrl+o")
+        await pilot.pause()
         assert app.state.tool_display == "calls"
         assert app.state.show_tool_results is False
         await pilot.press("ctrl+o")
@@ -7946,8 +7966,6 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
         await pilot.press("ctrl+o")
         await pilot.pause()
         assert app.state.tool_display == "summary"
-        await pilot.press("ctrl+o")
-        await pilot.pause()
 
     assert app.state.show_tool_results is False
 
@@ -7983,8 +8001,18 @@ async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
 
     async with app.run_test(size=(120, 30)) as pilot:
         await pilot.pause()
+        # The default mode is summary; the restored view starts collapsed.
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("2 tool calls" in text for text in texts)
+        assert not any("Counting" in text for text in texts)
+
+        # Cycling to calls restores the rows.
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.tool_display == "calls"
         texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
         assert any("Counting" in text for text in texts)
+        assert not any("tool calls" in text for text in texts)
 
         await pilot.press("ctrl+o")
         await pilot.pause()
@@ -7992,15 +8020,8 @@ async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
         await pilot.pause()
         assert app.state.tool_display == "summary"
         texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
-        assert any("→ 2 tool calls" in text for text in texts)
+        assert any("2 tool calls" in text for text in texts)
         assert not any("Counting" in text for text in texts)
-
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        assert app.state.tool_display == "calls"
-        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
-        assert any("Counting" in text for text in texts)
-        assert not any("tool calls" in text for text in texts)
 
 
 def test_tool_run_summary_item_renders_in_status_color() -> None:
@@ -8300,6 +8321,7 @@ async def test_tool_result_toggle_expands_full_bash_command() -> None:
     )
 
     async with app.run_test() as pilot:
+        await _set_tool_display_mode(app, "calls", pilot)
         widget = next(w for w in app.query(TranscriptMessageWidget) if w.item.role == "tool")
         assert widget.selection_text == "→ Running inline script"
 
@@ -8332,6 +8354,7 @@ async def test_tool_result_toggle_preserves_unrelated_message_widgets() -> None:
 
     async with app.run_test() as pilot:
         await pilot.pause()
+        await _set_tool_display_mode(app, "calls", pilot)
         history_widget = next(
             widget for widget in app.query(TranscriptMessageWidget) if widget.item.text == "earlier"
         )
@@ -8625,6 +8648,7 @@ async def test_tui_app_hidden_thinking_placeholder_stays_before_streamed_answer(
     app = TauTuiApp(session)
 
     async with app.run_test() as pilot:
+        await _set_tool_display_mode(app, "calls", pilot)
         await app._run_prompt("stream")
         await pilot.pause()
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8003,7 +8003,7 @@ async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
 
 
 @pytest.mark.anyio
-async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
+async def test_summary_mode_shows_live_rows_then_compacts_on_settle() -> None:
     app = TauTuiApp(FakeSession())
 
     async def stream(event: AgentEvent) -> None:
@@ -8016,6 +8016,10 @@ async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
         transcript = app.query_one("#transcript", TranscriptView)
         await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
 
+        def widget_texts() -> list[str]:
+            return [w.selection_text for w in app.query(TranscriptMessageWidget)]
+
+        await stream(AgentStartEvent())
         await stream(
             MessageEndEvent(
                 message=AssistantMessage(
@@ -8034,14 +8038,9 @@ async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
         )
         await pilot.pause()
 
-        def summary_texts() -> list[str]:
-            return [
-                w.selection_text
-                for w in app.query(TranscriptMessageWidget)
-                if "tool call" in w.selection_text
-            ]
-
-        assert summary_texts() == ["→ Running… 0/2 tool calls"]
+        # While the agent works, live call rows stay visible.
+        assert any("→ Reading 2 files" in text for text in widget_texts())
+        assert not any("tool calls" in text for text in widget_texts())
 
         await stream(
             ToolExecutionEndEvent(
@@ -8051,9 +8050,6 @@ async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
                 is_error=False,
             )
         )
-        await pilot.pause()
-        assert summary_texts() == ["→ Running… 1/2 tool calls"]
-
         await stream(
             ToolExecutionEndEvent(
                 tool_call_id="call-2",
@@ -8063,7 +8059,19 @@ async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
             )
         )
         await pilot.pause()
-        assert summary_texts() == ["→ Worked for 0s · 2 tool calls"]
+        assert any("→ Reading 2 files" in text for text in widget_texts())
+
+        # The turn settles: the run compacts into one summary line.
+        await stream(AgentSettledEvent())
+        await pilot.pause()
+        assert any("→ Worked for 0s · 2 tool calls" in text for text in widget_texts())
+        assert not any("→ Reading 2 files" in text for text in widget_texts())
+
+        # The next turn expands the rows again.
+        await stream(AgentStartEvent())
+        await pilot.pause()
+        assert any("→ Read 2 files" in text for text in widget_texts())
+        assert not any("tool calls" in text for text in widget_texts())
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -135,7 +135,7 @@ from tau_coding.tui.config import (
     tui_settings_path,
 )
 from tau_coding.tui.local_backends import LocalBackendScreen, LocalConfirmScreen
-from tau_coding.tui.state import ChatItem, TuiState
+from tau_coding.tui.state import ChatItem, TuiState, format_tool_run_summary
 from tau_coding.tui.terminal_notification import TerminalNotificationController
 from tau_coding.tui.terminal_title import TerminalTitleController
 from tau_coding.tui.widgets import (
@@ -1361,6 +1361,82 @@ def test_tui_state_indexes_tool_items_and_clears_index() -> None:
     assert state.find_tool_item("call-1") is item
     state.clear()
     assert state.find_tool_item("call-1") is None
+
+
+def test_state_cycles_tool_display_and_maps_show_tool_results() -> None:
+    state = TuiState()
+    assert state.tool_display == "calls"
+    assert state.show_tool_results is False
+
+    state.show_tool_results = True
+    assert state.tool_display == "expanded"
+    assert state.show_tool_results is True
+
+    assert state.cycle_tool_display() == "summary"
+    assert state.show_tool_results is False
+    assert state.cycle_tool_display() == "calls"
+    assert state.cycle_tool_display() == "expanded"
+    assert state.cycle_tool_display() == "summary"
+
+
+def test_tool_run_summary_reports_duration_count_and_failures() -> None:
+    start = 100.0
+    completed = ChatItem(
+        role="tool",
+        text="→ read a.py",
+        tool_name="read",
+        tool_result_text="✓ read",
+        started_at=start,
+        finished_at=start + 61,
+    )
+    failed = ChatItem(
+        role="tool",
+        text="→ bash true",
+        tool_name="bash",
+        tool_result_text="✗ bash",
+        started_at=start + 1,
+        finished_at=start + 62,
+    )
+    assert format_tool_run_summary([completed, failed]) == (
+        "→ Worked for 1m 2s · 2 tool calls · 1 failed"
+    )
+
+
+def test_tool_run_summary_running_shows_progress_line() -> None:
+    running = ChatItem(role="tool", text="→ bash", tool_name="bash", started_at=100.0)
+    assert format_tool_run_summary([running], now=105.0) == "→ Running… 0/1 tool call · 5s"
+
+    running.tool_result_text = "✓ bash"
+    running.finished_at = 130.0
+    assert format_tool_run_summary([running]) == "→ Worked for 30s · 1 tool call"
+
+
+def test_tool_run_summary_skips_subsecond_running_elapsed() -> None:
+    running = ChatItem(role="tool", text="→ bash", tool_name="bash", started_at=100.0)
+    assert format_tool_run_summary([running], now=100.2) == "→ Running… 0/1 tool call"
+
+
+def test_tool_run_summary_without_timing_falls_back_to_call_count() -> None:
+    item = ChatItem(role="tool", text="→ read a.py", tool_name="read", tool_result_text="✓ read")
+    assert format_tool_run_summary([item]) == "→ 1 tool call"
+
+
+def test_tool_run_summary_counts_batch_members() -> None:
+    rows = [
+        ChatItem(role="tool", text="→ read a.py", tool_name="read", tool_result_text="✓ read"),
+        ChatItem(role="tool", text="→ read b.py", tool_name="read", tool_result_text="✓ read"),
+    ]
+    head = ChatItem(role="tool", text="→ Read 2 files", tool_name="read", tool_batch_items=rows)
+    assert format_tool_run_summary([head]) == "→ 2 tool calls"
+
+
+def test_state_flags_custom_rendered_tools_as_uncollapsible() -> None:
+    state = TuiState()
+    item = ChatItem(role="tool", text="→ ext", tool_name="ext_tool", tool_arguments={})
+    assert state.has_custom_tool_rendering(item) is False
+
+    state.tool_call_renderer = lambda name, arguments: "card" if name == "ext_tool" else None
+    assert state.has_custom_tool_rendering(item) is True
 
 
 def test_tui_state_compacts_branch_summary_messages() -> None:
@@ -7860,14 +7936,134 @@ async def test_tui_app_toggles_tool_results_from_keybinding() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
+        assert app.state.tool_display == "calls"
         assert app.state.show_tool_results is False
         await pilot.press("ctrl+o")
         await pilot.pause()
+        assert app.state.tool_display == "expanded"
         assert app.state.show_tool_results is True
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.tool_display == "summary"
         await pilot.press("ctrl+o")
         await pilot.pause()
 
     assert app.state.show_tool_results is False
+
+
+@pytest.mark.anyio
+async def test_tool_display_cycle_collapses_tool_runs_into_summaries() -> None:
+    app = TauTuiApp(
+        FakeSession(
+            messages=[
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="call-1",
+                            name="bash",
+                            arguments={"command": "seq 3", "description": "Counting"},
+                        )
+                    ]
+                ),
+                ToolResultMessage(tool_call_id="call-1", tool_name="bash", content="1\n2\n3"),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="call-2",
+                            name="bash",
+                            arguments={"command": "seq 5", "description": "Counting more"},
+                        )
+                    ]
+                ),
+                ToolResultMessage(tool_call_id="call-2", tool_name="bash", content="1\n2\n3\n4\n5"),
+            ]
+        )
+    )
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("Counting" in text for text in texts)
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.tool_display == "summary"
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("→ 2 tool calls" in text for text in texts)
+        assert not any("Counting" in text for text in texts)
+
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        assert app.state.tool_display == "calls"
+        texts = [w.selection_text for w in app.query(TranscriptMessageWidget)]
+        assert any("Counting" in text for text in texts)
+        assert not any("tool calls" in text for text in texts)
+
+
+@pytest.mark.anyio
+async def test_summary_mode_streams_tool_runs_into_one_progress_line() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async def stream(event: AgentEvent) -> None:
+        app.adapter.apply(event)
+        await app._apply_streaming_transcript_event(event)
+
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.state.tool_display = "summary"
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.set_tool_display(app.state, theme=app.tui_settings.resolved_theme)
+
+        await stream(
+            MessageEndEvent(
+                message=AssistantMessage(
+                    content=[
+                        ToolCall(id="call-1", name="read", arguments={"path": "a.py"}),
+                        ToolCall(id="call-2", name="read", arguments={"path": "b.py"}),
+                    ]
+                )
+            )
+        )
+        await stream(
+            ToolExecutionStartEvent(tool_call_id="call-1", tool_name="read", args={"path": "a.py"})
+        )
+        await stream(
+            ToolExecutionStartEvent(tool_call_id="call-2", tool_name="read", args={"path": "b.py"})
+        )
+        await pilot.pause()
+
+        def summary_texts() -> list[str]:
+            return [
+                w.selection_text
+                for w in app.query(TranscriptMessageWidget)
+                if "tool call" in w.selection_text
+            ]
+
+        assert summary_texts() == ["→ Running… 0/2 tool calls"]
+
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-1",
+                tool_name="read",
+                result=AgentToolResult(content="one"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+        assert summary_texts() == ["→ Running… 1/2 tool calls"]
+
+        await stream(
+            ToolExecutionEndEvent(
+                tool_call_id="call-2",
+                tool_name="read",
+                result=AgentToolResult(content="two"),
+                is_error=False,
+            )
+        )
+        await pilot.pause()
+        assert summary_texts() == ["→ Worked for 0s · 2 tool calls"]
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -181,6 +181,21 @@ output for other tools. Compaction and grouping affect only the TUI display;
 execution, session history, and print-mode transcripts retain every complete call
 and result.
 
+**Ctrl+O** cycles through three display modes rather than toggling two states:
+
+1. **Summary** — each contiguous burst of tool activity collapses into one line
+   such as `Worked for 1m 23s · 5 tool calls` (with a live `Running… 2/5 tool
+   calls` progress line while tools execute). Restored sessions without timing
+   data show the call count only. Terminal `!` commands and extension-rendered
+   tool cards never collapse.
+2. **Calls** — the default: one compact line per tool call or grouped file
+   batch, without result contents.
+3. **Expanded** — call lines plus exact commands and result previews.
+
+Each burst of tool calls becomes a summary line independently, so assistant text
+between tool activity stays in place. Cycling back to **Calls** restores the
+exact transcript structure.
+
 Markdown link hover styling underlines only the linked text, never the rest of its
 row. User message blocks use the same theme background as the prompt field and sidebar,
 with light vertical padding so they read as blocks rather than highlighted lines.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -187,7 +187,9 @@ and result.
    works; once the turn settles, each burst of two or more tool calls compacts
    into one line such as `Worked for 1m 23s · 5 tool calls` (or a live `Running…
    2/5 tool calls` progress line for bursts left pending, e.g. after a cancel).
-   A single tool call keeps its own row. Restored sessions without timing data
+   A single tool call keeps its own row. Thinking blocks interleaved with a
+   summarized burst are swallowed into its summary line too; standalone thinking
+   stays under Ctrl+T control. Restored sessions without timing data
    show the call count only. Terminal `!` commands and extension-rendered tool
    cards never collapse.
 2. **Calls** — the default: one compact line per tool call or grouped file

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -184,11 +184,12 @@ and result.
 **Ctrl+O** cycles through three display modes rather than toggling two states:
 
 1. **Summary** — tool activity renders as live compact call rows while the agent
-   works; once the turn settles, each burst of tool calls compacts into one line
-   such as `Worked for 1m 23s · 5 tool calls` (or a live `Running… 2/5 tool
-   calls` progress line for bursts left pending, e.g. after a cancel). Restored
-   sessions without timing data show the call count only. Terminal `!` commands
-   and extension-rendered tool cards never collapse.
+   works; once the turn settles, each burst of two or more tool calls compacts
+   into one line such as `Worked for 1m 23s · 5 tool calls` (or a live `Running…
+   2/5 tool calls` progress line for bursts left pending, e.g. after a cancel).
+   A single tool call keeps its own row. Restored sessions without timing data
+   show the call count only. Terminal `!` commands and extension-rendered tool
+   cards never collapse.
 2. **Calls** — the default: one compact line per tool call or grouped file
    batch, without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -187,11 +187,12 @@ and result.
    works; once the turn settles, each burst of two or more tool calls compacts
    into one line such as `Worked for 1m 23s · 5 tool calls` (or a live `Running…
    2/5 tool calls` progress line for bursts left pending, e.g. after a cancel).
-   A single tool call keeps its own row. Thinking blocks interleaved with a
-   summarized burst are swallowed into its summary line too; standalone thinking
-   stays under Ctrl+T control. Restored sessions without timing data
-   show the call count only. Terminal `!` commands and extension-rendered tool
-   cards never collapse.
+   A single tool call keeps its own row. Thinking blocks and tool-driven skill
+   loads interleaved with a summarized burst are swallowed into its summary line
+   too (skill loads count toward the call total); standalone thinking and
+   user-invoked skill rows stay under their own controls. Restored sessions
+   without timing data show the call count only. Terminal `!` commands and
+   extension-rendered tool cards never collapse.
 2. **Calls** — the default: one compact line per tool call or grouped file
    batch, without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -183,18 +183,20 @@ and result.
 
 **Ctrl+O** cycles through three display modes rather than toggling two states:
 
-1. **Summary** — each contiguous burst of tool activity collapses into one line
-   such as `Worked for 1m 23s · 5 tool calls` (with a live `Running… 2/5 tool
-   calls` progress line while tools execute). Restored sessions without timing
-   data show the call count only. Terminal `!` commands and extension-rendered
-   tool cards never collapse.
+1. **Summary** — tool activity renders as live compact call rows while the agent
+   works; once the turn settles, each burst of tool calls compacts into one line
+   such as `Worked for 1m 23s · 5 tool calls` (or a live `Running… 2/5 tool
+   calls` progress line for bursts left pending, e.g. after a cancel). Restored
+   sessions without timing data show the call count only. Terminal `!` commands
+   and extension-rendered tool cards never collapse.
 2. **Calls** — the default: one compact line per tool call or grouped file
    batch, without result contents.
 3. **Expanded** — call lines plus exact commands and result previews.
 
 Each burst of tool calls becomes a summary line independently, so assistant text
-between tool activity stays in place. Cycling back to **Calls** restores the
-exact transcript structure.
+between tool activity stays in place. When a new turn starts, the compacted rows
+expand back into live call lines; cycling back to **Calls** keeps the exact
+transcript structure at all times.
 
 Markdown link hover styling underlines only the linked text, never the rest of its
 row. User message blocks use the same theme background as the prompt field and sidebar,

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -193,8 +193,8 @@ and result.
    user-invoked skill rows stay under their own controls. Restored sessions
    without timing data show the call count only. Terminal `!` commands and
    extension-rendered tool cards never collapse.
-2. **Calls** — the default: one compact line per tool call or grouped file
-   batch, without result contents.
+2. **Calls** — one compact line per tool call or grouped file batch, without
+   result contents.
 3. **Expanded** — call lines plus exact commands and result previews.
 
 Each burst of tool calls becomes a summary line independently, so assistant text

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -42,7 +42,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 
 | Key | Action |
 | --- | --- |
-| `Ctrl+O` | Toggle exact tool commands and full output (vs. compact previews) |
+| `Ctrl+O` | Cycle tool display: collapsed run summaries → compact call lines → expanded results |
 | `Ctrl+C` | Clear the prompt input |
 | `Ctrl+D` | Quit |
 


### PR DESCRIPTION
## Description

Reworks tool activity rendering in the TUI around a three-way display cycle and a new compact default.

**Ctrl+O now cycles three modes** (announced in a toast):

1. **Summary** (new default) — while the agent works, tool rows render as live compact call lines; when the turn settles, each contiguous burst representing two or more calls compacts into one line such as `Worked for 1m 23s · 5 tool calls` (failures counted, e.g. `· 1 failed`; bursts left pending after a cancel show `Running… 2/5 tool calls`). Thinking blocks and tool-driven skill loads interleaved with a summarized burst are swallowed into its line and skill loads count toward the call total. A single tool call keeps its own row.
2. **Calls** — the previous default: one compact line per call or grouped batch, without result contents.
3. **Expanded** — call lines plus exact commands and result previews.

The line renders in the tool status color (green on success, red on failures, neutral while pending). Starting a new turn expands the rows again; cycling is available at any time, including mid-turn.

## User-experience improvement

Long turns no longer bury the narrative under dozens of tool rows: the default transcript shows one green line per burst of work ("Worked for 1m 23s · 5 tool calls"), with full call/results detail still one Ctrl+O press away. Terminal `!` commands, extension-rendered tool cards, and user-invoked skill rows never collapse.

## Implementation notes

- `TuiState.tool_display` (`summary | calls | expanded`) replaces `show_tool_results` (kept as a property mapping to `expanded`, so per-row rendering call sites are unchanged); `cycle_tool_display()` advances the mode.
- Tool rows record `finished_at` (`started_at` is no longer cleared on completion; batch pending detection uses `tool_result_text`); restored sessions set a `_restoring` flag so no timing is invented and summaries fall back to call counts.
- `TranscriptView` owns collapse rendering via `_display_rows()` (hidden-thinking-placeholder pattern); member→summary-widget mappings let live `update_item` calls recompute the summary line in place. Turn boundaries (`AgentStartEvent` / `AgentEndEvent` / `AgentSettledEvent`) drive the expand/compact rebuilds.
- Custom-rendered tools, `always_show_tool_result` rows, and user-invoked skills are exempt from collapsing.

## Manual validation

- `uv run pytest tests` — 1866 passed, 2 skipped
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run mypy` — clean
- Interactive: run the TUI, submit a prompt that uses several tools, observe live call rows during the turn and green `Worked for …` summaries after; press Ctrl+O to cycle summary → calls → expanded.
