### PR TITLE
Fix Z.AI thinking request serialization

### DIFF
--- a/dev-notes/architecture/zai-thinking-serialization.md
+++ b/dev-notes/architecture/zai-thinking-serialization.md
@@ -1,0 +1,41 @@
+# Z.AI thinking serialization
+
+## What changed
+
+OpenAI-compatible requests for Z.AI now preserve Tau's logical thinking state
+when `supportsReasoningEffort` is false. The request uses Z.AI's documented
+`thinking` object:
+
+```json
+{"thinking": {"type": "enabled"}}
+```
+
+and sends `type: "disabled"` for Tau's `off` mode. It no longer sends the
+unrecognized `enable_thinking` field.
+
+Z.AI documents `reasoning_effort` as a separate field supported only by
+GLM-5.2 and newer, with model-dependent values. Tau emits that field only when
+compatibility metadata says the selected model supports it. This keeps the
+provider-wide guard for models such as GLM-5.1 while allowing an explicit
+model-level opt-in when catalog evidence supports it.
+
+## Why
+
+The old request builder filtered the logical effort to `None` before provider
+serialization whenever `supportsReasoningEffort` was false. Z.AI's serializer
+then saw thinking as disabled, even when the user selected `high`. Separating
+logical toggle handling from raw effort-field support fixes the state loss
+without enabling unsupported fields for other providers.
+
+## Validation
+
+Offline `httpx.MockTransport` tests cover:
+
+- Z.AI enabled and disabled thinking payloads;
+- Z.AI models with and without the separately supported effort field; and
+- the existing guard that omits unsupported OpenAI `reasoning_effort` fields.
+
+Protocol evidence:
+
+- <https://docs.z.ai/guides/capabilities/thinking>
+- <https://docs.z.ai/api-reference/llm/chat-completion>

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -829,10 +829,13 @@ def _build_chat_payload(
         payload["provider"] = openrouter_provider
     _apply_chat_reasoning(
         payload,
-        reasoning_effort=reasoning_effort if supports_reasoning_effort else None,
+        reasoning_effort=(
+            reasoning_effort if supports_reasoning_effort or thinking_format == "zai" else None
+        ),
         reasoning_effort_parameter=reasoning_effort_parameter,
         thinking_format=thinking_format,
         include_reasoning_effort_none=include_reasoning_effort_none,
+        supports_reasoning_effort=supports_reasoning_effort,
     )
     if tools:
         payload["tools"] = [_tool_to_openai(tool) for tool in tools]
@@ -848,9 +851,19 @@ def _apply_chat_reasoning(
     reasoning_effort_parameter: str,
     thinking_format: str,
     include_reasoning_effort_none: bool,
+    supports_reasoning_effort: bool = True,
 ) -> None:
     reasoning_enabled = reasoning_effort is not None and reasoning_effort != "none"
-    if thinking_format in {"zai", "qwen"}:
+    if thinking_format == "zai":
+        # Z.AI's OpenAI-compatible API uses the provider-specific ``thinking``
+        # object for every GLM model.  Only GLM-5.2+ accepts the separate
+        # reasoning_effort field, so keep that decision model-specific via
+        # supportsReasoningEffort instead of dropping the logical toggle.
+        payload["thinking"] = {"type": "enabled" if reasoning_enabled else "disabled"}
+        if supports_reasoning_effort and reasoning_enabled:
+            payload["reasoning_effort"] = reasoning_effort
+        return
+    if thinking_format == "qwen":
         payload["enable_thinking"] = reasoning_enabled
         return
     if thinking_format == "qwen-chat-template":

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1076,6 +1076,23 @@ def test_openai_compatible_config_from_provider_sets_reasoning_effort(
     assert plain.reasoning_effort is None
 
 
+def test_zai_config_preserves_logical_effort_for_provider_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ZAI_API_KEY", "test-key")
+    provider = load_provider_settings(TauPaths(home=Path("/missing"))).get_provider("zai")
+
+    config = openai_compatible_config_from_provider(
+        provider,
+        model="glm-5.1",
+        thinking_level="high",
+    )
+
+    assert config.reasoning_effort == "high"
+    assert config.thinking_format == "zai"
+    assert config.compat["supportsReasoningEffort"] is False
+
+
 @pytest.mark.parametrize(
     ("level", "expected_effort"),
     [("low", "low"), ("high", "high"), ("max", "max")],

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -456,6 +456,91 @@ async def test_openai_compatible_provider_includes_configured_reasoning_effort()
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("reasoning_effort", "supports_reasoning_effort", "expected_thinking", "expected_effort"),
+    [
+        ("high", False, {"type": "enabled"}, None),
+        ("none", False, {"type": "disabled"}, None),
+        ("high", True, {"type": "enabled"}, "high"),
+    ],
+)
+async def test_zai_provider_serializes_thinking_protocol(
+    reasoning_effort: str,
+    supports_reasoning_effort: bool,
+    expected_thinking: dict[str, str],
+    expected_effort: str | None,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://api.z.ai/api/paas/v4",
+                reasoning_effort=reasoning_effort,
+                thinking_format="zai",
+                compat={"supportsReasoningEffort": supports_reasoning_effort},
+            ),
+            client=client,
+        )
+        await _collect(
+            provider.stream_response(
+                model="glm-5.1",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    assert payload["thinking"] == expected_thinking
+    assert payload.get("reasoning_effort") == expected_effort
+    assert "enable_thinking" not in payload
+
+
+@pytest.mark.anyio
+async def test_unsupported_reasoning_effort_guard_remains_for_openai_format() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                reasoning_effort="high",
+                compat={"supportsReasoningEffort": False},
+            ),
+            client=client,
+        )
+        await _collect(
+            provider.stream_response(
+                model="test-model",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert "reasoning_effort" not in loads(requests[0].content)
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_includes_openrouter_provider_routing() -> None:
     requests: list[httpx.Request] = []
 

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -157,6 +157,23 @@ needed. Available models and plan limits change over time; consult the
 [OpenCode Go](https://opencode.ai/docs/go) and
 [OpenCode Zen](https://opencode.ai/docs/zen) pages for the current list.
 
+### Z.AI
+
+Log in with `/login zai` or set `ZAI_API_KEY`. Tau sends Z.AI's provider-specific
+thinking object rather than an OpenAI `reasoning_effort` field:
+`{"thinking": {"type": "enabled"}}` for an enabled logical mode and
+`{"thinking": {"type": "disabled"}}` for `off`. This keeps configured
+thinking enabled for GLM models whose endpoint does not accept the raw effort
+field.
+
+Z.AI documents `reasoning_effort` only for GLM-5.2 and newer, with model-specific
+values. Tau therefore emits that additional field only when the selected model's
+compatibility metadata explicitly supports it; unsupported providers and models
+continue to omit it. See the [Z.AI deep-thinking
+reference](https://docs.z.ai/guides/capabilities/thinking) and [chat-completion
+schema](https://docs.z.ai/api-reference/llm/chat-completion) for the authoritative
+wire contract.
+
 ### Hugging Face Inference Providers
 
 Log in with `/login huggingface` or set `HF_TOKEN`. Tau's Hugging Face model


### PR DESCRIPTION
## Summary

- Preserve Z.AI's logical thinking toggle when raw `reasoning_effort` is unsupported.
- Serialize the documented Z.AI `thinking` object and only send effort values for explicitly compatible models.
- Add MockTransport payload regressions, provider-config coverage, and protocol documentation.

## Verification

- `uv sync --dev --locked`
- `uv run pytest` (1878 passed, 3 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Hugo and Pagefind builds
- `git diff --check`

Fixes #674
