### PR TITLE
Style ListView scrollbars with Tau theme colors

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3334,6 +3334,16 @@ class TauTuiApp(App[None]):
         border: tall $tau-border;
     }
 
+    ListView {
+        scrollbar-background: $tau-transcript-background;
+        scrollbar-color: $tau-border;
+        scrollbar-color-hover: $tau-highlight-background;
+        scrollbar-background-hover: $tau-transcript-background;
+        scrollbar-color-active: $tau-accent;
+        scrollbar-background-active: $tau-transcript-background;
+        scrollbar-size-vertical: 2;
+    }
+
     ListView > ListItem.-highlight {
         background: $tau-highlight-background;
         color: $tau-highlight-text;

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3674,6 +3674,34 @@ def test_tui_app_uses_light_theme_css_variables() -> None:
     assert app.current_theme.dark is False
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "theme",
+    [TAU_DARK_THEME, TAU_LIGHT_THEME, HIGH_CONTRAST_THEME],
+    ids=lambda theme: theme.name,
+)
+async def test_list_view_scrollbars_use_theme_colors(theme: TuiTheme) -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme=theme.name))
+
+    async with app.run_test() as pilot:
+        await app.push_screen(SessionPickerScreen([], theme=theme))
+        await pilot.pause()
+
+        list_view = app.screen.query_one("#session-picker-list", ListView)
+
+        assert list_view.styles.scrollbar_background == Color.parse(theme.transcript_background)
+        assert list_view.styles.scrollbar_color == Color.parse(theme.border)
+        assert list_view.styles.scrollbar_background_hover == Color.parse(
+            theme.transcript_background
+        )
+        assert list_view.styles.scrollbar_color_hover == Color.parse(theme.highlight_background)
+        assert list_view.styles.scrollbar_background_active == Color.parse(
+            theme.transcript_background
+        )
+        assert list_view.styles.scrollbar_color_active == Color.parse(theme.accent)
+        assert list_view.styles.scrollbar_size_vertical == 2
+
+
 def test_tui_app_registers_only_tau_themes_with_textual() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
## Summary

- style `ListView` scrollbars with Tau theme variables for default, hover, and active states
- keep the existing 2-cell vertical scrollbar width consistent across themes
- add headless coverage for all built-in themes

This change is limited to picker/list scrollbars and does not enable transcript scrollbars.

Fixes #435

## Verification

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- website Hugo build and Pagefind indexing
- `git diff --check`
