### PR TITLE
Add session-only TUI sidebar toggle

### DIFF
--- a/dev-notes/tui-sidebar-visibility-toggle.md
+++ b/dev-notes/tui-sidebar-visibility-toggle.md
@@ -1,0 +1,29 @@
+# Session-only TUI sidebar visibility
+
+Tau's interactive TUI now exposes `/sidebar` in the slash-command palette. The
+command toggles the detailed session sidebar without changing `~/.tau/tui.json`
+or the configured `sidebar_position`.
+
+## Behavior
+
+- Configured `left` and `right` positions remain unchanged while the sidebar is
+  hidden and shown.
+- Responsive hiding still applies until the user explicitly changes visibility.
+- Once the user hides the sidebar, resizing the terminal does not unexpectedly
+  restore it.
+- A configured `off` sidebar can be shown for the current session at the
+  existing default right position. Restarting Tau honors the saved `off` value.
+
+The visibility override belongs to `TauTuiApp`, alongside other frontend-only
+state. It is intentionally not part of `TuiSettings`, so theme persistence and
+other durable TUI settings cannot accidentally serialize it.
+
+## Tests
+
+Deterministic Textual pilot tests cover left/right toggling, responsive resize
+behavior, configured-off temporary showing, and the no-write guarantee. Run the
+focused suite with:
+
+```bash
+uv run pytest tests/test_tui_app.py tests/test_commands.py
+```

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -1341,6 +1341,8 @@ async def run_print_mode(
                     "The /local command is interactive-only. In print mode, configure a "
                     "backend in the TUI, then use --provider and --model."
                 )
+            if command.sidebar_toggle_requested:
+                message = "The /sidebar command is interactive-only."
             if command.reload_requested:
                 try:
                     summary = await session.reload()

--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -114,6 +114,7 @@ class CommandResult:
     login_picker_requested: bool = False
     custom_provider_login_requested: bool = False
     local_requested: bool = False
+    sidebar_toggle_requested: bool = False
     login_provider: str | None = None
     login_method: str | None = None
     logout_picker_requested: bool = False
@@ -380,6 +381,15 @@ def create_default_command_registry() -> CommandRegistry:
             description="Configure and manage local backends.",
             handler=_local_command,
             search_terms=("backends", "inference"),
+        )
+    )
+    registry.register(
+        SlashCommand(
+            name="sidebar",
+            usage="/sidebar",
+            description="Show or hide the TUI sidebar for this session.",
+            handler=_sidebar_command,
+            search_terms=("toggle", "visibility", "panel"),
         )
     )
     registry.register(
@@ -751,6 +761,12 @@ def _local_command(context: CommandContext) -> CommandResult:
     if context.args:
         return CommandResult(handled=True, message="Usage: /local")
     return CommandResult(handled=True, local_requested=True)
+
+
+def _sidebar_command(context: CommandContext) -> CommandResult:
+    if context.args:
+        return CommandResult(handled=True, message="Usage: /sidebar")
+    return CommandResult(handled=True, sidebar_toggle_requested=True)
 
 
 def _login_command(context: CommandContext) -> CommandResult:

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -7,8 +7,9 @@ CLI entry point is `tau_coding.cli:app`.
 
 ## Local inference
 
-`/local` is interactive-only. It opens the provider-neutral local-backend host
-in the TUI; print mode never runs setup, probes endpoints, or picks a model
+`/local` and `/sidebar` are interactive-only. `/local` opens the provider-neutral
+local-backend host in the TUI; `/sidebar` toggles the session sidebar. Print mode
+never runs setup, probes endpoints, or picks a model
 implicitly. Configure llama.cpp through `/local`, then use its exact provider
 and model explicitly in headless mode:
 

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -21,6 +21,14 @@ four hours and failures leave the existing list usable. Use
 `tau update --models` for forced revalidation or `TAU_OFFLINE=1` to disable
 catalog network access.
 
+## `/sidebar`
+
+Use `/sidebar` to toggle the detailed session sidebar for the current TUI
+session. It preserves a configured `left` or `right` position and never writes
+`~/.tau/tui.json`; the choice is forgotten when Tau restarts. When
+`sidebar_position` is `"off"`, an explicit show temporarily uses the default
+right position.
+
 ## `/local`
 
 Type `/local` to open the generic local-backend host. It explicitly chooses a

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3804,6 +3804,9 @@ class TauTuiApp(App[None]):
         legacy_notices = (startup_notice,) if startup_notice else ()
         self.startup_notices = tuple((*startup_notices, *legacy_notices))
         self.initial_prompt = initial_prompt
+        # This override is deliberately separate from durable settings. It is
+        # reset with every app instance and never participates in tui.json.
+        self._sidebar_visibility_override: bool | None = None
         super().__init__()
         self._register_tau_textual_themes()
         # Assign the resolved theme's name: it is always registered, while the
@@ -4270,6 +4273,8 @@ class TauTuiApp(App[None]):
                 self._open_custom_provider_login()
             if command.local_requested:
                 self._open_local_backend_picker()
+            if command.sidebar_toggle_requested:
+                self._toggle_sidebar_visibility()
             if command.login_provider is not None:
                 self._open_login(command.login_provider, method=command.login_method)
             if command.logout_picker_requested:
@@ -6705,17 +6710,30 @@ class TauTuiApp(App[None]):
         )
 
     def _update_responsive_layout(self, width: int, height: int) -> None:
-        if self.tui_settings.sidebar_position == "off":
-            return
-        show_sidebar = width >= SIDEBAR_MIN_WIDTH and height >= SIDEBAR_MIN_HEIGHT
+        if self._sidebar_visibility_override is not None:
+            show_sidebar = self._sidebar_visibility_override
+        elif self.tui_settings.sidebar_position == "off":
+            show_sidebar = False
+        else:
+            show_sidebar = width >= SIDEBAR_MIN_WIDTH and height >= SIDEBAR_MIN_HEIGHT
         self.set_class(not show_sidebar, "-hide-sidebar")
 
     def _apply_sidebar_position(self) -> None:
-        """Apply CSS classes for the configured sidebar position."""
+        """Apply the configured (or off-setting fallback) sidebar position."""
         pos = self.tui_settings.sidebar_position
-        self.set_class(pos == "right", "-sidebar-right")
-        if pos == "off":
-            self.add_class("-hide-sidebar")
+        # A configured ``off`` has no prior visible position, so an explicit
+        # session-only show uses the normal right-hand placement.
+        show_right = pos == "right" or (pos == "off" and self._sidebar_visibility_override is True)
+        self.set_class(show_right, "-sidebar-right")
+
+    def _toggle_sidebar_visibility(self) -> None:
+        """Toggle sidebar visibility without changing durable TUI settings."""
+        currently_visible = not self.has_class("-hide-sidebar")
+        self._sidebar_visibility_override = not currently_visible
+        self._apply_sidebar_position()
+        self._update_responsive_layout(self.size.width, self.size.height)
+        state = "shown" if self._sidebar_visibility_override else "hidden"
+        self._notify(f"Sidebar {state} for this session.")
 
     def _build_completion_state(self, text: str) -> CompletionState:
         registry = _session_command_registry(self.session)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -140,6 +140,7 @@ def test_registered_commands_are_pi_aligned(tmp_path: Path) -> None:
         "resume",
         "scoped-models",
         "session",
+        "sidebar",
         "skill",
         "skills",
         "system",
@@ -155,6 +156,17 @@ def test_local_command_requests_host_action(tmp_path: Path) -> None:
 
     assert registry.execute(session, "/local").local_requested is True
     assert registry.execute(session, "/local extra").message == "Usage: /local"
+
+
+def test_sidebar_command_requests_host_action(tmp_path: Path) -> None:
+    registry = create_default_command_registry()
+    session = FakeSession(tmp_path)
+
+    result = registry.execute(session, "/sidebar")
+
+    assert result.handled is True
+    assert result.sidebar_toggle_requested is True
+    assert registry.execute(session, "/sidebar extra").message == "Usage: /sidebar"
 
 
 def test_prompts_command_requests_picker(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -345,6 +345,8 @@ class FakeSession:
             return CommandResult(handled=True, thinking_level=text.removeprefix("/thinking "))
         if text == "/theme":
             return CommandResult(handled=True, theme_picker_requested=True)
+        if text == "/sidebar":
+            return CommandResult(handled=True, sidebar_toggle_requested=True)
         if text.startswith("/theme "):
             return CommandResult(handled=True, theme=text.removeprefix("/theme "))
         if text.startswith("/name "):
@@ -3414,6 +3416,76 @@ async def test_tui_sidebar_shows_on_left_when_configured() -> None:
         assert sidebar.display is True
         assert not app.has_class("-sidebar-right")
         assert not app.has_class("-sidebar-off")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("position", ["left", "right"])
+async def test_tui_sidebar_command_toggles_visibility_without_changing_position(
+    position: str,
+) -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position=position))
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is True
+        assert app.has_class("-sidebar-right") is (position == "right")
+
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/sidebar"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert sidebar.display is False
+        assert app.has_class("-sidebar-right") is (position == "right")
+        assert app.tui_settings.sidebar_position == position
+
+        prompt.value = "/sidebar"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert sidebar.display is True
+        assert app.has_class("-sidebar-right") is (position == "right")
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_command_hides_user_sidebar_across_resize() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        sidebar = app.query_one("#sidebar")
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/sidebar"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert sidebar.display is False
+
+        await pilot.resize_terminal(width=80, height=30)
+        await pilot.resize_terminal(width=120, height=40)
+        await pilot.pause()
+        assert sidebar.display is False
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_off_can_be_shown_temporarily_on_right() -> None:
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(sidebar_position="off"))
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        sidebar = app.query_one("#sidebar")
+        assert sidebar.display is False
+        assert not app.has_class("-sidebar-right")
+
+        prompt = app.query_one("#prompt", PromptInput)
+        prompt.value = "/sidebar"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert sidebar.display is True
+        assert app.has_class("-sidebar-right")
+        assert app.tui_settings.sidebar_position == "off"
+        assert not tui_settings_path().exists()
+
+        prompt.value = "/sidebar"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert sidebar.display is False
+        assert not app.has_class("-sidebar-right")
 
 
 @pytest.mark.anyio

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -65,6 +65,7 @@ to search and run them. Common ones:
 - `/prompts` — search prompt templates, insert an invocation, or edit the template file with **Ctrl+E**
 - `/hotkeys` — show the keyboard shortcuts
 - `/local` — choose and manage a registered local backend
+- `/sidebar` — show or hide the sidebar for this session
 
 The full list is in the [Slash commands reference]({{< relref "../reference/slash-commands.md" >}}). For local inference, see the [local backends guide]({{< relref "./local-inference.md" >}}).
 
@@ -292,6 +293,10 @@ branch, and provider use the quieter metadata color.
 The sidebar appears on the **right** by default. It can be moved to the **left**
 or turned **off** entirely by setting `sidebar_position` in `~/.tau/tui.json` —
 see [Configuration]({{< relref "../reference/configuration.md#tui-settings" >}}).
+Use `/sidebar` to toggle visibility during a session. This is temporary: it
+preserves a configured left/right position, does not change `tui.json`, and is
+forgotten when Tau restarts. A configured `off` sidebar can be shown temporarily
+on the default right side.
 
 ## Next
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -409,7 +409,10 @@ Tau rejects invalid values, empty keys, and duplicate assignments.
 
 - `sidebar_position`: `"right"` (default), `"left"`, or `"off"`. Controls
   placement of the session metadata sidebar. `"off"` hides the sidebar entirely;
-  the compact session info row below the prompt still works.
+  the compact session info row below the prompt still works. In a running TUI,
+  `/sidebar` temporarily toggles visibility without writing this setting; a
+  temporarily shown `"off"` sidebar uses the default right position and the
+  saved setting is honored again after restart.
 - `turn_notification`: `"desktop"` (default), `"bell"`, or `"off"`. When Tau's
   terminal surface is unfocused and the agent becomes fully idle, `"desktop"`
   selects OSC 9 for Ghostty, iTerm2, and MinTTY, or Kitty's OSC 99 protocol for

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -23,6 +23,7 @@ command palette with **Ctrl+K**.
 | `/theme [name]` | Show or set the TUI theme |
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/local` | Choose and manage a registered local backend; interactive-only. Compatible llama.cpp routers add explicit load/unload, Hugging Face GGUF search, and server-side download actions with confirmation and reconciliation. |
+| `/sidebar` | Toggle the sidebar for this session without changing `tui.json` |
 | `/logout [provider]` | Remove saved credentials for a provider |
 | `/reload` | Reload local skills, prompts, extensions, and project context |
 | `/prompts` | Search loaded prompt templates; press Enter to insert an invocation or Ctrl+E to edit the file |


### PR DESCRIPTION
Fixes #672

## Summary
- add discoverable `/sidebar` TUI command
- keep visibility overrides session-only while preserving configured placement
- support temporarily showing a configured-off sidebar on the default right
- cover toggle, resize, left/right, off, and persistence behavior with pilot tests
- update TUI documentation and development notes

## Verification
- `uv sync --dev --locked`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Hugo build and Pagefind indexing
- `git diff --check`
