### PR TITLE
Fix interleaved Chat Completions reasoning and answer blocks

### DIFF
--- a/dev-notes/chat-stream-channels.md
+++ b/dev-notes/chat-stream-channels.md
@@ -1,0 +1,27 @@
+# Independent Chat Completions channels
+
+DeepSeek V4 Flash through Hugging Face/DeepInfra can interleave `content` and
+`reasoning_content` fragments, including both fields in one SSE chunk. The
+Chat Completions parser already accumulated each field correctly, but the
+canonical stream bridge treated every field switch as an ordered block boundary.
+That split both reasoning and answer sentences in the persisted transcript.
+
+The OpenAI-compatible adapter now selects independent channel assembly only for
+Chat Completions, using the same transport decision as request dispatch. Each
+channel keeps a stable content index and emits one start/end pair. Both remain
+open until tool calls or response completion; partial/error snapshots retain the
+assembled blocks. First-seen channel order is preserved. Responses and other
+providers retain sequential ordering; no model-name-specific workaround is used.
+
+The TUI keeps an open thinking widget while answer deltas arrive and closes it
+on the explicit thinking-end event. This follows Pi's indexed event lifecycle
+without adding frontend concerns to the portable harness. Final messages still
+use the normal adapter/persistence path. Existing saved sessions are not rewritten.
+
+Regression checks use mock SSE chunks matching the reported fragment pattern,
+including simultaneous fields, stable indices, signatures, immutable snapshots,
+and a Textual test for the live widgets. Run:
+
+```sh
+uv run pytest tests/test_chat_channels.py tests/test_tui_chat_channels.py tests/test_tau_ai.py
+```

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -115,6 +115,10 @@ class OpenAICompatibleProvider:
             api=self._config.api,
             provider=getattr(self._config, "provider_name", "openai-compatible"),
             model=model,
+            independent_channels=not (
+                self._config.api == "openai-responses"
+                or (self._config.infer_api_from_model and _use_responses_api(model))
+            ),
         )
 
     def _stream_provider_events(

--- a/src/tau_ai/stream.py
+++ b/src/tau_ai/stream.py
@@ -91,15 +91,19 @@ async def canonicalize_provider_stream(
     api: str,
     provider: str,
     model: str,
+    independent_channels: bool = False,
 ) -> AsyncIterator[AssistantMessageEvent]:
     """Canonicalize one old internal parser stream.
 
     Provider parsers remain isolated behind this private bridge while they are
     migrated incrementally. The public provider protocol exposes only Pi events.
+    Chat Completions uses independent channels: a channel switch does not end
+    either block. Other transports preserve their sequential block ordering.
     """
     partial = AssistantMessage(api=api, provider=provider, model=model)
     active_index: int | None = None
     active_kind: str | None = None
+    channel_indices: dict[str, int] = {}
     started = False
     terminal = False
 
@@ -119,12 +123,17 @@ async def canonicalize_provider_stream(
             yield AssistantStartEvent(partial=_snapshot(partial))
 
         if isinstance(event, ProviderTextDeltaEvent):
+            if independent_channels:
+                active_index = channel_indices.get("text")
+                active_kind = "text" if active_index is not None else None
             if active_kind != "text":
-                async for end_event in _end_active_block(partial, active_index):
-                    yield end_event
+                if not independent_channels:
+                    async for end_event in _end_active_block(partial, active_index):
+                        yield end_event
                 active_index = len(partial.content)
                 active_kind = "text"
                 partial.content.append(TextContent(text=""))
+                channel_indices["text"] = active_index
                 yield TextStartEvent(content_index=active_index, partial=_snapshot(partial))
             assert active_index is not None
             block = partial.content[active_index]
@@ -136,12 +145,17 @@ async def canonicalize_provider_stream(
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderThinkingDeltaEvent):
+            if independent_channels:
+                active_index = channel_indices.get("thinking")
+                active_kind = "thinking" if active_index is not None else None
             if active_kind != "thinking":
-                async for end_event in _end_active_block(partial, active_index):
-                    yield end_event
+                if not independent_channels:
+                    async for end_event in _end_active_block(partial, active_index):
+                        yield end_event
                 active_index = len(partial.content)
                 active_kind = "thinking"
                 partial.content.append(ThinkingContent(thinking=""))
+                channel_indices["thinking"] = active_index
                 yield ThinkingStartEvent(
                     content_index=active_index,
                     partial=_snapshot(partial),
@@ -156,8 +170,11 @@ async def canonicalize_provider_stream(
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderToolCallEvent):
-            async for end_event in _end_active_block(partial, active_index):
-                yield end_event
+            indices = list(channel_indices.values()) if independent_channels else [active_index]
+            for index in indices:
+                async for end_event in _end_active_block(partial, index):
+                    yield end_event
+            channel_indices.clear()
             active_index = None
             active_kind = None
             index = len(partial.content)
@@ -169,8 +186,11 @@ async def canonicalize_provider_stream(
                 partial=_snapshot(partial),
             )
         elif isinstance(event, ProviderResponseEndEvent):
-            async for end_event in _end_active_block(partial, active_index):
-                yield end_event
+            indices = list(channel_indices.values()) if independent_channels else [active_index]
+            for index in indices:
+                async for end_event in _end_active_block(partial, index):
+                    yield end_event
+            channel_indices.clear()
             active_index = None
             active_kind = None
 

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -62,6 +62,7 @@ from tau_agent.provider_events import (
     AssistantMessageEvent,
     TextDeltaEvent,
     ThinkingDeltaEvent,
+    ThinkingEndEvent,
 )
 from tau_agent.tools import AgentTool
 from tau_agent.types import JSONValue
@@ -5380,6 +5381,8 @@ class TauTuiApp(App[None]):
             nested = event.assistant_message_event
             if isinstance(nested, TextDeltaEvent):
                 await transcript.append_assistant_delta(nested.delta, theme=theme)
+            elif isinstance(nested, ThinkingEndEvent):
+                await transcript.finish_thinking_message()
             elif isinstance(nested, ThinkingDeltaEvent):
                 await transcript.append_thinking_delta(
                     nested.delta,

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -829,6 +829,10 @@ class TranscriptView(VerticalScroll):
 
         self.call_after_refresh(restore_anchor)
 
+    async def finish_thinking_message(self) -> None:
+        """Close a thinking block at its explicit stream boundary."""
+        await self._finalize_active_thinking_message()
+
     async def _finalize_active_thinking_message(self) -> None:
         """Stop streaming for a completed thinking block before another block starts."""
         widget = self._active_thinking_widget
@@ -1180,11 +1184,13 @@ class TranscriptView(VerticalScroll):
         *,
         theme: TuiTheme = TAU_DARK_THEME,
         scroll_end: bool = False,
+        preserve_thinking: bool = False,
     ) -> StreamingTranscriptMessageWidget:
         """Create the active assistant message widget if needed."""
         if self._active_assistant_widget is not None:
             return self._active_assistant_widget
-        await self._finalize_active_thinking_message()
+        if not preserve_thinking:
+            await self._finalize_active_thinking_message()
         should_follow = self._should_follow_output if not scroll_end else True
         widget = StreamingTranscriptMessageWidget(
             ChatItem(role="assistant", text=""),
@@ -1209,7 +1215,9 @@ class TranscriptView(VerticalScroll):
         if not self._window_is_latest:
             return
         should_follow = self._should_follow_output if not scroll_end else True
-        widget = await self.start_assistant_message(theme=theme, scroll_end=scroll_end)
+        widget = await self.start_assistant_message(
+            theme=theme, scroll_end=scroll_end, preserve_thinking=True
+        )
         await widget.append_fragment(delta)
         if should_follow:
             self._request_follow_scroll(force=scroll_end)

--- a/tests/test_chat_channels.py
+++ b/tests/test_chat_channels.py
@@ -1,0 +1,58 @@
+"""Chat Completions fields are independent channels, not ordered blocks."""
+
+import json
+
+import httpx
+import pytest
+
+from tau_agent.messages import ThinkingContent
+from tau_ai import OpenAICompatibleConfig, OpenAICompatibleProvider
+from tau_ai.events import AssistantDoneEvent, TextDeltaEvent
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("same_chunk", [False, True])
+async def test_interleaved_reasoning_keeps_stable_blocks(same_chunk: bool) -> None:
+    deltas = [
+        {"reasoning_content": "Done. C"},
+        {"content": "Done. Pr"},
+        {"reasoning_content": "reated and pushed."},
+        {"content": "ivate repo created."},
+    ]
+    if same_chunk:
+        deltas = [deltas[0] | deltas[1], deltas[2] | deltas[3]]
+    body = (
+        "".join("data: " + json.dumps({"choices": [{"delta": delta}]}) + "\n\n" for delta in deltas)
+        + "data: [DONE]\n\n"
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test", base_url="https://example.test/v1"),
+            client=client,
+        )
+        events = [
+            event
+            async for event in provider.stream_response(
+                model="deepseek-ai/DeepSeek-V4-Flash", system="", messages=[], tools=[]
+            )
+        ]
+    assert isinstance(events[-1], AssistantDoneEvent)
+    message = events[-1].message
+    assert len(message.content) == 2
+    assert message.text == "Done. Private repo created."
+    assert message.thinking_text == "Done. Created and pushed."
+    thinking = next(block for block in message.content if isinstance(block, ThinkingContent))
+    assert thinking.thinking_signature == "reasoning_content"
+    for kind in ("text", "thinking"):
+        starts = [event for event in events if event.type == f"{kind}_start"]
+        ends = [event for event in events if event.type == f"{kind}_end"]
+        fragments = [event for event in events if event.type == f"{kind}_delta"]
+        assert len(starts) == len(ends) == 1
+        assert {event.content_index for event in fragments} == {starts[0].content_index}
+        assert ends[0].content_index == starts[0].content_index
+    first_text = next(event for event in events if isinstance(event, TextDeltaEvent))
+    assert first_text.partial.text == "Done. Pr"

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -1044,9 +1044,9 @@ async def test_openai_compatible_provider_streams_reasoning_content() -> None:
         "thinking_start",
         "thinking_delta",
         "thinking_delta",
-        "thinking_end",
         "text_start",
         "text_delta",
+        "thinking_end",
         "text_end",
         "done",
     ]

--- a/tests/test_tui_chat_channels.py
+++ b/tests/test_tui_chat_channels.py
@@ -1,0 +1,26 @@
+"""Interleaved reasoning stays in one live thinking widget."""
+
+import pytest
+
+from tau_coding.tui.app import TauTuiApp
+from tau_coding.tui.widgets import StreamingTranscriptMessageWidget, TranscriptView
+from test_tui_app import FakeSession
+
+
+@pytest.mark.anyio
+async def test_text_delta_does_not_close_open_thinking_channel() -> None:
+    app = TauTuiApp(FakeSession())
+    async with app.run_test(size=(100, 30)):
+        transcript = app.query_one("#transcript", TranscriptView)
+        await transcript.append_thinking_delta("Done. C", show_thinking=True)
+        await transcript.append_assistant_delta("Done. Pr")
+        await transcript.append_thinking_delta("reated and pushed.", show_thinking=True)
+        await transcript.append_assistant_delta("ivate repo created.")
+        widgets = list(transcript.query(StreamingTranscriptMessageWidget))
+        assert len(widgets) == 2
+        assert [widget.item.text for widget in widgets] == [
+            "Done. Created and pushed.",
+            "Done. Private repo created.",
+        ]
+        await transcript.finish_thinking_message()
+        assert transcript._active_thinking_widget is None

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -27,6 +27,11 @@ to disable notifications. BEL and operating-system desktop notifications may
 produce sounds according to the user's terminal and system settings; see
 [Configuration]({{< relref "../reference/configuration.md#tui-settings" >}}).
 
+Chat Completions providers can interleave reasoning and answer fragments (for
+example, DeepSeek through Hugging Face). Tau keeps each channel in one continuous
+block while streaming and saving the reply, rather than splitting sentences at
+channel switches. Previously saved replies retain their original block layout.
+
 Clicking anywhere in the window returns focus to the prompt, so you can scroll
 the transcript and keep typing without tabbing back.
 


### PR DESCRIPTION
## Summary

- Keep Chat Completions reasoning and answer channels open across interleaved fragments instead of splitting sentences into separate blocks.
- Keep the live thinking widget open until its explicit stream-end event.
- Preserve sequential block behavior for other transports; existing saved sessions remain unchanged.
- Add mock SSE and Textual regression tests plus contributor and user documentation.

## Validation

- `uv run pytest`: 1,901 passed, 2 Windows-only skips.
- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run mypy`: passed.
- `uv build`: passed.
- `hugo --minify` and Pagefind search build: passed; Hugo warned about a missing taxonomy layout.
- Live provider validation not performed; deterministic tests reproduce the reported DeepSeek/DeepInfra fragment pattern.

## Manual validation

Run DeepSeek V4 Flash through Hugging Face with thinking enabled. Confirm reasoning and answer sentences remain continuous during streaming and after completion/resume, including responses around tool calls.
