### PR TITLE
fix(tui): ignore selection hits on detached transcript widgets

### DIFF
--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -315,6 +315,15 @@ class TauMarkdownFence(MarkdownFence):
 class ThemedMarkdownWidget(TextualMarkdown):
     """Textual Markdown widget reserved for Tau transcript streaming."""
 
+    @property
+    def allow_select(self) -> bool:
+        """Ignore stale mouse hits after a transcript widget is detached.
+
+        Textual's selection startup dereferences the selected widget's parent.
+        Its compositor can still return a removed widget before the next layout.
+        """
+        return self.parent is not None and super().allow_select
+
     BLOCKS = {
         **TextualMarkdown.BLOCKS,
         "paragraph_open": TauMarkdownBlock,

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2981,6 +2981,36 @@ async def test_tau_markdown_block_remains_selectable_after_mount() -> None:
 
 
 @pytest.mark.anyio
+async def test_detached_transcript_message_ignores_stale_selection_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        widget = StreamingTranscriptMessageWidget(
+            ChatItem(role="assistant", text="Select this message."), theme=TAU_DARK_THEME
+        )
+        assert widget.allow_select is False
+        await app.query_one("#transcript").mount(widget)
+        await widget.finalize()
+        await pilot.pause()
+        assert widget.allow_select is True
+        await widget.remove()
+        assert widget.parent is None
+        assert widget.allow_select is False
+
+        # Model a compositor hit left over from before the widget was removed.
+        from textual.geometry import Offset
+
+        monkeypatch.setattr(
+            app.screen, "get_widget_and_offset_at", lambda x, y: (widget, Offset(0, 0))
+        )
+        app.screen._forward_event(events.MouseDown(None, 1, 1, 0, 0, 1, False, False, False))
+        assert app.screen._select_state is None
+        await pilot.pause()
+
+
+@pytest.mark.anyio
 async def test_tui_app_disables_text_selection_while_agent_is_running() -> None:
     app = TauTuiApp(FakeSession())
 


### PR DESCRIPTION
## Summary

- Prevent detached transcript widgets from entering Textual's selection startup path.
- Add regression coverage for stale mouse hits after widget removal.

## Verification

- `uv run pytest tests/test_tui_app.py -k 'detached_transcript or markdown_block or disables_text_selection' tests/test_tui_chat_channels.py -q`
- `uv run ruff check src/tau_coding/tui/widgets.py tests/test_tui_app.py`
- `uv run ruff format --check src/tau_coding/tui/widgets.py tests/test_tui_app.py`
