### PR TITLE
feat: persist Codex live model catalogs

### DIFF
--- a/dev-notes/codex-live-model-catalog.md
+++ b/dev-notes/codex-live-model-catalog.md
@@ -24,20 +24,25 @@ order and reads verified names, text/image modalities,
 reasoning efforts, defaults, and limits. One in-memory fetch serves both model
 inventory and limit discovery.
 
-`tau_coding` publishes a successful snapshot as a process-local overlay on the
-durable `openai-codex` configuration. Active Codex sessions discover during
-load. Opening `/model` also discovers Codex while another provider is active by
-creating and closing a model-less provider. The picker initially renders its
-static snapshot and updates after background refresh, preserving its existing
+`tau_coding` publishes a successful snapshot as an overlay on the durable
+`openai-codex` configuration. Successful snapshots are persisted in the
+account-scoped `~/.tau/codex-models-store.json` cache, so a later session can
+render the discovered inventory immediately. Opening `/model` or
+`/scoped-models` discovers Codex while another provider is active by creating and
+closing a model-less provider. The pickers initially render their cached/static
+snapshot and update after background refresh, preserving their existing
 non-blocking behavior.
 
 ## Safety and persistence
 
-The authenticated catalog is account- and rollout-specific. Tau therefore does
-not write it into `catalog.toml`, `providers.json`, session JSONL, or the
-models.dev cache. The checked-in Codex rows remain the offline and failure
-fallback. Empty, malformed, unauthorized, or unavailable responses do not erase
-the fallback. `TAU_OFFLINE=1` skips authenticated discovery.
+The authenticated catalog is account- and rollout-specific. Tau persists only
+parsed model metadata and the account ID in `codex-models-store.json`; it does
+not write the snapshot into `catalog.toml`, `providers.json`, session JSONL, or
+the models.dev cache. A snapshot for another account is ignored. The last
+account-matched snapshot remains the fallback after a refresh failure, with the
+checked-in Codex rows used when no cache exists. Empty, malformed, unauthorized,
+or unavailable responses do not erase the fallback. `TAU_OFFLINE=1` skips
+authenticated discovery and uses the cache/static fallback.
 
 A live inventory is authoritative for picker visibility after successful
 discovery. The active session model is not silently changed when absent from a
@@ -46,8 +51,9 @@ do not persist discovered metadata. `~/.tau/codex-version-store.json` contains
 only public npm release metadata, never account-specific model data or secrets.
 
 This preserves Tau's package boundary: `tau_ai` owns authenticated transport and
-wire parsing, while `tau_coding` owns model selection and the ephemeral catalog
-overlay. `tau_agent` remains independent of provider catalogs and OAuth.
+wire parsing, while `tau_coding` owns model selection, the account-scoped
+cache, and the runtime catalog overlay. `tau_agent` remains independent of
+provider catalogs and OAuth.
 
 ## Lifecycle validation
 
@@ -86,7 +92,9 @@ Automated tests cover:
 - filtering hidden rows while retaining subscription-visible, non-public-API rows;
 - live names, modalities, reasoning levels, and context limits;
 - publication while Codex is active;
+- account-scoped cache serialization and startup reuse;
 - model-less discovery and provider cleanup while another provider is active;
+- refresh from both `/model` and `/scoped-models`;
 - existing static fallback behavior for discovery failures.
 
 Manual validation:

--- a/src/tau_ai/openai_codex.py
+++ b/src/tau_ai/openai_codex.py
@@ -105,6 +105,12 @@ class OpenAICodexProvider:
         self._owns_client = client is None
         self._discovered_model_catalog: RuntimeModelCatalog | None = None
         self._discovered_model_limits: dict[str, RuntimeModelLimits] | None = None
+        self._account_id: str | None = None
+
+    @property
+    def account_id(self) -> str | None:
+        """Return the account associated with the latest catalog request."""
+        return self._account_id
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client if this provider created it."""
@@ -134,6 +140,7 @@ class OpenAICodexProvider:
     async def _fetch_model_catalog(self) -> object:
         client = self._get_client()
         credentials = await self._config.credential_resolver()
+        self._account_id = credentials.account_id
         headers = _build_codex_headers(
             self._config.headers,
             access_token=credentials.access_token,

--- a/src/tau_coding/codex_model_store.py
+++ b/src/tau_coding/codex_model_store.py
@@ -1,0 +1,205 @@
+"""Persisted cache for authenticated OpenAI Codex model catalogs."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any, cast
+
+from tau_ai.model_catalog import (
+    RuntimeInputModality,
+    RuntimeModel,
+    RuntimeModelCatalog,
+    RuntimeThinkingLevel,
+)
+from tau_ai.model_limits import RuntimeModelLimits
+from tau_coding.paths import TauPaths
+
+CODEX_MODEL_STORE_SCHEMA_VERSION = 1
+
+
+def codex_model_store_path(paths: TauPaths | None = None) -> Path:
+    """Return the user-level Codex model-catalog cache path."""
+    return (paths or TauPaths()).codex_models_store_path
+
+
+def cached_codex_model_catalog(
+    paths: TauPaths | None = None,
+    *,
+    account_id: str | None,
+) -> RuntimeModelCatalog | None:
+    """Return the cached catalog only when it belongs to the active account."""
+    if not account_id:
+        return None
+    try:
+        raw = json.loads(codex_model_store_path(paths).read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict) or raw.get("schema_version") != CODEX_MODEL_STORE_SCHEMA_VERSION:
+        return None
+    if raw.get("account_id") != account_id:
+        return None
+    return _catalog_from_json(raw.get("catalog"))
+
+
+def save_codex_model_catalog(
+    catalog: RuntimeModelCatalog,
+    *,
+    account_id: str,
+    paths: TauPaths | None = None,
+    now: float | None = None,
+) -> Path:
+    """Persist one validated, account-scoped Codex model snapshot atomically."""
+    normalized_account_id = account_id.strip()
+    if not normalized_account_id:
+        raise ValueError("Codex account_id must be non-empty")
+    path = codex_model_store_path(paths)
+    value: dict[str, Any] = {
+        "schema_version": CODEX_MODEL_STORE_SCHEMA_VERSION,
+        "account_id": normalized_account_id,
+        "saved_at": time.time() if now is None else now,
+        "catalog": _catalog_to_json(catalog),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            "w",
+            dir=path.parent,
+            encoding="utf-8",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            json.dump(value, temporary_file, indent=2, sort_keys=True)
+            temporary_file.write("\n")
+            temporary_file.flush()
+        temporary_path.replace(path)
+    except Exception:
+        if temporary_path is not None:
+            with suppress(OSError):
+                temporary_path.unlink()
+        raise
+    return path
+
+
+def _catalog_to_json(catalog: RuntimeModelCatalog) -> dict[str, Any]:
+    return {"models": [_model_to_json(model) for model in catalog.models]}
+
+
+def _model_to_json(model: RuntimeModel) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "id": model.id,
+        "name": model.name,
+        "input_modalities": list(model.input_modalities),
+        "thinking_levels": list(model.thinking_levels),
+        "default_thinking_level": model.default_thinking_level,
+    }
+    if model.limits is not None:
+        result["limits"] = {
+            "context_window": model.limits.context_window,
+            "max_output_tokens": model.limits.max_output_tokens,
+            "effective_context_window_percent": model.limits.effective_context_window_percent,
+            "auto_compact_token_limit": model.limits.auto_compact_token_limit,
+        }
+    return result
+
+
+def _catalog_from_json(value: object) -> RuntimeModelCatalog | None:
+    if not isinstance(value, Mapping):
+        return None
+    models_value = value.get("models")
+    if not isinstance(models_value, list) or not models_value:
+        return None
+    models: list[RuntimeModel] = []
+    for item in models_value:
+        model = _model_from_json(item)
+        if model is None or any(existing.id == model.id for existing in models):
+            return None
+        models.append(model)
+    return RuntimeModelCatalog(tuple(models))
+
+
+def _model_from_json(value: object) -> RuntimeModel | None:
+    if not isinstance(value, Mapping):
+        return None
+    model_id = value.get("id")
+    name = value.get("name")
+    modalities_value = value.get("input_modalities")
+    thinking_value = value.get("thinking_levels")
+    default_value = value.get("default_thinking_level")
+    if not isinstance(model_id, str) or not model_id:
+        return None
+    if name is not None and not isinstance(name, str):
+        return None
+    if not isinstance(modalities_value, list) or not modalities_value:
+        return None
+    modalities = tuple(
+        cast(RuntimeInputModality, modality)
+        for modality in modalities_value
+        if modality in {"text", "image"}
+    )
+    if len(modalities) != len(modalities_value) or len(set(modalities)) != len(modalities):
+        return None
+    if not isinstance(thinking_value, list):
+        return None
+    thinking_levels = tuple(
+        cast(RuntimeThinkingLevel, level)
+        for level in thinking_value
+        if level in {"off", "minimal", "low", "medium", "high", "xhigh", "max"}
+    )
+    if len(thinking_levels) != len(thinking_value) or len(set(thinking_levels)) != len(
+        thinking_levels
+    ):
+        return None
+    if default_value is not None and default_value not in thinking_levels:
+        return None
+    limits = _limits_from_json(value.get("limits"))
+    if value.get("limits") is not None and limits is None:
+        return None
+    try:
+        return RuntimeModel(
+            id=model_id,
+            name=name,
+            limits=limits,
+            input_modalities=modalities,
+            thinking_levels=thinking_levels,
+            default_thinking_level=cast(RuntimeThinkingLevel | None, default_value),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _limits_from_json(value: object) -> RuntimeModelLimits | None:
+    if not isinstance(value, Mapping):
+        return None
+    context_window = value.get("context_window")
+    max_output_tokens = value.get("max_output_tokens")
+    effective_percent = value.get("effective_context_window_percent", 100)
+    auto_compact_token_limit = value.get("auto_compact_token_limit")
+    if not isinstance(context_window, int) or isinstance(context_window, bool):
+        return None
+    if max_output_tokens is not None and (
+        not isinstance(max_output_tokens, int) or isinstance(max_output_tokens, bool)
+    ):
+        return None
+    if not isinstance(effective_percent, int) or isinstance(effective_percent, bool):
+        return None
+    if auto_compact_token_limit is not None and (
+        not isinstance(auto_compact_token_limit, int) or isinstance(auto_compact_token_limit, bool)
+    ):
+        return None
+    try:
+        return RuntimeModelLimits(
+            context_window=context_window,
+            max_output_tokens=max_output_tokens,
+            effective_context_window_percent=effective_percent,
+            auto_compact_token_limit=auto_compact_token_limit,
+        )
+    except ValueError:
+        return None

--- a/src/tau_coding/codex_model_store.py
+++ b/src/tau_coding/codex_model_store.py
@@ -142,7 +142,7 @@ def _model_from_json(value: object) -> RuntimeModel | None:
     modalities = tuple(
         cast(RuntimeInputModality, modality)
         for modality in modalities_value
-        if modality in {"text", "image"}
+        if isinstance(modality, str) and modality in {"text", "image"}
     )
     if len(modalities) != len(modalities_value) or len(set(modalities)) != len(modalities):
         return None
@@ -151,7 +151,8 @@ def _model_from_json(value: object) -> RuntimeModel | None:
     thinking_levels = tuple(
         cast(RuntimeThinkingLevel, level)
         for level in thinking_value
-        if level in {"off", "minimal", "low", "medium", "high", "xhigh", "max"}
+        if isinstance(level, str)
+        and level in {"off", "minimal", "low", "medium", "high", "xhigh", "max"}
     )
     if len(thinking_levels) != len(thinking_value) or len(set(thinking_levels)) != len(
         thinking_levels

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -118,21 +118,26 @@ snapshot. Since Tau has no hosted catalog service, it fetches models.dev and
 NVIDIA directly and transforms them locally.
 
 The `openai-codex` provider is different: its inventory is account-specific.
-When Codex OAuth is configured, Tau fetches the authenticated Codex `/models`
-catalog at session startup and whenever `/model` refreshes. Because that endpoint
-filters models by official-client version, Tau first resolves the current stable
-`@openai/codex` release from the npm registry. The version lookup is
-ETag-revalidated, throttled to four hours, and cached at
-`~/.tau/codex-version-store.json`; a stale cached or bundled version is the
-non-fatal fallback. This lets newly gated models appear without a Tau release.
+When Codex OAuth is configured, Tau loads the last successful account-matched
+snapshot from `~/.tau/codex-models-store.json` at startup. This makes a model
+that was discovered in an earlier session available immediately. Opening
+`/model` or `/scoped-models` refreshes the authenticated Codex `/models` catalog
+in the background. Because that endpoint filters models by official-client
+version, Tau first resolves the current stable `@openai/codex` release from the
+npm registry. The version lookup is ETag-revalidated, throttled to four hours,
+and cached at `~/.tau/codex-version-store.json`; a stale cached or bundled
+version is the non-fatal fallback. This lets newly gated models appear without a
+Tau release.
 
 A successful live snapshot replaces the checked-in Codex inventory for that
 process and supplies model names, input modalities, reasoning efforts, and
-runtime limits. The account-specific snapshot is memory-only and never enters
-`catalog.toml`, `providers.json`, or either model cache. Missing credentials,
-malformed data, or network failures retain the static Codex fallback.
-`TAU_OFFLINE=1` disables all catalog network access and permits only the cached
-or bundled client version.
+runtime limits. Tau persists only parsed model metadata and the account ID, not
+OAuth tokens. The cache is never merged into `catalog.toml`, `providers.json`,
+or the models.dev cache. A different account does not use the previous
+account's snapshot. Missing credentials, malformed data, or network failures
+retain the account-matched snapshot or static Codex fallback.
+`TAU_OFFLINE=1` disables catalog network access and permits only the cached or
+bundled data.
 
 Explicit startup and resume of a Codex model absent from the static catalog
 perform authenticated discovery before model validation. Such live-only selections

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -13,13 +13,15 @@ token-weighted. TTFT is the arithmetic mean of provider-wait time through Tau's
 first text, thinking, or tool-call output event. Older assistant messages
 without persisted timing still count toward token usage but not these metrics.
 
-## `/model`
+## `/model` and `/scoped-models`
 
-The picker renders cached/bundled choices immediately, then refreshes remote
-catalogs in the background and updates the open list. Refreshes are throttled to
-four hours and failures leave the existing list usable. Use
-`tau update --models` for forced revalidation or `TAU_OFFLINE=1` to disable
-catalog network access.
+The pickers render cached/bundled choices immediately, then refresh remote
+catalogs in the background and update the open list. This includes the
+account-scoped OpenAI Codex model snapshot, so models discovered in an earlier
+session are available before a refresh. Both commands refresh the Codex catalog;
+refresh failures leave the existing list usable. Use `tau update --models` for
+forced public-catalog revalidation or `TAU_OFFLINE=1` to disable catalog network
+access.
 
 ## `/sidebar`
 

--- a/src/tau_coding/paths.py
+++ b/src/tau_coding/paths.py
@@ -45,6 +45,11 @@ class TauPaths:
         return self.home / "codex-version-store.json"
 
     @property
+    def codex_models_store_path(self) -> Path:
+        """Return the account-scoped Codex model-catalog cache path."""
+        return self.home / "codex-models-store.json"
+
+    @property
     def extension_state_dir(self) -> Path:
         """Return the user-level state directory owned by built-in extensions."""
         return self.home / "state" / "extensions"

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -6,7 +6,7 @@ import asyncio
 import string
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import suppress
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from os import environ
 from pathlib import Path
 from typing import Literal
@@ -45,6 +45,10 @@ from tau_agent.types import JSONValue
 from tau_ai.model_catalog import ModelCatalogProvider, RuntimeModel, RuntimeModelCatalog
 from tau_ai.model_limits import ModelLimitsProvider, RuntimeModelLimits
 from tau_coding.branch_summary import summarize_branch_messages_with_model
+from tau_coding.codex_model_store import (
+    cached_codex_model_catalog,
+    save_codex_model_catalog,
+)
 from tau_coding.commands import CommandRegistry, CommandResult, create_default_command_registry
 from tau_coding.context import discover_project_context_with_diagnostics
 from tau_coding.context_window import (
@@ -80,6 +84,7 @@ from tau_coding.extensions.provider_registry import DynamicProviderRegistry
 from tau_coding.extensions.providers import DynamicProvider, ProviderModel
 from tau_coding.extensions.runtime import ExtensionRuntime
 from tau_coding.models_dev_store import ModelsDevRefreshResult, refresh_models_dev_catalog
+from tau_coding.oauth import account_id_from_access_token
 from tau_coding.paths import TauPaths
 from tau_coding.project_trust import (
     CanonicalProjectPath,
@@ -333,6 +338,7 @@ class CodingSessionConfig:
     requested_model: str | None = None
     session_provider_name: str | None = None
     provider_settings: ProviderSettings | None = None
+    runtime_model_catalogs: Mapping[str, RuntimeModelCatalog] = field(default_factory=dict)
     runtime_provider_config: ProviderConfig | None = None
     dynamic_provider: DynamicProvider | None = None
     owns_initial_provider: bool = False
@@ -431,7 +437,7 @@ class CodingSession:
         )
         self._provider_settings = config.provider_settings
         self._durable_provider_settings = config.provider_settings
-        self._runtime_model_catalogs: dict[str, RuntimeModelCatalog] = {}
+        self._runtime_model_catalogs = dict(config.runtime_model_catalogs)
         self._model_catalog_discovery_errors: dict[str, str] = {}
         self._runtime_provider_config = config.runtime_provider_config
         self._resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
@@ -581,20 +587,51 @@ class CodingSession:
                 include_user_dir=False,
             )
 
+        runtime_model_catalogs = dict(config.runtime_model_catalogs)
+        if config.provider_settings is not None and "openai-codex" not in runtime_model_catalogs:
+            codex_config = _provider_config_or_none(config.provider_settings, "openai-codex")
+            if isinstance(codex_config, OpenAICodexProviderConfig):
+                account_id = _codex_account_id(codex_config, credential_store)
+                cached_catalog = cached_codex_model_catalog(
+                    runtime_paths,
+                    account_id=account_id,
+                )
+                if cached_catalog is not None:
+                    runtime_model_catalogs["openai-codex"] = cached_catalog
+        config = replace(config, runtime_model_catalogs=runtime_model_catalogs)
+        selection_settings = _provider_settings_with_runtime_catalogs(
+            config.provider_settings,
+            runtime_model_catalogs,
+        )
         selected_provider_name = (
             config.requested_provider or state.provider or config.session_provider_name
         )
         selected_model = config.requested_model or state.model
         rediscover_codex = False
         if selected_provider_name == "openai-codex" and config.provider_settings is not None:
-            selected_config = config.provider_settings.get_provider(selected_provider_name)
+            selected_config = _provider_config_or_none(
+                config.provider_settings,
+                selected_provider_name,
+            )
             rediscover_codex = (
                 isinstance(selected_config, OpenAICodexProviderConfig)
                 and selected_model not in selected_config.models
             )
+        preparation_settings = config.provider_settings
+        startup_catalog: RuntimeModelCatalog | None = None
+        effective_selected_config = (
+            _provider_config_or_none(selection_settings, selected_provider_name)
+            if selection_settings is not None
+            else None
+        )
+        if (
+            isinstance(effective_selected_config, OpenAICodexProviderConfig)
+            and selected_model in effective_selected_config.models
+        ):
+            preparation_settings = selection_settings
         if config.provider is None or rediscover_codex:
             prepared = await _prepare_provider_selection(
-                config,
+                replace(config, provider_settings=preparation_settings),
                 state=state,
                 provider_registry=extension_runtime.provider_registry,
                 credential_store=credential_store,
@@ -605,9 +642,13 @@ class CodingSession:
                 except BaseException:
                     await prepared.provider.aclose()
                     raise
+            startup_catalog = prepared.runtime_model_catalog
+            if startup_catalog is not None:
+                runtime_model_catalogs[prepared.provider_name] = startup_catalog
             config = replace(
                 config,
                 provider=prepared.provider,
+                runtime_model_catalogs=runtime_model_catalogs,
                 model=prepared.model,
                 provider_name=prepared.provider_name,
                 inference_provider=prepared.inference_provider,
@@ -701,8 +742,19 @@ class CodingSession:
             # Ownership starts before any repair/discovery work so every
             # failure path has exactly one closer for the candidate.
             session._owned_providers.append(config.provider)  # type: ignore[arg-type]
+        if startup_catalog is not None and config.provider_name == "openai-codex":
+            session._persist_codex_model_catalog(
+                config.provider,
+                startup_catalog,
+                (
+                    config.runtime_provider_config
+                    if isinstance(config.runtime_provider_config, OpenAICodexProviderConfig)
+                    else None
+                ),
+            )
         await session._persist_active_tool_history_repairs()
         try:
+            session._apply_runtime_model_catalogs()
             session._apply_thinking_level_override()
             session._sync_thinking_level_to_active_model()
             if not config.owns_initial_provider and config.provider is not None:
@@ -2103,9 +2155,16 @@ class CodingSession:
         ):
             return
         try:
+            cached_catalog = self._runtime_model_catalogs.get(self.provider_name)
+            if self.provider_name == "openai-codex" and cached_catalog is not None:
+                model = cached_catalog.model(self.model)
+                self._runtime_model_limits = model.limits if model is not None else None
+                return
             if isinstance(provider, ModelCatalogProvider):
                 catalog = await provider.discover_models()
                 self._publish_runtime_model_catalog(self.provider_name, catalog)
+                if self.provider_name == "openai-codex":
+                    self._persist_codex_model_catalog(provider, catalog)
             if isinstance(provider, ModelLimitsProvider):
                 self._runtime_model_limits = await provider.discover_model_limits(self.model)
         except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
@@ -2328,12 +2387,20 @@ class CodingSession:
 
     async def refresh_model_catalogs(self, *, force: bool = False) -> ModelsDevRefreshResult:
         """Refresh public and authenticated catalogs and publish them to this session."""
-        result = await refresh_models_dev_catalog(
-            paths=self._resource_paths.paths,
-            force=force,
-        )
-        self.reload_provider_settings()
+        public_error: Exception | None = None
+        result: ModelsDevRefreshResult | None = None
+        try:
+            result = await refresh_models_dev_catalog(
+                paths=self._resource_paths.paths,
+                force=force,
+            )
+            self.reload_provider_settings()
+        except Exception as error:  # noqa: BLE001 - authenticated refresh still runs
+            public_error = error
         await self._refresh_codex_model_catalog()
+        if public_error is not None:
+            raise public_error
+        assert result is not None
         return result
 
     async def _refresh_codex_model_catalog(self) -> None:
@@ -2364,12 +2431,39 @@ class CodingSession:
         try:
             catalog = await temporary_provider.discover_models()
             self._publish_runtime_model_catalog(provider_config.name, catalog)
+            self._persist_codex_model_catalog(temporary_provider, catalog, provider_config)
         except Exception as exc:  # noqa: BLE001 - static catalog remains the safe fallback
             self._model_catalog_discovery_errors[provider_config.name] = (
                 f"{type(exc).__name__}: {exc}"
             )
         finally:
             await temporary_provider.aclose()
+
+    def _persist_codex_model_catalog(
+        self,
+        provider: object,
+        catalog: RuntimeModelCatalog,
+        provider_config: OpenAICodexProviderConfig | None = None,
+    ) -> None:
+        config = provider_config or (
+            self._runtime_provider_config
+            if isinstance(self._runtime_provider_config, OpenAICodexProviderConfig)
+            else None
+        )
+        if config is None:
+            return
+        account_id = getattr(provider, "account_id", None) or _codex_account_id(
+            config,
+            self._credential_store,
+        )
+        if not isinstance(account_id, str) or not account_id:
+            return
+        with suppress(OSError, TypeError, ValueError):
+            save_codex_model_catalog(
+                catalog,
+                account_id=account_id,
+                paths=self._resource_paths.paths,
+            )
 
     def _publish_runtime_model_catalog(
         self,
@@ -2380,6 +2474,7 @@ class CodingSession:
             raise ValueError("provider returned an empty model catalog")
         self._runtime_model_catalogs[provider_name] = catalog
         self._model_catalog_discovery_errors.pop(provider_name, None)
+        self._invalidate_runtime_model_limits()
         self._apply_runtime_model_catalogs()
 
     def _apply_runtime_model_catalogs(self) -> None:
@@ -4061,6 +4156,7 @@ class _PreparedProvider:
     inference_provider_mode: InferenceProviderMode
     runtime_provider_config: ProviderConfig | None
     dynamic_provider: DynamicProvider | None
+    runtime_model_catalog: RuntimeModelCatalog | None = None
 
 
 async def _prepare_provider_selection(
@@ -4132,6 +4228,7 @@ async def _prepare_provider_selection(
             )
 
     settings = config.provider_settings
+    discovered_catalog: RuntimeModelCatalog | None = None
     if settings is None:
         raise ProviderConfigError(
             f"Provider is not available after trusted extension loading: "
@@ -4157,6 +4254,7 @@ async def _prepare_provider_selection(
             if isinstance(discovery_provider, ModelCatalogProvider):
                 catalog = await discovery_provider.discover_models()
                 if catalog.models:
+                    discovered_catalog = catalog
                     live_provider = _provider_with_runtime_model_catalog(selected_provider, catalog)
                     settings = replace(
                         settings,
@@ -4209,6 +4307,7 @@ async def _prepare_provider_selection(
         inference_provider_mode=inference_provider_mode,
         runtime_provider_config=selection.provider,
         dynamic_provider=None,
+        runtime_model_catalog=discovered_catalog,
     )
 
 
@@ -4565,6 +4664,42 @@ def _system_prompt_resource_signatures(
         append_system_prompt,
         tuple(str(path) for path in append_system_prompt_paths),
     )
+
+
+def _provider_config_or_none(
+    settings: ProviderSettings | None,
+    provider_name: str | None,
+) -> ProviderConfig | None:
+    if settings is None or provider_name is None:
+        return None
+    try:
+        return settings.get_provider(provider_name)
+    except ProviderConfigError:
+        return None
+
+
+def _codex_account_id(
+    provider: OpenAICodexProviderConfig,
+    credential_store: FileCredentialStore,
+) -> str | None:
+    if provider.credential_name:
+        credential = credential_store.get_oauth(provider.credential_name)
+        if credential is not None and credential.account_id:
+            return credential.account_id
+    return account_id_from_access_token(environ.get(provider.api_key_env, ""))
+
+
+def _provider_settings_with_runtime_catalogs(
+    settings: ProviderSettings | None,
+    catalogs: Mapping[str, RuntimeModelCatalog],
+) -> ProviderSettings | None:
+    if settings is None or not catalogs:
+        return settings
+    providers = tuple(
+        _provider_with_runtime_model_catalog(provider, catalogs.get(provider.name))
+        for provider in settings.providers
+    )
+    return replace(settings, providers=providers)
 
 
 def _provider_with_runtime_model_catalog(

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6408,6 +6408,29 @@ class TauTuiApp(App[None]):
             ),
             callback=self._handle_scoped_models_picker_result,
         )
+        self.run_worker(self._refresh_open_scoped_models_picker(), exclusive=False)
+
+    async def _refresh_open_scoped_models_picker(self) -> None:
+        refresh = getattr(self.session, "refresh_model_catalogs", None)
+        if not callable(refresh):
+            return
+        try:
+            await refresh()
+        except Exception as error:
+            if isinstance(self.screen, ModelPickerScreen):
+                self._notify(f"Could not refresh model catalogs: {error}", severity="warning")
+            return
+        if not isinstance(self.screen, ModelPickerScreen):
+            return
+        picker = self.screen
+        while not picker.is_mounted:
+            await asyncio.sleep(0)
+            if self.screen is not picker:
+                return
+        picker.update_choices(
+            self._available_model_choices(),
+            tuple(getattr(self.session, "scoped_model_choices", ())),
+        )
 
     def _toggle_scoped_model(self, choice: ModelChoice) -> Sequence[ModelChoice]:
         toggle_scoped_model = getattr(self.session, "toggle_scoped_model", None)

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -6408,29 +6408,7 @@ class TauTuiApp(App[None]):
             ),
             callback=self._handle_scoped_models_picker_result,
         )
-        self.run_worker(self._refresh_open_scoped_models_picker(), exclusive=False)
-
-    async def _refresh_open_scoped_models_picker(self) -> None:
-        refresh = getattr(self.session, "refresh_model_catalogs", None)
-        if not callable(refresh):
-            return
-        try:
-            await refresh()
-        except Exception as error:
-            if isinstance(self.screen, ModelPickerScreen):
-                self._notify(f"Could not refresh model catalogs: {error}", severity="warning")
-            return
-        if not isinstance(self.screen, ModelPickerScreen):
-            return
-        picker = self.screen
-        while not picker.is_mounted:
-            await asyncio.sleep(0)
-            if self.screen is not picker:
-                return
-        picker.update_choices(
-            self._available_model_choices(),
-            tuple(getattr(self.session, "scoped_model_choices", ())),
-        )
+        self.run_worker(self._refresh_open_model_picker(), exclusive=False)
 
     def _toggle_scoped_model(self, choice: ModelChoice) -> Sequence[ModelChoice]:
         toggle_scoped_model = getattr(self.session, "toggle_scoped_model", None)

--- a/tests/test_codex_model_store.py
+++ b/tests/test_codex_model_store.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from tau_ai.model_catalog import RuntimeModel, RuntimeModelCatalog
+from tau_ai.model_limits import RuntimeModelLimits
+from tau_coding.codex_model_store import (
+    cached_codex_model_catalog,
+    save_codex_model_catalog,
+)
+from tau_coding.paths import TauPaths
+
+
+def test_codex_model_catalog_round_trips_with_account_scope(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau")
+    catalog = RuntimeModelCatalog(
+        (
+            RuntimeModel(
+                id="gpt-live",
+                name="GPT Live",
+                limits=RuntimeModelLimits(
+                    context_window=400_000,
+                    max_output_tokens=100_000,
+                    effective_context_window_percent=95,
+                    auto_compact_token_limit=350_000,
+                ),
+                input_modalities=("text", "image"),
+                thinking_levels=("low", "high"),
+                default_thinking_level="high",
+            ),
+        )
+    )
+
+    path = save_codex_model_catalog(catalog, account_id="account-1", paths=paths, now=123.0)
+
+    assert path == paths.codex_models_store_path
+    assert cached_codex_model_catalog(paths, account_id="other-account") is None
+    assert cached_codex_model_catalog(paths, account_id="account-1") == catalog
+
+
+def test_codex_model_catalog_cache_rejects_invalid_documents(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau")
+    paths.codex_models_store_path.parent.mkdir(parents=True)
+    paths.codex_models_store_path.write_text(
+        '{"schema_version": 1, "account_id": "account-1", "catalog": {"models": []}}',
+        encoding="utf-8",
+    )
+
+    assert cached_codex_model_catalog(paths, account_id="account-1") is None

--- a/tests/test_codex_model_store.py
+++ b/tests/test_codex_model_store.py
@@ -1,4 +1,7 @@
+import json
 from pathlib import Path
+
+import pytest
 
 from tau_ai.model_catalog import RuntimeModel, RuntimeModelCatalog
 from tau_ai.model_limits import RuntimeModelLimits
@@ -34,6 +37,28 @@ def test_codex_model_catalog_round_trips_with_account_scope(tmp_path: Path) -> N
     assert path == paths.codex_models_store_path
     assert cached_codex_model_catalog(paths, account_id="other-account") is None
     assert cached_codex_model_catalog(paths, account_id="account-1") == catalog
+
+
+@pytest.mark.parametrize("field", ["input_modalities", "thinking_levels"])
+@pytest.mark.parametrize("invalid_item", [{}, [], None, 1, True, "unknown"])
+def test_codex_model_catalog_cache_rejects_invalid_model_values(
+    tmp_path: Path, field: str, invalid_item: object
+) -> None:
+    paths = TauPaths(home=tmp_path)
+    model = {
+        "id": "gpt-live",
+        "input_modalities": ["text"],
+        "thinking_levels": ["low"],
+    }
+    document = {
+        "schema_version": 1,
+        "account_id": "account-1",
+        "catalog": {"models": [model]},
+    }
+    model[field] = [invalid_item]
+    paths.codex_models_store_path.write_text(json.dumps(document), encoding="utf-8")
+
+    assert cached_codex_model_catalog(paths, account_id="account-1") is None
 
 
 def test_codex_model_catalog_cache_rejects_invalid_documents(tmp_path: Path) -> None:

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -66,6 +66,7 @@ from tau_coding import (
     save_provider_settings,
 )
 from tau_coding import session as coding_session_module
+from tau_coding.codex_model_store import cached_codex_model_catalog, save_codex_model_catalog
 from tau_coding.events import AgentSettledEvent, QueueUpdateEvent
 from tau_coding.extensions import (
     DynamicProvider,
@@ -3863,6 +3864,64 @@ async def test_session_uses_live_provider_limits_for_compaction_threshold(
 
 
 @pytest.mark.anyio
+async def test_session_uses_cached_codex_model_inventory_before_live_refresh(
+    tmp_path: Path,
+) -> None:
+    tau_paths = TauPaths(home=tmp_path / ".tau")
+    FileCredentialStore(tau_paths.home / "credentials.json").set_oauth(
+        "openai-codex",
+        OAuthCredential(
+            access="access-token",
+            refresh="refresh-token",
+            expires=4_000_000_000,
+            account_id="account-1",
+        ),
+    )
+    cached = RuntimeModelCatalog(
+        (
+            RuntimeModel(
+                id="cached-model",
+                limits=RuntimeModelLimits(context_window=500_000),
+            ),
+        )
+    )
+    save_codex_model_catalog(cached, account_id="account-1", paths=tau_paths)
+    provider = ModelCatalogFakeProvider([], catalog=RuntimeModelCatalog(()))
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=("static-model",),
+                default_model="static-model",
+                context_windows={"static-model": 272_000},
+            ),
+        ),
+    )
+
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model="static-model",
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    try:
+        assert provider.catalog_calls == 0
+        assert session.available_models == ("cached-model",)
+        live = session.provider_config("openai-codex")
+        assert live is not None
+        assert live.context_windows == {"cached-model": 500_000}
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.anyio
 async def test_session_publishes_authenticated_codex_model_inventory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -3943,6 +4002,7 @@ async def test_session_publishes_authenticated_codex_model_inventory(
     assert provider.catalog_calls == 1
     assert refreshed.catalog_calls == 1
     assert refreshed.closed is True
+    assert cached_codex_model_catalog(tau_paths, account_id="account-1") == refreshed.catalog
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7806,6 +7806,7 @@ async def test_tui_scoped_models_picker_toggles_scoped_models_without_switching_
         await pilot.pause()
 
         assert isinstance(app.screen, ModelPickerScreen)
+        assert session.model_catalog_refresh_count == 1
         tabs = app.screen.query_one("#model-picker-tabs", Static)
         assert str(tabs.render()) == "Tabs: ● All models  ○ Scoped models"
         await pilot.press("enter")
@@ -7844,6 +7845,7 @@ async def test_tui_scoped_models_picker_tab_shows_only_scoped_models_for_unselec
         await pilot.pause()
 
         assert isinstance(app.screen, ModelPickerScreen)
+        assert session.model_catalog_refresh_count == 1
         await pilot.press("tab")
         await pilot.pause()
 

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -108,23 +108,27 @@ window through Codex OAuth than through an API key. For example, the public
 GPT-5.6 Sol API advertises a 1.05M-token window, while Codex has advertised
 substantially smaller limits through its authenticated model catalog.
 
-Tau queries that catalog when a Codex session starts and whenever `/model`
-refreshes. Since OpenAI filters the response by official-client version, Tau
-resolves the current stable `@openai/codex` release from the npm registry and
-caches that safe, non-secret version for four hours at
-`~/.tau/codex-version-store.json`. Failed lookups use the stale cached version or
-Tau's bundled fallback. The authenticated result replaces the Codex model picker
-inventory for the current process, so newly enabled and newly client-gated models
-appear without a Tau release. Models unavailable to the account are not copied
-from the separate public API catalog. Tau also uses reported context windows,
-compaction thresholds, input modalities, and reasoning efforts when present.
+Tau loads the last successful account-specific snapshot from
+`~/.tau/codex-models-store.json` when a session starts, so models discovered in a
+previous session are immediately available without opening a picker. It refreshes
+the authenticated catalog in the background when `/model` or `/scoped-models`
+opens. Since OpenAI filters the response by official-client version, Tau resolves
+the current stable `@openai/codex` release from the npm registry and caches that
+safe, non-secret version for four hours at `~/.tau/codex-version-store.json`.
+Failed lookups use the stale cached version or Tau's bundled fallback. A
+successful refresh replaces the Codex model picker inventory, so newly enabled
+and newly client-gated models appear without a Tau release. Models unavailable to
+the account are not copied from the separate public API catalog. Tau also uses
+reported context windows, compaction thresholds, input modalities, and reasoning
+efforts when present.
 
-If discovery is unavailable or invalid, Tau retains the checked-in Codex model
-list and its conservative Codex-specific limits; it does not reuse the public
-API inventory or limits. `/session` reports whether the active context value
-came from the live provider catalog or Tau's configured fallback. Live snapshots
-are account-specific and memory-only; Tau does not write them to `catalog.toml`,
-`providers.json`, or its models.dev cache.
+If discovery is unavailable or invalid, Tau retains the last account-matched
+snapshot, or the checked-in Codex model list when no snapshot is available; it
+does not reuse the public API inventory or limits. `/session` reports whether the
+active context value came from the live provider catalog or Tau's configured
+fallback. The model cache contains only parsed account/model metadata (no OAuth
+tokens), is scoped to the saved Codex account ID, and is never written to
+`catalog.toml`, `providers.json`, or the models.dev cache.
 
 Starting or resuming a live-only Codex model discovers the account inventory
 before validating the selection. This requires successful discovery; offline

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -211,9 +211,13 @@ when you want to reduce what is sent to the model.
 ## Picking models and themes
 
 - **`/model`** opens the model picker. It shows cached/bundled models immediately,
-  refreshes catalogs in the background, and updates the open list. Selecting a
-  model from another provider switches the active provider too. Use
-  `tau update --models` to force refresh or `TAU_OFFLINE=1` to disable it.
+  refreshes catalogs in the background, and updates the open list. The
+  account-scoped Codex snapshot is also reused across sessions, and `/model`
+  refreshes it.
+- **`/scoped-models`** opens the favorite-model picker and refreshes provider
+  catalogs in the background too, so newly discovered Codex models can be
+  scoped without opening `/model` first. Use `tau update --models` to force
+  public-catalog refresh or `TAU_OFFLINE=1` to disable catalog network access.
 - **Ctrl+P** quickly cycles forward through your *scoped* (favorite) models;
   **Shift+Ctrl+P** cycles backward. Neither opens the picker. Manage that list
   with `/scoped-models` or by pressing `Space` on a model in the `/model` picker.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -14,6 +14,7 @@ those locations and file formats.
 ├── catalog.toml        # optional provider/model catalog overlay
 ├── providers.json      # provider/model preferences
 ├── models-store.json   # refreshed models.dev catalog cache
+├── codex-models-store.json # account-scoped Codex model snapshot
 ├── credentials.json    # saved API keys / OAuth tokens (0600, atomic writes)
 ├── state/extensions/    # built-in integration state, including llama.cpp
 ├── settings.json       # general settings (trust default, shell prefix)
@@ -47,6 +48,11 @@ Startup update checks cache their latest PyPI result in
 bundled snapshot. `/model` refreshes it in the background at most every four
 hours; `tau update --models` forces revalidation. Set `TAU_OFFLINE=1` to disable
 catalog network access. User `catalog.toml` overrides still apply after the cache.
+
+`codex-models-store.json` contains only parsed model metadata and the active
+Codex account ID. Tau loads it at startup, then refreshes it when `/model` or
+`/scoped-models` opens; a snapshot from a different account is ignored. It never
+contains OAuth tokens.
 
 ## System prompt files
 

--- a/website/content/reference/slash-commands.md
+++ b/website/content/reference/slash-commands.md
@@ -17,9 +17,9 @@ command palette with **Ctrl+K**.
 | `/resume [session-id]` | Resume a previous session, or open the picker |
 | `/tree` | Branch from an earlier point in the session tree |
 | `/name <new name>` | Rename the current session and, in supported terminals, the terminal tab title |
-| `/model` | Open the model picker |
+| `/model` | Refresh provider catalogs and open the model picker |
 | `/tools` | Browse active tools and open their full descriptions |
-| `/scoped-models` | Choose favorite models for the Ctrl+P / Shift+Ctrl+P quick-cycle |
+| `/scoped-models` | Refresh provider catalogs and choose favorite models for the Ctrl+P / Shift+Ctrl+P quick-cycle |
 | `/theme [name]` | Show or set the TUI theme |
 | `/login [provider]` | Connect a built-in provider with OAuth or an API key; Anthropic uses `anthropic-subscription` or `anthropic-api` |
 | `/local` | Choose and manage a registered local backend; interactive-only. Compatible llama.cpp routers add explicit load/unload, Hugging Face GGUF search, and server-side download actions with confirmation and reconciliation. |


### PR DESCRIPTION
## Summary

- Persist account-scoped OpenAI Codex OAuth model catalogs in `~/.tau/codex-models-store.json`.
- Reuse the cached catalog at startup and refresh it when `/model` or `/scoped-models` opens.
- Add cache validation, regression tests, and user/developer documentation.

## User experience

Models discovered from the live Codex catalog remain available in later Tau sessions without requiring `/model` first. Both model pickers still refresh in the background, so newly enabled models appear without restarting Tau.

## Issue

Addresses the requested OpenAI/Codex OAuth live-catalog persistence and `/scoped-models` refresh behavior.

## Manual validation

1. Authenticate with `/login openai-codex`.
2. Open `/model` and wait for the live Codex catalog refresh.
3. Exit and start Tau again; open `/model` and confirm the discovered models appear immediately.
4. Open `/scoped-models` and confirm it also refreshes the Codex catalog.
5. Set `TAU_OFFLINE=1` and confirm the account-matched cache remains available without network access.

## Verification

- `uv run pytest` — 1907 passed, 3 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — passed
- `uv build` — passed
- Hugo website build not run: `hugo` is not installed in the environment.
