### PR TITLE
Ignore Anthropic SSE [DONE] sentinel

### DIFF
--- a/src/tau_ai/anthropic.py
+++ b/src/tau_ai/anthropic.py
@@ -704,7 +704,9 @@ def _parse_sse_line(line: str) -> str | None:
     if not line or not line.startswith("data:"):
         return None
     data = line.removeprefix("data:").strip()
-    return data or None
+    if not data or data == "[DONE]":
+        return None
+    return data
 
 
 def _loads_object(text: str) -> dict[str, Any] | None:

--- a/tests/test_anthropic_sse.py
+++ b/tests/test_anthropic_sse.py
@@ -47,3 +47,40 @@ async def test_anthropic_provider_ignores_empty_data_frames() -> None:
 
     assert isinstance(events[-1], AssistantDoneEvent)
     assert events[-1].message.text == "ok"
+
+
+@pytest.mark.anyio
+async def test_anthropic_provider_ignores_done_sentinel() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"message_start","message":{"usage":{}}}\n\n'
+                'data: {"type":"content_block_delta","index":0,'
+                '"delta":{"type":"text_delta","text":"ok"}}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+                '"usage":{"output_tokens":1}}\n\n'
+                "data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = AnthropicProvider(
+            AnthropicConfig(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+            ),
+            client=client,
+        )
+        events = await _collect(
+            provider.stream_response(
+                model="claude-test",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    assert isinstance(events[-1], AssistantDoneEvent)
+    assert events[-1].message.text == "ok"


### PR DESCRIPTION
Follow-up to #679 and #680.

GitHub Copilot's Anthropic-compatible proxy can terminate a stream with `data: [DONE]` instead of an Anthropic `message_stop` event. The Anthropic SSE parser currently forwards that sentinel to the JSON decoder, which turns it into `Provider returned invalid JSON chunk`.

This change:

* ignores the `[DONE]` SSE sentinel in the Anthropic parser, alongside blank `data:` frames
* adds a focused regression test using `httpx.MockTransport` that completes successfully when the stream ends with `data: [DONE]`

The change is intentionally scoped to the Anthropic-compatible path reported in #679.
