### PR TITLE
fix(tui): re-theme sidebar collapsible titles on theme switch (#693)

### DIFF
--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4125,10 +4125,12 @@ class TauTuiApp(App[None]):
         if getattr(self, "_applying_settings_theme", False):
             return
         tau_theme: TuiThemeName = theme_name
-        if self.tui_settings.theme == tau_theme:
-            return
-        self._replace_tui_settings(theme=tau_theme)
-        save_tui_settings(self.tui_settings)
+        if self.tui_settings.theme != tau_theme:
+            self._replace_tui_settings(theme=tau_theme)
+            save_tui_settings(self.tui_settings)
+        # Re-render theme-baked chrome so a Textual-side theme switch updates
+        # the sidebar even when Tau's durable settings already match.
+        self._refresh_chrome_if_mounted()
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Return Tau-specific CSS variables for the selected TUI theme."""

--- a/src/tau_coding/tui/widgets.py
+++ b/src/tau_coding/tui/widgets.py
@@ -115,6 +115,32 @@ class SessionSummarySource(Protocol):
     def session_stats(self) -> SessionStats: ...
 
 
+def _set_collapsible_title(collapsible: Collapsible, title: str) -> None:
+    """Set a Collapsible title, forcing a re-render on style-only changes.
+
+    Textual's ``CollapsibleTitle`` keeps the title in a reactive ``label`` whose
+    change detection compares plain text only, so re-theming a title whose text
+    is unchanged leaves the previously baked colors in place. When the new
+    markup differs from the current label, push it directly onto the label
+    widget and keep its reactive state in sync so later collapse/expand toggles
+    keep the new colors.
+    """
+    collapsible.title = title
+    title_widget = collapsible._title
+    new_label = Content.from_markup(title)
+    current_label = title_widget.label
+    if isinstance(current_label, Content) and new_label.is_same(current_label):
+        return
+    symbol = (
+        title_widget.expanded_symbol
+        if not title_widget.collapsed
+        else title_widget.collapsed_symbol
+    )
+    title_widget.update(Content.assemble(symbol, " ", new_label))
+    if hasattr(title_widget, "_reactive_label"):
+        title_widget._reactive_label = new_label
+
+
 class SessionSidebar(Vertical):
     """Compact sidebar with collapsible resource lists and pinned branding."""
 
@@ -164,13 +190,16 @@ class SessionSidebar(Vertical):
             Group(*_separate_sidebar_sections(content.summary_sections, theme=theme)),
         )
         skills = self.query_one("#sidebar-skills", Collapsible)
-        skills.title = _skill_section_title(session, theme=theme)
+        _set_collapsible_title(skills, _skill_section_title(session, theme=theme))
         self.query_one("#sidebar-skills-content", Static).update(content.skills)
         prompts = self.query_one("#sidebar-prompts", Collapsible)
-        prompts.title = _sidebar_resource_title(
-            "prompts",
-            str(len(session.prompt_templates)),
-            theme=theme,
+        _set_collapsible_title(
+            prompts,
+            _sidebar_resource_title(
+                "prompts",
+                str(len(session.prompt_templates)),
+                theme=theme,
+            ),
         )
         self.query_one("#sidebar-prompts-content", Static).update(content.prompts)
         self.query_one("#sidebar-extensions-content", Static).update(

--- a/tests/test_tui_components.py
+++ b/tests/test_tui_components.py
@@ -12,14 +12,16 @@ transcript.
 from pathlib import Path
 
 import pytest
+from rich.style import Style as RichStyle
 from textual.containers import Container
-from textual.widgets import Static
+from textual.widgets import Collapsible, Static
 
 from conftest import isolate_home
 from tau_coding.extensions import ExtensionRuntime
 from tau_coding.tui.app import PromptInput, TauTuiApp
 from tau_coding.tui.config import TuiSettings
-from tau_coding.tui.widgets import TranscriptView
+from tau_coding.tui.themes import get_tui_theme
+from tau_coding.tui.widgets import SessionSidebar, TranscriptView
 from test_tui_app import (  # noqa: E402 - sibling test module (see docstring)
     FakeSession,
     _component_bridge,
@@ -445,6 +447,65 @@ async def test_sidebar_factory_rebuilds_with_live_theme(
             app.query_one("#sidebar-extension-sections .theme-body", Static).render().plain
             == "tau-light"
         )
+
+
+def _collapsible_title_color(collapsible: Collapsible) -> str:
+    """Return the hex color of the first styled span in the title label."""
+
+    def _hex(color) -> str:  # noqa: ANN001
+        triplet = color.triplet
+        return f"{triplet.red:02x}{triplet.green:02x}{triplet.blue:02x}"
+
+    label = collapsible._title.label
+    for span in label.spans:
+        if span.start == 0:
+            style = span.style
+            if hasattr(style, "color"):
+                assert style.color is not None
+                return _hex(style.color)
+            parsed = RichStyle.parse(str(style))
+            assert parsed.color is not None
+            return _hex(parsed.color)
+    raise AssertionError(f"no styled span covers the title start: {label.plain!r}")
+
+
+@pytest.mark.anyio
+async def test_sidebar_collapsible_titles_retheme_on_theme_switch() -> None:
+    """skills/prompts titles must re-render their baked colors on theme switch.
+
+    Textual's CollapsibleTitle stores the title in a reactive label whose
+    change detection compares plain text only, so a theme switch that keeps the
+    title text unchanged leaves the old colors behind. The sidebar must force
+    the label to re-render whenever the themed markup differs.
+    """
+    dark = get_tui_theme("tau-dark")
+    light = get_tui_theme("tau-light")
+    app = TauTuiApp(FakeSession(), tui_settings=TuiSettings(theme="tau-dark"))
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        sidebar = app.query_one("#sidebar", SessionSidebar)
+        skills = sidebar.query_one("#sidebar-skills", Collapsible)
+        prompts = sidebar.query_one("#sidebar-prompts", Collapsible)
+
+        assert _collapsible_title_color(skills) == dark.prompt_text.lstrip("#")
+        assert _collapsible_title_color(prompts) == dark.prompt_text.lstrip("#")
+
+        # Tau's own /theme route.
+        app._set_tui_theme("tau-light")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _collapsible_title_color(skills) == light.prompt_text.lstrip("#")
+        assert _collapsible_title_color(prompts) == light.prompt_text.lstrip("#")
+
+        # Textual-native theme assignment must refresh chrome too.
+        app.theme = "tau-dark"
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _collapsible_title_color(skills) == dark.prompt_text.lstrip("#")
+        assert _collapsible_title_color(prompts) == dark.prompt_text.lstrip("#")
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #693

## Motivation

The skills and prompts collapsible section titles in the sidebar keep the dark-theme color #e5e7eb after switching to the light theme, instead of using the light-theme color #111827. All other sidebar content switches correctly.

## Root cause

Textual's CollapsibleTitle stores the title in a reactive label whose change detection compares plain text only. textual.content.Content.__eq__ ignores styles, so when a theme switch changes only the title colors and not the text, the reactive check sees no change and the old colored spans are kept.

## Changes

- widgets.py adds _set_collapsible_title, which compares the new label with Content.is_same and forces a re-render when only the styling changed
- app.py _watch_theme now calls _refresh_chrome_if_mounted so Textual-native theme switches refresh the sidebar too
- test_tui_components.py adds a regression test covering both switch routes

## Verification

- pytest: 1921 passed
- ruff check: passed
- ruff format: passed
- mypy: passed
