### PR TITLE
Fix subscription sessions showing API cost estimates

### DIFF
--- a/dev-notes/subscription-pricing.md
+++ b/dev-notes/subscription-pricing.md
@@ -8,10 +8,10 @@ cache, timing, and tool-usage totals, but their dollar estimate is unavailable.
 The TUI and HTML usage dashboard therefore show no API-equivalent cost for them.
 
 The session marks each persisted assistant response with `usage.pricing_mode =
-"subscription"`. This keeps later views from changing newly recorded API
-responses when a session is resumed with a subscription credential. Provider-
-neutral agent messages leave the field unset and retain the existing catalog-
-pricing behavior.
+"subscription"` or `"api"`. This keeps later views from changing newly recorded
+responses when a session is resumed with a different credential. Provider-neutral
+agent messages leave the field unset and retain the existing catalog-pricing
+behavior.
 
 ## Why
 

--- a/dev-notes/subscription-pricing.md
+++ b/dev-notes/subscription-pricing.md
@@ -1,0 +1,34 @@
+# Subscription-backed pricing
+
+## What changed
+
+Tau no longer applies catalog API rates to assistant responses made through
+subscription-backed OAuth credentials. Those responses still contribute token,
+cache, timing, and tool-usage totals, but their dollar estimate is unavailable.
+The TUI and HTML usage dashboard therefore show no API-equivalent cost for them.
+
+The session marks each persisted assistant response with `usage.pricing_mode =
+"subscription"`. This keeps later views from changing newly recorded API
+responses when a session is resumed with a subscription credential. Provider-
+neutral agent messages leave the field unset and retain the existing catalog-
+pricing behavior.
+
+## Why
+
+Catalog rates describe metered API list prices. They do not describe a ChatGPT,
+Claude, or other subscription's quota accounting. Authentication and pricing
+are consequently resolved separately: API-key requests may use catalog rates,
+while OAuth-backed subscription requests do not.
+
+Anthropic is supported in both modes. Tau checks the credential actually used,
+not merely whether the provider supports OAuth. OpenAI Codex remains
+subscription-backed by provider type.
+
+## Validation
+
+```bash
+uv run pytest tests/test_session_stats.py tests/test_session_usage.py tests/test_coding_session.py
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/src/tau_agent/__init__.py
+++ b/src/tau_agent/__init__.py
@@ -31,6 +31,7 @@ from tau_agent.messages import (
     CompactionSummaryMessage,
     CustomMessage,
     ImageContent,
+    PricingMode,
     ResponseTiming,
     TextContent,
     ThinkingContent,

--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -42,6 +42,9 @@ class UsageCost(WireModel):
     total: float = 0.0
 
 
+PricingMode = Literal["api", "subscription"]
+
+
 class Usage(WireModel):
     """Provider-reported token usage for one assistant response."""
 
@@ -53,6 +56,9 @@ class Usage(WireModel):
     reasoning: int | None = None
     total_tokens: int = 0
     cost: UsageCost = UsageCost()
+    # Coding-session hosts set this when the request used subscription OAuth.
+    # ``None`` preserves compatibility with provider-neutral and legacy messages.
+    pricing_mode: PricingMode | None = None
 
 
 class ResponseTiming(WireModel):

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -57,6 +57,8 @@ class RpcSession(Protocol):
 
     def provider_config(self, provider_name: str) -> ProviderConfig | None: ...
 
+    def provider_uses_subscription_auth(self, provider_name: str) -> bool: ...
+
     @property
     def messages(self) -> tuple[object, ...]: ...
 
@@ -602,7 +604,12 @@ def _model_wire(session: RpcSession, *, choice: ModelChoice | None = None) -> di
         if provider is not None
         else None
     )
-    cost = metadata.cost if metadata is not None else {}
+    cost = (
+        metadata.cost
+        if metadata is not None
+        and not session.provider_uses_subscription_auth(selected.provider_name)
+        else {}
+    )
     return {
         "id": selected.model,
         "name": metadata.name if metadata is not None and metadata.name else selected.model,

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -3413,23 +3413,25 @@ class CodingSession:
 
     async def _persist_on_message_end(self, event: AgentEvent) -> None:
         if isinstance(event, MessageEndEvent):
-            self._mark_subscription_pricing(event.message)
+            self._mark_pricing_mode(event.message)
             self._ended_message_ids.add(id(event.message))
             await self._persist_message(event.message)
 
-    def _mark_subscription_pricing(self, message: AgentMessage) -> None:
-        """Mark responses made through subscription-backed authentication.
+    def _mark_pricing_mode(self, message: AgentMessage) -> None:
+        """Persist the authentication pricing mode used for a response.
 
-        The marker is persisted with the response so later session views do not
-        reinterpret historical API requests using the credential active at view
-        time. Provider-neutral callers that do not go through CodingSession keep
-        the field unset and retain the existing catalog-pricing behavior.
+        Recording both modes keeps later session views from reinterpreting
+        historical requests using the credential active at view time.
+        Provider-neutral callers that do not go through CodingSession keep the
+        field unset and retain the existing catalog-pricing behavior.
         """
         if not isinstance(message, AssistantMessage):
             return
         provider_name = message.provider if message.provider != "unknown" else self.provider_name
-        if self.provider_uses_subscription_auth(provider_name):
-            message.usage = message.usage.model_copy(update={"pricing_mode": "subscription"})
+        pricing_mode = (
+            "subscription" if self.provider_uses_subscription_auth(provider_name) else "api"
+        )
+        message.usage = message.usage.model_copy(update={"pricing_mode": pricing_mode})
 
     async def _persist_message(self, message: AgentMessage) -> None:
         """Persist one completed message at the active branch tip, idempotently.

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -85,6 +85,7 @@ from tau_coding.extensions.providers import DynamicProvider, ProviderModel
 from tau_coding.extensions.runtime import ExtensionRuntime
 from tau_coding.models_dev_store import ModelsDevRefreshResult, refresh_models_dev_catalog
 from tau_coding.oauth import account_id_from_access_token
+from tau_coding.oauth_registry import get_oauth_provider
 from tau_coding.paths import TauPaths
 from tau_coding.project_trust import (
     CanonicalProjectPath,
@@ -1237,12 +1238,26 @@ class CodingSession:
         """Return loaded extension names in load order."""
         return self._extension_runtime.extension_names
 
+    def provider_uses_subscription_auth(self, provider_name: str) -> bool:
+        """Return whether the active credentials use a subscription endpoint."""
+        provider = self.provider_config(provider_name)
+        if provider is None:
+            return False
+        if isinstance(provider, OpenAICodexProviderConfig):
+            return True
+        return bool(
+            provider.credential_name
+            and get_oauth_provider(provider_name) is not None
+            and self._credential_store.get_oauth(provider.credential_name) is not None
+        )
+
     @property
     def session_stats(self) -> SessionStats:
-        """Return cumulative activity and billed usage for the active branch."""
+        """Return cumulative activity and estimated usage for the active branch."""
         return calculate_session_stats(
             self._state.entries,
             pricing=self._pricing_for_response,
+            subscription_pricing=self.provider_uses_subscription_auth,
         )
 
     def _pricing_for_response(
@@ -3398,8 +3413,23 @@ class CodingSession:
 
     async def _persist_on_message_end(self, event: AgentEvent) -> None:
         if isinstance(event, MessageEndEvent):
+            self._mark_subscription_pricing(event.message)
             self._ended_message_ids.add(id(event.message))
             await self._persist_message(event.message)
+
+    def _mark_subscription_pricing(self, message: AgentMessage) -> None:
+        """Mark responses made through subscription-backed authentication.
+
+        The marker is persisted with the response so later session views do not
+        reinterpret historical API requests using the credential active at view
+        time. Provider-neutral callers that do not go through CodingSession keep
+        the field unset and retain the existing catalog-pricing behavior.
+        """
+        if not isinstance(message, AssistantMessage):
+            return
+        provider_name = message.provider if message.provider != "unknown" else self.provider_name
+        if self.provider_uses_subscription_auth(provider_name):
+            message.usage = message.usage.model_copy(update={"pricing_mode": "subscription"})
 
     async def _persist_message(self, message: AgentMessage) -> None:
         """Persist one completed message at the active branch tip, idempotently.

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -10,12 +10,13 @@ from tau_agent.session import MessageEntry
 from tau_agent.session.entries import SessionEntry
 
 PricingResolver = Callable[[str, str, int], Mapping[str, float] | None]
+SubscriptionPricingResolver = Callable[[str], bool]
 _TOKENS_PER_MILLION = 1_000_000
 
 
 @dataclass(frozen=True, slots=True)
 class SessionStats:
-    """Cumulative activity and billed usage for one active branch."""
+    """Cumulative activity and estimated usage for one active branch."""
 
     turn_count: int = 0
     tool_call_count: int = 0
@@ -72,6 +73,7 @@ def calculate_session_stats(
     entries: Sequence[SessionEntry],
     *,
     pricing: PricingResolver,
+    subscription_pricing: SubscriptionPricingResolver | None = None,
 ) -> SessionStats:
     """Aggregate original branch messages, including messages replaced by compaction."""
     turn_count = 0
@@ -124,6 +126,19 @@ def calculate_session_stats(
             continue
 
         has_billable_usage = True
+        is_subscription = usage.pricing_mode == "subscription" or (
+            usage.pricing_mode is None
+            and subscription_pricing is not None
+            and subscription_pricing(message.provider)
+        )
+        if is_subscription:
+            if usage.cost.total > 0:
+                # A provider-reported cost is still useful when a subscription
+                # endpoint explicitly reports a charge.
+                estimated_cost += usage.cost.total
+            else:
+                has_complete_pricing = False
+            continue
         rates = pricing(message.provider, message.model, prompt_tokens)
         if rates is None:
             if usage.cost.total > 0:

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from tau_agent.messages import AssistantMessage
+from tau_agent.messages import AssistantMessage, PricingMode
 from tau_agent.session import (
     BranchSummaryEntry,
     CompactionEntry,
@@ -19,6 +19,9 @@ from tau_agent.session import (
 from tau_coding.provider_catalog import builtin_provider_entry, model_cost_for_input_tokens
 from tau_coding.session_stats import _response_cost
 from tau_coding.tui.themes import TAU_DARK_THEME, TAU_LIGHT_THEME
+
+_SUBSCRIPTION_PROVIDERS = frozenset({"openai-codex", "github-copilot"})
+
 
 __all__ = [
     "RequestUsage",
@@ -48,6 +51,7 @@ class RequestUsage:
     reasoning: int
     stop_reason: str
     estimated_cost: float | None
+    pricing_mode: PricingMode | None
 
     @property
     def prompt(self) -> int:
@@ -120,8 +124,11 @@ def estimated_request_cost(
     cache_write: int,
     cache_write_1h: int,
     output: int,
+    pricing_mode: PricingMode | None = None,
 ) -> float | None:
     """Estimate a request cost in USD from the built-in provider catalog rates."""
+    if pricing_mode == "subscription" or provider in _SUBSCRIPTION_PROVIDERS:
+        return None
     entry = builtin_provider_entry(provider)
     metadata = entry.model_metadata.get(model) if entry is not None else None
     if metadata is None:
@@ -174,6 +181,7 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
             cache_write=usage.cache_write,
             cache_write_1h=cache_write_1h,
             output=usage.output,
+            pricing_mode=usage.pricing_mode,
         )
         if estimated is None and usage.cost.total > 0:
             estimated = usage.cost.total
@@ -193,6 +201,7 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                 reasoning=usage.reasoning or 0,
                 stop_reason=message.stop_reason,
                 estimated_cost=estimated,
+                pricing_mode=usage.pricing_mode,
             )
         )
         events.extend(
@@ -484,8 +493,8 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
 
     return (
         f'<div class="usage-cards">{cards_html}</div>'
-        '<p class="usage-note">Costs use Tau\'s provider catalog rates. OAuth subscription '
-        "estimates are API-rate equivalents, not actual subscription charges. Hover a request "
+        '<p class="usage-note">Costs use Tau\'s provider catalog rates. Subscription-backed '
+        "requests are shown without API-equivalent dollar estimates. Hover a request "
         "for exact values, select a legend item to hide a series, and use PNG to save a "
         "chart. Event markers show compactions, model or thinking changes, and branch summaries."
         "</p>"

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -107,7 +107,13 @@ def _assert_messages(actual: object, expected: object) -> None:
     def dump(message: object) -> object:
         model_dump = getattr(message, "model_dump", None)
         if callable(model_dump):
-            return model_dump(exclude={"timestamp", "timing"})
+            return model_dump(
+                exclude={
+                    "timestamp": True,
+                    "timing": True,
+                    "usage": {"pricing_mode"},
+                }
+            )
         return message
 
     assert [dump(message) for message in actual] == [dump(message) for message in expected]  # type: ignore[union-attr]
@@ -4004,8 +4010,19 @@ async def test_session_pricing_respects_anthropic_auth_mode(
             if isinstance(entry, MessageEntry) and isinstance(entry.message, AssistantMessage)
         )
 
-        assert assistant.usage.pricing_mode == ("subscription" if oauth else None)
+        assert assistant.usage.pricing_mode == ("subscription" if oauth else "api")
         assert session.session_stats.estimated_cost == (None if oauth else 3.3)
+        if not oauth:
+            credential_store.set_oauth(
+                "anthropic",
+                OAuthCredential(
+                    access="access-token",
+                    refresh="refresh-token",
+                    expires=4_000_000_000,
+                ),
+            )
+            assert session.provider_uses_subscription_auth("anthropic") is True
+            assert session.session_stats.estimated_cost == 3.3
     finally:
         await session.aclose()
 

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -47,6 +47,7 @@ from tau_ai import (
 )
 from tau_ai.events import AssistantMessageEvent
 from tau_coding import (
+    AnthropicProviderConfig,
     CodingSession,
     CodingSessionConfig,
     FileCredentialStore,
@@ -3861,6 +3862,152 @@ async def test_session_uses_live_provider_limits_for_compaction_threshold(
     assert session.auto_compact_token_threshold == 334_800
     assert session.context_window_source == "provider live catalog"
     assert session.model_limits_discovery_error is None
+
+
+@pytest.mark.anyio
+async def test_session_marks_codex_subscription_usage_without_estimated_cost(
+    tmp_path: Path,
+) -> None:
+    tau_paths = TauPaths(home=tmp_path / ".tau")
+    model = "gpt-5.6-sol"
+    settings = ProviderSettings(
+        default_provider="openai-codex",
+        providers=(
+            OpenAICodexProviderConfig(
+                models=(model,),
+                default_model=model,
+                model_metadata={
+                    model: ProviderModelMetadata(
+                        cost={
+                            "input": 5.0,
+                            "output": 30.0,
+                            "cacheRead": 0.5,
+                            "cacheWrite": 0.0,
+                        }
+                    )
+                },
+            ),
+        ),
+    )
+    provider = FakeProvider(
+        [
+            [
+                assistant_done(
+                    AssistantMessage(
+                        provider="openai-codex",
+                        model=model,
+                        content="Done.",
+                        usage=Usage(input=1_000_000, output=20_000),
+                    )
+                )
+            ]
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=settings,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    try:
+        await _collect_session_events(session.prompt("Finish the task."))
+        assistant = next(
+            entry.message
+            for entry in await session.session_entries()
+            if isinstance(entry, MessageEntry) and isinstance(entry.message, AssistantMessage)
+        )
+
+        assert assistant.usage.pricing_mode == "subscription"
+        assert session.session_stats.estimated_cost is None
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("oauth", [False, True])
+async def test_session_pricing_respects_anthropic_auth_mode(
+    tmp_path: Path,
+    oauth: bool,
+) -> None:
+    tau_paths = TauPaths(home=tmp_path / ".tau")
+    credential_store = FileCredentialStore(tau_paths.home / "credentials.json")
+    if oauth:
+        credential_store.set_oauth(
+            "anthropic",
+            OAuthCredential(
+                access="access-token",
+                refresh="refresh-token",
+                expires=4_000_000_000,
+            ),
+        )
+    else:
+        credential_store.set("anthropic", "api-key")
+    model = "claude-sonnet-4-6"
+    settings = ProviderSettings(
+        default_provider="anthropic",
+        providers=(
+            AnthropicProviderConfig(
+                models=(model,),
+                default_model=model,
+                model_metadata={
+                    model: ProviderModelMetadata(
+                        cost={
+                            "input": 3.0,
+                            "output": 15.0,
+                            "cacheRead": 0.3,
+                            "cacheWrite": 0.0,
+                        }
+                    )
+                },
+            ),
+        ),
+    )
+    provider = FakeProvider(
+        [
+            [
+                assistant_done(
+                    AssistantMessage(
+                        provider="anthropic",
+                        model=model,
+                        content="Done.",
+                        usage=Usage(input=1_000_000, output=20_000),
+                    )
+                )
+            ]
+        ]
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=provider,
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="anthropic",
+            provider_settings=settings,
+            resource_paths=TauResourcePaths(root=tau_paths.home, paths=tau_paths),
+        )
+    )
+
+    try:
+        await _collect_session_events(session.prompt("Finish the task."))
+        assistant = next(
+            entry.message
+            for entry in await session.session_entries()
+            if isinstance(entry, MessageEntry) and isinstance(entry.message, AssistantMessage)
+        )
+
+        assert assistant.usage.pricing_mode == ("subscription" if oauth else None)
+        assert session.session_stats.estimated_cost == (None if oauth else 3.3)
+    finally:
+        await session.aclose()
 
 
 @pytest.mark.anyio

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -15,6 +15,7 @@ from tau_coding import (
     CodingSession,
     CodingSessionConfig,
     ModelChoice,
+    OpenAICodexProviderConfig,
     OpenAICompatibleProviderConfig,
     ProviderSettings,
     SessionManager,
@@ -189,6 +190,42 @@ async def test_rpc_model_shape_uses_catalog_metadata(
         "maxTokens": 32768,
         "cost": {"input": 1.0, "output": 2.0, "cacheRead": 0.0, "cacheWrite": 0.0},
     }
+
+
+@pytest.mark.anyio
+async def test_rpc_subscription_model_omits_catalog_cost(tmp_path: Path) -> None:
+    model = "gpt-5.6-sol"
+    provider_config = OpenAICodexProviderConfig(
+        models=(model,),
+        default_model=model,
+        model_metadata={model: ProviderModelMetadata(cost={"input": 5.0, "output": 30.0})},
+    )
+    session = await CodingSession.load(
+        CodingSessionConfig(
+            provider=FakeProvider([]),
+            model=model,
+            system="You are Tau.",
+            storage=JsonlSessionStorage(tmp_path / "session.jsonl"),
+            cwd=tmp_path,
+            provider_name="openai-codex",
+            provider_settings=ProviderSettings(
+                default_provider="openai-codex", providers=(provider_config,)
+            ),
+        )
+    )
+    stdin = StringIO('{"id":"state","type":"get_state"}\n')
+    stdout = StringIO()
+
+    await RpcServer(session, stdin=stdin, stdout=stdout).run()
+
+    model_wire = json.loads(stdout.getvalue())["data"]["model"]
+    assert model_wire["cost"] == {
+        "input": 0.0,
+        "output": 0.0,
+        "cacheRead": 0.0,
+        "cacheWrite": 0.0,
+    }
+    await session.aclose()
 
 
 @pytest.mark.anyio

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -224,6 +224,30 @@ def test_calculate_session_stats_marks_cost_unavailable_when_pricing_is_missing(
     assert stats.estimated_cost is None
 
 
+def test_calculate_session_stats_excludes_subscription_pricing() -> None:
+    entry = MessageEntry(
+        message=AssistantMessage(
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            usage=Usage(input=1_000_000, output=20_000, pricing_mode="subscription"),
+        )
+    )
+
+    stats = calculate_session_stats(
+        [entry],
+        pricing=lambda _provider, _model, _input: {
+            "input": 5.0,
+            "output": 30.0,
+            "cacheRead": 0.5,
+            "cacheWrite": 0.0,
+        },
+    )
+
+    assert stats.input_tokens == 1_000_000
+    assert stats.output_tokens == 20_000
+    assert stats.estimated_cost is None
+
+
 def test_calculate_session_stats_prices_one_hour_cache_writes() -> None:
     """Anthropic's cache_write total includes 1h writes, billed at cacheWrite1h."""
     entry = MessageEntry(

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -95,6 +95,22 @@ def test_collect_session_usage_estimates_cost_from_catalog() -> None:
     assert unknown.requests[0].estimated_cost is None
 
 
+def test_collect_session_usage_excludes_subscription_pricing() -> None:
+    usage = collect_session_usage(
+        [
+            _assistant(
+                "a1",
+                provider="openai-codex",
+                model="gpt-5.6-sol",
+                usage=Usage(input=1_000_000, output=20_000, pricing_mode="subscription"),
+            )
+        ]
+    )
+
+    assert usage.requests[0].estimated_cost is None
+    assert usage.total_cost is None
+
+
 def test_collect_session_usage_falls_back_to_reported_cost_and_keeps_partial_total() -> None:
     usage = collect_session_usage(
         [

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -281,8 +281,10 @@ both performance metrics.
 Cumulative usage and cost cover the active branch, including history replaced by
 compaction. Input usage counts tokens processed on every
 provider request, so it can be much larger than the context used by the next
-request. Cost is an estimate based on provider-reported usage and configured
-catalog rates; the sidebar shows `$N/A` when Tau lacks complete pricing data.
+request. For metered API requests, cost is an estimate based on provider-reported
+usage and configured catalog rates. Subscription-backed OAuth requests do not
+show API-equivalent dollar estimates; the sidebar shows `$N/A` when pricing is
+not applicable or unavailable.
 
 The cache line separates the latest model request from the cumulative session.
 Both rates are the share of prompt tokens the provider served from its cache


### PR DESCRIPTION
## Summary

- Mark assistant usage produced through subscription-backed OAuth credentials.
- Exclude API catalog rates from TUI, RPC model metadata, and HTML usage estimates for subscription requests.
- Preserve catalog estimates for direct API-key requests, including Anthropic API-key usage.
- Add regression tests and document the behavior.

## User experience

Subscription sessions no longer display misleading API-equivalent dollar costs. Token, cache, timing, and tool usage remain available; API-key sessions retain their estimated costs.

## Issue

Addresses the reported issue where subscription-backed sessions showed direct API pricing. No tracked issue number was provided.

## Manual validation

1. Log in to an OAuth/subscription provider such as OpenAI Codex or Anthropic.
2. Run a prompt with enough usage to populate the session sidebar.
3. Confirm the session does not show an API-equivalent dollar estimate (`$N/A` is expected when no provider-reported charge exists).
4. Repeat with a direct API key and confirm catalog-based estimates still appear.
5. Optionally export both sessions and verify the Usage tab follows the same behavior.

## Verification

- `uv run pytest` — 1925 passed, 3 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
