### PR TITLE
Summarize model catalog updates

### DIFF
--- a/dev-notes/models-dev-catalog.md
+++ b/dev-notes/models-dev-catalog.md
@@ -47,8 +47,10 @@ Tau also mirrors Pi's refreshable-catalog behavior. Opening `/model` renders the
 last-known snapshot immediately and refreshes models.dev in the background.
 Refreshes are throttled to four hours, use ETag revalidation, apply the same live
 NVIDIA filter as generation, and atomically cache the transformed catalog in
-`~/.tau/models-store.json`. `tau update --models` bypasses the freshness window
-and forces immediate revalidation.
+`~/.tau/models-store.json`. `tau update --models` bypasses the freshness window,
+forces immediate revalidation, and summarizes model additions, removals, and
+metadata updates relative to the previous cache. The first refresh compares
+against the bundled snapshot.
 
 Unlike Pi, which serves transformed provider catalogs from `pi.dev`, Tau has no
 catalog service, so it fetches models.dev and NVIDIA directly and performs the
@@ -90,5 +92,5 @@ model lists, limits, costs, modalities, and thinking controls.
 Focused coverage lives in `tests/test_models_dev.py` and the provider catalog,
 configuration, runtime, and thinking suites. It covers Pi-compatible effort
 conversion, distinct `max`, full model generation, new-model discovery,
-provider aliases, malformed-resource fallback, user preference fallback, and
-GLM-5.2 wire behavior.
+provider aliases, malformed-resource fallback, user preference fallback,
+refresh change summaries, and GLM-5.2 wire behavior.

--- a/src/tau_coding/cli.py
+++ b/src/tau_coding/cli.py
@@ -683,6 +683,12 @@ def update_models_command() -> None:
     typer.echo(
         f"Model catalogs {status}: {result.model_count} models cached at {result.cache_path}"
     )
+    typer.echo(
+        "Model changes: "
+        f"{len(result.changes.added)} added, "
+        f"{len(result.changes.removed)} removed, "
+        f"{len(result.changes.updated)} updated"
+    )
 
 
 def update_command() -> None:

--- a/src/tau_coding/data/docs/cli.md
+++ b/src/tau_coding/data/docs/cli.md
@@ -60,8 +60,10 @@ tau update --models
 
 This forces ETag revalidation of models.dev and the live NVIDIA model filter,
 then atomically caches the transformed catalog at `~/.tau/models-store.json`.
-Opening `/model` performs the same refresh in the background, subject to a
-four-hour freshness window. Cached/bundled models remain available on failure;
+The command reports the total cached models plus counts of models added,
+removed, and updated compared with the previous cache (or bundled snapshot on
+the first refresh). Opening `/model` performs the same refresh in the background,
+subject to a four-hour freshness window. Cached/bundled models remain available on failure;
 set `TAU_OFFLINE=1` to disable catalog network access.
 
 ## Safety boundary

--- a/src/tau_coding/data/docs/models.md
+++ b/src/tau_coding/data/docs/models.md
@@ -112,7 +112,9 @@ Pi. Provider/manual behavior remains in effect for those models.
 
 Tau also refreshes catalogs like Pi. Opening `/model` shows the current snapshot
 immediately and refreshes in the background. `tau update --models` forces a
-refresh. Results are ETag-revalidated, throttled to four hours, and cached at
+refresh and reports counts of added, removed, and updated models compared with
+the previous cache or, on first refresh, the bundled snapshot. Results are
+ETag-revalidated, throttled to four hours, and cached at
 `~/.tau/models-store.json`; a cache applies only when newer than the bundled
 snapshot. Since Tau has no hosted catalog service, it fetches models.dev and
 NVIDIA directly and transforms them locally.

--- a/src/tau_coding/models_dev_store.py
+++ b/src/tau_coding/models_dev_store.py
@@ -33,11 +33,19 @@ class ModelsDevRefreshError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class ModelsDevCatalogChanges:
+    added: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    updated: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class ModelsDevRefreshResult:
     refreshed: bool
     not_modified: bool
     model_count: int
     cache_path: Path
+    changes: ModelsDevCatalogChanges = ModelsDevCatalogChanges()
 
 
 def models_store_path(paths: TauPaths | None = None) -> Path:
@@ -140,11 +148,15 @@ async def refresh_models_dev_catalog(
             "catalog": document,
         }
         _write_cache(path, cache_document)
+        previous_document = (
+            cache["catalog"] if cache is not None else bundled_models_dev_catalog_document()
+        )
         return ModelsDevRefreshResult(
             refreshed=True,
             not_modified=False,
             model_count=_model_count(document),
             cache_path=path,
+            changes=_catalog_changes(previous_document, document),
         )
     except (httpx.HTTPError, TypeError, ValueError, json.JSONDecodeError) as error:
         raise ModelsDevRefreshError(f"Could not refresh model catalogs: {error}") from error
@@ -181,6 +193,47 @@ def _model_count(document: dict[str, Any]) -> int:
         for provider in providers.values()
         if isinstance(provider, dict) and isinstance(provider.get("models"), list)
     )
+
+
+def _catalog_changes(
+    previous: dict[str, Any] | None,
+    current: dict[str, Any],
+) -> ModelsDevCatalogChanges:
+    previous_models = _catalog_models(previous)
+    current_models = _catalog_models(current)
+    previous_ids = set(previous_models)
+    current_ids = set(current_models)
+    return ModelsDevCatalogChanges(
+        added=tuple(sorted(current_ids - previous_ids)),
+        removed=tuple(sorted(previous_ids - current_ids)),
+        updated=tuple(
+            sorted(
+                model_id
+                for model_id in previous_ids & current_ids
+                if previous_models[model_id] != current_models[model_id]
+            )
+        ),
+    )
+
+
+def _catalog_models(document: dict[str, Any] | None) -> dict[str, object]:
+    if document is None:
+        return {}
+    providers = document.get("providers")
+    if not isinstance(providers, dict):
+        return {}
+    models: dict[str, object] = {}
+    for provider_name, provider in providers.items():
+        if not isinstance(provider_name, str) or not isinstance(provider, dict):
+            continue
+        provider_models = provider.get("models")
+        metadata = provider.get("model_metadata")
+        if not isinstance(provider_models, list) or not isinstance(metadata, dict):
+            continue
+        for model_id in provider_models:
+            if isinstance(model_id, str):
+                models[f"{provider_name}:{model_id}"] = metadata.get(model_id)
+    return models
 
 
 def _write_cache(path: Path, value: dict[str, Any]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from tau_ai import (
 )
 from tau_coding import CodingSessionRecord, SessionManager, cli
 from tau_coding.cli import app, run_print_mode
+from tau_coding.models_dev_store import ModelsDevCatalogChanges
 from tau_coding.paths import TauPaths
 from tau_coding.provider_config import (
     OpenAICompatibleProviderConfig,
@@ -391,6 +392,11 @@ def test_update_models_force_refreshes_catalog(monkeypatch: pytest.MonkeyPatch) 
             not_modified=False,
             model_count=42,
             cache_path=Path("/tmp/models-store.json"),
+            changes=ModelsDevCatalogChanges(
+                added=("huggingface:new-model", "nvidia:new-model"),
+                removed=("openai:old-model",),
+                updated=("anthropic:changed-model",),
+            ),
         )
 
     monkeypatch.setattr(cli, "refresh_models_dev_catalog", refresh_models)
@@ -400,6 +406,7 @@ def test_update_models_force_refreshes_catalog(monkeypatch: pytest.MonkeyPatch) 
     assert result.exit_code == 0
     assert calls == [True]
     assert "Model catalogs refreshed: 42 models" in result.stdout
+    assert "Model changes: 2 added, 1 removed, 1 updated" in result.stdout
 
 
 def test_update_command_reports_windows_handoff_without_claiming_completion(

--- a/tests/test_models_dev_store.py
+++ b/tests/test_models_dev_store.py
@@ -142,3 +142,35 @@ async def test_fresh_cache_skips_network_and_failed_force_preserves_it(tmp_path:
                 now=2000.0,
             )
     assert first.cache_path.read_text(encoding="utf-8") == cached_text
+
+
+@pytest.mark.anyio
+async def test_refresh_summarizes_added_removed_and_updated_models(tmp_path: Path) -> None:
+    paths = TauPaths(home=tmp_path / ".tau")
+    async with _client(_source()) as client:
+        await refresh_models_dev_catalog(paths=paths, force=True, client=client, now=1000.0)
+
+    changed_source = _source()
+    huggingface = changed_source["huggingface"]
+    assert isinstance(huggingface, dict)
+    models = huggingface["models"]
+    assert isinstance(models, dict)
+    added_model = dict(models.pop("example/new-tool-model"))
+    added_model["id"] = "example/added-model"
+    added_model["name"] = "Added Model"
+    models["example/added-model"] = added_model
+    kimi = models["moonshotai/Kimi-K3"]
+    assert isinstance(kimi, dict)
+    kimi["name"] = "Updated Kimi K3"
+
+    async with _client(changed_source) as client:
+        result = await refresh_models_dev_catalog(
+            paths=paths,
+            force=True,
+            client=client,
+            now=2000.0,
+        )
+
+    assert result.changes.added == ("huggingface:example/added-model",)
+    assert result.changes.removed == ("huggingface:example/new-tool-model",)
+    assert result.changes.updated == ("huggingface:moonshotai/Kimi-K3",)

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -200,8 +200,10 @@ behavior. Hugging Face `zai-org/GLM-5.2` currently uses a narrow verified
 correction exposing `off`, `high`, and `max`, so Tau never sends its unsupported
 `medium` value. A bundled snapshot keeps startup offline. Opening `/model`
 refreshes catalogs in the background and caches them in
-`~/.tau/models-store.json`; run `tau update --models` to force revalidation.
-New models and capability changes can therefore arrive without upgrading Tau.
+`~/.tau/models-store.json`; run `tau update --models` to force revalidation and
+see counts of models added, removed, and updated since the previous cached (or
+bundled) snapshot. New models and capability changes can therefore arrive
+without upgrading Tau.
 Set `TAU_OFFLINE=1` to use cached/bundled data without catalog network access.
 
 For a new session without an explicit preference, Hugging Face initially routes

--- a/website/content/reference/cli.md
+++ b/website/content/reference/cli.md
@@ -31,7 +31,7 @@ features and fixes.
 | `tau` | Open the interactive TUI |
 | `tau "<prompt>"` | Open the TUI with an initial prompt |
 | `tau update` | Upgrade Tau with the installer that owns its environment. Windows uv-tool updates are handed off and begin after Tau exits; follow the printed log path for the final result. |
-| `tau update --models` | Force-refresh models.dev catalogs and cache them in `~/.tau/models-store.json` without upgrading Tau. |
+| `tau update --models` | Force-refresh models.dev catalogs, cache them in `~/.tau/models-store.json`, and summarize added, removed, and updated models without upgrading Tau. |
 | `tau install <source> [--force]` | Install a trusted local or Git extension under `~/.tau/extensions/`; `--force` replaces an existing install. |
 | `tau sessions` | List indexed sessions (id, title, model, cwd) |
 | `tau export <ref> [dest] [--format html\|jsonl]` | Export a session id or JSONL path (HTML default) |


### PR DESCRIPTION
## Description

- compare each successful public model-catalog refresh with the previous cached catalog
- fall back to the bundled snapshot as the baseline for a first refresh
- report counts for added, removed, and metadata-updated models from `tau update --models`
- document the new command output and cover catalog diffing in tests

## User experience

Users can immediately see whether refreshing the catalog changed model availability or metadata instead of receiving only the final model count.

## Issue

No linked issue.

## Manual validation

1. Run `tau update --models` once to establish or refresh `~/.tau/models-store.json`.
2. Run it again after upstream models.dev data changes.
3. Confirm output includes `Model changes: <n> added, <n> removed, <n> updated`.
