### PR TITLE
Drop persisted leaf session entries

### DIFF
--- a/dev-notes/architecture/phase-20-2-thinking-controls.md
+++ b/dev-notes/architecture/phase-20-2-thinking-controls.md
@@ -27,9 +27,9 @@ mode that Tau cannot safely send.
 ## Session Persistence
 
 New sessions append an initial `thinking_level_change` entry after the initial
-model entry. Explicit changes append another `thinking_level_change` entry and a
-leaf pointer, so resume reconstructs the active thinking mode from the session
-tree.
+model entry. Explicit changes append another `thinking_level_change` entry. As
+the last non-legacy-leaf entry, it becomes the active tip, so resume reconstructs
+the active thinking mode from the session tree.
 
 `CodingSession` exposes:
 

--- a/dev-notes/architecture/phase-22-compaction-foundation.md
+++ b/dev-notes/architecture/phase-22-compaction-foundation.md
@@ -98,8 +98,9 @@ Tau now supports model-generated manual compaction in the TUI:
 
 The command uses Tau's built-in Pi-style compaction prompt. Optional
 instructions are appended to that prompt as extra focus. The generated summary is
-stored in a `CompactionEntry`, followed by a new leaf pointer. Tau then replays
-the session and replaces the in-memory harness transcript for future turns.
+stored in a `CompactionEntry`, which becomes the active file-order tip. Tau then
+replays the session and replaces the in-memory harness transcript for future
+turns.
 
 See [Context Compaction](../context-compaction.md) for the current prompt,
 trigger conditions, and known limitations.

--- a/dev-notes/architecture/phase-24-session-tree-branching.md
+++ b/dev-notes/architecture/phase-24-session-tree-branching.md
@@ -18,12 +18,16 @@ marks the active leaf, and supports two actions:
 - `Ctrl+T` toggles tool-call entries on or off for easier navigation in
   tool-heavy histories.
 
-Both actions preserve all existing JSONL entries. Tau records navigation by
-appending a new `leaf` entry, so reopening the session restores the selected
-branch. The picker intentionally hides metadata entries such as model changes,
-thinking-level changes, leaf pointers, and session info; it only shows user
-messages, assistant messages, tool calls, compaction summaries, and branch
-summaries.
+Both actions preserve all existing JSONL entries. Plain navigation is in-memory
+only. If the user quits immediately, reopening selects the last non-legacy-leaf
+entry in file order rather than restoring that uncommitted selection. The next
+message or state change is appended with the selected target as its parent and
+therefore makes the new branch durable. Summary navigation appends its
+`branch_summary` immediately, so that summary becomes the durable tip. The
+picker intentionally hides metadata entries such as model changes,
+thinking-level changes, historical leaf pointers, and session info; it only
+shows user messages, assistant messages, tool calls, compaction summaries, and
+branch summaries.
 
 ## Branch Summaries
 

--- a/dev-notes/architecture/phase-8-coding-session.md
+++ b/dev-notes/architecture/phase-8-coding-session.md
@@ -87,7 +87,7 @@ async for event in session.prompt("Read README.md"):
     ...
 ```
 
-After the run completes, all new harness messages are appended as `MessageEntry` records. Tau also appends a `LeafEntry` pointing at the newest message entry.
+After the run completes, all new harness messages are appended as `MessageEntry` records. Each entry becomes the active tip by being the last non-legacy-leaf line in the file; Tau no longer writes a separate pointer.
 
 `CodingSession.continue_()` resumes from restored state without appending a new user message first.
 

--- a/dev-notes/design/04-sessions.md
+++ b/dev-notes/design/04-sessions.md
@@ -22,7 +22,7 @@ src/tau_agent/session/
 - `compaction`
 - `branch_summary`
 - `label`
-- `leaf`
+- `leaf` (legacy read compatibility only; never written)
 - `session_info`
 - `custom`
 
@@ -50,7 +50,7 @@ This mirrors Pi's session model and matters for interactive UIs:
 
 A message whose `message_end` never fired is deliberately not persisted: abandoning a run before the first completed message leaves no durable trace, so an aborted first prompt does not index a new session.
 
-Each persisted message is followed by a `leaf` entry pointing at that message. The leaf entries form an append-only history of the active branch pointer.
+The active tip is the last non-`leaf` entry in file order. Every new entry points to the current in-memory tip, so an append both records the operation and makes its branch active. Historical `leaf` entries still deserialize but are ignored for tip selection.
 
 Empty sessions are still deferred: loading a new session prepares initial metadata in memory, but Tau does not create the transcript file until the first durable session entry is appended. The first append materializes the pending `session_info`, model, and thinking-level entries before writing the message.
 

--- a/dev-notes/design/602-session-preparation-lifecycle.md
+++ b/dev-notes/design/602-session-preparation-lifecycle.md
@@ -254,8 +254,8 @@ Adoption does this:
 
 1. Require the outgoing harness to be idle.
 2. Attach the candidate frontend bridge in buffered mode.
-3. Atomically append the complete staged transcript batch, ending in the active
-   `LeafEntry`. This is the durable commit point.
+3. Atomically append the complete staged transcript batch. Its final non-leaf
+   entry becomes the active tip and is the durable commit point.
 4. Enter a serialized no-fail publication boundary.
 5. For replacement, emit outgoing shutdown while its API is valid and clear its
    UI; handler failures become diagnostics.
@@ -267,8 +267,8 @@ Adoption does this:
 10. Retire outgoing provider, tasks, and extension generation.
 
 After step 3, expected extension, UI, trust-store, and index errors cannot escape
-as ordinary rollback failures. A crash after step 3 leaves a complete leaf that
-the next resume can recover.
+as ordinary rollback failures. A crash after step 3 leaves a complete final
+entry that the next resume selects by file order.
 
 `abort()` is idempotent. `adopt()` and `abort()` are mutually exclusive state
 transitions.
@@ -276,8 +276,8 @@ transitions.
 ### 7. Transcript is authoritative; index is repairable
 
 Add optional `provider` to `ModelChangeEntry`. Every new initial selection and
-switch writes it. A provider/model change and its final `LeafEntry` are one
-atomic storage batch.
+switch writes it. The provider/model change itself becomes the active file-order
+tip.
 
 Selection precedence is:
 
@@ -311,7 +311,7 @@ A switch transaction is candidate-first:
 validate effective provider/model
 → create candidate provider
 → prepare history/thinking/route/image state
-→ atomic provider-aware ModelChangeEntry + LeafEntry batch
+→ append provider-aware ModelChangeEntry as the new file-order tip
 → synchronous no-fail in-memory publication
 → repairable index update
 → close replaced provider

--- a/dev-notes/drop-leaf-session-entries.md
+++ b/dev-notes/drop-leaf-session-entries.md
@@ -1,0 +1,36 @@
+# Drop persisted leaf session entries (#700)
+
+Tau now follows Pi's file-order rule for session tips: the active tip is the
+last non-`leaf` entry in JSONL order.
+
+## Changes
+
+- `CodingSession` no longer writes `LeafEntry` after messages, model or thinking
+  changes, custom entries, history repairs, compactions, or tree navigation.
+- Message persistence retries retain one stable `MessageEntry`. If append writes
+  and then raises, retry reads durable ids and does not duplicate it.
+- Replay ignores historical leaf pointers when selecting the tip. `LeafEntry`
+  remains in the discriminated entry union so old files deserialize safely.
+- Plain `/tree` navigation changes only the in-memory tip. A later write parents
+  from that selection and makes the branch durable. Navigation with a branch
+  summary writes the summary immediately, making it the file-order tip.
+- HTML export derives the active path from the last non-leaf entry and can render
+  historical leaf records without a special visibility filter.
+
+## Compatibility and restart behavior
+
+Old leaf records are data, not active-pointer commands. Even if a trailing leaf
+points to an older branch, resume uses the last non-leaf entry in file order.
+This intentionally changes one edge case: selecting an older entry with `/tree`
+and quitting before any subsequent write does not preserve that selection.
+
+## Validation
+
+```bash
+uv run pytest tests/test_session.py tests/test_session_export.py tests/test_coding_session.py -q
+uv run pytest
+```
+
+Coverage includes linear and branched resume, stale historical leaf records,
+model/thinking tips, in-memory navigation followed by branch writes, single-entry
+retry after before/after-append failures, and export rendering.

--- a/dev-notes/push-based-persistence.md
+++ b/dev-notes/push-based-persistence.md
@@ -57,11 +57,11 @@ change moves persistence to the same side of the event stream.
   run generator and retries only messages whose `message_end` fired but whose
   write failed. It is keyed on message identity, never counts: the loop emits
   an assistant's `message_end` before appending it to the transcript, so
-  count-based sweeps can double-write. Each pending write retains stable
-  message and leaf entry ids; a retry reads durable ids and appends only the
-  missing pieces, so a failure between the two appends cannot duplicate the
-  message. Only retries pay that read — a first attempt mints ids that cannot
-  already be on disk, so the streaming path keeps one storage read per message. Repeated failures are logged without masking cancellation, retained,
+  count-based sweeps can double-write. Each pending write retains one stable
+  message entry id; a retry reads durable ids and skips an entry whose append
+  reached disk before raising. Only retries pay that read — a first attempt
+  mints an id that cannot already be on disk. Repeated failures are logged
+  without masking cancellation, retained,
   and flushed before the next prompt, continuation, compaction, or contextual
   terminal command.
 
@@ -88,8 +88,8 @@ Key regression tests:
   harness contract; `test_entry_path_repair_is_pushed_to_listeners` also pins
   canonical run event ordering.
 - `test_message_persistence_retry_is_idempotent` injects failures before and
-  after the message and leaf appends, plus during refresh, and verifies retry
-  leaves exactly one message and one leaf. The next-prompt test verifies a write
+  after the single message append, plus during refresh, and verifies retry
+  leaves exactly one message and no leaf pointer. The next-prompt test verifies a write
   that fails twice is retained and flushed before provider context is built.
 - `test_session_resumes_indexed_session` asserts each message persists exactly
   once after resume (guards the listener detach in `_adopt_replacement`).

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -85,7 +85,7 @@ class LabelEntry(BaseSessionEntry):
 
 
 class LeafEntry(BaseSessionEntry):
-    """The active branch leaf pointer entry."""
+    """A legacy active-tip pointer retained only for deserialization."""
 
     type: Literal["leaf"] = "leaf"
     entry_id: str | None = None

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -41,20 +41,20 @@ class SessionState:
         *,
         leaf_id: str | None | object = _UNSET_LEAF_ID,
     ) -> SessionState:
-        """Replay entries into state.
+        """Replay the branch ending at the active entry.
 
-        When `leaf_id` is provided, only the root-to-leaf path is replayed. Passing
-        ``None`` explicitly replays the empty path before the first root entry.
-        Without it, entries are replayed linearly in storage order.
+        By default the active entry is the last non-leaf entry in file order.
+        Historical ``leaf`` records remain readable but never select the tip.
+        An explicit `leaf_id` supports in-memory tree navigation; passing
+        ``None`` selects the empty path before the first root entry.
         """
-        replay_all = leaf_id is _UNSET_LEAF_ID
-        resolved_leaf_id = None if replay_all else cast(str | None, leaf_id)
+        resolved_leaf_id = (
+            _last_non_leaf_id(entries)
+            if leaf_id is _UNSET_LEAF_ID
+            else cast(str | None, leaf_id)
+        )
         replay_entries = (
-            entries
-            if replay_all
-            else path_to_entry(entries, resolved_leaf_id)
-            if resolved_leaf_id is not None
-            else []
+            path_to_entry(entries, resolved_leaf_id) if resolved_leaf_id is not None else []
         )
 
         message_rows: list[tuple[str, AgentMessage]] = []
@@ -80,7 +80,7 @@ class SessionState:
                 case "label":
                     label = entry.label
                 case "leaf":
-                    active_leaf_id = entry.entry_id
+                    pass  # Backward-compatible historical record; never selects the tip.
                 case "session_info":
                     session_info = entry
                 case "custom":
@@ -106,6 +106,13 @@ class SessionState:
             context_entry_ids=tuple(entry_id for entry_id, _message in message_rows),
             entries=tuple(replay_entries),
         )
+
+
+def _last_non_leaf_id(entries: list[SessionEntry]) -> str | None:
+    for entry in reversed(entries):
+        if entry.type != "leaf":
+            return entry.id
+    return None
 
 
 def _apply_compaction(

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -49,9 +49,7 @@ class SessionState:
         ``None`` selects the empty path before the first root entry.
         """
         resolved_leaf_id = (
-            _last_non_leaf_id(entries)
-            if leaf_id is _UNSET_LEAF_ID
-            else cast(str | None, leaf_id)
+            _last_non_leaf_id(entries) if leaf_id is _UNSET_LEAF_ID else cast(str | None, leaf_id)
         )
         replay_entries = (
             path_to_entry(entries, resolved_leaf_id) if resolved_leaf_id is not None else []

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -28,7 +28,6 @@ from tau_agent.session import (
     CustomEntry,
     JsonlSessionStorage,
     LabelEntry,
-    LeafEntry,
     MessageEntry,
     ModelChangeEntry,
     SessionInfoEntry,
@@ -307,11 +306,10 @@ class ManualCompactionResult:
 
 @dataclass(frozen=True, slots=True)
 class _PendingMessageWrite:
-    """Stable entries retained while a message persistence attempt is retried."""
+    """Stable entry retained while a message persistence attempt is retried."""
 
     message: AgentMessage
     message_entry: MessageEntry
-    leaf_entry: LeafEntry
 
 
 @dataclass(frozen=True, slots=True)
@@ -488,13 +486,7 @@ class CodingSession:
         else:
             entries = _detach_missing_parents(entries)
 
-        linear_state = SessionState.from_entries(entries)
-        latest_leaf = _latest_leaf_entry(entries)
-        state = (
-            SessionState.from_entries(entries, leaf_id=latest_leaf.entry_id)
-            if latest_leaf is not None
-            else linear_state
-        )
+        state = SessionState.from_entries(entries)
         unfiltered_resource_paths = resource_paths_with_cwd(config.resource_paths, config.cwd)
 
         # A runtime is cwd-bound because it may contain project registrations.
@@ -1001,10 +993,10 @@ class CodingSession:
             target_id = selected_entry.parent_id
             input_prefill = selected_entry.message.text
 
-        leaf = LeafEntry(parent_id=target_id, entry_id=target_id)
-        await self._append_session_entry(leaf)
         self._last_parent_id = target_id
 
+        # Plain navigation is in-memory only. A summary above is the sole write,
+        # and becomes the file-order tip when present.
         await self._refresh_persisted_state(leaf_id=target_id)
         history_repair = await self._persist_active_tool_history_repairs()
         if history_repair is None:
@@ -1330,8 +1322,6 @@ class CodingSession:
         entry = CustomEntry(parent_id=self._last_parent_id, namespace=namespace, data=data)
         await self._append_session_entry(entry)
         self._last_parent_id = entry.id
-        leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-        await self._append_session_entry(leaf)
         await self._refresh_persisted_state(leaf_id=entry.id)
 
     @property
@@ -1471,8 +1461,7 @@ class CodingSession:
             model=model,
             provider=self.provider_name,
         )
-        leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-        await self._append_session_batch((entry, leaf))
+        await self._append_session_entry(entry)
         self._last_parent_id = entry.id
         await self._refresh_persisted_state(leaf_id=entry.id)
 
@@ -1480,7 +1469,7 @@ class CodingSession:
         """Switch provider/model with candidate-first durable publication.
 
         No active state changes until the candidate runtime exists and the
-        provider-aware model entry plus leaf are committed as one batch.
+        provider-aware model entry is committed.
         """
         if self._harness.is_running:
             raise RuntimeError(
@@ -1562,8 +1551,7 @@ class CodingSession:
                 model=choice.model,
                 provider=choice.provider_name,
             )
-            leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-            await self._append_session_batch((entry, leaf))
+            await self._append_session_entry(entry)
         except BaseException:
             if candidate is not None:
                 await candidate.aclose()
@@ -1817,8 +1805,6 @@ class CodingSession:
             thinking_level=normalized,
         )
         await self._append_session_entry(entry)
-        leaf = LeafEntry(parent_id=entry.id, entry_id=entry.id)
-        await self._append_session_entry(leaf)
         self._last_parent_id = entry.id
 
         self._persist_thinking_level_choice()
@@ -3367,8 +3353,6 @@ class CodingSession:
             )
             staged.append(copied_entry)
             parent_id = copied_entry.id
-        staged.append(LeafEntry(parent_id=parent_id, entry_id=parent_id))
-
         if self._config.defer_authoritative_writes:
             self._prepared_entries.extend(staged)
             self._last_parent_id = parent_id
@@ -3404,24 +3388,16 @@ class CodingSession:
     async def _persist_message(self, message: AgentMessage) -> None:
         """Persist one completed message at the active branch tip, idempotently.
 
-        Message lifecycle events are the durable-message boundary. Stable entry
-        ids let a retry finish a partially completed message/leaf pair without
-        appending the message a second time.
-
-        Only a retry reads durable ids: a first attempt mints ids that cannot
-        already be on disk, so the extra full-file read is skipped on the hot
-        path.
+        Message lifecycle events are the durable-message boundary. A stable entry
+        id lets a retry recognize an append that reached disk before raising.
+        Only retries pay for a full-file read.
         """
         message_id = id(message)
         pending = self._pending_message_writes.get(message_id)
         is_retry = pending is not None
         if pending is None:
             entry = MessageEntry(parent_id=self._last_parent_id, message=message)
-            pending = _PendingMessageWrite(
-                message=message,
-                message_entry=entry,
-                leaf_entry=LeafEntry(parent_id=entry.id, entry_id=entry.id),
-            )
+            pending = _PendingMessageWrite(message=message, message_entry=entry)
             self._pending_message_writes[message_id] = pending
 
         durable_ids = (
@@ -3430,8 +3406,6 @@ class CodingSession:
         if pending.message_entry.id not in durable_ids:
             await self._append_session_entry(pending.message_entry)
         self._last_parent_id = pending.message_entry.id
-        if pending.leaf_entry.id not in durable_ids:
-            await self._append_session_entry(pending.leaf_entry)
 
         await self._refresh_persisted_state(leaf_id=self._last_parent_id)
         self._persisted_message_ids.add(message_id)
@@ -3850,8 +3824,6 @@ class CodingSession:
             tokens_before=tokens_before,
         )
         await self._append_session_entry(compaction)
-        leaf = LeafEntry(parent_id=compaction.id, entry_id=compaction.id)
-        await self._append_session_entry(leaf)
         self._last_parent_id = compaction.id
 
         await self._refresh_persisted_state(leaf_id=compaction.id)
@@ -3958,13 +3930,6 @@ def _last_parent_id_from_state(state: SessionState) -> str | None:
         return state.active_leaf_id
     if state.entries:
         return state.entries[-1].id
-    return None
-
-
-def _latest_leaf_entry(entries: list[SessionEntry]) -> LeafEntry | None:
-    for entry in reversed(entries):
-        if isinstance(entry, LeafEntry):
-            return entry
     return None
 
 

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -183,7 +183,10 @@ def render_session_html(
     entry_list = list(entries)
     active_leaf_id = _active_leaf_id(entry_list)
     active_path_ids = _active_path_ids(entry_list, active_leaf_id)
-    tree_html = _render_tree(entry_list, active_path_ids, active_leaf_id)
+    tree_entries: list[SessionEntry] = [
+        entry for entry in entry_list if not isinstance(entry, LeafEntry)
+    ]
+    tree_html = _render_tree(tree_entries, active_path_ids, active_leaf_id)
     details_html = _render_entry_details(entry_list, active_path_ids, active_leaf_id)
     source_html = f'<p class="source">Source: <code>{_escape(source)}</code></p>' if source else ""
     system_prompt_html = _render_system_prompt(system_prompt)

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -183,20 +183,18 @@ def render_session_html(
     entry_list = list(entries)
     active_leaf_id = _active_leaf_id(entry_list)
     active_path_ids = _active_path_ids(entry_list, active_leaf_id)
-    visible_entries = _visible_entries(entry_list)
-    tree_html = _render_tree(visible_entries, active_path_ids, active_leaf_id)
-    details_html = _render_entry_details(visible_entries, active_path_ids, active_leaf_id)
+    tree_html = _render_tree(entry_list, active_path_ids, active_leaf_id)
+    details_html = _render_entry_details(entry_list, active_path_ids, active_leaf_id)
     source_html = f'<p class="source">Source: <code>{_escape(source)}</code></p>' if source else ""
     system_prompt_html = _render_system_prompt(system_prompt)
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
     jsonl_b64 = base64.b64encode(_session_jsonl_text(entry_list).encode("utf-8")).decode("ascii")
     jsonl_filename = _jsonl_filename(title, source)
-    tool_count = sum(1 for entry in visible_entries if _entry_filter_kind(entry) == "tool")
-    event_count = sum(1 for entry in visible_entries if _entry_filter_kind(entry) == "event")
+    tool_count = sum(1 for entry in entry_list if _entry_filter_kind(entry) == "tool")
+    event_count = sum(1 for entry in entry_list if _entry_filter_kind(entry) == "event")
     usage_html = render_usage_dashboard(
         collect_session_usage(
-            [entry for entry in visible_entries if entry.id in active_path_ids]
-            or list(visible_entries)
+            [entry for entry in entry_list if entry.id in active_path_ids] or entry_list
         )
     )
     light_theme_css = _export_theme_css(TAU_LIGHT_THEME)
@@ -1075,22 +1073,10 @@ def _render_system_prompt(system_prompt: str | None) -> str:
     )
 
 
-def _visible_entries(entries: Sequence[SessionEntry]) -> list[SessionEntry]:
-    """Filter out entries that are pointers/plumbing rather than transcript content.
-
-    Leaf pointer entries only record which entry is the current tip of a branch;
-    that information is already conveyed by the active-path/active-leaf styling,
-    so showing them as their own rows would just add noise to the export.
-    """
-    return [entry for entry in entries if not isinstance(entry, LeafEntry)]
-
-
 def _active_leaf_id(entries: Sequence[SessionEntry]) -> str | None:
     for entry in reversed(entries):
-        if isinstance(entry, LeafEntry):
-            return entry.entry_id
-    if entries:
-        return entries[-1].id
+        if not isinstance(entry, LeafEntry):
+            return entry.id
     return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -852,7 +852,7 @@ async def test_run_print_mode_persists_session_entries(
     assert [message.role for message in messages] == ["user", "assistant"]
     assert messages[0].content == "Say hello"
     assert messages[1].text == "Done"
-    assert any(entry.type == "leaf" for entry in entries)
+    assert not any(entry.type == "leaf" for entry in entries)
 
 
 @pytest.mark.anyio
@@ -860,9 +860,14 @@ async def test_run_print_mode_resumes_persisted_conversation(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
-    await storage.append(MessageEntry(message=UserMessage(content="First question")))
-    await storage.append(MessageEntry(message=AssistantMessage(content="First answer")))
-    await storage.append(ModelChangeEntry(model="model-a"))
+    user_entry = MessageEntry(message=UserMessage(content="First question"))
+    assistant_entry = MessageEntry(
+        parent_id=user_entry.id,
+        message=AssistantMessage(content="First answer"),
+    )
+    await storage.append(user_entry)
+    await storage.append(assistant_entry)
+    await storage.append(ModelChangeEntry(parent_id=assistant_entry.id, model="model-a"))
     provider = FakeProvider(
         [
             [

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -548,12 +548,7 @@ class _FaultInjectingStorage:
         self.failures_remaining = 2 if phase == "message_twice" else 1
 
     async def append(self, entry: SessionEntry) -> None:
-        target = (
-            self.phase.startswith("message")
-            and isinstance(entry, MessageEntry)
-            or self.phase.startswith("leaf")
-            and isinstance(entry, LeafEntry)
-        )
+        target = self.phase.startswith("message") and isinstance(entry, MessageEntry)
         if target and (self.failures_remaining > 0 or self.phase == "message_always"):
             self.failed = True
             self.failures_remaining -= 1
@@ -566,7 +561,7 @@ class _FaultInjectingStorage:
         if (
             self.phase == "refresh"
             and not self.failed
-            and any(isinstance(entry, LeafEntry) for entry in self.entries)
+            and any(isinstance(entry, MessageEntry) for entry in self.entries)
         ):
             self.failed = True
             raise OSError("simulated refresh failure")
@@ -576,7 +571,7 @@ class _FaultInjectingStorage:
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "phase",
-    ["message_before", "message_after", "leaf_before", "leaf_after", "refresh"],
+    ["message_before", "message_after", "refresh"],
 )
 async def test_message_persistence_retry_is_idempotent(tmp_path: Path, phase: str) -> None:
     storage = _FaultInjectingStorage(phase)
@@ -596,12 +591,7 @@ async def test_message_persistence_retry_is_idempotent(tmp_path: Path, phase: st
     messages = [entry for entry in storage.entries if isinstance(entry, MessageEntry)]
     assert len(messages) == 1
     assert messages[0].message.text == "go"
-    leaves = [
-        entry
-        for entry in storage.entries
-        if isinstance(entry, LeafEntry) and entry.entry_id == messages[0].id
-    ]
-    assert len(leaves) == 1
+    assert not any(isinstance(entry, LeafEntry) for entry in storage.entries)
     restored = await CodingSession.load(
         CodingSessionConfig(
             provider=FakeProvider([]),
@@ -1146,7 +1136,7 @@ async def test_load_persists_repair_for_historical_interrupted_tool_call(
 
 
 @pytest.mark.anyio
-async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -> None:
+async def test_prompt_persists_user_and_assistant_entries_without_leaves(tmp_path: Path) -> None:
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
         [
@@ -1186,9 +1176,8 @@ async def test_prompt_persists_user_assistant_and_leaf_entries(tmp_path: Path) -
             AssistantMessage(content="Hi"),
         ],
     )
-    assert [entry.entry_id for entry in leaf_entries] == [entry.id for entry in message_entries]
-    assert entries[-1].type == "leaf"
-    assert entries[-1].entry_id == message_entries[-1].id
+    assert leaf_entries == []
+    assert entries[-1] == message_entries[-1]
     _assert_messages(
         session.messages, (UserMessage(content="Hello"), AssistantMessage(content="Hi"))
     )
@@ -1319,10 +1308,7 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
         entry.message for entry in entries_before_release if entry.type == "message"
     ]
     _assert_messages(before_release_messages, [UserMessage(content="Hello")])
-    assert entries_before_release[-1].type == "leaf"
-    assert entries_before_release[-1].entry_id == next(
-        entry.id for entry in entries_before_release if entry.type == "message"
-    )
+    assert entries_before_release[-1].type == "message"
     _assert_messages(
         session.messages,
         (
@@ -1337,7 +1323,7 @@ async def test_prompt_queues_steering_while_session_is_running(tmp_path: Path) -
     message_entries = [entry for entry in entries if entry.type == "message"]
     leaf_entries = [entry for entry in entries if entry.type == "leaf"]
     assert [entry.message for entry in message_entries] == list(session.messages)
-    assert [entry.entry_id for entry in leaf_entries] == [entry.id for entry in message_entries]
+    assert leaf_entries == []
     assert not any(isinstance(event, QueueUpdateEvent) for event in run_events)
 
 
@@ -1375,8 +1361,7 @@ async def test_tree_can_branch_from_first_user_message_before_assistant_response
     assert message_entries[0].message.text == "Start here"
     assert isinstance(message_entries[1].message, AssistantMessage)
     assert message_entries[1].message.stop_reason == "error"
-    assert isinstance(entries[-1], LeafEntry)
-    assert entries[-1].entry_id == message_entries[0].parent_id
+    assert entries[-1] == message_entries[-1]
 
 
 @pytest.mark.anyio
@@ -1478,7 +1463,18 @@ async def test_branch_to_entry_repairs_orphaned_tool_result(tmp_path: Path) -> N
         parent_id=orphan.id,
         message=AssistantMessage(content="answer"),
     )
-    for entry in (root, orphan, answer, LeafEntry(parent_id=root.id, entry_id=root.id)):
+    active_tip = ThinkingLevelChangeEntry(
+        id="tip",
+        parent_id=root.id,
+        thinking_level="medium",
+    )
+    for entry in (
+        root,
+        orphan,
+        answer,
+        active_tip,
+        LeafEntry(parent_id=root.id, entry_id=root.id),
+    ):
         await storage.append(entry)
     session = await CodingSession.load(
         CodingSessionConfig(
@@ -1616,7 +1612,8 @@ async def test_session_persists_and_replays_thinking_level_changes(tmp_path: Pat
     assert session.thinking_level == "high"
     assert len(thinking_entries) == 2
     assert thinking_entries[-1].thinking_level == "high"
-    assert leaves[-1].entry_id == thinking_entries[-1].id
+    assert leaves == []
+    assert entries[-1] == thinking_entries[-1]
     assert restored.thinking_level == "high"
     assert restored.state.thinking_level == "high"
 
@@ -2040,8 +2037,9 @@ async def test_load_restores_explicit_empty_leaf_branch(tmp_path: Path) -> None:
         input_prefill="Root",
     )
     assert session.messages == ()
-    assert reloaded.messages == ()
-    assert reloaded.state.active_leaf_id is None
+    # Navigation without a write is intentionally not restored.
+    assert reloaded.messages == (root.message,)
+    assert reloaded.state.active_leaf_id == "root"
 
 
 @pytest.mark.anyio
@@ -2061,7 +2059,8 @@ async def test_load_restores_active_leaf_branch(tmp_path: Path) -> None:
     await storage.append(root)
     await storage.append(left)
     await storage.append(right)
-    await storage.append(LeafEntry(entry_id="right"))
+    # A stale historical pointer is ignored; file order selects `right`.
+    await storage.append(LeafEntry(entry_id="left"))
 
     session = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
 
@@ -2143,8 +2142,9 @@ async def test_session_branches_to_previous_entry_without_destroying_history(
         session.messages, (UserMessage(content="Root"), AssistantMessage(content="Left"))
     )
     assert [entry.id for entry in entries if entry.type == "message"] == ["root", "left", "right"]
+    # Plain /tree navigation is in-memory only; the historical pointer is unchanged.
     assert isinstance(entries[-1], LeafEntry)
-    assert entries[-1].entry_id == "left"
+    assert entries[-1].entry_id == "right"
 
 
 @pytest.mark.anyio
@@ -2195,6 +2195,10 @@ async def test_persist_after_branch_keeps_state_on_active_branch(tmp_path: Path)
     )
     assert "abandoned" not in session.state.context_entry_ids
     assert "abandoned-answer" not in session.state.context_entry_ids
+    reloaded = await CodingSession.load(_config(tmp_path, FakeProvider([]), storage))
+    assert reloaded.messages == session.messages
+    assert reloaded.state.active_leaf_id == session.state.active_leaf_id
+    assert len([entry for entry in await storage.read_all() if entry.type == "leaf"]) == 1
 
     await session.compact()
     compactions = [entry for entry in await storage.read_all() if entry.type == "compaction"]
@@ -2242,7 +2246,7 @@ async def test_session_branches_to_before_selected_user_message_with_prefill(
         "followup",
     ]
     assert isinstance(entries[-1], LeafEntry)
-    assert entries[-1].entry_id == "assistant"
+    assert entries[-1].entry_id == "followup"
 
 
 @pytest.mark.anyio
@@ -2346,7 +2350,7 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
 
     result = await session.branch_to_entry("root", summarize=True)
     entries = await storage.read_all()
-    summary = entries[-2]
+    summary = entries[-1]
 
     assert "with branch summary" in result.message
     assert summary.type == "branch_summary"
@@ -2431,7 +2435,7 @@ async def test_session_branch_with_summary_tracks_file_operations(tmp_path: Path
 
     await session.branch_to_entry("root", summarize=True)
     entries = await storage.read_all()
-    summary = entries[-2]
+    summary = entries[-1]
 
     assert summary.type == "branch_summary"
     assert "<read-files>\nsrc/read_only.py\n</read-files>" in summary.summary
@@ -2458,7 +2462,7 @@ async def test_session_branch_with_summary_falls_back_when_model_summary_is_unav
 
     result = await session.branch_to_entry("root", summarize=True)
     entries = await storage.read_all()
-    summary = entries[-2]
+    summary = entries[-1]
 
     assert "with branch summary" in result.message
     assert summary.type == "branch_summary"
@@ -3638,7 +3642,8 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
     assert isinstance(compactions[0], CompactionEntry)
     assert compactions[0].summary == "Generated session summary"
     assert compactions[0].replaces_entry_ids == message_entries_before
-    assert leaves[-1].entry_id == compactions[0].id
+    assert leaves == []
+    assert entries_after_compact[-1] == compactions[0]
     assert provider.calls[1][1].startswith("You are a context summarization assistant.")
     assert "Additional focus: Focus on session persistence." in provider.calls[1][2][0].content
     _assert_messages(
@@ -5472,10 +5477,15 @@ async def test_session_resumes_indexed_session(tmp_path: Path) -> None:
             session_manager=manager,
         )
     )
-    await second_storage.append(SessionInfoEntry(cwd=str(second_record.cwd)))
-    await second_storage.append(ModelChangeEntry(model="fake"))
-    await second_storage.append(MessageEntry(message=UserMessage(content="Earlier")))
-    await second_storage.append(MessageEntry(message=AssistantMessage(content="Restored")))
+    info_entry = SessionInfoEntry(cwd=str(second_record.cwd))
+    model_entry = ModelChangeEntry(parent_id=info_entry.id, model="fake")
+    user_entry = MessageEntry(parent_id=model_entry.id, message=UserMessage(content="Earlier"))
+    await second_storage.append(info_entry)
+    await second_storage.append(model_entry)
+    await second_storage.append(user_entry)
+    await second_storage.append(
+        MessageEntry(parent_id=user_entry.id, message=AssistantMessage(content="Restored"))
+    )
 
     message = await session.resume(second_record.id)
     _events = await _collect_session_events(session.prompt("Continue."))
@@ -6295,10 +6305,21 @@ async def test_session_context_usage_recalculates_after_resume(tmp_path: Path) -
         )
     )
     before_resume_usage = session.context_usage
-    await second_storage.append(SessionInfoEntry(cwd=str(second_record.cwd)))
-    await second_storage.append(ModelChangeEntry(model="fake"))
-    await second_storage.append(MessageEntry(message=UserMessage(content="Earlier " * 20)))
-    await second_storage.append(MessageEntry(message=AssistantMessage(content="Restored " * 20)))
+    info_entry = SessionInfoEntry(cwd=str(second_record.cwd))
+    model_entry = ModelChangeEntry(parent_id=info_entry.id, model="fake")
+    user_entry = MessageEntry(
+        parent_id=model_entry.id,
+        message=UserMessage(content="Earlier " * 20),
+    )
+    await second_storage.append(info_entry)
+    await second_storage.append(model_entry)
+    await second_storage.append(user_entry)
+    await second_storage.append(
+        MessageEntry(
+            parent_id=user_entry.id,
+            message=AssistantMessage(content="Restored " * 20),
+        )
+    )
 
     _message = await session.resume(second_record.id)
     after_resume_usage = session.context_usage

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -312,11 +312,12 @@ def test_session_state_replays_linear_entries() -> None:
     assistant = AssistantMessage(content="Hello", timestamp=2)
     entries = [
         MessageEntry(id="user", message=user),
-        ModelChangeEntry(id="model", model="fake-model"),
-        MessageEntry(id="assistant", message=assistant),
-        LabelEntry(id="label", label="Greeting"),
-        CustomEntry(id="custom", namespace="test", data={"ok": True}),
-        LeafEntry(id="leaf", entry_id="assistant"),
+        ModelChangeEntry(id="model", parent_id="user", model="fake-model"),
+        MessageEntry(id="assistant", parent_id="model", message=assistant),
+        LabelEntry(id="label", parent_id="assistant", label="Greeting"),
+        CustomEntry(id="custom", parent_id="label", namespace="test", data={"ok": True}),
+        # Historical pointers deserialize but do not override the file-order tip.
+        LeafEntry(id="leaf", parent_id="custom", entry_id="assistant"),
     ]
 
     state = SessionState.from_entries(entries)
@@ -324,19 +325,28 @@ def test_session_state_replays_linear_entries() -> None:
     assert state.messages == (user, assistant)
     assert state.model == "fake-model"
     assert state.label == "Greeting"
-    assert state.active_leaf_id == "assistant"
+    assert state.active_leaf_id == "custom"
 
 
 def test_session_state_applies_compaction_and_branch_summary() -> None:
     entries = [
         MessageEntry(id="user", message=UserMessage(content="Explain sessions.")),
-        MessageEntry(id="assistant", message=AssistantMessage(content="They are trees.")),
+        MessageEntry(
+            id="assistant",
+            parent_id="user",
+            message=AssistantMessage(content="They are trees."),
+        ),
         CompactionEntry(
             id="compact",
+            parent_id="assistant",
             summary="The user asked about sessions.",
             replaces_entry_ids=["user", "assistant"],
         ),
-        BranchSummaryEntry(id="branch", summary="A side branch explored storage."),
+        BranchSummaryEntry(
+            id="branch",
+            parent_id="compact",
+            summary="A side branch explored storage.",
+        ),
     ]
 
     state = SessionState.from_entries(entries)

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -53,7 +53,7 @@ def test_render_session_html_preserves_branch_tree() -> None:
             summary="The right branch was compacted.",
             replaces_entry_ids=["root", "right", "tool"],
         ),
-        LeafEntry(id="leaf", parent_id="compact", entry_id="compact"),
+        LeafEntry(id="leaf", parent_id="compact", entry_id="left"),
     ]
 
     html = render_session_html(entries, title="Test Export", source="/tmp/session.jsonl")
@@ -63,7 +63,8 @@ def test_render_session_html_preserves_branch_tree() -> None:
     assert 'id="entry-root"' in html
     assert 'id="entry-left"' in html
     assert 'id="entry-right"' in html
-    assert 'id="entry-compact"' in html
+    assert 'id="entry-compact" class="entry active-entry"' in html
+    assert 'id="entry-leaf" class="entry"' in html
     assert "Start &lt;session&gt;" in html
     assert "Right branch" in html
     assert "active-path" in html
@@ -242,7 +243,7 @@ def test_render_session_html_includes_jsonl_download() -> None:
     assert match is not None
     decoded = base64.b64decode(match.group(1)).decode("utf-8")
     lines = decoded.splitlines()
-    # The download embeds every entry, including leaf pointers filtered from the view,
+    # The download embeds every entry, including historical leaf pointers,
     # but keeps the live prompt outside persisted transcript data.
     assert len(lines) == 3
     assert '"id":"leaf"' in lines[2]

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -72,6 +72,34 @@ def test_render_session_html_preserves_branch_tree() -> None:
     assert "Replaces entries" in html
 
 
+def test_render_session_html_handles_long_legacy_leaf_history() -> None:
+    entries: list[MessageEntry | LeafEntry] = []
+    parent_id: str | None = None
+    for index in range(1_100):
+        message = MessageEntry(
+            id=f"message-{index}",
+            parent_id=parent_id,
+            message=UserMessage(content=f"Message {index}"),
+        )
+        entries.extend(
+            [
+                message,
+                LeafEntry(
+                    id=f"leaf-{index}",
+                    parent_id=message.id,
+                    entry_id=message.id,
+                ),
+            ]
+        )
+        parent_id = message.id
+
+    html = render_session_html(entries, title="Legacy session")
+
+    assert 'id="entry-message-1099"' in html
+    assert 'id="entry-leaf-1099"' in html
+    assert 'href="#entry-leaf-1099"' not in html
+
+
 def test_render_session_html_uses_static_document_layout() -> None:
     entries = [MessageEntry(id="root", message=UserMessage(content="Export layout"))]
 

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -58,6 +58,13 @@ Run `/tree` to open the session tree, then select an earlier entry:
 
 If a summary request fails, Tau falls back to a deterministic summary.
 
+The active branch tip is the last session entry written. Plain **Enter**
+navigation is in-memory only: quitting before another action and reopening will
+return to the last non-legacy-leaf entry in file order. Your next message or
+state change uses the selected point as its parent, making the new branch the
+active persisted tip. **S** writes its branch summary immediately, so summarized
+navigation survives a restart even before another message.
+
 ## Recovering older sessions
 
 Older Tau versions could leave malformed tool-call history when a run was
@@ -144,7 +151,8 @@ nested accordions. The export header includes controls to:
 - hide session events—such as session info, model and thinking changes,
   compactions, labels, and custom entries—to focus on user and assistant messages
 - download the session as a JSONL file—the complete entry data is embedded in
-  the page, so the download works offline and includes every entry
+  the page, so the download works offline and includes every entry (including
+  historical `leaf` records from older Tau versions)
 
 Tool rows are titled `Tool: <name>` (for example, `Tool: read`), and the
 session tree labels tool entries with just the tool name for readability.
@@ -156,6 +164,9 @@ session tree labels tool entries with just the tool name for readability.
 ```
 
 For example, `/Users/you/repos/tau` becomes something like
-`repos-tau-a1b2c3`. The original JSONL is append-only — compaction and branching
-change the *active* view, never the recorded history. See
+`repos-tau-a1b2c3`. The original JSONL is append-only. New Tau versions do not
+write separate `leaf` pointer records; the last non-`leaf` entry in file order
+is the active tip. Older files containing `leaf` records remain readable, but
+those records do not override file-order tip selection. Compaction and
+branching change the *active* view, never the recorded history. See
 [Configuration]({{< relref "../reference/configuration.md#sessions" >}}) for the exact layout.

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -438,8 +438,9 @@ Full list in [Keyboard shortcuts]({{< relref "./keybindings.md" >}}).
 ```
 
 Each working directory gets its own subdirectory; transcripts are append-only
-JSONL preserving messages, model changes, and the active leaf of the session
-tree. Metadata is indexed per project. See the
+JSONL preserving messages and state changes. The last non-legacy-leaf entry in
+file order is the active session-tree tip; historical `leaf` records remain
+readable but are ignored. Metadata is indexed per project. See the
 [Sessions guide]({{< relref "../guides/sessions.md" >}}).
 
 ## Skills, prompts & project context


### PR DESCRIPTION
## Summary

- stop persisting redundant `leaf` session entries from every state-changing write path
- derive the active branch from the last non-`leaf` JSONL entry while retaining historical `LeafEntry` deserialization support
- simplify idempotent message persistence to a single-entry retry and update session export behavior
- document the file-order resume rule and `/tree` navigation behavior across restarts

## User experience

Session files are smaller and less noisy, session replay avoids processing nearly one pointer row per message, and retry paths no longer need to coordinate message/leaf pairs. Tau now follows Pi's simpler rule that the final substantive JSONL line is the resumable branch tip.

Plain `/tree` navigation remains active in memory. If the user exits before appending anything, reopening resumes from the last substantive line in the file; the next message or state change anchors the selected branch durably.

## Issue

Closes #700.

## Manual validation

1. Start Tau with a persisted session and send multiple prompts.
2. Inspect the session JSONL and verify that it contains no entries with `"type":"leaf"`.
3. Branch from an older `/tree` entry, send a prompt, restart Tau, and confirm that the new branch is restored.
4. Open an older session containing `leaf` entries and confirm it loads without errors and resumes from its last non-`leaf` entry.
5. Export a session and verify the active path and active tip render correctly.

## Checks

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` (from `website/`)
- `npx --yes pagefind@latest --site public` (from `website/`)
