### PR TITLE
Record usage for generated session summaries

### DIFF
--- a/dev-notes/summary-request-usage.md
+++ b/dev-notes/summary-request-usage.md
@@ -3,10 +3,11 @@
 ## What changed
 
 Compaction and branch-summary entries now have optional `usage`, `provider`,
-and `model` fields. `usage` uses `tau_agent.messages.Usage`, the same strict
-token-and-cost model stored on assistant messages. The coding session captures
-the final provider event's usage when it generates a summary and persists it
-with the exact logical provider and model used for that request.
+`model`, and `response_provider` fields. `usage` uses `tau_agent.messages.Usage`,
+the same strict token-and-cost model stored on assistant messages. The coding
+session captures the final provider event's usage when it generates a summary
+and persists it with the exact logical provider, model, and resolved routing
+provider used for that request.
 Multiple completion events are combined field by field so the entry represents
 the total cost of producing the summary.
 
@@ -18,8 +19,11 @@ The HTML export's usage collector treats persisted summary usage as a real,
 separately labeled request. The cumulative session-statistics collector does the
 same for the TUI sidebar. Both include those tokens in prompt, cache, output,
 hit-rate, and estimated-cost totals. New entries provide the exact persisted
-provider/model; legacy entries fall back to preceding model-change or assistant
-metadata. The shared Pi-compatible `Usage` object itself intentionally contains
+provider/model and, when reported, the resolved provider used by a routing
+service; legacy entries fall back to preceding model-change or assistant
+metadata. Summary requests are recorded before the compaction or branch event
+that they produce, so event markers remain attached to the next context request.
+The shared Pi-compatible `Usage` object itself intentionally contains
 only tokens and cost. RPC entry projections include `usage` where present, and the
 transcript detail panel displays the raw usage object.
 

--- a/dev-notes/summary-request-usage.md
+++ b/dev-notes/summary-request-usage.md
@@ -1,0 +1,56 @@
+# Persist summary-request usage
+
+## What changed
+
+Compaction and branch-summary entries now have an optional `usage` field using
+`tau_agent.messages.Usage`, the same strict token-and-cost model stored on
+assistant messages. The coding session captures the final provider event's
+usage when it generates a summary and persists it with the summary entry.
+Multiple completion events are combined field by field so the entry represents
+the total cost of producing the summary.
+
+Model-assisted branch summaries retain usage. If generation fails or produces
+no usable text, Tau's deterministic heuristic remains the fallback and the
+entry records `usage=None` because no successful model summary was used.
+
+The HTML export's usage collector treats persisted summary usage as a real,
+separately labeled request. The cumulative session-statistics collector does the
+same for the TUI sidebar. Both include those tokens in prompt, cache, output,
+hit-rate, and estimated-cost totals. They associate the request with
+the provider/model established by preceding model-change or assistant entries;
+the shared Pi-compatible `Usage` object itself intentionally contains only
+tokens and cost. RPC entry projections include `usage` where present, and the
+transcript detail panel displays the raw usage object.
+
+## Why it exists
+
+Summary generation can reread most of a session and may be one of its largest
+requests. Previously Tau discarded its final usage event, so session exports
+systematically underreported token consumption and estimated cost. Persisting
+usage on the session entry follows Pi's separation: the portable session schema
+owns durable request facts, while the coding-session layer captures them and UI
+analytics consume them.
+
+## Session compatibility
+
+The field defaults to `None` and JSONL serialization excludes null values.
+Therefore session files written before this change load unchanged, and newly
+written heuristic summaries have the same shape as legacy summaries. Analytics
+skip missing usage rather than creating a synthetic zero-token request.
+
+## Validation
+
+Run:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+uv build
+cd website && hugo --minify && npx --yes pagefind@latest --site public
+```
+
+Tests cover model-event capture for both summary paths, fallback and legacy
+`None` behavior, JSONL aliases/round trips, aggregate analytics, RPC projection,
+and HTML export rendering.

--- a/dev-notes/summary-request-usage.md
+++ b/dev-notes/summary-request-usage.md
@@ -2,10 +2,11 @@
 
 ## What changed
 
-Compaction and branch-summary entries now have an optional `usage` field using
-`tau_agent.messages.Usage`, the same strict token-and-cost model stored on
-assistant messages. The coding session captures the final provider event's
-usage when it generates a summary and persists it with the summary entry.
+Compaction and branch-summary entries now have optional `usage`, `provider`,
+and `model` fields. `usage` uses `tau_agent.messages.Usage`, the same strict
+token-and-cost model stored on assistant messages. The coding session captures
+the final provider event's usage when it generates a summary and persists it
+with the exact logical provider and model used for that request.
 Multiple completion events are combined field by field so the entry represents
 the total cost of producing the summary.
 
@@ -16,10 +17,10 @@ entry records `usage=None` because no successful model summary was used.
 The HTML export's usage collector treats persisted summary usage as a real,
 separately labeled request. The cumulative session-statistics collector does the
 same for the TUI sidebar. Both include those tokens in prompt, cache, output,
-hit-rate, and estimated-cost totals. They associate the request with
-the provider/model established by preceding model-change or assistant entries;
-the shared Pi-compatible `Usage` object itself intentionally contains only
-tokens and cost. RPC entry projections include `usage` where present, and the
+hit-rate, and estimated-cost totals. New entries provide the exact persisted
+provider/model; legacy entries fall back to preceding model-change or assistant
+metadata. The shared Pi-compatible `Usage` object itself intentionally contains
+only tokens and cost. RPC entry projections include `usage` where present, and the
 transcript detail panel displays the raw usage object.
 
 ## Why it exists
@@ -33,7 +34,7 @@ analytics consume them.
 
 ## Session compatibility
 
-The field defaults to `None` and JSONL serialization excludes null values.
+The new fields default to `None` and JSONL serialization excludes null values.
 Therefore session files written before this change load unchanged, and newly
 written heuristic summaries have the same shape as legacy summaries. Analytics
 skip missing usage rather than creating a synthetic zero-token request.

--- a/src/tau_agent/messages.py
+++ b/src/tau_agent/messages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from time import time
 from typing import Annotated, Any, Literal
 
@@ -53,6 +54,36 @@ class Usage(WireModel):
     reasoning: int | None = None
     total_tokens: int = 0
     cost: UsageCost = UsageCost()
+
+
+def sum_usage(usages: Iterable[Usage]) -> Usage:
+    """Return the field-wise total for one or more provider requests."""
+    items = tuple(usages)
+
+    def optional_total(field: Literal["cache_write_1h", "reasoning"]) -> int | None:
+        values = [getattr(item, field) for item in items]
+        return (
+            sum(value for value in values if value is not None)
+            if any(value is not None for value in values)
+            else None
+        )
+
+    return Usage(
+        input=sum(item.input for item in items),
+        output=sum(item.output for item in items),
+        cache_read=sum(item.cache_read for item in items),
+        cache_write=sum(item.cache_write for item in items),
+        cache_write_1h=optional_total("cache_write_1h"),
+        reasoning=optional_total("reasoning"),
+        total_tokens=sum(item.total_tokens for item in items),
+        cost=UsageCost(
+            input=sum(item.cost.input for item in items),
+            output=sum(item.cost.output for item in items),
+            cache_read=sum(item.cost.cache_read for item in items),
+            cache_write=sum(item.cost.cache_write for item in items),
+            total=sum(item.cost.total for item in items),
+        ),
+    )
 
 
 class ResponseTiming(WireModel):

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -70,6 +70,7 @@ class CompactionEntry(BaseSessionEntry):
     usage: Usage | None = None
     provider: str | None = None
     model: str | None = None
+    response_provider: str | None = None
 
 
 class BranchSummaryEntry(BaseSessionEntry):
@@ -81,6 +82,7 @@ class BranchSummaryEntry(BaseSessionEntry):
     usage: Usage | None = None
     provider: str | None = None
     model: str | None = None
+    response_provider: str | None = None
 
 
 class LabelEntry(BaseSessionEntry):

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from tau_agent.messages import AgentMessage
+from tau_agent.messages import AgentMessage, Usage
 from tau_agent.types import JSONValue
 
 
@@ -67,6 +67,7 @@ class CompactionEntry(BaseSessionEntry):
     replaces_entry_ids: list[str] = Field(default_factory=list)
     first_kept_entry_id: str | None = None
     tokens_before: int | None = None
+    usage: Usage | None = None
 
 
 class BranchSummaryEntry(BaseSessionEntry):
@@ -75,6 +76,7 @@ class BranchSummaryEntry(BaseSessionEntry):
     type: Literal["branch_summary"] = "branch_summary"
     summary: str
     branch_root_id: str | None = None
+    usage: Usage | None = None
 
 
 class LabelEntry(BaseSessionEntry):

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -68,6 +68,8 @@ class CompactionEntry(BaseSessionEntry):
     first_kept_entry_id: str | None = None
     tokens_before: int | None = None
     usage: Usage | None = None
+    provider: str | None = None
+    model: str | None = None
 
 
 class BranchSummaryEntry(BaseSessionEntry):
@@ -77,6 +79,8 @@ class BranchSummaryEntry(BaseSessionEntry):
     summary: str
     branch_root_id: str | None = None
     usage: Usage | None = None
+    provider: str | None = None
+    model: str | None = None
 
 
 class LabelEntry(BaseSessionEntry):

--- a/src/tau_coding/branch_summary.py
+++ b/src/tau_coding/branch_summary.py
@@ -72,8 +72,8 @@ async def summarize_branch_messages_with_model(
     messages: Sequence[AgentMessage],
     custom_instructions: str | None = None,
     replace_instructions: bool = False,
-) -> tuple[str, Usage] | None:
-    """Return a model-generated branch summary and its usage, or None on failure."""
+) -> tuple[str, Usage, str | None] | None:
+    """Return a generated summary, usage, and resolved provider, or None on failure."""
     if not messages:
         return None
 
@@ -104,7 +104,11 @@ async def summarize_branch_messages_with_model(
     summary = response.text.strip()
     if not summary:
         return None
-    return _add_branch_summary_context(summary, messages), sum_usage(response_usages)
+    return (
+        _add_branch_summary_context(summary, messages),
+        sum_usage(response_usages),
+        response.response_provider,
+    )
 
 
 def _branch_summary_prompt(

--- a/src/tau_coding/branch_summary.py
+++ b/src/tau_coding/branch_summary.py
@@ -9,8 +9,10 @@ from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
     ToolResultMessage,
+    Usage,
     UserMessage,
     message_text,
+    sum_usage,
 )
 from tau_agent.provider import ModelProvider
 from tau_agent.provider_events import AssistantDoneEvent, AssistantErrorEvent
@@ -70,12 +72,13 @@ async def summarize_branch_messages_with_model(
     messages: Sequence[AgentMessage],
     custom_instructions: str | None = None,
     replace_instructions: bool = False,
-) -> str | None:
-    """Return a model-generated branch summary, or None when generation fails."""
+) -> tuple[str, Usage] | None:
+    """Return a model-generated branch summary and its usage, or None on failure."""
     if not messages:
         return None
 
     response: AssistantMessage | None = None
+    response_usages: list[Usage] = []
     async for event in provider.stream_response(
         model=model,
         system=BRANCH_SUMMARY_SYSTEM_PROMPT,
@@ -94,13 +97,14 @@ async def summarize_branch_messages_with_model(
             return None
         if isinstance(event, AssistantDoneEvent):
             response = event.message
+            response_usages.append(event.message.usage)
 
     if response is None:
         return None
     summary = response.text.strip()
     if not summary:
         return None
-    return _add_branch_summary_context(summary, messages)
+    return _add_branch_summary_context(summary, messages), sum_usage(response_usages)
 
 
 def _branch_summary_prompt(

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -715,6 +715,7 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
                 "data": {
                     "summary": entry.summary,
                     "replacesEntryIds": list(entry.replaces_entry_ids),
+                    **({"usage": _jsonable(entry.usage)} if entry.usage is not None else {}),
                 },
             }
         return {
@@ -722,6 +723,7 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
             "summary": entry.summary,
             "firstKeptEntryId": entry.first_kept_entry_id,
             "tokensBefore": entry.tokens_before,
+            **({"usage": _jsonable(entry.usage)} if entry.usage is not None else {}),
             "details": {"tauReplacedEntryIds": list(entry.replaces_entry_ids)},
         }
     if entry.type == "branch_summary":
@@ -729,6 +731,7 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
             **base,
             "fromId": entry.branch_root_id or entry.parent_id or entry.id,
             "summary": entry.summary,
+            **({"usage": _jsonable(entry.usage)} if entry.usage is not None else {}),
             "details": {},
         }
     if entry.type == "custom":

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -17,8 +17,10 @@ from tau_agent.messages import (
     AgentMessage,
     AssistantMessage,
     CustomMessage,
+    Usage,
     UserMessage,
     message_text,
+    sum_usage,
 )
 from tau_agent.provider import ModelProvider
 from tau_agent.provider_events import AssistantDoneEvent, AssistantErrorEvent, TextDeltaEvent
@@ -291,6 +293,14 @@ class CompactionPlan:
 
     replace_entry_ids: tuple[str, ...]
     messages_to_summarize: tuple[AgentMessage, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _GeneratedSummary:
+    """Summary text paired with the provider usage spent producing it."""
+
+    text: str
+    usage: Usage | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -977,7 +987,7 @@ class CodingSession:
                 self._last_parent_id,
             )
             if abandoned_messages:
-                summary = await self._summarize_branch_messages(
+                generated = await self._summarize_branch_messages(
                     abandoned_messages,
                     custom_instructions=custom_instructions,
                     replace_instructions=replace_instructions,
@@ -985,7 +995,8 @@ class CodingSession:
                 summary_entry = BranchSummaryEntry(
                     parent_id=entry_id,
                     branch_root_id=entry_id,
-                    summary=summary,
+                    summary=generated.text,
+                    usage=generated.usage,
                 )
                 await self._append_session_entry(summary_entry)
                 target_id = summary_entry.id
@@ -2850,18 +2861,19 @@ class CodingSession:
             raise ValueError("Not enough context to compact while preserving recent entries")
         first_kept_entry_id = rows[len(plan.replace_entry_ids)][0]
         tokens_before = self.context_token_estimate
-        summary = await self._generate_compaction_summary(
+        generated = await self._generate_compaction_summary(
             plan.messages_to_summarize,
             custom_instructions=instructions,
         )
         compaction = await self._append_compaction(
-            summary,
+            generated.text,
             replace_entry_ids=plan.replace_entry_ids,
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
+            usage=generated.usage,
         )
         return ManualCompactionResult(
-            summary=summary,
+            summary=generated.text,
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
             estimated_tokens_after=self.context_token_estimate,
@@ -2872,14 +2884,15 @@ class CodingSession:
         """Generate a manual compaction summary and rebuild active context."""
         await self._flush_pending_message_writes(context=self._diagnostic_context())
         plan = self._manual_compaction_plan()
-        summary = await self._generate_compaction_summary(
+        generated = await self._generate_compaction_summary(
             plan.messages_to_summarize,
             custom_instructions=instructions,
         )
         compaction = await self._append_compaction(
-            summary,
+            generated.text,
             replace_entry_ids=plan.replace_entry_ids,
             tokens_before=self.context_token_estimate,
+            usage=generated.usage,
         )
         return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
 
@@ -3619,8 +3632,12 @@ class CodingSession:
             plan = self._recent_preserving_compaction_plan()
             if plan is None:
                 return False
-            summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-            await self._append_compaction(summary, replace_entry_ids=plan.replace_entry_ids)
+            generated = await self._generate_compaction_summary(plan.messages_to_summarize)
+            await self._append_compaction(
+                generated.text,
+                replace_entry_ids=plan.replace_entry_ids,
+                usage=generated.usage,
+            )
             return True
         except Exception as exc:  # noqa: BLE001 - the original overflow remains visible
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -3717,8 +3734,12 @@ class CodingSession:
         plan = self._recent_preserving_compaction_plan()
         if plan is None:
             return False
-        summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-        await self._append_compaction(summary, replace_entry_ids=plan.replace_entry_ids)
+        generated = await self._generate_compaction_summary(plan.messages_to_summarize)
+        await self._append_compaction(
+            generated.text,
+            replace_entry_ids=plan.replace_entry_ids,
+            usage=generated.usage,
+        )
         return True
 
     async def _generate_compaction_summary(
@@ -3726,13 +3747,14 @@ class CodingSession:
         messages: tuple[AgentMessage, ...],
         *,
         custom_instructions: str | None = None,
-    ) -> str:
+    ) -> _GeneratedSummary:
         prompt = build_compaction_summary_prompt(
             messages,
             custom_instructions=custom_instructions,
         )
         text_parts: list[str] = []
         final_text: str | None = None
+        response_usages: list[Usage] = []
         summary_messages: list[AgentMessage] = [UserMessage(content=prompt)]
         async for event in self._harness.config.provider.stream_response(
             model=self.model,
@@ -3744,6 +3766,7 @@ class CodingSession:
                 text_parts.append(event.delta)
             elif isinstance(event, AssistantDoneEvent):
                 final_text = event.message.text
+                response_usages.append(event.message.usage)
             elif isinstance(event, AssistantErrorEvent):
                 raise RuntimeError(
                     f"Compaction summarization failed: {event.error.error_message or event.reason}"
@@ -3752,7 +3775,10 @@ class CodingSession:
         summary = (final_text if final_text is not None else "".join(text_parts)).strip()
         if not summary:
             raise RuntimeError("Compaction summarization returned an empty summary")
-        return summary
+        return _GeneratedSummary(
+            text=summary,
+            usage=sum_usage(response_usages) if response_usages else None,
+        )
 
     async def _summarize_branch_messages(
         self,
@@ -3760,9 +3786,9 @@ class CodingSession:
         *,
         custom_instructions: str | None = None,
         replace_instructions: bool = False,
-    ) -> str:
+    ) -> _GeneratedSummary:
         try:
-            summary = await summarize_branch_messages_with_model(
+            result = await summarize_branch_messages_with_model(
                 provider=self._harness.config.provider,
                 model=self.model,
                 messages=messages,
@@ -3770,8 +3796,14 @@ class CodingSession:
                 replace_instructions=replace_instructions,
             )
         except Exception:
-            summary = None
-        return summary or summarize_messages_for_compaction(messages)
+            result = None
+        if result is not None:
+            summary, usage = result
+            return _GeneratedSummary(text=summary, usage=usage)
+        return _GeneratedSummary(
+            text=summarize_messages_for_compaction(messages),
+            usage=None,
+        )
 
     def _manual_compaction_plan(self) -> CompactionPlan:
         rows = self._active_context_rows()
@@ -3812,6 +3844,7 @@ class CodingSession:
         replace_entry_ids: tuple[str, ...],
         first_kept_entry_id: str | None = None,
         tokens_before: int | None = None,
+        usage: Usage | None = None,
     ) -> CompactionEntry:
         if not replace_entry_ids:
             raise ValueError("No active context messages to compact")
@@ -3822,6 +3855,7 @@ class CodingSession:
             replaces_entry_ids=list(replace_entry_ids),
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
+            usage=usage,
         )
         await self._append_session_entry(compaction)
         self._last_parent_id = compaction.id

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -303,6 +303,7 @@ class _GeneratedSummary:
     usage: Usage | None
     provider: str | None = None
     model: str | None = None
+    response_provider: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1001,6 +1002,7 @@ class CodingSession:
                     usage=generated.usage,
                     provider=generated.provider,
                     model=generated.model,
+                    response_provider=generated.response_provider,
                 )
                 await self._append_session_entry(summary_entry)
                 target_id = summary_entry.id
@@ -2877,6 +2879,7 @@ class CodingSession:
             usage=generated.usage,
             provider=generated.provider,
             model=generated.model,
+            response_provider=generated.response_provider,
         )
         return ManualCompactionResult(
             summary=generated.text,
@@ -2901,6 +2904,7 @@ class CodingSession:
             usage=generated.usage,
             provider=generated.provider,
             model=generated.model,
+            response_provider=generated.response_provider,
         )
         return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
 
@@ -3647,6 +3651,7 @@ class CodingSession:
                 usage=generated.usage,
                 provider=generated.provider,
                 model=generated.model,
+                response_provider=generated.response_provider,
             )
             return True
         except Exception as exc:  # noqa: BLE001 - the original overflow remains visible
@@ -3751,6 +3756,7 @@ class CodingSession:
             usage=generated.usage,
             provider=generated.provider,
             model=generated.model,
+            response_provider=generated.response_provider,
         )
         return True
 
@@ -3767,6 +3773,7 @@ class CodingSession:
         text_parts: list[str] = []
         final_text: str | None = None
         response_usages: list[Usage] = []
+        response_provider: str | None = None
         summary_messages: list[AgentMessage] = [UserMessage(content=prompt)]
         async for event in self._harness.config.provider.stream_response(
             model=self.model,
@@ -3779,6 +3786,7 @@ class CodingSession:
             elif isinstance(event, AssistantDoneEvent):
                 final_text = event.message.text
                 response_usages.append(event.message.usage)
+                response_provider = event.message.response_provider
             elif isinstance(event, AssistantErrorEvent):
                 raise RuntimeError(
                     f"Compaction summarization failed: {event.error.error_message or event.reason}"
@@ -3792,6 +3800,7 @@ class CodingSession:
             usage=sum_usage(response_usages) if response_usages else None,
             provider=self.provider_name,
             model=self.model,
+            response_provider=response_provider,
         )
 
     async def _summarize_branch_messages(
@@ -3812,12 +3821,13 @@ class CodingSession:
         except Exception:
             result = None
         if result is not None:
-            summary, usage = result
+            summary, usage, response_provider = result
             return _GeneratedSummary(
                 text=summary,
                 usage=usage,
                 provider=self.provider_name,
                 model=self.model,
+                response_provider=response_provider,
             )
         return _GeneratedSummary(
             text=summarize_messages_for_compaction(messages),
@@ -3866,6 +3876,7 @@ class CodingSession:
         usage: Usage | None = None,
         provider: str | None = None,
         model: str | None = None,
+        response_provider: str | None = None,
     ) -> CompactionEntry:
         if not replace_entry_ids:
             raise ValueError("No active context messages to compact")
@@ -3879,6 +3890,7 @@ class CodingSession:
             usage=usage,
             provider=provider,
             model=model,
+            response_provider=response_provider,
         )
         await self._append_session_entry(compaction)
         self._last_parent_id = compaction.id

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -301,6 +301,8 @@ class _GeneratedSummary:
 
     text: str
     usage: Usage | None
+    provider: str | None = None
+    model: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -997,6 +999,8 @@ class CodingSession:
                     branch_root_id=entry_id,
                     summary=generated.text,
                     usage=generated.usage,
+                    provider=generated.provider,
+                    model=generated.model,
                 )
                 await self._append_session_entry(summary_entry)
                 target_id = summary_entry.id
@@ -2871,6 +2875,8 @@ class CodingSession:
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
             usage=generated.usage,
+            provider=generated.provider,
+            model=generated.model,
         )
         return ManualCompactionResult(
             summary=generated.text,
@@ -2893,6 +2899,8 @@ class CodingSession:
             replace_entry_ids=plan.replace_entry_ids,
             tokens_before=self.context_token_estimate,
             usage=generated.usage,
+            provider=generated.provider,
+            model=generated.model,
         )
         return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
 
@@ -3637,6 +3645,8 @@ class CodingSession:
                 generated.text,
                 replace_entry_ids=plan.replace_entry_ids,
                 usage=generated.usage,
+                provider=generated.provider,
+                model=generated.model,
             )
             return True
         except Exception as exc:  # noqa: BLE001 - the original overflow remains visible
@@ -3739,6 +3749,8 @@ class CodingSession:
             generated.text,
             replace_entry_ids=plan.replace_entry_ids,
             usage=generated.usage,
+            provider=generated.provider,
+            model=generated.model,
         )
         return True
 
@@ -3778,6 +3790,8 @@ class CodingSession:
         return _GeneratedSummary(
             text=summary,
             usage=sum_usage(response_usages) if response_usages else None,
+            provider=self.provider_name,
+            model=self.model,
         )
 
     async def _summarize_branch_messages(
@@ -3799,7 +3813,12 @@ class CodingSession:
             result = None
         if result is not None:
             summary, usage = result
-            return _GeneratedSummary(text=summary, usage=usage)
+            return _GeneratedSummary(
+                text=summary,
+                usage=usage,
+                provider=self.provider_name,
+                model=self.model,
+            )
         return _GeneratedSummary(
             text=summarize_messages_for_compaction(messages),
             usage=None,
@@ -3845,6 +3864,8 @@ class CodingSession:
         first_kept_entry_id: str | None = None,
         tokens_before: int | None = None,
         usage: Usage | None = None,
+        provider: str | None = None,
+        model: str | None = None,
     ) -> CompactionEntry:
         if not replace_entry_ids:
             raise ValueError("No active context messages to compact")
@@ -3856,6 +3877,8 @@ class CodingSession:
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
             usage=usage,
+            provider=provider,
+            model=model,
         )
         await self._append_session_entry(compaction)
         self._last_parent_id = compaction.id

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -1307,15 +1307,33 @@ def _render_entry_body(entry: SessionEntry) -> str:
         level = entry.thinking_level if entry.thinking_level is not None else "off"
         return f"<p>Thinking level changed to <code>{_escape(level)}</code>.</p>"
     if isinstance(entry, CompactionEntry):
+        usage = (
+            _render_block(
+                "Summary request usage",
+                _render_json_block(entry.usage.model_dump(mode="json", by_alias=True)),
+            )
+            if entry.usage is not None
+            else ""
+        )
         return (
             f"<pre>{_escape(entry.summary)}</pre>"
             f"{_render_list('Replaces entries', entry.replaces_entry_ids)}"
+            f"{usage}"
         )
     if isinstance(entry, BranchSummaryEntry):
         branch_root = entry.branch_root_id or "none"
+        usage = (
+            _render_block(
+                "Summary request usage",
+                _render_json_block(entry.usage.model_dump(mode="json", by_alias=True)),
+            )
+            if entry.usage is not None
+            else ""
+        )
         return (
             f"<p>Branch root: <code>{_escape(branch_root)}</code></p>"
             f"<pre>{_escape(entry.summary)}</pre>"
+            f"{usage}"
         )
     if isinstance(entry, LabelEntry):
         return f"<p>Session label: <strong>{_escape(entry.label)}</strong></p>"

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 
 from tau_agent.messages import AssistantMessage, CustomMessage, UserMessage
-from tau_agent.session import MessageEntry
+from tau_agent.session import BranchSummaryEntry, CompactionEntry, MessageEntry, ModelChangeEntry
 from tau_agent.session.entries import SessionEntry
 
 PricingResolver = Callable[[str, str, int], Mapping[str, float] | None]
@@ -89,19 +89,39 @@ def calculate_session_stats(
     estimated_cost = 0.0
     has_billable_usage = False
     has_complete_pricing = True
+    current_provider = "unknown"
+    current_model = "unknown"
 
     for entry in entries:
-        if not isinstance(entry, MessageEntry):
-            continue
-        message = entry.message
-        if isinstance(message, (UserMessage, CustomMessage)):
-            turn_count += 1
-            continue
-        if not isinstance(message, AssistantMessage):
+        if isinstance(entry, ModelChangeEntry):
+            current_model = entry.model
+            if entry.provider is not None:
+                current_provider = entry.provider
             continue
 
-        tool_call_count += len(message.tool_calls)
-        usage = message.usage
+        message: AssistantMessage | None = None
+        if isinstance(entry, MessageEntry):
+            if isinstance(entry.message, (UserMessage, CustomMessage)):
+                turn_count += 1
+                continue
+            if not isinstance(entry.message, AssistantMessage):
+                continue
+            message = entry.message
+            current_provider = message.provider
+            current_model = message.model
+            tool_call_count += len(message.tool_calls)
+            usage = message.usage
+            provider = message.provider
+            model = message.model
+        elif isinstance(entry, CompactionEntry | BranchSummaryEntry):
+            if entry.usage is None:
+                continue
+            usage = entry.usage
+            provider = current_provider
+            model = current_model
+        else:
+            continue
+
         prompt_tokens = usage.input + usage.cache_read + usage.cache_write
         latest_prompt_tokens = prompt_tokens
         latest_cached_input_tokens = usage.cache_read
@@ -109,7 +129,7 @@ def calculate_session_stats(
         cached_input_tokens += usage.cache_read
         cache_write_tokens += usage.cache_write
         output_tokens += usage.output
-        timing = message.timing
+        timing = message.timing if message is not None else None
         if timing is not None:
             # TPS is token-weighted and requires usable output usage. TTFT is a
             # per-call arithmetic mean whenever output was observed, even if a
@@ -124,7 +144,7 @@ def calculate_session_stats(
             continue
 
         has_billable_usage = True
-        rates = pricing(message.provider, message.model, prompt_tokens)
+        rates = pricing(provider, model, prompt_tokens)
         if rates is None:
             if usage.cost.total > 0:
                 estimated_cost += usage.cost.total

--- a/src/tau_coding/session_stats.py
+++ b/src/tau_coding/session_stats.py
@@ -117,8 +117,8 @@ def calculate_session_stats(
             if entry.usage is None:
                 continue
             usage = entry.usage
-            provider = current_provider
-            model = current_model
+            provider = entry.provider or current_provider
+            model = entry.model or current_model
         else:
             continue
 

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from tau_agent.messages import AssistantMessage
+from tau_agent.messages import AssistantMessage, Usage
 from tau_agent.session import (
     BranchSummaryEntry,
     CompactionEntry,
@@ -36,6 +36,7 @@ class RequestUsage:
     """Token usage for a single assistant response."""
 
     number: int
+    kind: str
     timestamp: str
     provider: str
     model: str
@@ -149,26 +150,23 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
     compactions = 0
     pending_events: list[tuple[str, str, str]] = []
     events: list[UsageEvent] = []
-    for entry in entries:
-        event = _usage_event(entry)
-        if event is not None:
-            kind, label = event
-            pending_events.append((_entry_time(entry.timestamp), kind, label))
-            if isinstance(entry, CompactionEntry):
-                compactions += 1
-            continue
-        if not isinstance(entry, MessageEntry):
-            continue
-        message = entry.message
-        if not isinstance(message, AssistantMessage):
-            continue
-        for call in message.tool_calls:
-            tools[call.name] = tools.get(call.name, 0) + 1
-        usage = message.usage
+    current_provider = "unknown"
+    current_model = "unknown"
+
+    def append_request(
+        usage: Usage,
+        *,
+        timestamp: float,
+        kind: str,
+        provider: str,
+        model: str,
+        response_provider: str | None = None,
+        stop_reason: str = "-",
+    ) -> None:
         cache_write_1h = usage.cache_write_1h or 0
         estimated = estimated_request_cost(
-            message.provider,
-            message.model,
+            provider,
+            model,
             fresh=usage.input,
             cached=usage.cache_read,
             cache_write=usage.cache_write,
@@ -181,30 +179,81 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
         requests.append(
             RequestUsage(
                 number=request_number,
-                timestamp=datetime.fromtimestamp(entry.timestamp, tz=UTC).strftime("%H:%M:%S"),
-                provider=message.provider,
-                model=message.model,
-                response_provider=message.response_provider,
+                kind=kind,
+                timestamp=_entry_time(timestamp),
+                provider=provider,
+                model=model,
+                response_provider=response_provider,
                 fresh=usage.input,
                 cached=usage.cache_read,
                 cache_write=usage.cache_write,
                 cache_write_1h=cache_write_1h,
                 output=usage.output,
                 reasoning=usage.reasoning or 0,
-                stop_reason=message.stop_reason,
+                stop_reason=stop_reason,
                 estimated_cost=estimated,
             )
         )
         events.extend(
             UsageEvent(
                 request_number=request_number,
-                timestamp=timestamp,
-                kind=kind,
+                timestamp=event_timestamp,
+                kind=event_kind,
                 label=label,
             )
-            for timestamp, kind, label in pending_events
+            for event_timestamp, event_kind, label in pending_events
         )
         pending_events.clear()
+
+    for entry in entries:
+        event = _usage_event(entry)
+        if event is not None:
+            kind, label = event
+            pending_events.append((_entry_time(entry.timestamp), kind, label))
+        if isinstance(entry, CompactionEntry):
+            compactions += 1
+            if entry.usage is not None:
+                append_request(
+                    entry.usage,
+                    timestamp=entry.timestamp,
+                    kind="compaction summary",
+                    provider=current_provider,
+                    model=current_model,
+                )
+            continue
+        if isinstance(entry, BranchSummaryEntry):
+            if entry.usage is not None:
+                append_request(
+                    entry.usage,
+                    timestamp=entry.timestamp,
+                    kind="branch summary",
+                    provider=current_provider,
+                    model=current_model,
+                )
+            continue
+        if isinstance(entry, ModelChangeEntry):
+            current_model = entry.model
+            if entry.provider is not None:
+                current_provider = entry.provider
+            continue
+        if not isinstance(entry, MessageEntry):
+            continue
+        message = entry.message
+        if not isinstance(message, AssistantMessage):
+            continue
+        current_provider = message.provider
+        current_model = message.model
+        for call in message.tool_calls:
+            tools[call.name] = tools.get(call.name, 0) + 1
+        append_request(
+            message.usage,
+            timestamp=entry.timestamp,
+            kind="assistant",
+            provider=message.provider,
+            model=message.model,
+            response_provider=message.response_provider,
+            stop_reason=message.stop_reason,
+        )
     if requests:
         events.extend(
             UsageEvent(
@@ -463,8 +512,8 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
     show_hit_rates = cache_hit_rate is not None
 
     table_rows = "".join(
-        f"<tr><td>{item.number}</td><td>{html.escape(item.timestamp)}</td>"
-        f"<td>{html.escape(item.provider)}</td>"
+        f"<tr><td>{item.number}</td><td>{html.escape(item.kind)}</td>"
+        f"<td>{html.escape(item.timestamp)}</td><td>{html.escape(item.provider)}</td>"
         f"<td>{html.escape(item.response_provider) if item.response_provider else '-'}</td>"
         f"<td>{html.escape(item.model)}</td><td>{item.fresh:,}</td><td>{item.cached:,}</td>"
         f"<td>{item.cache_write:,}</td><td>{item.prompt:,}</td>"
@@ -492,7 +541,7 @@ def render_usage_dashboard(usage: SessionUsage) -> str:
         f'<div class="usage-charts">{charts_html}</div>'
         '<div class="usage-details">'
         '<div class="usage-panel"><h2>Requests</h2><div class="usage-table-wrap"><table>'
-        "<thead><tr><th>#</th><th>Time</th><th>Provider</th>"
+        "<thead><tr><th>#</th><th>Request</th><th>Time</th><th>Provider</th>"
         "<th>Response Provider</th><th>Model</th><th>Fresh</th>"
         "<th>Cached</th>"
         "<th>Written</th><th>Prompt</th><th>Hit rate</th><th>Output</th><th>Est. cost</th>"
@@ -674,10 +723,10 @@ USAGE_STYLES = """
       text-transform: uppercase;
       border-bottom: 1px solid var(--line-strong);
     }
-    .usage-panel th:nth-child(3), .usage-panel th:nth-child(4),
-    .usage-panel th:nth-child(5),
-    .usage-panel td:nth-child(3), .usage-panel td:nth-child(4),
-    .usage-panel td:nth-child(5) { text-align: left; }
+    .usage-panel th:nth-child(2), .usage-panel th:nth-child(4),
+    .usage-panel th:nth-child(5), .usage-panel th:nth-child(6),
+    .usage-panel td:nth-child(2), .usage-panel td:nth-child(4),
+    .usage-panel td:nth-child(5), .usage-panel td:nth-child(6) { text-align: left; }
     .usage-tool {
       display: flex;
       justify-content: space-between;

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -6,6 +6,7 @@ import html
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Literal
 
 from tau_agent.messages import AssistantMessage, Usage
 from tau_agent.session import (
@@ -67,6 +68,7 @@ class UsageEvent:
     timestamp: str
     kind: str
     label: str
+    position: Literal["before", "after"] = "before"
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,9 +209,6 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
 
     for entry in entries:
         event = _usage_event(entry)
-        if event is not None:
-            kind, label = event
-            pending_events.append((_entry_time(entry.timestamp), kind, label))
         if isinstance(entry, CompactionEntry):
             compactions += 1
             if entry.usage is not None:
@@ -219,7 +218,11 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                     kind="compaction summary",
                     provider=entry.provider or current_provider,
                     model=entry.model or current_model,
+                    response_provider=entry.response_provider,
                 )
+            if event is not None:
+                kind, label = event
+                pending_events.append((_entry_time(entry.timestamp), kind, label))
             continue
         if isinstance(entry, BranchSummaryEntry):
             if entry.usage is not None:
@@ -229,8 +232,15 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                     kind="branch summary",
                     provider=entry.provider or current_provider,
                     model=entry.model or current_model,
+                    response_provider=entry.response_provider,
                 )
+            if event is not None:
+                kind, label = event
+                pending_events.append((_entry_time(entry.timestamp), kind, label))
             continue
+        if event is not None:
+            kind, label = event
+            pending_events.append((_entry_time(entry.timestamp), kind, label))
         if isinstance(entry, ModelChangeEntry):
             current_model = entry.model
             if entry.provider is not None:
@@ -261,6 +271,7 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                 timestamp=timestamp,
                 kind=kind,
                 label=label,
+                position="after",
             )
             for timestamp, kind, label in pending_events
         )
@@ -386,7 +397,9 @@ def _line_chart(
     for event_index, event in enumerate(events):
         x, _ = point(max(0, min(count - 1, event.request_number - 1)), 0)
         marker_y = top + 7 + (event_index % 3) * 9
-        description = f"{event.label} before request {event.request_number} at {event.timestamp}"
+        description = (
+            f"{event.label} {event.position} request {event.request_number} at {event.timestamp}"
+        )
         parts.append(
             f'<g class="usage-event usage-event-{html.escape(event.kind, quote=True)}" '
             f'data-request="{event.request_number}" '

--- a/src/tau_coding/session_usage.py
+++ b/src/tau_coding/session_usage.py
@@ -217,8 +217,8 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                     entry.usage,
                     timestamp=entry.timestamp,
                     kind="compaction summary",
-                    provider=current_provider,
-                    model=current_model,
+                    provider=entry.provider or current_provider,
+                    model=entry.model or current_model,
                 )
             continue
         if isinstance(entry, BranchSummaryEntry):
@@ -227,8 +227,8 @@ def collect_session_usage(entries: Sequence[SessionEntry]) -> SessionUsage:
                     entry.usage,
                     timestamp=entry.timestamp,
                     kind="branch summary",
-                    provider=current_provider,
-                    model=current_model,
+                    provider=entry.provider or current_provider,
+                    model=entry.model or current_model,
                 )
             continue
         if isinstance(entry, ModelChangeEntry):

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2368,6 +2368,8 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
     )
     assert "The abandoned branch went left." in summary.summary
     assert summary.usage == Usage(input=120, output=15, cache_read=30, cache_write=4)
+    assert summary.provider == "openai"
+    assert summary.model == "fake"
     assert provider.calls[0][3] == []
     assert "<conversation>" in provider.calls[0][2][0].content
     assert "Use this EXACT format:" in provider.calls[0][2][0].content
@@ -3663,6 +3665,8 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
         cache_read=200,
         cache_write=50,
     )
+    assert compactions[0].provider == "openai"
+    assert compactions[0].model == "fake"
     assert compactions[0].replaces_entry_ids == message_entries_before
     assert leaves == []
     assert entries_after_compact[-1] == compactions[0]

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2331,7 +2331,14 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
         [
             [
                 assistant_start(model="fake"),
-                assistant_done(message=AssistantMessage(content="The abandoned branch went left.")),
+                assistant_done(
+                    message=AssistantMessage(
+                        content="The abandoned branch went left.",
+                        provider="openai",
+                        model="fake",
+                        usage=Usage(input=120, output=15, cache_read=30, cache_write=4),
+                    )
+                ),
             ]
         ]
     )
@@ -2360,6 +2367,7 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
         "The user explored a different conversation branch before returning here."
     )
     assert "The abandoned branch went left." in summary.summary
+    assert summary.usage == Usage(input=120, output=15, cache_read=30, cache_write=4)
     assert provider.calls[0][3] == []
     assert "<conversation>" in provider.calls[0][2][0].content
     assert "Use this EXACT format:" in provider.calls[0][2][0].content
@@ -2466,6 +2474,7 @@ async def test_session_branch_with_summary_falls_back_when_model_summary_is_unav
 
     assert "with branch summary" in result.message
     assert summary.type == "branch_summary"
+    assert summary.usage is None
     assert "Automatically compacted 2 prior message(s)." in summary.summary
     assert "Abandoned follow-up" in summary.summary
     assert len(session.messages) == 2
@@ -3614,7 +3623,14 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
             ],
             [
                 assistant_start(model="fake"),
-                assistant_done(message=AssistantMessage(content="Generated session summary")),
+                assistant_done(
+                    message=AssistantMessage(
+                        content="Generated session summary",
+                        provider="openai",
+                        model="fake",
+                        usage=Usage(input=1_000, output=80, cache_read=200, cache_write=50),
+                    )
+                ),
             ],
             [
                 assistant_start(model="fake"),
@@ -3641,6 +3657,12 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
     assert len(compactions) == 1
     assert isinstance(compactions[0], CompactionEntry)
     assert compactions[0].summary == "Generated session summary"
+    assert compactions[0].usage == Usage(
+        input=1_000,
+        output=80,
+        cache_read=200,
+        cache_write=50,
+    )
     assert compactions[0].replaces_entry_ids == message_entries_before
     assert leaves == []
     assert entries_after_compact[-1] == compactions[0]

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2336,6 +2336,7 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
                         content="The abandoned branch went left.",
                         provider="openai",
                         model="fake",
+                        response_provider="branch-route",
                         usage=Usage(input=120, output=15, cache_read=30, cache_write=4),
                     )
                 ),
@@ -2370,6 +2371,7 @@ async def test_session_branch_with_summary_rebuilds_context(tmp_path: Path) -> N
     assert summary.usage == Usage(input=120, output=15, cache_read=30, cache_write=4)
     assert summary.provider == "openai"
     assert summary.model == "fake"
+    assert summary.response_provider == "branch-route"
     assert provider.calls[0][3] == []
     assert "<conversation>" in provider.calls[0][2][0].content
     assert "Use this EXACT format:" in provider.calls[0][2][0].content
@@ -3630,6 +3632,7 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
                         content="Generated session summary",
                         provider="openai",
                         model="fake",
+                        response_provider="compaction-route",
                         usage=Usage(input=1_000, output=80, cache_read=200, cache_write=50),
                     )
                 ),
@@ -3667,6 +3670,7 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
     )
     assert compactions[0].provider == "openai"
     assert compactions[0].model == "fake"
+    assert compactions[0].response_provider == "compaction-route"
     assert compactions[0].replaces_entry_ids == message_entries_before
     assert leaves == []
     assert entries_after_compact[-1] == compactions[0]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -287,7 +287,13 @@ async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: P
         [
             [
                 assistant_start(model="fake"),
-                assistant_done(AssistantMessage(content="real summary", model="fake")),
+                assistant_done(
+                    AssistantMessage(
+                        content="real summary",
+                        model="fake",
+                        usage=Usage(input=800, output=40, cache_read=200),
+                    )
+                ),
             ]
         ]
     )
@@ -300,12 +306,12 @@ async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: P
             cwd=tmp_path,
         )
     )
-    stdin = StringIO('{"id":"compact","type":"compact"}\n')
+    stdin = StringIO('{"id":"compact","type":"compact"}\n{"id":"entries","type":"get_entries"}\n')
     stdout = StringIO()
 
     await RpcServer(session, stdin=stdin, stdout=stdout).run()
 
-    response = json.loads(stdout.getvalue())
+    response, entries_response = [json.loads(line) for line in stdout.getvalue().splitlines()]
     compaction = next(entry for entry in await storage.read_all() if entry.type == "compaction")
     boundary = response["data"]["firstKeptEntryId"]
     assert response["data"]["summary"] == "real summary"
@@ -314,6 +320,12 @@ async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: P
     assert boundary != compaction.id
     assert compaction.first_kept_entry_id == boundary
     assert compaction.tokens_before == response["data"]["tokensBefore"]
+    projected = next(
+        entry for entry in entries_response["data"]["entries"] if entry["type"] == "compaction"
+    )
+    assert projected["usage"]["input"] == 800
+    assert projected["usage"]["cacheRead"] == 200
+    assert projected["usage"]["output"] == 40
 
 
 @pytest.mark.anyio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -341,10 +341,12 @@ def test_legacy_summary_entries_load_without_usage() -> None:
     assert compaction.usage is None
     assert compaction.provider is None
     assert compaction.model is None
+    assert compaction.response_provider is None
     assert isinstance(branch, BranchSummaryEntry)
     assert branch.usage is None
     assert branch.provider is None
     assert branch.model is None
+    assert branch.response_provider is None
 
 
 def test_sum_usage_combines_tokens_optional_fields_and_cost() -> None:
@@ -376,12 +378,14 @@ def test_summary_entry_usage_round_trips_with_camel_case_usage_fields() -> None:
         usage=Usage(input=10, cache_read=20, cache_write_1h=5),
         provider="anthropic",
         model="claude-test",
+        response_provider="inference-route",
     )
 
     line = entry_to_json_line(entry)
 
     assert '"cacheRead":20' in line
     assert '"cacheWrite1H":5' in line
+    assert '"response_provider":"inference-route"' in line
     assert entry_from_json_line(line) == entry
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,8 +11,11 @@ from tau_agent import (
     TextContent,
     ThinkingContent,
     ToolResultMessage,
+    Usage,
+    UsageCost,
     UserMessage,
 )
+from tau_agent.messages import sum_usage
 from tau_agent.session import (
     BranchSummaryEntry,
     CompactionEntry,
@@ -326,6 +329,54 @@ def test_session_state_replays_linear_entries() -> None:
     assert state.model == "fake-model"
     assert state.label == "Greeting"
     assert state.active_leaf_id == "custom"
+
+
+def test_legacy_summary_entries_load_without_usage() -> None:
+    compaction = entry_from_json_line(
+        '{"type":"compaction","id":"compact","summary":"old","replaces_entry_ids":[]}'
+    )
+    branch = entry_from_json_line('{"type":"branch_summary","id":"branch","summary":"old"}')
+
+    assert isinstance(compaction, CompactionEntry)
+    assert compaction.usage is None
+    assert isinstance(branch, BranchSummaryEntry)
+    assert branch.usage is None
+
+
+def test_sum_usage_combines_tokens_optional_fields_and_cost() -> None:
+    combined = sum_usage(
+        [
+            Usage(input=10, reasoning=2, cost=UsageCost(input=0.1, total=0.1)),
+            Usage(
+                input=20,
+                output=5,
+                cache_write_1h=3,
+                cost=UsageCost(output=0.2, total=0.2),
+            ),
+        ]
+    )
+
+    assert combined.input == 30
+    assert combined.output == 5
+    assert combined.reasoning == 2
+    assert combined.cache_write_1h == 3
+    assert combined.cost.input == 0.1
+    assert combined.cost.output == 0.2
+    assert combined.cost.total == pytest.approx(0.3)
+
+
+def test_summary_entry_usage_round_trips_with_camel_case_usage_fields() -> None:
+    entry = CompactionEntry(
+        id="compact",
+        summary="summary",
+        usage=Usage(input=10, cache_read=20, cache_write_1h=5),
+    )
+
+    line = entry_to_json_line(entry)
+
+    assert '"cacheRead":20' in line
+    assert '"cacheWrite1H":5' in line
+    assert entry_from_json_line(line) == entry
 
 
 def test_session_state_applies_compaction_and_branch_summary() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -339,8 +339,12 @@ def test_legacy_summary_entries_load_without_usage() -> None:
 
     assert isinstance(compaction, CompactionEntry)
     assert compaction.usage is None
+    assert compaction.provider is None
+    assert compaction.model is None
     assert isinstance(branch, BranchSummaryEntry)
     assert branch.usage is None
+    assert branch.provider is None
+    assert branch.model is None
 
 
 def test_sum_usage_combines_tokens_optional_fields_and_cost() -> None:
@@ -370,6 +374,8 @@ def test_summary_entry_usage_round_trips_with_camel_case_usage_fields() -> None:
         id="compact",
         summary="summary",
         usage=Usage(input=10, cache_read=20, cache_write_1h=5),
+        provider="anthropic",
+        model="claude-test",
     )
 
     line = entry_to_json_line(entry)

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -52,6 +52,7 @@ def test_render_session_html_preserves_branch_tree() -> None:
             parent_id="tool",
             summary="The right branch was compacted.",
             replaces_entry_ids=["root", "right", "tool"],
+            usage=Usage(input=100, output=10, cache_read=20),
         ),
         LeafEntry(id="leaf", parent_id="compact", entry_id="left"),
     ]
@@ -70,6 +71,9 @@ def test_render_session_html_preserves_branch_tree() -> None:
     assert "active-path" in html
     assert "active-leaf" in html
     assert "Replaces entries" in html
+    assert "Summary request usage" in html
+    assert "cacheRead" in html
+    assert "compaction summary" in html
 
 
 def test_render_session_html_handles_long_legacy_leaf_history() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -189,6 +189,7 @@ def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:
         parent_id=extension_turn.id,
         summary="Earlier work",
         replaces_entry_ids=[user.id, assistant.id],
+        usage=Usage(input=200_000, output=10_000, cache_read=100_000),
     )
 
     stats = calculate_session_stats(
@@ -203,9 +204,10 @@ def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:
 
     assert stats.turn_count == 2
     assert stats.tool_call_count == 2
-    assert stats.input_tokens == 1_500_000
-    assert stats.output_tokens == 100_000
-    assert stats.estimated_cost == 3.05
+    assert stats.input_tokens == 1_800_000
+    assert stats.output_tokens == 110_000
+    assert stats.latest_cache_hit_rate == 1 / 3
+    assert stats.estimated_cost == 3.58
 
 
 def test_calculate_session_stats_marks_cost_unavailable_when_pricing_is_missing() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -190,18 +190,29 @@ def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:
         summary="Earlier work",
         replaces_entry_ids=[user.id, assistant.id],
         usage=Usage(input=200_000, output=10_000, cache_read=100_000),
+        provider="summary-provider",
+        model="summary-model",
     )
+    priced_requests: list[tuple[str, str, int]] = []
 
-    stats = calculate_session_stats(
-        [user, assistant, extension_turn, compaction],
-        pricing=lambda provider, model, input_tokens: {
+    def pricing(provider: str, model: str, input_tokens: int) -> dict[str, float]:
+        priced_requests.append((provider, model, input_tokens))
+        return {
             "input": 2.0,
             "output": 8.0,
             "cacheRead": 0.5,
             "cacheWrite": 0.0,
-        },
+        }
+
+    stats = calculate_session_stats(
+        [user, assistant, extension_turn, compaction],
+        pricing=pricing,
     )
 
+    assert priced_requests == [
+        ("openai", "gpt-test", 1_500_000),
+        ("summary-provider", "summary-model", 300_000),
+    ]
     assert stats.turn_count == 2
     assert stats.tool_call_count == 2
     assert stats.input_tokens == 1_800_000

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -59,6 +59,41 @@ def test_collect_session_usage_aggregates_requests_tools_and_compactions() -> No
     assert usage.hit_rate == 2850 / 3050
 
 
+def test_collect_session_usage_includes_labeled_summary_requests() -> None:
+    entries = [
+        ModelChangeEntry(
+            id="model",
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+        ),
+        CompactionEntry(
+            id="compact",
+            summary="summary",
+            usage=Usage(input=1_000, output=20, cache_read=500, cache_write=100),
+        ),
+        BranchSummaryEntry(
+            id="branch",
+            summary="branch",
+            usage=Usage(input=200, output=10, cache_read=50),
+        ),
+    ]
+
+    usage = collect_session_usage(entries)
+
+    assert [request.kind for request in usage.requests] == [
+        "compaction summary",
+        "branch summary",
+    ]
+    assert [request.model for request in usage.requests] == [
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-5",
+    ]
+    assert usage.total_prompt == 1_850
+    assert usage.total_output == 30
+    assert usage.hit_rate == 550 / 1_850
+    assert usage.total_cost is not None
+
+
 def test_collect_session_usage_positions_notable_events_at_next_request() -> None:
     entries = [
         ModelChangeEntry(id="model", timestamp=1, model="claude-sonnet-4-5"),
@@ -125,6 +160,7 @@ def test_render_usage_dashboard_renders_charts_and_table() -> None:
     assert "Prompt input by request" in markup
     assert "Cache hit rate" in markup
     assert "claude-sonnet-4-5" in markup
+    assert "assistant" in markup
 
 
 def test_render_usage_dashboard_marks_events_on_prompt_input_chart() -> None:

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -69,7 +69,15 @@ def test_collect_session_usage_includes_labeled_summary_requests() -> None:
         CompactionEntry(
             id="compact",
             summary="summary",
-            usage=Usage(input=1_000, output=20, cache_read=500, cache_write=100),
+            usage=Usage(
+                input=1_000,
+                output=20,
+                cache_read=500,
+                cache_write=100,
+                cost=UsageCost(total=0.5),
+            ),
+            provider="summary-provider",
+            model="summary-model",
         ),
         BranchSummaryEntry(
             id="branch",
@@ -84,9 +92,9 @@ def test_collect_session_usage_includes_labeled_summary_requests() -> None:
         "compaction summary",
         "branch summary",
     ]
-    assert [request.model for request in usage.requests] == [
-        "claude-sonnet-4-5",
-        "claude-sonnet-4-5",
+    assert [(request.provider, request.model) for request in usage.requests] == [
+        ("summary-provider", "summary-model"),
+        ("anthropic", "claude-sonnet-4-5"),
     ]
     assert usage.total_prompt == 1_850
     assert usage.total_output == 30

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -78,6 +78,7 @@ def test_collect_session_usage_includes_labeled_summary_requests() -> None:
             ),
             provider="summary-provider",
             model="summary-model",
+            response_provider="routed-summary-provider",
         ),
         BranchSummaryEntry(
             id="branch",
@@ -96,6 +97,10 @@ def test_collect_session_usage_includes_labeled_summary_requests() -> None:
         ("summary-provider", "summary-model"),
         ("anthropic", "claude-sonnet-4-5"),
     ]
+    assert [request.response_provider for request in usage.requests] == [
+        "routed-summary-provider",
+        None,
+    ]
     assert usage.total_prompt == 1_850
     assert usage.total_output == 30
     assert usage.hit_rate == 550 / 1_850
@@ -111,6 +116,7 @@ def test_collect_session_usage_positions_notable_events_at_next_request() -> Non
             timestamp=2,
             summary="summary",
             replaces_entry_ids=["a1"],
+            usage=Usage(input=15),
         ),
         ThinkingLevelChangeEntry(id="thinking", timestamp=3, thinking_level="high"),
         _assistant("a2", usage=Usage(input=20)),
@@ -121,10 +127,11 @@ def test_collect_session_usage_positions_notable_events_at_next_request() -> Non
 
     assert [(event.request_number, event.kind, event.label) for event in usage.events] == [
         (1, "model", "Model changed to claude-sonnet-4-5"),
-        (2, "compaction", "Compaction"),
-        (2, "thinking", "Thinking changed to high"),
-        (2, "branch", "Branch summary"),
+        (3, "compaction", "Compaction"),
+        (3, "thinking", "Thinking changed to high"),
+        (3, "branch", "Branch summary"),
     ]
+    assert [event.position for event in usage.events] == ["before", "before", "before", "after"]
 
 
 def test_collect_session_usage_estimates_cost_from_catalog() -> None:

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -173,9 +173,9 @@ is the active tip. Older files containing `leaf` records remain readable, but
 those records do not override file-order tip selection. Compaction and
 branching change the *active* view, never the recorded history.
 
-New compaction and branch-summary entries include an optional `usage` object
-with the tokens and cost reported by the model call that generated the summary.
-The field uses the same `Usage` shape as assistant messages (`input`, `output`,
+New compaction and branch-summary entries include optional `usage`, `provider`,
+and `model` fields for the model call that generated the summary. The `usage`
+field uses the same shape as assistant messages (`input`, `output`,
 `cacheRead`, `cacheWrite`, optional `cacheWrite1H` and `reasoning`, `totalTokens`,
 and `cost`). If more than one completion contributes to a summary, Tau stores
 the field-wise total. Older entries and heuristic branch-summary fallbacks omit

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -174,8 +174,9 @@ those records do not override file-order tip selection. Compaction and
 branching change the *active* view, never the recorded history.
 
 New compaction and branch-summary entries include optional `usage`, `provider`,
-and `model` fields for the model call that generated the summary. The `usage`
-field uses the same shape as assistant messages (`input`, `output`,
+`model`, and `response_provider` fields for the model call that generated the
+summary. `response_provider` identifies the resolved backend when a routing
+service reports one. The `usage` field uses the same shape as assistant messages (`input`, `output`,
 `cacheRead`, `cacheWrite`, optional `cacheWrite1H` and `reasoning`, `totalTokens`,
 and `cost`). If more than one completion contributes to a summary, Tau stores
 the field-wise total. Older entries and heuristic branch-summary fallbacks omit

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -123,8 +123,11 @@ model as context.
 
 HTML exports are self-contained and include two tabs: **Transcript** preserves
 the session tree and entries in storage order, while **Cache** summarizes the
-active branch's model requests, prompt caching, output and reasoning tokens,
-estimated API-rate cost, tool calls, and compactions. Cache charts are
+active branch's model requests, including the requests that generate compaction
+and branch summaries, prompt caching, output and reasoning tokens, estimated
+API-rate cost, tool calls, and compactions. Summary-generation requests are
+labeled separately in the request table rather than blended into assistant turns.
+Cache charts are
 interactive—hover for exact values and select a legend item to hide a
 series—and can be downloaded as static PNG images with white backgrounds. The
 export follows Tau's themes: tau-light in light mode and tau-dark in dark mode,
@@ -168,5 +171,16 @@ For example, `/Users/you/repos/tau` becomes something like
 write separate `leaf` pointer records; the last non-`leaf` entry in file order
 is the active tip. Older files containing `leaf` records remain readable, but
 those records do not override file-order tip selection. Compaction and
-branching change the *active* view, never the recorded history. See
+branching change the *active* view, never the recorded history.
+
+New compaction and branch-summary entries include an optional `usage` object
+with the tokens and cost reported by the model call that generated the summary.
+The field uses the same `Usage` shape as assistant messages (`input`, `output`,
+`cacheRead`, `cacheWrite`, optional `cacheWrite1H` and `reasoning`, `totalTokens`,
+and `cost`). If more than one completion contributes to a summary, Tau stores
+the field-wise total. Older entries and heuristic branch-summary fallbacks omit
+`usage`; they continue to load normally and do not add a zero-cost request to
+usage analytics.
+
+See
 [Configuration]({{< relref "../reference/configuration.md#sessions" >}}) for the exact layout.

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -279,9 +279,10 @@ history still counts toward cumulative token usage and cost but is omitted from
 both performance metrics.
 
 Cumulative usage and cost cover the active branch, including history replaced by
-compaction. Input usage counts tokens processed on every
-provider request, so it can be much larger than the context used by the next
-request. Cost is an estimate based on provider-reported usage and configured
+compaction and the model requests used to generate compaction or branch summaries.
+Heuristic summary fallbacks have no provider usage and add nothing. Input usage
+counts tokens processed on every provider request, so it can be much larger than
+the context used by the next request. Cost is an estimate based on provider-reported usage and configured
 catalog rates; the sidebar shows `$N/A` when Tau lacks complete pricing data.
 
 The cache line separates the latest model request from the cumulative session.

--- a/website/content/reference/rpc.md
+++ b/website/content/reference/rpc.md
@@ -61,6 +61,9 @@ RPC compaction preserves recent entries and returns the first pre-existing retai
 `firstKeptEntryId`, matching Pi. Older Tau compaction records and TUI compactions that replaced
 all active context have no such boundary; session inspection exposes those honestly as
 `customType: "tau.compaction"` entries instead of fabricating Pi compaction metadata.
+When available, projected compaction and branch-summary entries include Pi-compatible
+`usage` data from the request that generated the summary. Legacy entries and heuristic
+fallback summaries omit the field.
 
 Tau mirrors Pi where its public `CodingSession` has equivalent behavior. Direct `bash` is
 supported, but `abort_bash` requires a future cancellable session API. Queue delivery modes,


### PR DESCRIPTION
## Summary

This PR makes model-generated session summaries visible in Tau's persisted usage accounting. Before this change, normal assistant responses contributed token and cost data, but requests made to compact context or summarize an abandoned branch did not. Those requests can be among the largest in a session, so excluding them understated totals and obscured which model/provider handled them.

Closes #701.

## What this implements

### Persisted session schema

- Adds optional `usage` to both compaction and branch-summary entries, using the same `Usage` token and cost shape as assistant messages.
- Persists the requested `provider` and `model` beside generated summaries so analytics do not incorrectly infer attribution from an earlier assistant response or model-change entry.
- Persists the routed `response_provider` reported by the completion when it differs from the logical provider selection.
- Keeps all new fields optional so existing JSONL sessions and heuristic summaries remain valid.

### Summary generation paths

- Captures the final completion's usage and routing metadata for manual, automatic, and overflow-recovery compactions.
- Captures equivalent metadata when Tau generates a branch summary while navigating the session tree.
- Leaves heuristic/fallback branch summaries unmetered rather than inventing zero-token usage.
- Carries the metadata through the compaction plan/result types to the appended session entry.

### Statistics, usage reports, RPC, and exports

- Includes generated summaries in cumulative TUI session statistics.
- Adds separate `compaction summary` and `branch summary` rows to the HTML usage request table.
- Includes prompt, cache-read, cache-write, output-token, and estimated-cost totals where the provider reports them.
- Displays summary request metadata in HTML entry details.
- Projects persisted `usage` through RPC `get_entries` while preserving Pi-compatible entry shapes; Tau-only persistence attribution remains outside the RPC projection.

## User-visible behavior

Tau's usage totals now reflect the requests spent reducing or summarizing context, not only ordinary assistant turns. This is especially important for long sessions where compaction prompts can dominate input and cache usage.

Historical summary entries continue to load unchanged. If an entry has no usage data, it contributes no synthetic request and no fabricated zero-token totals.

## Compatibility details

- `usage`, `provider`, `model`, and `response_provider` are optional on read.
- Existing assistant-message accounting is unchanged.
- The `usage` object reuses Tau's existing provider-neutral model rather than embedding provider or model identity inside it.
- Attribution falls back to surrounding session metadata only for old entries that lack explicit summary request identity.

## Validation coverage

Tests cover:

- usage persistence for manual, automatic, and overflow compaction;
- model-assisted branch summaries and heuristic fallback;
- provider/model and routed-provider attribution;
- aggregate session statistics and per-request usage rows;
- JSONL round trips, RPC projection, and HTML export;
- backward compatibility when optional fields are absent.

## Manual validation

1. Run `/compact`, inspect the newest compaction JSONL entry, and confirm it contains `usage` plus request attribution.
2. Navigate away from a branch with summary generation enabled and inspect the branch-summary entry.
3. Confirm a failed model request followed by heuristic fallback does not create fake usage.
4. Open the sidebar and verify cumulative usage increases after summary generation.
5. Export HTML and verify labeled summary rows appear in the usage table.
6. Query RPC `get_entries` and verify generated summary entries expose `usage` when present.

## Checks

- `uv run pytest` — 1,923 passed, 2 platform skips
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify` from `website/`
- `npx --yes pagefind@latest --site public` from `website/`
