### PR TITLE
Use Pi-compatible first-kept compaction boundaries

### DIFF
--- a/dev-notes/architecture/phase-22-compaction-foundation.md
+++ b/dev-notes/architecture/phase-22-compaction-foundation.md
@@ -23,8 +23,8 @@ src/tau_coding/commands.py
 When `SessionState.from_entries()` sees a modern compaction entry, it:
 
 1. inserts one provider-neutral summary message
-2. finds `first_kept_entry_id` on the active root-to-leaf message path
-3. keeps that boundary entry and every later active message
+2. finds `first_kept_entry_id` on the complete active root-to-leaf entry path
+3. keeps context-producing entries at that boundary and later in path order
 4. keeps the original append-only entries intact
 
 This matches Pi's inclusive first-kept semantics. If the boundary is missing or cannot

--- a/dev-notes/architecture/phase-22-compaction-foundation.md
+++ b/dev-notes/architecture/phase-22-compaction-foundation.md
@@ -20,12 +20,17 @@ src/tau_coding/commands.py
 
 `CompactionEntry` is now meaningful during session replay.
 
-When `SessionState.from_entries()` sees a compaction entry, it:
+When `SessionState.from_entries()` sees a modern compaction entry, it:
 
-1. removes message entries whose ids appear in `replaces_entry_ids`
-2. inserts one provider-neutral summary message at the first replaced position
-3. keeps any non-replaced recent messages in chronological order
+1. inserts one provider-neutral summary message
+2. finds `first_kept_entry_id` on the active root-to-leaf message path
+3. keeps that boundary entry and every later active message
 4. keeps the original append-only entries intact
+
+This matches Pi's inclusive first-kept semantics. If the boundary is missing or cannot
+be found, replay keeps no pre-compaction message and still includes later successors.
+Tau sessions written before this encoding used `replaces_entry_ids`; a non-empty legacy
+list takes precedence and retains the original arbitrary-set replay behavior.
 
 The summary message currently uses this stable form:
 
@@ -45,7 +50,8 @@ SessionState.messages = reconstructed active context
 ```
 
 Manual `/compact` work can append `CompactionEntry` values without editing or
-deleting old entries.
+deleting old entries. New records persist one first-kept boundary rather than a list of
+all summarized entry ids.
 
 ## Context Size Estimation
 
@@ -128,9 +134,10 @@ tests/test_tui_app.py
 
 The tests verify:
 
-- compaction entries round-trip through JSONL
-- linear replay replaces compacted messages with a summary
+- compaction entries round-trip through JSONL without writing an empty legacy id list
+- linear replay keeps the first boundary entry inclusively and handles every boundary depth
 - branch replay applies compaction only on the active branch path
+- fixture-based legacy replay preserves replacement-list precedence
 - context-size estimation is deterministic
 - `/status` includes an estimated context token count
 - `/compact [instructions]` requests model-generated compaction

--- a/dev-notes/first-kept-compaction.md
+++ b/dev-notes/first-kept-compaction.md
@@ -1,0 +1,67 @@
+# Pi-Compatible First-Kept Compaction
+
+## What changed
+
+Tau compactions now persist `first_kept_entry_id`, the id of the first active-context
+message retained after the summarized prefix. Fresh JSONL records omit the empty legacy
+`replaces_entry_ids` field. The persisted cost is therefore constant instead of growing by
+one id for every summarized entry.
+
+`CompactionPlan` carries the boundary and a transient replaced-entry count. The count keeps
+manual status text accurate without storing all replaced ids. Manual, threshold, and
+overflow compaction all use the same recent-preserving plan, and a compaction is not written
+unless it has a real retained boundary.
+
+## Replay semantics
+
+Replay follows the active root-to-leaf path. At a modern compaction it produces:
+
+```text
+[summary] + [first kept message ... messages before compaction] + [successor messages]
+```
+
+The boundary is inclusive. If a hand-edited or boundary-less entry has no resolvable kept
+id, the pre-compaction result is only the summary; normal path replay still adds successors
+written after that compaction. This matches Pi's historical `firstKeptEntryId` behavior.
+
+Tau applies compactions while walking the selected path, so branches not on that path never
+influence the boundary lookup. A boundary at the first, middle, or final active message is
+covered deterministically.
+
+## Legacy compatibility
+
+Older Tau versions persisted `replaces_entry_ids`, including records that also have a
+`first_kept_entry_id`. A non-empty legacy list deliberately takes precedence. That preserves
+the old set-based behavior, including arbitrary non-prefix replacement sets and summaries
+inserted at the first replaced position. The field remains accepted by the strict Pydantic
+discriminated union and is serialized only when non-empty.
+
+RPC session inspection no longer emits `replacesEntryIds` or
+`details.tauReplacedEntryIds`. Modern entries map directly to Pi's compaction shape. Legacy
+entries without the complete Pi boundary/token pair remain `tau.compaction` custom records
+with their summary, while local replay continues to honor the private compatibility field.
+HTML export displays the first-kept boundary rather than the replaced-id list; raw JSONL
+exports retain legacy data.
+
+## Why this belongs at these layers
+
+- `tau_agent` owns entry compatibility and deterministic replay.
+- `tau_coding` owns compaction planning, status text, RPC projection, and HTML presentation.
+
+This keeps the portable harness independent of CLI and rendering policy while preserving
+Tau's append-only session history.
+
+## Validation
+
+Focused coverage lives in `tests/test_session.py`, `tests/test_coding_session.py`,
+`tests/test_rpc.py`, and `tests/test_session_export.py`. The legacy fixture is
+`tests/fixtures/legacy_compaction.jsonl`.
+
+Run the CI-equivalent suite with:
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+```

--- a/dev-notes/first-kept-compaction.md
+++ b/dev-notes/first-kept-compaction.md
@@ -2,15 +2,16 @@
 
 ## What changed
 
-Tau compactions now persist `first_kept_entry_id`, the id of the first active-context
-message retained after the summarized prefix. Fresh JSONL records omit the empty legacy
-`replaces_entry_ids` field. The persisted cost is therefore constant instead of growing by
-one id for every summarized entry.
+Tau compactions now persist `first_kept_entry_id`, the id of the first active-path
+entry retained after the summarized prefix. The boundary may be a metadata entry that does
+not itself produce a message. Fresh JSONL records omit the empty legacy `replaces_entry_ids`
+field. The persisted cost is therefore constant instead of growing by one id for every
+summarized entry.
 
 `CompactionPlan` carries the boundary and a transient replaced-entry count. The count keeps
 manual status text accurate without storing all replaced ids. Manual, threshold, and
-overflow compaction all use the same recent-preserving plan, and a compaction is not written
-unless it has a real retained boundary.
+overflow compaction all use the same recent-preserving plan, record the pre-compaction token
+estimate, and do not write a compaction unless it has a real retained boundary.
 
 ## Replay semantics
 
@@ -20,9 +21,11 @@ Replay follows the active root-to-leaf path. At a modern compaction it produces:
 [summary] + [first kept message ... messages before compaction] + [successor messages]
 ```
 
-The boundary is inclusive. If a hand-edited or boundary-less entry has no resolvable kept
-id, the pre-compaction result is only the summary; normal path replay still adds successors
-written after that compaction. This matches Pi's historical `firstKeptEntryId` behavior.
+The boundary is inclusive and is resolved against every entry on the active path, including
+metadata and earlier compaction entries; only context-producing entries become messages. If
+a hand-edited or boundary-less entry has no resolvable kept id, the pre-compaction result is
+only the summary; normal path replay still adds successors written after that compaction.
+This matches Pi's historical `firstKeptEntryId` behavior.
 
 Tau applies compactions while walking the selected path, so branches not on that path never
 influence the boundary lookup. A boundary at the first, middle, or final active message is
@@ -31,10 +34,11 @@ covered deterministically.
 ## Legacy compatibility
 
 Older Tau versions persisted `replaces_entry_ids`, including records that also have a
-`first_kept_entry_id`. A non-empty legacy list deliberately takes precedence. That preserves
-the old set-based behavior, including arbitrary non-prefix replacement sets and summaries
-inserted at the first replaced position. The field remains accepted by the strict Pydantic
-discriminated union and is serialized only when non-empty.
+`first_kept_entry_id`. An explicitly stored legacy list deliberately takes precedence, even
+when it is empty. That preserves the old set-based behavior, including arbitrary non-prefix
+replacement sets and summaries inserted at the first replaced position. The field remains
+accepted by the strict Pydantic discriminated union and is omitted from fresh records when
+it was not supplied.
 
 RPC session inspection no longer emits `replacesEntryIds` or
 `details.tauReplacedEntryIds`. Modern entries map directly to Pi's compaction shape. Legacy

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -64,7 +64,9 @@ class CompactionEntry(BaseSessionEntry):
 
     type: Literal["compaction"] = "compaction"
     summary: str
-    replaces_entry_ids: list[str] = Field(default_factory=list)
+    # Legacy Tau sessions stored every replaced id. Keep accepting and replaying
+    # that shape, but omit the empty compatibility field from new JSONL records.
+    replaces_entry_ids: list[str] = Field(default_factory=list, exclude_if=lambda ids: not ids)
     first_kept_entry_id: str | None = None
     tokens_before: int | None = None
 

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -117,22 +117,36 @@ def _apply_compaction(
     message_rows: list[tuple[str, AgentMessage]],
     entry: CompactionEntry,
 ) -> list[tuple[str, AgentMessage]]:
-    replaced_ids = set(entry.replaces_entry_ids)
-    retained: list[tuple[str, AgentMessage]] = []
-    inserted_summary = False
-    for entry_id, message in message_rows:
-        if entry_id not in replaced_ids:
-            retained.append((entry_id, message))
-            continue
-        if not inserted_summary:
-            retained.append(
-                (entry.id, UserMessage(content=_format_compaction_summary(entry.summary)))
-            )
-            inserted_summary = True
+    summary_row = (entry.id, UserMessage(content=_format_compaction_summary(entry.summary)))
 
-    if not inserted_summary:
-        retained.append((entry.id, UserMessage(content=_format_compaction_summary(entry.summary))))
-    return retained
+    # Tau originally persisted arbitrary replacement-id sets. They take
+    # precedence when present so old sessions retain their exact replay.
+    if entry.replaces_entry_ids:
+        replaced_ids = set(entry.replaces_entry_ids)
+        retained: list[tuple[str, AgentMessage]] = []
+        inserted_summary = False
+        for entry_id, message in message_rows:
+            if entry_id not in replaced_ids:
+                retained.append((entry_id, message))
+                continue
+            if not inserted_summary:
+                retained.append(summary_row)
+                inserted_summary = True
+        if not inserted_summary:
+            retained.append(summary_row)
+        return retained
+
+    # Pi's first-kept encoding replaces the active-path prefix. A missing or
+    # unreachable boundary means there is no retained pre-compaction entry.
+    first_kept_index = next(
+        (
+            index
+            for index, (entry_id, _message) in enumerate(message_rows)
+            if entry_id == entry.first_kept_entry_id
+        ),
+        len(message_rows),
+    )
+    return [summary_row, *message_rows[first_kept_index:]]
 
 
 def _format_compaction_summary(summary: str) -> str:

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -65,7 +65,7 @@ class SessionState:
         custom_entries: list[CustomEntry] = []
         compaction_entries: list[CompactionEntry] = []
 
-        for entry in replay_entries:
+        for entry_index, entry in enumerate(replay_entries):
             match entry.type:
                 case "message":
                     message_rows.append((entry.id, entry.message))
@@ -85,7 +85,11 @@ class SessionState:
                     custom_entries.append(entry)
                 case "compaction":
                     compaction_entries.append(entry)
-                    message_rows = _apply_compaction(message_rows, entry)
+                    message_rows = _apply_compaction(
+                        message_rows,
+                        entry,
+                        path_before=replay_entries[:entry_index],
+                    )
                 case "branch_summary":
                     message_rows.append(
                         (entry.id, UserMessage(content=_format_branch_summary(entry)))
@@ -116,12 +120,15 @@ def _last_non_leaf_id(entries: list[SessionEntry]) -> str | None:
 def _apply_compaction(
     message_rows: list[tuple[str, AgentMessage]],
     entry: CompactionEntry,
+    *,
+    path_before: list[SessionEntry],
 ) -> list[tuple[str, AgentMessage]]:
     summary_row = (entry.id, UserMessage(content=_format_compaction_summary(entry.summary)))
 
-    # Tau originally persisted arbitrary replacement-id sets. They take
-    # precedence when present so old sessions retain their exact replay.
-    if entry.replaces_entry_ids:
+    # Tau originally persisted arbitrary replacement-id sets. Explicit legacy
+    # fields take precedence, including an empty list, so old sessions retain
+    # their exact replay behavior.
+    if "replaces_entry_ids" in entry.model_fields_set:
         replaced_ids = set(entry.replaces_entry_ids)
         retained: list[tuple[str, AgentMessage]] = []
         inserted_summary = False
@@ -136,17 +143,27 @@ def _apply_compaction(
             retained.append(summary_row)
         return retained
 
-    # Pi's first-kept encoding replaces the active-path prefix. A missing or
-    # unreachable boundary means there is no retained pre-compaction entry.
+    # Pi resolves the boundary against the complete active path, not only
+    # message-producing entries. Reorder retained context by that path as well:
+    # a previous compaction can itself occur after the kept boundary.
     first_kept_index = next(
         (
             index
-            for index, (entry_id, _message) in enumerate(message_rows)
-            if entry_id == entry.first_kept_entry_id
+            for index, path_entry in enumerate(path_before)
+            if path_entry.id == entry.first_kept_entry_id
         ),
-        len(message_rows),
+        None,
     )
-    return [summary_row, *message_rows[first_kept_index:]]
+    if first_kept_index is None:
+        return [summary_row]
+
+    retained_by_id = dict(message_rows)
+    retained = [
+        (path_entry.id, retained_by_id[path_entry.id])
+        for path_entry in path_before[first_kept_index:]
+        if path_entry.id in retained_by_id
+    ]
+    return [summary_row, *retained]
 
 
 def _format_compaction_summary(summary: str) -> str:

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -712,17 +712,14 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
                 **base,
                 "type": "custom",
                 "customType": "tau.compaction",
-                "data": {
-                    "summary": entry.summary,
-                    "replacesEntryIds": list(entry.replaces_entry_ids),
-                },
+                "data": {"summary": entry.summary},
             }
         return {
             **base,
             "summary": entry.summary,
             "firstKeptEntryId": entry.first_kept_entry_id,
             "tokensBefore": entry.tokens_before,
-            "details": {"tauReplacedEntryIds": list(entry.replaces_entry_ids)},
+            "details": {},
         }
     if entry.type == "branch_summary":
         return {

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -3607,8 +3607,13 @@ class CodingSession:
             plan = self._recent_preserving_compaction_plan()
             if plan is None:
                 return False
+            tokens_before = self.context_token_estimate
             summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-            await self._append_compaction(summary, first_kept_entry_id=plan.first_kept_entry_id)
+            await self._append_compaction(
+                summary,
+                first_kept_entry_id=plan.first_kept_entry_id,
+                tokens_before=tokens_before,
+            )
             return True
         except Exception as exc:  # noqa: BLE001 - the original overflow remains visible
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -3705,8 +3710,13 @@ class CodingSession:
         plan = self._recent_preserving_compaction_plan()
         if plan is None:
             return False
+        tokens_before = self.context_token_estimate
         summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-        await self._append_compaction(summary, first_kept_entry_id=plan.first_kept_entry_id)
+        await self._append_compaction(
+            summary,
+            first_kept_entry_id=plan.first_kept_entry_id,
+            tokens_before=tokens_before,
+        )
         return True
 
     async def _generate_compaction_summary(

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -289,7 +289,8 @@ class SessionResources:
 class CompactionPlan:
     """Prepared active-context entries for a compaction run."""
 
-    replace_entry_ids: tuple[str, ...]
+    first_kept_entry_id: str
+    replaced_entry_count: int
     messages_to_summarize: tuple[AgentMessage, ...]
 
 
@@ -2844,44 +2845,31 @@ class CodingSession:
     async def compact_detailed(self, instructions: str | None = None) -> ManualCompactionResult:
         """Compact older context while preserving a real recent-entry boundary."""
         await self._flush_pending_message_writes(context=self._diagnostic_context())
-        rows = self._active_context_rows()
         plan = self._recent_preserving_compaction_plan()
         if plan is None:
             raise ValueError("Not enough context to compact while preserving recent entries")
-        first_kept_entry_id = rows[len(plan.replace_entry_ids)][0]
         tokens_before = self.context_token_estimate
         summary = await self._generate_compaction_summary(
             plan.messages_to_summarize,
             custom_instructions=instructions,
         )
-        compaction = await self._append_compaction(
+        await self._append_compaction(
             summary,
-            replace_entry_ids=plan.replace_entry_ids,
-            first_kept_entry_id=first_kept_entry_id,
+            first_kept_entry_id=plan.first_kept_entry_id,
             tokens_before=tokens_before,
         )
         return ManualCompactionResult(
             summary=summary,
-            first_kept_entry_id=first_kept_entry_id,
+            first_kept_entry_id=plan.first_kept_entry_id,
             tokens_before=tokens_before,
             estimated_tokens_after=self.context_token_estimate,
-            replaced_entry_count=len(compaction.replaces_entry_ids),
+            replaced_entry_count=plan.replaced_entry_count,
         )
 
     async def compact(self, instructions: str | None = None) -> str:
         """Generate a manual compaction summary and rebuild active context."""
-        await self._flush_pending_message_writes(context=self._diagnostic_context())
-        plan = self._manual_compaction_plan()
-        summary = await self._generate_compaction_summary(
-            plan.messages_to_summarize,
-            custom_instructions=instructions,
-        )
-        compaction = await self._append_compaction(
-            summary,
-            replace_entry_ids=plan.replace_entry_ids,
-            tokens_before=self.context_token_estimate,
-        )
-        return f"Compacted {len(compaction.replaces_entry_ids)} context entries."
+        result = await self.compact_detailed(instructions)
+        return f"Compacted {result.replaced_entry_count} context entries."
 
     async def aclose(self) -> None:
         """Close every owned extension/provider resource exactly once.
@@ -3620,7 +3608,7 @@ class CodingSession:
             if plan is None:
                 return False
             summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-            await self._append_compaction(summary, replace_entry_ids=plan.replace_entry_ids)
+            await self._append_compaction(summary, first_kept_entry_id=plan.first_kept_entry_id)
             return True
         except Exception as exc:  # noqa: BLE001 - the original overflow remains visible
             self._last_diagnostic_log_path = self._diagnostic_logger.log_exception(
@@ -3718,7 +3706,7 @@ class CodingSession:
         if plan is None:
             return False
         summary = await self._generate_compaction_summary(plan.messages_to_summarize)
-        await self._append_compaction(summary, replace_entry_ids=plan.replace_entry_ids)
+        await self._append_compaction(summary, first_kept_entry_id=plan.first_kept_entry_id)
         return True
 
     async def _generate_compaction_summary(
@@ -3773,15 +3761,6 @@ class CodingSession:
             summary = None
         return summary or summarize_messages_for_compaction(messages)
 
-    def _manual_compaction_plan(self) -> CompactionPlan:
-        rows = self._active_context_rows()
-        if not rows:
-            raise ValueError("No active context messages to compact")
-        return CompactionPlan(
-            replace_entry_ids=tuple(entry_id for entry_id, _message in rows),
-            messages_to_summarize=tuple(message for _entry_id, message in rows),
-        )
-
     def _recent_preserving_compaction_plan(self) -> CompactionPlan | None:
         rows = self._active_context_rows()
         if len(rows) < 2:
@@ -3794,11 +3773,13 @@ class CodingSession:
         if first_kept_index <= 0:
             return None
 
-        replaced = rows[:first_kept_index]
-        if not replaced:
+        if first_kept_index >= len(rows):
             return None
+
+        replaced = rows[:first_kept_index]
         return CompactionPlan(
-            replace_entry_ids=tuple(entry_id for entry_id, _message in replaced),
+            first_kept_entry_id=rows[first_kept_index][0],
+            replaced_entry_count=len(replaced),
             messages_to_summarize=tuple(message for _entry_id, message in replaced),
         )
 
@@ -3809,17 +3790,15 @@ class CodingSession:
         self,
         summary: str,
         *,
-        replace_entry_ids: tuple[str, ...],
-        first_kept_entry_id: str | None = None,
+        first_kept_entry_id: str,
         tokens_before: int | None = None,
     ) -> CompactionEntry:
-        if not replace_entry_ids:
-            raise ValueError("No active context messages to compact")
+        if first_kept_entry_id not in self._state.context_entry_ids:
+            raise ValueError("First kept entry is not in the active context")
 
         compaction = CompactionEntry(
             parent_id=self._last_parent_id,
             summary=summary,
-            replaces_entry_ids=list(replace_entry_ids),
             first_kept_entry_id=first_kept_entry_id,
             tokens_before=tokens_before,
         )

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -1307,9 +1307,10 @@ def _render_entry_body(entry: SessionEntry) -> str:
         level = entry.thinking_level if entry.thinking_level is not None else "off"
         return f"<p>Thinking level changed to <code>{_escape(level)}</code>.</p>"
     if isinstance(entry, CompactionEntry):
+        boundary = entry.first_kept_entry_id or "unavailable (legacy compaction)"
         return (
+            f"<p>First kept entry: <code>{_escape(boundary)}</code></p>"
             f"<pre>{_escape(entry.summary)}</pre>"
-            f"{_render_list('Replaces entries', entry.replaces_entry_ids)}"
         )
     if isinstance(entry, BranchSummaryEntry):
         branch_root = entry.branch_root_id or "none"

--- a/tests/fixtures/legacy_compaction.jsonl
+++ b/tests/fixtures/legacy_compaction.jsonl
@@ -1,0 +1,5 @@
+{"type":"message","id":"root","parent_id":null,"timestamp":1,"message":{"role":"user","content":"replace root","timestamp":1}}
+{"type":"message","id":"middle","parent_id":"root","timestamp":2,"message":{"role":"assistant","content":[{"type":"text","text":"keep middle"}],"api":"","provider":"","model":"","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0.0,"output":0.0,"cacheRead":0.0,"cacheWrite":0.0,"total":0.0}},"stopReason":"stop","timestamp":2}}
+{"type":"message","id":"tail","parent_id":"middle","timestamp":3,"message":{"role":"user","content":"replace tail","timestamp":3}}
+{"type":"compaction","id":"compact","parent_id":"tail","timestamp":4,"summary":"legacy summary","replaces_entry_ids":["root","tail"],"first_kept_entry_id":"tail"}
+{"type":"message","id":"after","parent_id":"compact","timestamp":5,"message":{"role":"assistant","content":[{"type":"text","text":"after compaction"}],"api":"","provider":"","model":"","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0.0,"output":0.0,"cacheRead":0.0,"cacheWrite":0.0,"total":0.0}},"stopReason":"stop","timestamp":5}}

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -3726,6 +3726,8 @@ async def test_session_auto_compacts_after_response_when_threshold_is_exceeded(
     assert compactions[0].summary == "Generated automatic summary"
     assert compactions[0].replaces_entry_ids == []
     assert compactions[0].first_kept_entry_id in session.state.context_entry_ids
+    assert compactions[0].tokens_before is not None
+    assert compactions[0].tokens_before > 0
     assert "Explain sessions." in provider.calls[2][2][0].content
     _assert_messages(
         provider.calls[3][2],
@@ -4323,6 +4325,8 @@ async def test_session_compacts_and_retries_once_after_context_overflow(
 
     assert len(compactions) == 1
     assert compactions[0].summary == "Overflow recovery summary"
+    assert compactions[0].tokens_before is not None
+    assert compactions[0].tokens_before > 0
     assert any(
         getattr(event, "type", None) == "message_end"
         and getattr(getattr(event, "message", None), "text", None) == "Recovered answer"

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -1562,7 +1562,11 @@ async def test_context_usage_is_cached_until_session_context_changes(
 
 
 @pytest.mark.anyio
-async def test_context_usage_recalculates_after_prompt_and_compaction(tmp_path: Path) -> None:
+async def test_context_usage_recalculates_after_prompt_and_compaction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(coding_session_module, "DEFAULT_COMPACTION_KEEP_RECENT_TOKENS", 1)
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
         [
@@ -1591,8 +1595,9 @@ async def test_context_usage_recalculates_after_prompt_and_compaction(tmp_path: 
     _message = await session.compact("Context accounting was discussed.")
     after_compaction_usage = session.context_usage
 
-    assert after_compaction_usage.message_count == 1
-    assert after_compaction_usage.total_tokens < after_prompt_usage.total_tokens
+    assert after_compaction_usage is not after_prompt_usage
+    assert after_compaction_usage.message_count == 2
+    assert after_compaction_usage.total_tokens != after_prompt_usage.total_tokens
     assert session.context_token_estimate == after_compaction_usage.total_tokens
 
 
@@ -2148,7 +2153,11 @@ async def test_session_branches_to_previous_entry_without_destroying_history(
 
 
 @pytest.mark.anyio
-async def test_persist_after_branch_keeps_state_on_active_branch(tmp_path: Path) -> None:
+async def test_persist_after_branch_keeps_state_on_active_branch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(coding_session_module, "DEFAULT_COMPACTION_KEEP_RECENT_TOKENS", 1)
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
         [
@@ -2203,8 +2212,9 @@ async def test_persist_after_branch_keeps_state_on_active_branch(tmp_path: Path)
     await session.compact()
     compactions = [entry for entry in await storage.read_all() if entry.type == "compaction"]
     assert len(compactions) == 1
-    assert "abandoned" not in compactions[0].replaces_entry_ids
-    assert "abandoned-answer" not in compactions[0].replaces_entry_ids
+    assert compactions[0].replaces_entry_ids == []
+    assert compactions[0].first_kept_entry_id in session.state.context_entry_ids
+    assert compactions[0].first_kept_entry_id not in {"abandoned", "abandoned-answer"}
     assert "Abandoned" not in provider.calls[1][2][0].content
 
 
@@ -3604,7 +3614,11 @@ async def test_session_provider_settings_reload_uses_session_paths(
 
 
 @pytest.mark.anyio
-async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: Path) -> None:
+async def test_session_compact_persists_summary_and_rebuilds_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(coding_session_module, "DEFAULT_COMPACTION_KEEP_RECENT_TOKENS", 1)
     storage = JsonlSessionStorage(tmp_path / "session.jsonl")
     provider = FakeProvider(
         [
@@ -3637,11 +3651,19 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
 
     _next_events = await _collect_session_events(session.prompt("Continue."))
 
-    assert result == f"Compacted {message_count_before} context entries."
+    assert result == f"Compacted {message_count_before - 1} context entries."
     assert len(compactions) == 1
     assert isinstance(compactions[0], CompactionEntry)
     assert compactions[0].summary == "Generated session summary"
-    assert compactions[0].replaces_entry_ids == message_entries_before
+    assert compactions[0].replaces_entry_ids == []
+    assert compactions[0].first_kept_entry_id == message_entries_before[-1]
+    persisted_payload = next(
+        payload
+        for line in storage.path.read_text().splitlines()
+        if (payload := json.loads(line))["type"] == "compaction"
+    )
+    assert "replaces_entry_ids" not in persisted_payload
+    assert persisted_payload["first_kept_entry_id"] == message_entries_before[-1]
     assert leaves == []
     assert entries_after_compact[-1] == compactions[0]
     assert provider.calls[1][1].startswith("You are a context summarization assistant.")
@@ -3650,6 +3672,7 @@ async def test_session_compact_persists_summary_and_rebuilds_context(tmp_path: P
         provider.calls[2][2],
         [
             UserMessage(content=("Previous conversation summary:\nGenerated session summary")),
+            AssistantMessage(content="Session answer"),
             UserMessage(content="Continue."),
         ],
     )
@@ -3701,6 +3724,8 @@ async def test_session_auto_compacts_after_response_when_threshold_is_exceeded(
 
     assert len(compactions) == 1
     assert compactions[0].summary == "Generated automatic summary"
+    assert compactions[0].replaces_entry_ids == []
+    assert compactions[0].first_kept_entry_id in session.state.context_entry_ids
     assert "Explain sessions." in provider.calls[2][2][0].content
     _assert_messages(
         provider.calls[3][2],

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -9,7 +9,13 @@ from typer.testing import CliRunner
 
 from pi_event_helpers import assistant_done, assistant_start, text_delta
 from tau_agent import AssistantMessage, Usage, UserMessage
-from tau_agent.session import JsonlSessionStorage, LeafEntry, MessageEntry, ModelChangeEntry
+from tau_agent.session import (
+    CompactionEntry,
+    JsonlSessionStorage,
+    LeafEntry,
+    MessageEntry,
+    ModelChangeEntry,
+)
 from tau_ai import FakeProvider
 from tau_coding import (
     CodingSession,
@@ -310,10 +316,49 @@ async def test_rpc_compaction_returns_canonical_summary_and_boundary(tmp_path: P
     boundary = response["data"]["firstKeptEntryId"]
     assert response["data"]["summary"] == "real summary"
     assert boundary in original_ids
-    assert boundary not in compaction.replaces_entry_ids
+    assert compaction.replaces_entry_ids == []
     assert boundary != compaction.id
     assert compaction.first_kept_entry_id == boundary
     assert compaction.tokens_before == response["data"]["tokensBefore"]
+
+    entries_stdout = StringIO()
+    await RpcServer(
+        session,
+        stdin=StringIO('{"id":"entries","type":"get_entries"}\n'),
+        stdout=entries_stdout,
+    ).run()
+    projected = json.loads(entries_stdout.getvalue())["data"]["entries"][-1]
+    assert projected["firstKeptEntryId"] == boundary
+    assert projected["details"] == {}
+    assert "replacesEntryIds" not in json.dumps(projected)
+    assert "tauReplacedEntryIds" not in json.dumps(projected)
+
+
+@pytest.mark.anyio
+async def test_rpc_projects_legacy_compaction_without_id_list_bridge(tmp_path: Path) -> None:
+    storage = JsonlSessionStorage(tmp_path / "session.jsonl")
+    await storage.append(MessageEntry(id="user", message=UserMessage(content="hi")))
+    await storage.append(
+        CompactionEntry(
+            id="compact",
+            parent_id="user",
+            summary="legacy",
+            replaces_entry_ids=["user"],
+        )
+    )
+    session = await _session(tmp_path, FakeProvider([]))
+    stdout = StringIO()
+
+    await RpcServer(
+        session,
+        stdin=StringIO('{"id":"entries","type":"get_entries"}\n'),
+        stdout=stdout,
+    ).run()
+
+    projected = json.loads(stdout.getvalue())["data"]["entries"][-1]
+    assert projected["type"] == "custom"
+    assert projected["customType"] == "tau.compaction"
+    assert projected["data"] == {"summary": "legacy"}
 
 
 @pytest.mark.anyio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -328,6 +328,27 @@ def test_session_state_replays_linear_entries() -> None:
     assert state.active_leaf_id == "custom"
 
 
+def test_compaction_entry_omits_empty_legacy_id_list_from_jsonl() -> None:
+    line = entry_to_json_line(
+        CompactionEntry(
+            id="compact",
+            summary="summary",
+            first_kept_entry_id="kept",
+            tokens_before=42,
+        )
+    )
+
+    assert json.loads(line) == {
+        "id": "compact",
+        "timestamp": json.loads(line)["timestamp"],
+        "type": "compaction",
+        "summary": "summary",
+        "first_kept_entry_id": "kept",
+        "tokens_before": 42,
+    }
+    assert entry_from_json_line(line).replaces_entry_ids == []
+
+
 def test_session_state_applies_compaction_and_branch_summary() -> None:
     entries = [
         MessageEntry(id="user", message=UserMessage(content="Explain sessions.")),
@@ -354,6 +375,101 @@ def test_session_state_applies_compaction_and_branch_summary() -> None:
     assert [message.role for message in state.messages] == ["user", "user"]
     assert "The user asked about sessions." in state.messages[0].text
     assert "A side branch explored storage." in state.messages[1].text
+
+
+@pytest.mark.parametrize(
+    ("boundary", "expected"),
+    [
+        ("first", ["summary", "first", "middle", "last"]),
+        ("middle", ["summary", "middle", "last"]),
+        ("last", ["summary", "last"]),
+        ("missing", ["summary"]),
+        (None, ["summary"]),
+    ],
+)
+def test_session_state_applies_first_kept_boundary_inclusively(
+    boundary: str | None,
+    expected: list[str],
+) -> None:
+    entries = [
+        MessageEntry(id="first", message=UserMessage(content="first")),
+        MessageEntry(
+            id="middle",
+            parent_id="first",
+            message=AssistantMessage(content="middle"),
+        ),
+        MessageEntry(id="last", parent_id="middle", message=UserMessage(content="last")),
+        CompactionEntry(
+            id="compact",
+            parent_id="last",
+            summary="summary",
+            first_kept_entry_id=boundary,
+        ),
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert [
+        message.text.removeprefix("Previous conversation summary:\n") for message in state.messages
+    ] == expected
+    assert state.context_entry_ids == (
+        "compact",
+        *(entry_id for entry_id in ("first", "middle", "last") if entry_id in expected),
+    )
+
+
+def test_session_state_applies_first_kept_boundary_on_active_branch_only() -> None:
+    entries = [
+        MessageEntry(id="root", message=UserMessage(content="root")),
+        MessageEntry(
+            id="left",
+            parent_id="root",
+            message=AssistantMessage(content="abandoned left"),
+        ),
+        MessageEntry(
+            id="right",
+            parent_id="root",
+            message=AssistantMessage(content="kept right"),
+        ),
+        CompactionEntry(
+            id="compact",
+            parent_id="right",
+            summary="right summary",
+            first_kept_entry_id="right",
+        ),
+        MessageEntry(id="after", parent_id="compact", message=UserMessage(content="after")),
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert [message.text for message in state.messages] == [
+        "Previous conversation summary:\nright summary",
+        "kept right",
+        "after",
+    ]
+    assert state.context_entry_ids == ("compact", "right", "after")
+
+
+@pytest.mark.anyio
+async def test_legacy_compaction_fixture_replays_with_id_list_precedence(
+    tmp_path: Path,
+) -> None:
+    fixture = Path(__file__).parent / "fixtures" / "legacy_compaction.jsonl"
+    session_path = tmp_path / "legacy_compaction.jsonl"
+    session_path.write_bytes(fixture.read_bytes())
+    entries = await JsonlSessionStorage(session_path).read_all()
+
+    compaction = next(entry for entry in entries if entry.type == "compaction")
+    state = SessionState.from_entries(entries)
+
+    assert compaction.replaces_entry_ids == ["root", "tail"]
+    assert compaction.first_kept_entry_id == "tail"
+    assert [message.text for message in state.messages] == [
+        "Previous conversation summary:\nlegacy summary",
+        "keep middle",
+        "after compaction",
+    ]
+    assert state.context_entry_ids == ("compact", "middle", "after")
 
 
 def test_path_to_entry_follows_parent_chain() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -380,11 +380,11 @@ def test_session_state_applies_compaction_and_branch_summary() -> None:
 @pytest.mark.parametrize(
     ("boundary", "expected"),
     [
-        ("first", ["summary", "first", "middle", "last"]),
-        ("middle", ["summary", "middle", "last"]),
-        ("last", ["summary", "last"]),
-        ("missing", ["summary"]),
-        (None, ["summary"]),
+        ("first", ["summary", "first", "middle", "last", "after"]),
+        ("middle", ["summary", "middle", "last", "after"]),
+        ("last", ["summary", "last", "after"]),
+        ("missing", ["summary", "after"]),
+        (None, ["summary", "after"]),
     ],
 )
 def test_session_state_applies_first_kept_boundary_inclusively(
@@ -405,6 +405,7 @@ def test_session_state_applies_first_kept_boundary_inclusively(
             summary="summary",
             first_kept_entry_id=boundary,
         ),
+        MessageEntry(id="after", parent_id="compact", message=UserMessage(content="after")),
     ]
 
     state = SessionState.from_entries(entries)
@@ -414,7 +415,7 @@ def test_session_state_applies_first_kept_boundary_inclusively(
     ] == expected
     assert state.context_entry_ids == (
         "compact",
-        *(entry_id for entry_id in ("first", "middle", "last") if entry_id in expected),
+        *(entry_id for entry_id in ("first", "middle", "last", "after") if entry_id in expected),
     )
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -419,6 +419,73 @@ def test_session_state_applies_first_kept_boundary_inclusively(
     )
 
 
+def test_first_kept_boundary_can_reference_non_message_path_entry() -> None:
+    entries = [
+        MessageEntry(id="first", message=UserMessage(content="first")),
+        ModelChangeEntry(
+            id="model",
+            parent_id="first",
+            model="new-model",
+        ),
+        MessageEntry(id="kept", parent_id="model", message=UserMessage(content="kept")),
+        CompactionEntry(
+            id="compact",
+            parent_id="kept",
+            summary="summary",
+            first_kept_entry_id="model",
+        ),
+        MessageEntry(id="after", parent_id="compact", message=UserMessage(content="after")),
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert [message.text for message in state.messages] == [
+        "Previous conversation summary:\nsummary",
+        "kept",
+        "after",
+    ]
+    assert state.context_entry_ids == ("compact", "kept", "after")
+
+
+def test_first_kept_replay_includes_compaction_after_boundary_in_path_order() -> None:
+    entries = [
+        MessageEntry(id="first", message=UserMessage(content="first")),
+        MessageEntry(id="kept", parent_id="first", message=UserMessage(content="kept")),
+        CompactionEntry(
+            id="old-compact",
+            parent_id="kept",
+            summary="old summary",
+            first_kept_entry_id="kept",
+        ),
+        MessageEntry(
+            id="after-old",
+            parent_id="old-compact",
+            message=UserMessage(content="after old"),
+        ),
+        CompactionEntry(
+            id="new-compact",
+            parent_id="after-old",
+            summary="new summary",
+            first_kept_entry_id="kept",
+        ),
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert [message.text for message in state.messages] == [
+        "Previous conversation summary:\nnew summary",
+        "kept",
+        "Previous conversation summary:\nold summary",
+        "after old",
+    ]
+    assert state.context_entry_ids == (
+        "new-compact",
+        "kept",
+        "old-compact",
+        "after-old",
+    )
+
+
 def test_session_state_applies_first_kept_boundary_on_active_branch_only() -> None:
     entries = [
         MessageEntry(id="root", message=UserMessage(content="root")),
@@ -449,6 +516,33 @@ def test_session_state_applies_first_kept_boundary_on_active_branch_only() -> No
         "after",
     ]
     assert state.context_entry_ids == ("compact", "right", "after")
+
+
+def test_legacy_compaction_with_explicit_empty_id_list_keeps_prior_context() -> None:
+    legacy_compaction = entry_from_json_line(
+        json.dumps(
+            {
+                "type": "compaction",
+                "id": "compact",
+                "parent_id": "first",
+                "timestamp": 2,
+                "summary": "legacy summary",
+                "replaces_entry_ids": [],
+            }
+        )
+    )
+    entries = [
+        MessageEntry(id="first", message=UserMessage(content="first")),
+        legacy_compaction,
+    ]
+
+    state = SessionState.from_entries(entries)
+
+    assert [message.text for message in state.messages] == [
+        "first",
+        "Previous conversation summary:\nlegacy summary",
+    ]
+    assert state.context_entry_ids == ("first", "compact")
 
 
 @pytest.mark.anyio

--- a/tests/test_session_export.py
+++ b/tests/test_session_export.py
@@ -51,7 +51,7 @@ def test_render_session_html_preserves_branch_tree() -> None:
             id="compact",
             parent_id="tool",
             summary="The right branch was compacted.",
-            replaces_entry_ids=["root", "right", "tool"],
+            first_kept_entry_id="tool",
         ),
         LeafEntry(id="leaf", parent_id="compact", entry_id="left"),
     ]
@@ -69,7 +69,9 @@ def test_render_session_html_preserves_branch_tree() -> None:
     assert "Right branch" in html
     assert "active-path" in html
     assert "active-leaf" in html
-    assert "Replaces entries" in html
+    assert "First kept entry" in html
+    assert "<code>tool</code>" in html
+    assert "Replaces entries" not in html
 
 
 def test_render_session_html_handles_long_legacy_leaf_history() -> None:

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -188,7 +188,7 @@ def test_calculate_session_stats_keeps_compacted_active_branch_usage() -> None:
     compaction = CompactionEntry(
         parent_id=extension_turn.id,
         summary="Earlier work",
-        replaces_entry_ids=[user.id, assistant.id],
+        first_kept_entry_id=extension_turn.id,
     )
 
     stats = calculate_session_stats(

--- a/tests/test_session_usage.py
+++ b/tests/test_session_usage.py
@@ -39,7 +39,7 @@ def test_collect_session_usage_aggregates_requests_tools_and_compactions() -> No
             usage=Usage(input=100, output=20, cache_read=900, cache_write=50),
             tools=[ToolCall(id="c1", name="read", arguments={})],
         ),
-        CompactionEntry(id="compact", summary="summary", replaces_entry_ids=["user"]),
+        CompactionEntry(id="compact", summary="summary", first_kept_entry_id="a1"),
         _assistant(
             "a2",
             usage=Usage(input=50, output=10, cache_read=1950, cache_write=0, reasoning=5),
@@ -67,7 +67,7 @@ def test_collect_session_usage_positions_notable_events_at_next_request() -> Non
             id="compact",
             timestamp=2,
             summary="summary",
-            replaces_entry_ids=["a1"],
+            first_kept_entry_id="a1",
         ),
         ThinkingLevelChangeEntry(id="thinking", timestamp=3, thinking_level="high"),
         _assistant("a2", usage=Usage(input=20)),
@@ -136,7 +136,7 @@ def test_render_usage_dashboard_marks_events_on_prompt_input_chart() -> None:
                 id="compact",
                 timestamp=2,
                 summary="summary",
-                replaces_entry_ids=["a1"],
+                first_kept_entry_id="a1",
             ),
             _assistant("a2", usage=Usage(input=20, cache_read=80)),
         ]

--- a/website/content/guides/context.md
+++ b/website/content/guides/context.md
@@ -80,9 +80,10 @@ Compact on demand any time:
 /compact focus on the database migration work
 ```
 
-Optional text after `/compact` is added as extra focus for the summary. Manual
-compaction summarizes the whole active context into one summary and fails visibly
-if the request fails.
+Optional text after `/compact` is added as extra focus for the summary. Like automatic
+compaction, manual compaction summarizes an older prefix and keeps a recent suffix. If
+there is not enough older context to summarize while retaining a real entry, Tau reports
+that the context is too short to compact. Summary generation failures remain visible.
 
 In the TUI, a manual compaction looks like a normal working turn: the prompt
 activity indicator and terminal tab title animate while it runs, and a

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -140,6 +140,13 @@ The system prompt is display-only export metadata, not a transcript entry.
 Direct JSONL exports and JSONL downloaded from the HTML remain entry-only and do
 not contain it.
 
+New compaction entries store a `first_kept_entry_id` boundary: replay inserts the
+summary, then keeps that active-path entry and everything after it. This is a fixed-size,
+Pi-compatible replacement for older Tau files' `replaces_entry_ids` arrays. Older arrays
+remain readable and take precedence during replay, so exporting or resuming a legacy
+session does not change its message history. HTML entry details show the first-kept
+boundary for modern compactions and identify unavailable legacy boundaries.
+
 Every transcript entry is a compact accordion row
 (icon, title, one-line preview, timestamp) that expands to reveal the full
 content; thinking blocks, tool-call arguments, and tool-result details are

--- a/website/content/reference/rpc.md
+++ b/website/content/reference/rpc.md
@@ -57,10 +57,12 @@ tau.stdout.on("data", chunk => {
 tau.stdin.write(JSON.stringify({ id: "1", type: "prompt", message: "Hello" }) + "\n");
 ```
 
-RPC compaction preserves recent entries and returns the first pre-existing retained entry as
-`firstKeptEntryId`, matching Pi. Older Tau compaction records and TUI compactions that replaced
-all active context have no such boundary; session inspection exposes those honestly as
-`customType: "tau.compaction"` entries instead of fabricating Pi compaction metadata.
+RPC and TUI compaction preserve recent entries and return or persist the first pre-existing
+retained entry as `firstKeptEntryId`, matching Pi. Session inspection emits modern compactions
+in Pi's native shape without Tau's former replacement-id bridge. Older Tau records can lack a
+boundary; inspection exposes those honestly as `customType: "tau.compaction"` entries instead
+of fabricating Pi compaction metadata. Their legacy id lists remain usable for local replay but
+are not added to the RPC wire format.
 
 Tau mirrors Pi where its public `CodingSession` has equivalent behavior. Direct `bash` is
 supported, but `abort_bash` requires a future cancellable session API. Queue delivery modes,


### PR DESCRIPTION
## Summary

This PR replaces newly written variable-size compaction replacement lists with Pi-compatible first-kept boundaries. A compaction now records the first original entry that remains after the summary; replay treats the summary as replacing everything earlier on that active branch.

This keeps new compaction records constant in size while retaining exact replay semantics for historical Tau files.

Closes #703.

## What this implements

### Session schema

- Adds optional `first_kept_entry_id` to `CompactionEntry` (serialized as Tau's canonical `first_kept_entry_id`).
- Stops writing `replaces_entry_ids` for new compactions.
- Retains the legacy field in the reader/model solely for backward compatibility with existing Tau sessions.
- Projects the Pi wire name `firstKeptEntryId` through RPC and removes replacement-id reporting from modern RPC and HTML representations.

### Compaction planning

- Selects a concrete recent-context boundary before writing manual, automatic, or overflow compactions.
- Uses the same recent-context retention rules for manual compaction instead of treating it as a special full-replacement path.
- Rejects invalid boundaries that are not part of the active context.
- Avoids writing a compaction when there is no valid replaced prefix or no retained successor entry.
- Preserves accurate transient compaction counts even though the persisted entry no longer enumerates every replaced ID.

### Replay semantics

For modern entries with `first_kept_entry_id`, replay:

1. follows the selected leaf's active ancestry;
2. locates the first-kept entry on that path;
3. removes the active-path prefix before that entry; and
4. inserts the compaction summary while retaining the boundary entry and everything after it.

The boundary is inclusive: the identified entry remains in provider context.

### Historical compatibility

Historical compactions with an explicit `replaces_entry_ids` field continue to use Tau's exact set-based replay semantics. This includes an explicitly empty list, which is meaningful legacy data and must not be interpreted as a modern boundary compaction. Existing JSONL files are read in place and are not rewritten.

A dedicated legacy fixture and replay tests cover branched histories, out-of-path IDs, explicit empty lists, missing boundaries, nested compactions, and mixed old/new entries.

## User-visible behavior

- Compaction entries remain fixed-size regardless of how much history they summarize.
- New JSONL is closer to Pi's session format.
- Recent messages retained by the compaction remain available after restart and branch navigation.
- Old Tau sessions resume with their original context semantics.

## Interfaces affected

- Core session entry models and in-memory replay.
- Manual, automatic, and overflow compaction creation.
- Session statistics and usage reconstruction.
- RPC `get_entries` projections.
- HTML/JSONL export and published session/context documentation.

## Validation coverage

Tests cover:

- inclusive first-kept replay on linear and branched trees;
- modern compactions mixed with historical set-based entries;
- explicit empty legacy replacement lists;
- nested and repeated compactions;
- invalid or absent first-kept successors;
- manual/automatic/overflow write paths;
- RPC, exports, statistics, and usage behavior.

## Checks

- `uv sync --dev --locked`
- `uv run pytest` — 1,928 passed, 2 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `hugo --minify` from `website/`
- `npx --yes pagefind@latest --site public` from `website/`
