### PR TITLE
Prepare Tau 0.4.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.4.1"
+version = "0.4.2"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,30 @@
 [
   {
+    "version": "0.4.2",
+    "date": "2026-09-10",
+    "sections": {
+      "New": [
+        "Bookmark specific moments in the session tree with persistent per-entry labels, including create, edit, clear, filter, and timestamp controls in /tree.",
+        "Persist extension-injected model context as first-class custom_message entries and expose extension APIs for custom messages and session labels.",
+        "Discover and persist live OpenAI Codex subscription model catalogs so newly available models can be selected without waiting for a Tau release.",
+        "Show or hide the TUI sidebar for the current session without changing the saved global preference."
+      ],
+      "Changed": [
+        "Align session storage more closely with Pi: stop writing redundant leaf pointers, store fixed-size first-kept compaction boundaries, and retain backward-compatible replay for older session files.",
+        "Include compaction and branch-summary model usage in session analytics, exports, and RPC inspection with provider and routed-provider attribution.",
+        "Make the prompt newline shortcut configurable and add a scoped-only tab to the scoped-model picker.",
+        "Expose resolved Tau paths to extensions through ExtensionContext.paths and align Anthropic usage accounting with the provider contract."
+      ],
+      "Fixed": [
+        "Preserve interleaved Chat Completions reasoning and answer blocks instead of losing or misordering streamed content.",
+        "Reject or retry incomplete Anthropic-compatible streams rather than accepting empty SSE frames as successful responses.",
+        "Serialize Z.AI thinking requests correctly.",
+        "Disconnect shell-command standard input after execution and ignore selection events from detached TUI transcript widgets.",
+        "Highlight the initial provider correctly when the login picker opens."
+      ]
+    }
+  },
+  {
     "version": "0.4.1",
     "date": "2026-08-28",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -867,7 +867,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.4.1" in console.export_text()
+    assert "τ = 2π  0.4.2" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Prepare Tau 0.4.2 for publication:

- bump the package and lockfile version from `0.4.1` to `0.4.2`
- add structured startup and website release notes for changes since 0.4.1
- update the versioned TUI branding assertion

## Highlights

- Pi-aligned session storage: first-kept compactions, first-class custom messages, per-entry labels, summary usage accounting, and removal of redundant leaf writes
- persistent live Codex model discovery and improved extension/TUI controls
- streaming and provider fixes for Anthropic-compatible, Chat Completions, and Z.AI paths

## Validation

- `uv run pytest` — 1,952 passed, 2 Windows-only skips
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `hugo --minify`
- `npx --yes pagefind@latest --site public`

## Publication

After this PR merges, publish GitHub Release `v0.4.2` from `main`. The release event triggers the trusted PyPI publishing workflow.
