### PR TITLE
fix: preserve streamed Responses arguments when final value is empty

### DIFF
--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -766,7 +766,7 @@ class _ResponsesToolCallBuilder:
             self.call_id = call_id
         if name:
             self.name = name
-        if isinstance(arguments, str):
+        if isinstance(arguments, str) and arguments:
             self.arguments_final = arguments
         if output_index is not None:
             self.output_index = output_index

--- a/tests/test_responses_empty_arguments.py
+++ b/tests/test_responses_empty_arguments.py
@@ -1,0 +1,114 @@
+from json import dumps, loads
+
+import httpx
+import pytest
+
+from tau_agent import AssistantMessage, ToolResultMessage, UserMessage
+from tau_ai import (
+    AssistantDoneEvent,
+    OpenAICompatibleConfig,
+    OpenAICompatibleProvider,
+    ToolCallEndEvent,
+)
+
+
+def item_event(kind: str, index: int, item_id: str, call_id: str, arguments: str = "") -> dict:
+    return {
+        "type": f"response.output_item.{kind}",
+        "output_index": index,
+        "item": {
+            "type": "function_call",
+            "id": item_id,
+            "call_id": call_id,
+            "name": "get_weather",
+            "arguments": arguments,
+        },
+    }
+
+
+async def stream_calls(chunks: list[dict]) -> AssistantMessage:
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(loads(request.content))
+        events = chunks if len(requests) == 1 else []
+        completed = {"type": "response.completed", "response": {"status": "completed"}}
+        return httpx.Response(
+            200,
+            text="".join(f"data: {dumps(event)}\n\n" for event in [*events, completed]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(api_key="test-key", base_url="https://example.test/v1"),
+            client=client,
+        )
+        events = [
+            event
+            async for event in provider.stream_response(
+                model="gpt-5.5", system="", messages=[UserMessage(content="weather?")], tools=[]
+            )
+        ]
+        end = events[-1]
+        assert isinstance(end, AssistantDoneEvent)
+        calls = end.message.tool_calls
+        assert (
+            tuple(event.tool_call for event in events if isinstance(event, ToolCallEndEvent))
+            == calls
+        )
+        assert all(call.name == "get_weather" for call in calls)
+        history = [UserMessage(content="weather?"), end.message]
+        history.extend(
+            ToolResultMessage(tool_call_id=call.id, tool_name=call.name, content="sunny")
+            for call in calls
+        )
+        _ = [
+            event
+            async for event in provider.stream_response(
+                model="gpt-5.5", system="", messages=history, tools=[]
+            )
+        ]
+
+    replayed = [item for item in requests[1]["input"] if item.get("type") == "function_call"]
+    assert [(item["call_id"], item["name"], loads(item["arguments"])) for item in replayed] == [
+        (call.id, call.name, call.arguments) for call in calls
+    ]
+    return end.message
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("final_kind", ["arguments", "item", "both"])
+async def test_responses_empty_final_arguments_preserve_deltas(final_kind: str) -> None:
+    chunks = [
+        item_event("added", 0, "fc_a", "call_a"),
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_a",
+            "delta": '{"city":"Paris"}',
+        },
+    ]
+    if final_kind in ("arguments", "both"):
+        chunks.append(
+            {"type": "response.function_call_arguments.done", "item_id": "fc_a", "arguments": ""}
+        )
+    if final_kind in ("item", "both"):
+        chunks.append(item_event("done", 0, "fc_a", "call_a"))
+    message = await stream_calls(chunks)
+    assert message.tool_calls[0].arguments == {"city": "Paris"}
+
+
+@pytest.mark.anyio
+async def test_responses_nonempty_final_arguments_override_deltas() -> None:
+    message = await stream_calls(
+        [
+            item_event("added", 0, "fc_a", "call_a"),
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_a",
+                "delta": '{"city":"Paris"}',
+            },
+            item_event("done", 0, "fc_a", "call_a", '{"city":"London"}'),
+        ]
+    )
+    assert message.tool_calls[0].arguments == {"city": "London"}

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -47,6 +47,10 @@ GitHub Copilot asks for a GitHub Enterprise Server URL/domain. Leave it blank
 for `github.com`. Device login also works in SSH/headless sessions: open the
 shown verification URL on any device and enter the displayed code.
 
+For Copilot models using the Responses API, an empty final argument field
+preserves the tool arguments already received in the stream, so tool calls
+and their history retain the complete parameters.
+
 Anthropic uses distinct direct-login aliases so the authentication method is
 unambiguous: `/login anthropic-subscription` starts OAuth, while
 `/login anthropic-api` saves an API key. The top-level `/login` picker still


### PR DESCRIPTION
Addresses the empty-final-arguments part of #678. Related: #665, which handles tool-call identity correlation.

Some compatible Responses providers stream complete tool arguments and then send an empty `arguments` field in `response.function_call_arguments.done` or `response.output_item.done`. The empty final value currently replaces the streamed JSON, leaving the tool and its replayed history with an empty argument object.

Treat only non-empty final strings as authoritative. Non-empty final arguments still override the streamed value. This is independent of the identity-correlation changes in #665.

Add HTTP/SSE regression coverage for both final event types, their combination, and the non-empty override case. Each case also checks the serialized tool call on the following request. Update the provider guide.

Validation:
- The new cases produce 3 failures and 1 pass on unchanged main; all 4 pass with the fix.
- 151 tests pass across provider streaming, cross-provider history, agent loop, multimodal payloads, provider runtime and OAuth providers.
- Ruff lint and formatting checks pass; mypy passes for all 122 source files.
- Full-suite validation is incomplete in this environment: three CLI tests fail on project-trust warnings (reproduced on unchanged main), and an earlier full run stalled at `test_tui_surfaces_bad_model_as_clean_error`.
- Provider behavior is covered by deterministic HTTP/SSE fixtures; no live Copilot account was used.
