### PR TITLE
fix(session): persist names in append-only transcript entries

### DIFF
--- a/dev-notes/session-name-persistence.md
+++ b/dev-notes/session-name-persistence.md
@@ -1,0 +1,49 @@
+# Append-only session names
+
+Session names previously lived only in the project discovery index. A transcript
+copied without that index therefore lost its current name. Naming now appends a
+`SessionInfoEntry(name=...)` through `SessionStorage` before updating the index or
+emitting `session_info_changed`.
+
+## Replay and compatibility
+
+- `SessionState.session_name` resolves the latest nonempty `name` in file order,
+  independently of the active branch and entry timestamps. Names do not enter
+  model context. The existing root metadata remains available as `session_info`.
+- `CodingSession` resolves new transcript names first, then old index-only titles,
+  then legacy root titles. The index takes precedence over a legacy root title
+  because older Tau versions could rename that title only in the index.
+- Loading does not append a migration record. Explicitly setting an index-only
+  name, even to the same value, records it in the transcript. Setting an already
+  durable name to the same value is a no-op.
+- New entries use Tau's existing snake_case wrapper fields and the naming field
+  `name`. The RPC projection exposes the same name. JSONL exports preserve all
+  naming entries, and standalone HTML exports can derive their title from them.
+
+## Index and failure boundaries
+
+Listing still reads the small project index; it does not scan every transcript.
+Successful renames update the cache, and loading repairs a conflicting cached
+title. Prepared sessions defer cache repair until their commit boundary.
+An index write failure records a diagnostic but does not undo a durable rename;
+reloading can repair the cache. A failed transcript append leaves the old name
+and index intact.
+
+Manual and automatic naming share the same asynchronous persistence path. A
+session-local lock serializes renames, and automatic naming checks again after
+generation so it cannot overwrite a name set manually while generation waited.
+This does not introduce cross-process session ownership or serialize unrelated
+session writes; those remain the existing harness/storage contracts.
+
+## Checks
+
+```bash
+uv run pytest tests/test_session_names.py tests/test_session.py \
+  tests/test_coding_session.py tests/test_extensions.py \
+  tests/test_session_export.py tests/test_rpc.py
+```
+
+The regressions cover append-only bytes, repeated and concurrent renames,
+copy/reload/export without an index, file-order versus branch/time ordering,
+root metadata preservation, old index/root precedence, stale-cache repair,
+staged loading, write failures, automatic naming, and manual naming races.

--- a/src/tau_agent/session/entries.py
+++ b/src/tau_agent/session/entries.py
@@ -113,12 +113,13 @@ class LeafEntry(BaseSessionEntry):
 
 
 class SessionInfoEntry(BaseSessionEntry):
-    """Basic session metadata entry."""
+    """Initial session metadata or an append-only session name change."""
 
     type: Literal["session_info"] = "session_info"
     created_at: float = Field(default_factory=current_timestamp)
     cwd: str | None = None
     title: str | None = None
+    name: str | None = None
 
 
 class CustomEntry(BaseSessionEntry):

--- a/src/tau_agent/session/memory.py
+++ b/src/tau_agent/session/memory.py
@@ -34,6 +34,9 @@ class SessionState:
     compaction_entries: tuple[CompactionEntry, ...]
     context_entry_ids: tuple[str, ...]
     entries: tuple[SessionEntry, ...]
+    # Names are session-wide, not tied to the selected branch. Legacy root
+    # titles remain in session_info so hosts can prefer an old index-only rename.
+    session_name: str | None = None
 
     @classmethod
     def from_entries(
@@ -94,7 +97,8 @@ class SessionState:
                 case "leaf":
                     pass  # Backward-compatible historical record; never selects the tip.
                 case "session_info":
-                    session_info = entry
+                    if session_info is None or entry.name is None:
+                        session_info = entry
                 case "custom":
                     custom_entries.append(entry)
                 case "compaction":
@@ -122,6 +126,14 @@ class SessionState:
             compaction_entries=tuple(compaction_entries),
             context_entry_ids=tuple(entry_id for entry_id, _message in message_rows),
             entries=tuple(replay_entries),
+            session_name=next(
+                (
+                    entry.name
+                    for entry in reversed(entries)
+                    if isinstance(entry, SessionInfoEntry) and entry.name
+                ),
+                None,
+            ),
         )
 
 

--- a/src/tau_coding/rpc.py
+++ b/src/tau_coding/rpc.py
@@ -737,7 +737,7 @@ def _entry_wire(entry: SessionEntry, provider_name: str) -> dict[str, JSONValue]
     if entry.type == "label":
         return {**base, "targetId": entry.target_id, "label": entry.label}
     if entry.type == "session_info":
-        return {**base, "name": entry.title}
+        return {**base, "name": entry.name or entry.title}
     raise AssertionError(f"Unhandled Tau session entry: {entry.type}")
 
 

--- a/src/tau_coding/session.py
+++ b/src/tau_coding/session.py
@@ -479,6 +479,7 @@ class CodingSession:
         self._persisted_message_ids: set[int] = set()
         self._ended_message_ids: set[int] = set()
         self._pending_message_writes: dict[int, _PendingMessageWrite] = {}
+        self._session_name_lock = asyncio.Lock()
         self._attach_persistence_listener()
 
     @classmethod
@@ -778,6 +779,8 @@ class CodingSession:
             # after installing their UI bridge.
             session._session_start_pending = True
             session._project_trust_commit_pending = not trust_resolution.cancelled
+            if not config.defer_authoritative_writes:
+                session._sync_session_name_index()
         except BaseException:
             # Once constructed, this session explicitly owns every candidate
             # provider until load returns it to the caller.
@@ -1375,17 +1378,18 @@ class CodingSession:
 
     @property
     def session_title(self) -> str | None:
-        """Return this session's indexed human-friendly title, if named."""
-        if self._config.session_id is None or self._config.session_manager is None:
-            return None
-        record = self._config.session_manager.get_session(self._config.session_id)
-        if record is None:
-            return None
-        return record.title
+        """Resolve the transcript name, then legacy index and root titles."""
+        if self._state.session_name is not None:
+            return self._state.session_name
+        if self._config.session_id is not None and self._config.session_manager is not None:
+            record = self._config.session_manager.get_session(self._config.session_id)
+            if record is not None and record.title:
+                return record.title
+        return self._state.session_info.title if self._state.session_info is not None else None
 
     @property
     def session_name(self) -> str | None:
-        """Return this session's indexed human-friendly name, if named."""
+        """Return this session's human-friendly name, if named."""
         return self.session_title
 
     @property
@@ -2657,7 +2661,7 @@ class CodingSession:
     async def set_session_name(self, name: str) -> str:
         """Persist a session name and notify extensions after it changes."""
         normalized = normalize_session_name(name)
-        persisted = self._persist_session_name(
+        persisted = await self._persist_session_name(
             normalized,
             only_if_unnamed=False,
             index_if_missing=True,
@@ -2667,40 +2671,50 @@ class CodingSession:
         await self._extension_runtime.emit_event(SessionInfoChangedEvent(name=persisted))
         return persisted
 
-    def _persist_session_name(
+    async def _persist_session_name(
         self,
         name: str,
         *,
         only_if_unnamed: bool,
         index_if_missing: bool,
     ) -> str | None:
-        """Persist and return a changed name; return None for a no-op."""
+        """Append a changed name before updating the discovery cache."""
         normalized = normalize_session_name(name)
+        async with self._session_name_lock:
+            if only_if_unnamed and self.session_title:
+                return None
+            if self._state.session_name == normalized:
+                self._sync_session_name_index()
+                return None
+            await self._flush_pending_message_writes(context=self._diagnostic_context())
+            await self._ensure_session_initialized()
+            entry = SessionInfoEntry(parent_id=self._last_parent_id, name=normalized)
+            await self._config.storage.append(entry)
+            self._last_parent_id = entry.id
+            self._state = SessionState.from_entries(
+                await self._read_session_entries(), leaf_id=entry.id
+            )
+            if index_if_missing:
+                try:
+                    self._index_current_session()
+                except Exception as exc:
+                    self._record_session_index_diagnostic(exc)
+            self._sync_session_name_index()
+            return normalized
+
+    def _sync_session_name_index(self) -> None:
+        """Repair an existing listing cache without making it authoritative."""
         manager = self._config.session_manager
         session_id = self._config.session_id
         if manager is None or session_id is None:
-            raise ValueError("Session manager is not available")
-        record = manager.get_session(session_id)
-        if record is None and index_if_missing:
-            self.ensure_session_indexed()
+            return
+        try:
+            title = self.session_title
             record = manager.get_session(session_id)
-        if record is None:
-            return None
-        if only_if_unnamed and record.title:
-            return None
-        if record.title == normalized:
-            return None
-        updated = manager.touch_session(
-            session_id,
-            model=self.model,
-            provider_name=self.provider_name,
-            title=normalized,
-        )
-        if updated is None:
-            if index_if_missing:
-                raise ValueError(f"Unknown session: {session_id}")
-            return None
-        return updated.title or normalized
+            if title is not None and record is not None and record.title != title:
+                manager.touch_session(session_id, title=title)
+        except Exception as exc:
+            self._record_session_index_diagnostic(exc)
 
     async def new_session(self) -> str:
         """Replace this session's active state with a pending unindexed session."""
@@ -3387,7 +3401,10 @@ class CodingSession:
             self._prepared_entries.extend(staged)
             self._last_parent_id = parent_id
             replay_entries = [*self._state.entries, *staged]
-            self._state = SessionState.from_entries(replay_entries, leaf_id=parent_id)
+            self._state = replace(
+                SessionState.from_entries(replay_entries, leaf_id=parent_id),
+                session_name=self._state.session_name,
+            )
         else:
             await self._append_session_batch(staged)
             self._last_parent_id = parent_id
@@ -3512,6 +3529,7 @@ class CodingSession:
                 inference_provider=self._inference_provider,
                 inference_provider_mode=self._inference_provider_mode,
                 preserve_inference_provider=False,
+                title=self.session_title,
             )
 
     async def _read_session_entries(self) -> list[SessionEntry]:
@@ -3541,6 +3559,7 @@ class CodingSession:
                 self._index_current_session()
         except Exception as exc:  # index is a rebuildable cache, not authority
             self._record_session_index_diagnostic(exc)
+        self._sync_session_name_index()
 
     async def _append_session_entry(self, entry: SessionEntry) -> None:
         """Append one durable entry after flushing deferred session metadata."""
@@ -3622,6 +3641,7 @@ class CodingSession:
             provider_name=self.provider_name,
             inference_provider=self._inference_provider,
             session_id=self._config.session_id,
+            title=self.session_title,
         )
 
     async def _try_auto_compact(
@@ -3690,7 +3710,7 @@ class CodingSession:
             title = _fallback_session_name(first_message)
         if title is None:
             return
-        persisted = self._persist_session_name(
+        persisted = await self._persist_session_name(
             title,
             only_if_unnamed=True,
             index_if_missing=False,
@@ -3701,8 +3721,7 @@ class CodingSession:
     def _should_auto_name_session(self) -> bool:
         if self._config.session_id is None or self._config.session_manager is None:
             return False
-        record = self._config.session_manager.get_session(self._config.session_id)
-        if record is not None and record.title:
+        if self.session_title:
             return False
         return sum(isinstance(message, UserMessage) for message in self._harness.messages) == 1
 

--- a/src/tau_coding/session_export.py
+++ b/src/tau_coding/session_export.py
@@ -183,6 +183,22 @@ def render_session_html(
 ) -> str:
     """Render a session transcript/tree as standalone HTML."""
     entry_list = list(entries)
+    if title == "Tau Session Export":
+        title = next(
+            (
+                entry.name
+                for entry in reversed(entry_list)
+                if isinstance(entry, SessionInfoEntry) and entry.name
+            ),
+            None,
+        ) or next(
+            (
+                entry.title
+                for entry in reversed(entry_list)
+                if isinstance(entry, SessionInfoEntry) and entry.title
+            ),
+            title,
+        )
     active_leaf_id = _active_leaf_id(entry_list)
     active_path_ids = _active_path_ids(entry_list, active_leaf_id)
     visible_entries = _visible_export_entries(entry_list)
@@ -1401,6 +1417,8 @@ def _render_entry_body(entry: SessionEntry) -> str:
         leaf = entry.entry_id or "none"
         return f"<p>Active leaf pointer: <code>{_escape(leaf)}</code></p>"
     if isinstance(entry, SessionInfoEntry):
+        if entry.name is not None:
+            return f"<p>Session name: <strong>{_escape(entry.name)}</strong></p>"
         return (
             f"<p>Title: <strong>{_escape(entry.title or 'Untitled')}</strong></p>"
             f"<p>Working directory: <code>{_escape(entry.cwd or 'unknown')}</code></p>"
@@ -1667,7 +1685,7 @@ def _entry_preview(entry: SessionEntry) -> str:
     if isinstance(entry, LeafEntry):
         return entry.entry_id or "none"
     if isinstance(entry, SessionInfoEntry):
-        return entry.title or entry.cwd or "session metadata"
+        return entry.name or entry.title or entry.cwd or "session metadata"
     if isinstance(entry, CustomEntry):
         return f"{len(entry.data)} field(s)"
     return entry.id

--- a/tests/test_coding_session.py
+++ b/tests/test_coding_session.py
@@ -2802,6 +2802,12 @@ async def test_session_auto_names_first_unnamed_managed_session(tmp_path: Path) 
     renamed = manager.get_session(record.id)
     assert renamed is not None
     assert renamed.title == "Fix broken CLI output"
+    names = [
+        entry.name
+        for entry in await storage.read_all()
+        if isinstance(entry, SessionInfoEntry) and entry.name is not None
+    ]
+    assert names == ["Fix broken CLI output"]
     assert provider.calls[0][0] == "fake"
     assert provider.calls[0][3] == []
     assert "Please fix the broken CLI output." in provider.calls[0][2][0].content
@@ -3014,6 +3020,12 @@ async def test_manual_name_wins_while_auto_name_is_in_flight(
     assert updated is not None
     assert updated.title == "Manual name"
     assert metadata_names == ["Manual name"]
+    names = [
+        entry.name
+        for entry in await storage.read_all()
+        if isinstance(entry, SessionInfoEntry) and entry.name is not None
+    ]
+    assert names == ["Manual name"]
 
 
 @pytest.mark.anyio

--- a/tests/test_session_names.py
+++ b/tests/test_session_names.py
@@ -1,0 +1,213 @@
+"""Session names survive transcript copies independently of the discovery index."""
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from tau_agent import UserMessage
+from tau_agent.session import (
+    InMemorySessionStorage,
+    JsonlSessionStorage,
+    MessageEntry,
+    SessionEntry,
+    SessionInfoEntry,
+    SessionState,
+    entry_from_json_line,
+    entry_to_json_line,
+)
+from tau_ai import FakeProvider
+from tau_coding import CodingSession, CodingSessionConfig, SessionManager, TauPaths
+from tau_coding.rpc import _entry_wire
+from tau_coding.session_export import export_session_jsonl, render_session_html
+
+
+def session_config(tmp_path: Path) -> CodingSessionConfig:
+    manager = SessionManager(TauPaths(home=tmp_path / ".tau", agents_home=tmp_path / ".agents"))
+    record = manager.create_session(cwd=tmp_path, model="fake")
+    return CodingSessionConfig(
+        provider=FakeProvider([]),
+        model="fake",
+        system="You are Tau.",
+        storage=JsonlSessionStorage(record.path),
+        cwd=tmp_path,
+        session_id=record.id,
+        session_manager=manager,
+    )
+
+
+@pytest.mark.anyio
+async def test_renames_append_without_rewriting_history_and_survive_copy(tmp_path: Path) -> None:
+    config = session_config(tmp_path)
+    session = await CodingSession.load(config)
+    await session.set_session_name("First name")
+    assert isinstance(config.storage, JsonlSessionStorage)
+    original = config.storage.path.read_bytes()
+
+    await session.set_session_name("Latest name")
+    renamed = config.storage.path.read_bytes()
+    assert renamed.startswith(original)
+    assert len(renamed) > len(original)
+    await session.set_session_name("Latest name")
+    assert config.storage.path.read_bytes() == renamed
+
+    copied = tmp_path / "copied.jsonl"
+    copied.write_bytes(renamed)
+    restored = await CodingSession.load(
+        replace(config, storage=JsonlSessionStorage(copied), session_id=None, session_manager=None)
+    )
+    assert restored.session_name == "Latest name"
+    assert restored.messages == session.messages
+
+
+@pytest.mark.anyio
+async def test_legacy_root_title_is_readable_without_index(tmp_path: Path) -> None:
+    config = session_config(tmp_path)
+    await config.storage.append(SessionInfoEntry(cwd=str(tmp_path), title="Legacy title"))
+    session = await CodingSession.load(replace(config, session_id=None, session_manager=None))
+    assert session.session_name == "Legacy title"
+
+
+def test_name_is_global_in_file_order_and_does_not_replace_root_metadata() -> None:
+    root = SessionInfoEntry(id="root", cwd="/project", created_at=1, title="Legacy")
+    message = MessageEntry(id="message", parent_id=root.id, message=UserMessage(content="Hello"))
+    first = SessionInfoEntry(id="first", parent_id=message.id, name="First", timestamp=20)
+    latest = SessionInfoEntry(id="latest", parent_id=root.id, name="Latest", timestamp=10)
+    entries = [root, message, first, latest]
+
+    for leaf_id in (None, message.id, first.id, latest.id):
+        state = SessionState.from_entries(entries, leaf_id=leaf_id)
+        assert state.session_name == "Latest"
+    state = SessionState.from_entries(entries, leaf_id=first.id)
+    assert state.session_info == root
+    assert state.messages == (message.message,)
+    assert entry_from_json_line(entry_to_json_line(latest)) == latest
+    assert _entry_wire(latest, "fake")["name"] == "Latest"
+    assert _entry_wire(root, "fake")["name"] == "Legacy"
+
+
+@pytest.mark.anyio
+async def test_transcript_name_repairs_disagreeing_index_on_load(tmp_path: Path) -> None:
+    config = session_config(tmp_path)
+    assert config.session_manager is not None and config.session_id is not None
+    await config.storage.append(SessionInfoEntry(name="Durable name"))
+    config.session_manager.touch_session(config.session_id, title="Stale cache")
+    before = await config.storage.read_all()
+
+    session = await CodingSession.load(config)
+
+    assert session.session_name == "Durable name"
+    assert config.session_manager.list_sessions(tmp_path)[0].title == "Durable name"
+    assert await config.storage.read_all() == before
+
+
+@pytest.mark.anyio
+async def test_legacy_index_rename_wins_over_root_until_explicitly_persisted(
+    tmp_path: Path,
+) -> None:
+    config = session_config(tmp_path)
+    assert config.session_manager is not None and config.session_id is not None
+    root = SessionInfoEntry(title="Old root title")
+    await config.storage.append(root)
+    config.session_manager.touch_session(config.session_id, title="Index-only rename")
+
+    session = await CodingSession.load(config)
+    assert session.session_name == "Index-only rename"
+    assert await config.storage.read_all() == [root]
+
+    await session.set_session_name("Index-only rename")
+    entries = await config.storage.read_all()
+    assert entries[0] == root
+    assert isinstance(entries[-1], SessionInfoEntry)
+    assert entries[-1].name == "Index-only rename"
+    restored = await CodingSession.load(replace(config, session_id=None, session_manager=None))
+    assert restored.session_name == "Index-only rename"
+
+
+@pytest.mark.anyio
+async def test_prepared_session_does_not_repair_index_before_commit(tmp_path: Path) -> None:
+    config = session_config(tmp_path)
+    assert config.session_manager is not None and config.session_id is not None
+    await config.storage.append(SessionInfoEntry(name="Durable name"))
+    config.session_manager.touch_session(config.session_id, title="Stale cache")
+
+    session = await CodingSession.load(replace(config, defer_authoritative_writes=True))
+    assert session.session_name == "Durable name"
+    assert config.session_manager.list_sessions(tmp_path)[0].title == "Stale cache"
+    await session._commit_prepared_entries()
+    assert config.session_manager.list_sessions(tmp_path)[0].title == "Durable name"
+
+
+@pytest.mark.anyio
+async def test_failed_name_append_keeps_old_name_and_index(tmp_path: Path) -> None:
+    class FailingStorage(InMemorySessionStorage):
+        async def append(self, entry: SessionEntry) -> None:
+            raise OSError("Transcript unavailable")
+
+    config = session_config(tmp_path)
+    assert config.session_manager is not None and config.session_id is not None
+    config.session_manager.touch_session(config.session_id, title="Old name")
+    storage = FailingStorage([SessionInfoEntry(name="Old name")])
+    session = await CodingSession.load(replace(config, storage=storage))
+
+    with pytest.raises(OSError, match="Transcript unavailable"):
+        await session.set_session_name("Unsaved name")
+
+    assert session.session_name == "Old name"
+    assert config.session_manager.list_sessions(tmp_path)[0].title == "Old name"
+    assert len(await storage.read_all()) == 1
+
+
+@pytest.mark.anyio
+async def test_cache_write_failure_does_not_lose_durable_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = session_config(tmp_path)
+    assert config.session_manager is not None
+    session = await CodingSession.load(config)
+
+    def fail_cache_write(*args: object, **kwargs: object) -> None:
+        raise OSError("Index unavailable")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(config.session_manager, "touch_session", fail_cache_write)
+        assert await session.set_session_name("Durable name") == "Durable name"
+        assert session.session_name == "Durable name"
+
+    restored = await CodingSession.load(config)
+    assert restored.session_name == "Durable name"
+    assert config.session_manager.list_sessions(tmp_path)[0].title == "Durable name"
+
+
+@pytest.mark.anyio
+async def test_concurrent_standalone_renames_extend_the_same_branch(tmp_path: Path) -> None:
+    storage = InMemorySessionStorage()
+    config = replace(
+        session_config(tmp_path), storage=storage, session_id=None, session_manager=None
+    )
+    session = await CodingSession.load(config)
+    await asyncio.gather(session.set_session_name("First"), session.set_session_name("Second"))
+    entries = await storage.read_all()
+    names = [entry for entry in entries if isinstance(entry, SessionInfoEntry) and entry.name]
+    assert [entry.name for entry in names] == ["First", "Second"]
+    assert names[1].parent_id == names[0].id
+    assert (await CodingSession.load(config)).session_name == "Second"
+
+
+@pytest.mark.anyio
+async def test_exports_preserve_the_name_without_an_index(tmp_path: Path) -> None:
+    config = session_config(tmp_path)
+    session = await CodingSession.load(config)
+    await session.set_session_name("Fix <parser> & tests")
+    entries = await session.session_entries()
+    exported = export_session_jsonl(entries, tmp_path / "export.jsonl")
+    restored = await CodingSession.load(
+        replace(
+            config, storage=JsonlSessionStorage(exported), session_id=None, session_manager=None
+        )
+    )
+    assert restored.session_name == "Fix <parser> & tests"
+    html = render_session_html(entries)
+    assert "<title>Fix &lt;parser&gt; &amp; tests</title>" in html
+    assert "<title>Explicit title</title>" in render_session_html(entries, title="Explicit title")

--- a/website/content/guides/sessions.md
+++ b/website/content/guides/sessions.md
@@ -107,6 +107,20 @@ when possible.
 Use `/name` at any time to manually override the automatic name. Tau will not
 replace a name you set yourself.
 
+Names and renames are appended to the session JSONL as `session_info` entries
+with a `name` field. The latest naming entry in file order wins across all
+branches, so copying or exporting the transcript preserves its name without
+the original project index. Naming does not add a message to the model context
+or rewrite earlier entries.
+
+The project index still caches names for fast `/resume` listings. Tau updates
+that cache after a rename and repairs a stale name when loading the session.
+Older sessions remain readable: without a naming entry, Tau uses the legacy
+index title first, then the original `session_info.title`. For an old name stored
+only in the index, run `/name` with that same name before copying the transcript
+to persist it in the new format. Simply opening an old session does not rewrite
+its history.
+
 ## Exporting
 
 Export a session to a shareable file:


### PR DESCRIPTION
Session names currently live only in the project index, so copying a transcript loses its current name. This records manual and automatic renames as append-only `session_info` entries containing `name`.

Closes #713.

## Changes

- Resolve the latest name in file order across branches, preserving root metadata and model context.
- Persist the transcript before updating the listing cache or notifying extensions. Repair stale cached names on load, respecting prepared-session commit boundaries.
- Preserve names in RPC inspection and JSONL/HTML exports.
- Add regressions for copies, reloads, renames, cache disagreement, write failures, automatic naming, and manual-name races.

## Compatibility

Existing sessions fall back to their index title, then the legacy root `session_info.title`. Loading does not append a migration entry. Explicitly setting an old index-only name, even to the same value, persists it in the new format. The session guide documents this migration path.

## Validation

- `PYTHONPATH=src uv run --no-sync pytest -q`: 1961 passed, 3 platform-specific skips.
- `uv run --no-sync ruff check .`: passed.
- `uv run --no-sync ruff format --check .`: passed.
- `PYTHONPATH=src uv run --no-sync mypy`: passed, 122 source files.
- Initial rename/copy and legacy-title regressions failed on the unchanged base.