### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ tau
 ```
 
 Tau ships with support for OpenAI, Anthropic, OpenAI Codex subscription auth,
-OpenRouter, Hugging Face, and custom OpenAI-compatible endpoints, including local
-models. See the [providers guide](https://twotimespi.dev/guides/providers-and-models/).
+OpenRouter, Requesty, Hugging Face, and custom OpenAI-compatible endpoints, including
+local models. See the [providers guide](https://twotimespi.dev/guides/providers-and-models/).
 
 The built-in catalog lives in `src/tau_coding/data/catalog.toml`; add your own
 providers and models by dropping a `~/.tau/catalog.toml` with the same schema —

--- a/src/tau_ai/openai_compatible.py
+++ b/src/tau_ai/openai_compatible.py
@@ -831,6 +831,9 @@ def _build_chat_payload(
     openrouter_provider = resolved_compat.get("openrouterProvider")
     if isinstance(openrouter_provider, dict):
         payload["provider"] = openrouter_provider
+    requesty_options = resolved_compat.get("requestyOptions")
+    if isinstance(requesty_options, dict):
+        payload["requesty"] = requesty_options
     _apply_chat_reasoning(
         payload,
         reasoning_effort=(

--- a/src/tau_coding/data/catalog.toml
+++ b/src/tau_coding/data/catalog.toml
@@ -3357,6 +3357,257 @@ max_tokens = 128000
 cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
 
 [[providers]]
+name = "requesty"
+display_name = "Requesty"
+kind = "openai-compatible"
+base_url = "https://router.requesty.ai/v1"
+api_key_env = "REQUESTY_API_KEY"
+credential_name = "requesty"
+models = ["anthropic/claude-haiku-4-5", "anthropic/claude-opus-4-6", "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-5", "anthropic/claude-sonnet-4-6", "deepseek/deepseek-chat", "deepseek/deepseek-reasoner", "google/gemini-2.5-flash", "google/gemini-2.5-pro", "google/gemini-3.5-flash", "openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4o-mini", "openai/gpt-5", "openai/gpt-5-mini", "openai/gpt-5.4", "openai/gpt-5.4-mini", "openai/gpt-5.5", "claude-haiku-4-5", "claude-opus-4-7", "claude-sonnet-4-6", "deepseek-v4-flash", "gemini-3.5-flash", "gpt-5.4", "gpt-5.4-mini", "kimi-k3"]
+default_model = "openai/gpt-4o-mini"
+docs_url = "https://docs.requesty.ai"
+api = "openai-completions"
+thinking_levels = ["off", "minimal", "low", "medium", "high", "xhigh"]
+thinking_default = "medium"
+thinking_parameter = "reasoning_effort"
+
+[providers.context_windows]
+"anthropic/claude-haiku-4-5" = 200000
+"anthropic/claude-opus-4-6" = 1000000
+"anthropic/claude-opus-4-7" = 1000000
+"anthropic/claude-sonnet-4-5" = 1000000
+"anthropic/claude-sonnet-4-6" = 1000000
+"deepseek/deepseek-chat" = 1000000
+"deepseek/deepseek-reasoner" = 1000000
+"google/gemini-2.5-flash" = 1048576
+"google/gemini-2.5-pro" = 1048576
+"google/gemini-3.5-flash" = 1048576
+"openai/gpt-4.1" = 1047576
+"openai/gpt-4.1-mini" = 1047576
+"openai/gpt-4o-mini" = 128000
+"openai/gpt-5" = 400000
+"openai/gpt-5-mini" = 400000
+"openai/gpt-5.4" = 1050000
+"openai/gpt-5.4-mini" = 400000
+"openai/gpt-5.5" = 1050000
+claude-haiku-4-5 = 200000
+claude-opus-4-7 = 1000000
+claude-sonnet-4-6 = 1000000
+deepseek-v4-flash = 1048576
+"gemini-3.5-flash" = 1048576
+"gpt-5.4" = 1050000
+"gpt-5.4-mini" = 400000
+kimi-k3 = 1048576
+
+[providers.model_metadata."anthropic/claude-haiku-4-5"]
+name = "Anthropic: Claude Haiku 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4-6"]
+name = "Anthropic: Claude Opus 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata."anthropic/claude-opus-4-7"]
+name = "Anthropic: Claude Opus 4.7"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4-5"]
+name = "Anthropic: Claude Sonnet 4.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 64000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."anthropic/claude-sonnet-4-6"]
+name = "Anthropic: Claude Sonnet 4.6"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata."deepseek/deepseek-chat"]
+name = "DeepSeek: DeepSeek Chat"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+cost = { input = 0.14, output = 0.28, cacheRead = 0.028, cacheWrite = 0 }
+
+[providers.model_metadata."deepseek/deepseek-reasoner"]
+name = "DeepSeek: DeepSeek Reasoner"
+reasoning = false
+input = ["text"]
+context_window = 1000000
+max_tokens = 384000
+cost = { input = 0.14, output = 0.28, cacheRead = 0.028, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-flash"]
+name = "Google: Gemini 2.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 0.3, output = 2.5, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."google/gemini-2.5-pro"]
+name = "Google: Gemini 2.5 Pro"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 1.25, output = 10, cacheRead = 0.31, cacheWrite = 2.375 }
+
+[providers.model_metadata."google/gemini-3.5-flash"]
+name = "Google: Gemini 3.5 Flash"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 1.583 }
+
+[providers.model_metadata."openai/gpt-4.1"]
+name = "OpenAI: GPT-4.1"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 2, output = 8, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4.1-mini"]
+name = "OpenAI: GPT-4.1 Mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 1047576
+max_tokens = 32768
+cost = { input = 0.4, output = 1.6, cacheRead = 0.1, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-4o-mini"]
+name = "OpenAI: GPT-4o-mini"
+reasoning = false
+input = ["text", "image"]
+context_window = 128000
+max_tokens = 16384
+cost = { input = 0.15, output = 0.6, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5"]
+name = "OpenAI: GPT-5"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 1.25, output = 10, cacheRead = 0.125, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5-mini"]
+name = "OpenAI: GPT-5 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.25, output = 2, cacheRead = 0.025, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4"]
+name = "OpenAI: GPT-5.4"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.5, output = 15, cacheRead = 0.25, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.4-mini"]
+name = "OpenAI: GPT-5.4 Mini"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata."openai/gpt-5.5"]
+name = "OpenAI: GPT-5.5"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 5, output = 30, cacheRead = 0.5, cacheWrite = 0 }
+
+[providers.model_metadata.claude-haiku-4-5]
+name = "Claude Haiku 4.5 (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 200000
+max_tokens = 64000
+cost = { input = 1, output = 5, cacheRead = 0.1, cacheWrite = 1.25 }
+
+[providers.model_metadata.claude-opus-4-7]
+name = "Claude Opus 4.7 (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 5, output = 25, cacheRead = 0.5, cacheWrite = 6.25 }
+
+[providers.model_metadata.claude-sonnet-4-6]
+name = "Claude Sonnet 4.6 (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1000000
+max_tokens = 128000
+cost = { input = 3, output = 15, cacheRead = 0.3, cacheWrite = 3.75 }
+
+[providers.model_metadata.deepseek-v4-flash]
+name = "DeepSeek V4 Flash (managed policy)"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 131072
+cost = { input = 0.28, output = 0.56, cacheRead = 0.07, cacheWrite = 0 }
+
+[providers.model_metadata."gemini-3.5-flash"]
+name = "Gemini 3.5 Flash (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1048576
+max_tokens = 65535
+cost = { input = 1.5, output = 9, cacheRead = 0.15, cacheWrite = 1.583 }
+
+[providers.model_metadata."gpt-5.4"]
+name = "GPT-5.4 (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 1050000
+max_tokens = 128000
+cost = { input = 2.75, output = 16.5, cacheRead = 0.275, cacheWrite = 0 }
+
+[providers.model_metadata."gpt-5.4-mini"]
+name = "GPT-5.4 Mini (managed policy)"
+reasoning = true
+input = ["text", "image"]
+context_window = 400000
+max_tokens = 128000
+cost = { input = 0.75, output = 4.5, cacheRead = 0.075, cacheWrite = 0 }
+
+[providers.model_metadata.kimi-k3]
+name = "Kimi K3 (managed policy)"
+reasoning = true
+input = ["text"]
+context_window = 1048576
+max_tokens = 262144
+cost = { input = 3, output = 15, cacheRead = 0.45, cacheWrite = 0 }
+
+[[providers]]
 name = "zai"
 display_name = "ZAI"
 kind = "openai-compatible"

--- a/src/tau_coding/data/models-dev-catalog.json
+++ b/src/tau_coding/data/models-dev-catalog.json
@@ -14871,6 +14871,4276 @@
         "~z-ai/glm-latest"
       ]
     },
+    "requesty": {
+      "model_metadata": {
+        "claude-fable-5": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 1.0,
+            "cacheWrite": 12.5,
+            "input": 10.0,
+            "output": 50.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Fable 5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-fable-5.1": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.25,
+            "cacheWrite": 12.5,
+            "input": 10.0,
+            "output": 50.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Fable 5.1",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-fable-5.1@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.275,
+            "cacheWrite": 13.75,
+            "input": 11.0,
+            "output": 55.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Fable 5.1 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-fable-5@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 1.1,
+            "cacheWrite": 13.75,
+            "input": 11.0,
+            "output": 55.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Fable 5 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-haiku-4-5": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.1,
+            "cacheWrite": 1.25,
+            "input": 1.0,
+            "output": 5.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Haiku 4.5 (latest)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-haiku-4-5@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.11,
+            "cacheWrite": 1.375,
+            "input": 1.1,
+            "output": 5.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Haiku 4.5 (latest) (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-1": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 1.5,
+            "cacheWrite": 18.75,
+            "input": 15.0,
+            "output": 75.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32000,
+          "name": "Claude Opus 4.1 (latest)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-5": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 6.25,
+            "input": 5.0,
+            "output": 25.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Opus 4.5 (latest)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-5@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 6.875,
+            "input": 5.5,
+            "output": 27.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Opus 4.5 (latest) (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-6": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 6.25,
+            "input": 5.0,
+            "output": 25.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.6",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-6@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 6.875,
+            "input": 5.5,
+            "output": 27.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.6 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-7": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 6.25,
+            "input": 5.0,
+            "output": 25.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.7",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-7@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 6.875,
+            "input": 5.5,
+            "output": 27.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.7 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-8": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 6.25,
+            "input": 5.0,
+            "output": 25.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.8",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-4-8@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 6.875,
+            "input": 5.5,
+            "output": 27.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 4.8 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-5": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 6.25,
+            "input": 5.0,
+            "output": 25.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-opus-5@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 6.875,
+            "input": 5.5,
+            "output": 27.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Opus 5 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-4-5": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.3,
+            "cacheWrite": 3.75,
+            "input": 3.0,
+            "output": 15.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.3,
+              "cacheWrite": 3.75,
+              "input": 3.0,
+              "max_input_tokens": 200000,
+              "output": 15.0
+            },
+            {
+              "cacheRead": 0.6,
+              "cacheWrite": 7.5,
+              "input": 6.0,
+              "output": 22.5
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Sonnet 4.5 (latest)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-4-5@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.3,
+            "cacheWrite": 4.125,
+            "input": 3.3,
+            "output": 16.5
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.3,
+              "cacheWrite": 4.125,
+              "input": 3.3,
+              "max_input_tokens": 200000,
+              "output": 16.5
+            },
+            {
+              "cacheRead": 0.6,
+              "cacheWrite": 8.25,
+              "input": 6.6,
+              "output": 24.75
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Sonnet 4.5 (latest) (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-4-6": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.3,
+            "cacheWrite": 3.75,
+            "input": 3.0,
+            "output": 15.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Sonnet 4.6",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-4-6@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.3,
+            "cacheWrite": 4.125,
+            "input": 3.3,
+            "output": 16.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Sonnet 4.6 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-4@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.3,
+            "cacheWrite": 3.75,
+            "input": 3.0,
+            "output": 15.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.3,
+              "cacheWrite": 3.75,
+              "input": 3.0,
+              "max_input_tokens": 200000,
+              "output": 15.0
+            },
+            {
+              "cacheRead": 0.6,
+              "cacheWrite": 7.5,
+              "input": 6.0,
+              "output": 22.5
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 64000,
+          "name": "Claude Sonnet 4 (latest) (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-5": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 2.5,
+            "input": 2.0,
+            "output": 10.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Sonnet 5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "claude-sonnet-5@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.22,
+            "cacheWrite": 2.75,
+            "input": 2.2,
+            "output": 11.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Claude Sonnet 5 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.28,
+            "output": 0.56
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "DeepSeek V4 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-flash-0731": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.28,
+            "output": 0.56
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "DeepSeek V4 Flash 0731",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-flash-0731@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.28,
+            "output": 0.56
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "DeepSeek V4 Flash 0731 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-pro": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.044,
+            "cacheWrite": 0.0,
+            "input": 1.32,
+            "output": 3.96
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "DeepSeek V4 Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-pro-0813": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.044,
+            "cacheWrite": 0.0,
+            "input": 1.32,
+            "output": 3.96
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "DeepSeek V4 Pro 0813",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-pro-0813@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 1.75,
+            "output": 3.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 1048576,
+          "name": "DeepSeek V4 Pro 0813 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4-pro@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 1.75,
+            "output": 3.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 1048576,
+          "name": "DeepSeek V4 Pro (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "deepseek-v4.1-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.007,
+            "cacheWrite": 0.0,
+            "input": 0.22,
+            "output": 0.66
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 393216,
+          "name": "DeepSeek V4.1 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "devstral-latest": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 0.44,
+            "output": 2.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 256000,
+          "name": "devstral-latest",
+          "reasoning": false
+        },
+        "devstral-latest@eu": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 0.44,
+            "output": 2.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 256000,
+          "name": "devstral-latest@eu",
+          "reasoning": false
+        },
+        "fugu-ultra": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 0.0,
+            "input": 5.0,
+            "output": 30.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.5,
+              "cacheWrite": 0.0,
+              "input": 5.0,
+              "max_input_tokens": 272000,
+              "output": 30.0
+            },
+            {
+              "cacheRead": 1.0,
+              "cacheWrite": 0.0,
+              "input": 10.0,
+              "output": 45.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Fugu Ultra",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-2.5-flash-lite@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.01,
+            "cacheWrite": 0.18333,
+            "input": 0.1,
+            "output": 0.4
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 2.5 Flash-Lite (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-2.5-flash@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.075,
+            "cacheWrite": 0.55,
+            "input": 0.3,
+            "output": 2.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 2.5 Flash (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-2.5-pro@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.31,
+            "cacheWrite": 2.375,
+            "input": 1.25,
+            "output": 10.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.31,
+              "cacheWrite": 2.375,
+              "input": 1.25,
+              "max_input_tokens": 200000,
+              "output": 10.0
+            },
+            {
+              "cacheRead": 0.62,
+              "cacheWrite": 4.75,
+              "input": 2.5,
+              "output": 15.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 2.5 Pro (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3-pro-image": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 4.5,
+            "input": 2.0,
+            "output": 12.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "Nano Banana Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.1-flash-image": {
+          "context_window": 131072,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.5,
+            "output": 2.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "Nano Banana 2",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.1-flash-lite": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.025,
+            "cacheWrite": 0.08333,
+            "input": 0.25,
+            "output": 1.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.1 Flash Lite",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.1-flash-lite@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0275,
+            "cacheWrite": 0.091663,
+            "input": 0.275,
+            "output": 1.65
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.1 Flash Lite (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.1-pro-preview": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 4.5,
+            "input": 2.0,
+            "output": 12.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.2,
+              "cacheWrite": 4.5,
+              "input": 2.0,
+              "max_input_tokens": 200000,
+              "output": 12.0
+            },
+            {
+              "cacheRead": 0.4,
+              "cacheWrite": 9.0,
+              "input": 4.0,
+              "output": 18.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.1 Pro Preview",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.5-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.15,
+            "cacheWrite": 1.583,
+            "input": 1.5,
+            "output": 9.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.5 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.5-flash-lite": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.03,
+            "cacheWrite": 0.0,
+            "input": 0.3,
+            "output": 2.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.5 Flash Lite",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.5-flash-lite@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.033,
+            "cacheWrite": 0.0,
+            "input": 0.33,
+            "output": 2.75
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.5 Flash Lite (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.5-flash@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.165,
+            "cacheWrite": 1.7413,
+            "input": 1.65,
+            "output": 9.9
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.5 Flash (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.6-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.15,
+            "cacheWrite": 0.0,
+            "input": 1.5,
+            "output": 7.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.6 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.7-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.075,
+            "cacheWrite": 0.0,
+            "input": 0.75,
+            "output": 3.75
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.7 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.7-flash@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0825,
+            "cacheWrite": 0.0,
+            "input": 0.825,
+            "output": 4.125
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.7 Flash (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.8-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.075,
+            "cacheWrite": 0.0,
+            "input": 0.75,
+            "output": 3.75
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.8 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemini-3.8-flash@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0825,
+            "cacheWrite": 0.0,
+            "input": 0.825,
+            "output": 4.125
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65535,
+          "name": "Gemini 3.8 Flash (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemma-4-26b-a4b-it": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.07,
+            "output": 0.34
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Gemma 4 26B A4B IT",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gemma-4-31b-it": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 8192,
+          "name": "Gemma 4 31B IT",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.1": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.26,
+            "cacheWrite": 0.0,
+            "input": 1.4,
+            "output": 4.4
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 128000,
+          "name": "GLM-5.1",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.1@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 1.4,
+            "cacheWrite": 0.0,
+            "input": 1.4,
+            "output": 4.4
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 200000,
+          "name": "GLM-5.1 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.2": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.16,
+            "cacheWrite": 0.0,
+            "input": 0.8,
+            "output": 2.55
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "GLM-5.2",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.2-fast": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.21,
+            "cacheWrite": 0.0,
+            "input": 2.1,
+            "output": 6.6
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "glm-5.2-fast",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.2@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.26,
+            "cacheWrite": 0.0,
+            "input": 1.2,
+            "output": 4.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "GLM-5.2 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.3": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.26,
+            "cacheWrite": 0.0,
+            "input": 1.2,
+            "output": 4.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 1048576,
+          "name": "GLM-5.3",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.3-flash": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 0.6
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "GLM-5.3-Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.3-flash@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.07,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 0.6
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "GLM-5.3-Flash (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "glm-5.3@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.26,
+            "cacheWrite": 0.0,
+            "input": 1.2,
+            "output": 4.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 1048576,
+          "name": "GLM-5.3 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-4.1-mini@eu": {
+          "context_window": 1047576,
+          "cost": {
+            "cacheRead": 0.11,
+            "cacheWrite": 0.0,
+            "input": 0.44,
+            "output": 1.76
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "GPT-4.1 mini (EU)",
+          "reasoning": false
+        },
+        "gpt-4.1-nano@eu": {
+          "context_window": 1047576,
+          "cost": {
+            "cacheRead": 0.0275,
+            "cacheWrite": 0.0,
+            "input": 0.11,
+            "output": 0.44
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "GPT-4.1 nano (EU)",
+          "reasoning": false
+        },
+        "gpt-4.1@eu": {
+          "context_window": 1047576,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 0.0,
+            "input": 2.2,
+            "output": 8.8
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "GPT-4.1 (EU)",
+          "reasoning": false
+        },
+        "gpt-4o-mini@eu": {
+          "context_window": 128000,
+          "cost": {
+            "cacheRead": 0.0825,
+            "cacheWrite": 0.0,
+            "input": 0.165,
+            "output": 0.66
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 16000,
+          "name": "GPT-4o mini (EU)",
+          "reasoning": false
+        },
+        "gpt-5-mini@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.0275,
+            "cacheWrite": 0.0,
+            "input": 0.275,
+            "output": 2.2
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 100000,
+          "name": "GPT-5 Mini (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5-nano@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.0055,
+            "cacheWrite": 0.0,
+            "input": 0.055,
+            "output": 0.44
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 100000,
+          "name": "GPT-5 Nano (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.1@eu": {
+          "context_window": 400000,
+          "cost": {
+            "cacheRead": 0.1375,
+            "cacheWrite": 0.0,
+            "input": 1.375,
+            "output": 11.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.1 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.3-codex": {
+          "context_window": 400000,
+          "cost": {
+            "cacheRead": 0.175,
+            "cacheWrite": 0.0,
+            "input": 1.75,
+            "output": 14.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.3 Codex",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.4": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.275,
+            "cacheWrite": 0.0,
+            "input": 2.75,
+            "output": 16.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.4",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.4-mini": {
+          "context_window": 400000,
+          "cost": {
+            "cacheRead": 0.075,
+            "cacheWrite": 0.0,
+            "input": 0.75,
+            "output": 4.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.4 mini",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.4-nano": {
+          "context_window": 400000,
+          "cost": {
+            "cacheRead": 0.02,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 1.25
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.4 nano",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.4-pro": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 30.0,
+            "cacheWrite": 0.0,
+            "input": 30.0,
+            "output": 180.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.4 Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.4@eu": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.25,
+            "cacheWrite": 0.0,
+            "input": 2.5,
+            "output": 15.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.25,
+              "cacheWrite": 0.0,
+              "input": 2.5,
+              "max_input_tokens": 272000,
+              "output": 15.0
+            },
+            {
+              "cacheRead": 0.5,
+              "cacheWrite": 0.0,
+              "input": 5.0,
+              "output": 22.5
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.4 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.5": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 0.0,
+            "input": 5.5,
+            "output": 33.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.5-pro": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 30.0,
+            "output": 180.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.5 Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.5@eu": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 0.0,
+            "input": 5.0,
+            "output": 30.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.5,
+              "cacheWrite": 0.0,
+              "input": 5.0,
+              "max_input_tokens": 272000,
+              "output": 30.0
+            },
+            {
+              "cacheRead": 1.0,
+              "cacheWrite": 0.0,
+              "input": 10.0,
+              "output": 45.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.5 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-luna": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.02,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 1.2
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.02,
+              "cacheWrite": 0.0,
+              "input": 0.2,
+              "max_input_tokens": 272000,
+              "output": 1.2
+            },
+            {
+              "cacheRead": 0.04,
+              "cacheWrite": 0.0,
+              "input": 0.4,
+              "output": 1.8
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Luna",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-luna@eu": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.022,
+            "cacheWrite": 0.0,
+            "input": 0.22,
+            "output": 1.32
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Luna (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-sol": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.4,
+            "cacheWrite": 5.0,
+            "input": 4.0,
+            "output": 20.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.4,
+              "cacheWrite": 5.0,
+              "input": 4.0,
+              "max_input_tokens": 272000,
+              "output": 20.0
+            },
+            {
+              "cacheRead": 0.8,
+              "cacheWrite": 10.0,
+              "input": 8.0,
+              "output": 30.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Sol",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-sol@eu": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.55,
+            "cacheWrite": 0.0,
+            "input": 5.5,
+            "output": 33.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Sol (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-terra": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 0.0,
+            "input": 2.0,
+            "output": 12.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.2,
+              "cacheWrite": 0.0,
+              "input": 2.0,
+              "max_input_tokens": 272000,
+              "output": 12.0
+            },
+            {
+              "cacheRead": 0.4,
+              "cacheWrite": 0.0,
+              "input": 4.0,
+              "output": 18.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Terra",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5.6-terra@eu": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 0.22,
+            "cacheWrite": 0.0,
+            "input": 2.2,
+            "output": 13.2
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5.6 Terra (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-5@eu": {
+          "context_window": 400000,
+          "cost": {
+            "cacheRead": 0.1375,
+            "cacheWrite": 0.0,
+            "input": 1.375,
+            "output": 11.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-5 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "gpt-6-astra": {
+          "context_window": 1050000,
+          "cost": {
+            "cacheRead": 1.0,
+            "cacheWrite": 0.0,
+            "input": 10.0,
+            "output": 50.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 1.0,
+              "cacheWrite": 0.0,
+              "input": 10.0,
+              "max_input_tokens": 272000,
+              "output": 50.0
+            },
+            {
+              "cacheRead": 2.0,
+              "cacheWrite": 0.0,
+              "input": 20.0,
+              "output": 75.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "GPT-6 Astra",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "grok-4.2-beta": {
+          "context_window": 2000000,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 2.0,
+            "input": 2.0,
+            "output": 6.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.2,
+              "cacheWrite": 2.0,
+              "input": 2.0,
+              "max_input_tokens": 200000,
+              "output": 6.0
+            },
+            {
+              "cacheRead": 0.4,
+              "cacheWrite": 4.0,
+              "input": 4.0,
+              "output": 12.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 2000000,
+          "name": "grok-4.2-beta",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "grok-4.3": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 1.25,
+            "input": 1.25,
+            "output": 2.5
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.2,
+              "cacheWrite": 1.25,
+              "input": 1.25,
+              "max_input_tokens": 200000,
+              "output": 2.5
+            },
+            {
+              "cacheRead": 0.4,
+              "cacheWrite": 2.5,
+              "input": 2.5,
+              "output": 5.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 1000000,
+          "name": "Grok 4.3",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "grok-4.5": {
+          "context_window": 500000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 2.0,
+            "input": 2.0,
+            "output": 6.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.5,
+              "cacheWrite": 2.0,
+              "input": 2.0,
+              "max_input_tokens": 200000,
+              "output": 6.0
+            },
+            {
+              "cacheRead": 1.0,
+              "cacheWrite": 4.0,
+              "input": 4.0,
+              "output": 12.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 500000,
+          "name": "Grok 4.5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "grok-4.6": {
+          "context_window": 500000,
+          "cost": {
+            "cacheRead": 0.5,
+            "cacheWrite": 2.0,
+            "input": 2.0,
+            "output": 6.0
+          },
+          "cost_tiers": [
+            {
+              "cacheRead": 0.5,
+              "cacheWrite": 2.0,
+              "input": 2.0,
+              "max_input_tokens": 200000,
+              "output": 6.0
+            },
+            {
+              "cacheRead": 1.0,
+              "cacheWrite": 4.0,
+              "input": 4.0,
+              "output": 12.0
+            }
+          ],
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 500000,
+          "name": "Grok 4.6",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "grok-build-0.1": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.1,
+            "cacheWrite": 0.0,
+            "input": 1.0,
+            "output": 2.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Grok Build 0.1",
+          "reasoning": false
+        },
+        "hy3": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.035,
+            "cacheWrite": 0.0,
+            "input": 0.14,
+            "output": 0.58
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "Hy3",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "inkling": {
+          "context_window": 65536,
+          "cost": {
+            "cacheRead": 0.374,
+            "cacheWrite": 0.0,
+            "input": 1.87,
+            "output": 4.68
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "Inkling",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "inkling-256k": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.374,
+            "cacheWrite": 0.0,
+            "input": 1.87,
+            "output": 4.68
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 32768,
+          "name": "inkling-256k",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kat-coder-pro": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.3,
+            "output": 1.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 256000,
+          "name": "kat-coder-pro",
+          "reasoning": false
+        },
+        "kimi-k2.6": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.16,
+            "cacheWrite": 0.0,
+            "input": 0.95,
+            "output": 4.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Kimi K2.6",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kimi-k2.6@eu": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.95,
+            "cacheWrite": 0.0,
+            "input": 0.95,
+            "output": 4.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "Kimi K2.6 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kimi-k2.7-code": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.19,
+            "cacheWrite": 0.0,
+            "input": 0.95,
+            "output": 4.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Kimi K2.7 Code",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kimi-k2.7-code@eu": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.31,
+            "cacheWrite": 0.0,
+            "input": 1.25,
+            "output": 4.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Kimi K2.7 Code (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kimi-k3": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.45,
+            "cacheWrite": 0.0,
+            "input": 3.0,
+            "output": 15.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Kimi K3",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "kimi-k3@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.45,
+            "cacheWrite": 0.0,
+            "input": 3.0,
+            "output": 15.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Kimi K3 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "leanstral-1-5": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 32768,
+          "name": "leanstral-1-5",
+          "reasoning": false
+        },
+        "leanstral-1-5@eu": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 32768,
+          "name": "leanstral-1-5@eu",
+          "reasoning": false
+        },
+        "ling-2.6-1t": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.3,
+            "output": 2.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "ling-2.6-1t",
+          "reasoning": false
+        },
+        "ling-2.6-flash": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.1,
+            "output": 0.3
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "ling-2.6-flash",
+          "reasoning": false
+        },
+        "ling-3.0-tiny": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 32768,
+          "name": "ling-3.0-tiny",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mimo-v2.5": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0028,
+            "cacheWrite": 0.0,
+            "input": 0.14,
+            "output": 0.28
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "MiMo-V2.5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mimo-v2.5-pro": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0036,
+            "cacheWrite": 0.0,
+            "input": 0.435,
+            "output": 0.87
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "MiMo-V2.5-Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "minimax-m2.7": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.06,
+            "cacheWrite": 1.2,
+            "input": 0.3,
+            "output": 1.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 128000,
+          "name": "MiniMax-M2.7",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "minimax-m2.7-highspeed": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.06,
+            "cacheWrite": 1.2,
+            "input": 0.6,
+            "output": 2.4
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 128000,
+          "name": "MiniMax-M2.7-highspeed",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "minimax-m3": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.06,
+            "cacheWrite": 0.0,
+            "input": 0.3,
+            "output": 1.2
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 128000,
+          "name": "MiniMax-M3",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "minimax-m3@eu": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.1,
+            "cacheWrite": 0.0,
+            "input": 0.4,
+            "output": 2.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 1048576,
+          "name": "MiniMax-M3 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mistral-medium-3-5": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 1.65,
+            "cacheWrite": 0.0,
+            "input": 1.65,
+            "output": 8.25
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "mistral-medium-3-5",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mistral-medium-3-5@eu": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 1.65,
+            "cacheWrite": 0.0,
+            "input": 1.65,
+            "output": 8.25
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "mistral-medium-3-5@eu",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mistral-medium-latest": {
+          "context_window": 131072,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 0.44,
+            "output": 2.2
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Mistral Medium (latest)",
+          "reasoning": false
+        },
+        "mistral-medium-latest@eu": {
+          "context_window": 131072,
+          "cost": {
+            "cacheRead": 0.44,
+            "cacheWrite": 0.0,
+            "input": 0.44,
+            "output": 2.2
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Mistral Medium (latest) (EU)",
+          "reasoning": false
+        },
+        "mistral-small-2603": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.165,
+            "cacheWrite": 0.0,
+            "input": 0.165,
+            "output": 0.66
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Mistral Small 4",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "mistral-small-2603@eu": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.165,
+            "cacheWrite": 0.0,
+            "input": 0.165,
+            "output": 0.66
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Mistral Small 4 (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "muse-glimmer-30b": {
+          "context_window": 131072,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 20480,
+          "name": "Muse Glimmer 30B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-nano-omni": {
+          "context_window": 300000,
+          "cost": {
+            "cacheRead": 0.06,
+            "cacheWrite": 0.0,
+            "input": 0.06,
+            "output": 0.24
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 300000,
+          "name": "nemotron-3-nano-omni",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-nano-omni-30b-a3b-reasoning": {
+          "context_window": 131072,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 20480,
+          "name": "Nemotron 3 Nano Omni 30B A3B Reasoning",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-nano-omni@eu": {
+          "context_window": 300000,
+          "cost": {
+            "cacheRead": 0.06,
+            "cacheWrite": 0.0,
+            "input": 0.06,
+            "output": 0.24
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 300000,
+          "name": "nemotron-3-nano-omni@eu",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-super-120b-a12b": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 65536,
+          "name": "Nemotron 3 Super 120B A12B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-ultra-550b-a55b": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 65536,
+          "name": "Nemotron 3 Ultra 550B A55B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3-ultra-nvfp4": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.12,
+            "cacheWrite": 0.0,
+            "input": 0.6,
+            "output": 2.4
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "nemotron-3-ultra-nvfp4",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-3.5-lightning-30b-a3b": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.0,
+            "output": 0.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 65536,
+          "name": "nemotron-3.5-lightning-30b-a3b",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nemotron-lightning-3.5-30b-a3b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.01,
+            "cacheWrite": 0.0,
+            "input": 0.05,
+            "output": 0.2
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "nemotron-lightning-3.5-30b-a3b",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "nvidia-nemotron-3-super-120b-a12b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.1,
+            "output": 0.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "nvidia-nemotron-3-super-120b-a12b",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "o4-mini@eu": {
+          "context_window": 200000,
+          "cost": {
+            "cacheRead": 0.3025,
+            "cacheWrite": 0.0,
+            "input": 1.21,
+            "output": 4.84
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 100000,
+          "name": "o4-mini (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.5-27b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.26,
+            "output": 2.6
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.5 27B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.5-2b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.02,
+            "output": 0.1
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "qwen3.5-2b",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.5-35b-a3b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.14,
+            "output": 1.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.5 35B-A3B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.6-plus": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.625,
+            "input": 0.5,
+            "output": 3.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 65536,
+          "name": "Qwen3.6 Plus",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.7-max": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.25,
+            "cacheWrite": 3.125,
+            "input": 2.5,
+            "output": 7.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 131072,
+          "name": "Qwen3.7 Max",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.7-plus": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.032,
+            "cacheWrite": 0.4,
+            "input": 0.32,
+            "output": 1.28
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Qwen3.7 Plus",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-2.4T-A95B": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.2,
+            "cacheWrite": 0.0,
+            "input": 2.0,
+            "output": 6.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.8 2.4T A95B",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-2.4T-A95B@eu": {
+          "context_window": 1000000,
+          "cost": {
+            "cacheRead": 0.63,
+            "cacheWrite": 0.0,
+            "input": 2.5,
+            "output": 6.0
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.8 2.4T A95B (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-flash": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.016,
+            "cacheWrite": 0.2,
+            "input": 0.16,
+            "output": 0.47
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Qwen3.8 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-flash-next": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 0.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.8 Flash Next",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-flash-next@eu": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 0.5
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 262144,
+          "name": "Qwen3.8 Flash Next (EU)",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "qwen3.8-max": {
+          "context_window": 1048576,
+          "cost": {
+            "cacheRead": 0.25,
+            "cacheWrite": 2.5,
+            "input": 2.0,
+            "output": 6.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 131072,
+          "name": "Qwen3.8 Max",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "ring-2.6-1t": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+            "input": 0.3,
+            "output": 2.5
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 262144,
+          "name": "ring-2.6-1t",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "seed-1.8": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.25,
+            "output": 2.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "seed-1.8",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "seed-2.0-code": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.1,
+            "cacheWrite": 0.0,
+            "input": 0.5,
+            "output": 3.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Seed 2.0 Code",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "seed-2.0-mini": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.02,
+            "cacheWrite": 0.0,
+            "input": 0.1,
+            "output": 0.4
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Seed 2.0 Mini",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "seed-2.0-pro": {
+          "context_window": 256000,
+          "cost": {
+            "cacheRead": 0.1,
+            "cacheWrite": 0.0,
+            "input": 0.5,
+            "output": 3.0
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Seed 2.0 Pro",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "step-3.7-flash": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.04,
+            "cacheWrite": 0.0,
+            "input": 0.2,
+            "output": 1.15
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "max_tokens": 256000,
+          "name": "Step 3.7 Flash",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "thinkingcap-qwen3.6-27b": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.4,
+            "output": 2.6
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 32768,
+          "name": "thinkingcap-qwen3.6-27b",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        },
+        "thinkingcap-qwen3.6-27b@eu": {
+          "context_window": 262144,
+          "cost": {
+            "cacheRead": 0.05,
+            "cacheWrite": 0.0,
+            "input": 0.4,
+            "output": 2.6
+          },
+          "input": [
+            "text"
+          ],
+          "max_tokens": 32768,
+          "name": "thinkingcap-qwen3.6-27b@eu",
+          "reasoning": true,
+          "thinking_level_map": {
+            "high": "high",
+            "low": "low",
+            "max": "max",
+            "medium": "medium",
+            "off": "none"
+          },
+          "unsupported_thinking_levels": [
+            "minimal",
+            "xhigh"
+          ]
+        }
+      },
+      "models": [
+        "claude-haiku-4-5",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "deepseek-v4-flash",
+        "gemini-3.5-flash",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "kimi-k3",
+        "anthropic/claude-haiku-4-5",
+        "anthropic/claude-opus-4-6",
+        "anthropic/claude-opus-4-7",
+        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-sonnet-4-6",
+        "deepseek/deepseek-chat",
+        "deepseek/deepseek-reasoner",
+        "google/gemini-2.5-flash",
+        "google/gemini-2.5-pro",
+        "google/gemini-3.5-flash",
+        "openai/gpt-4.1",
+        "openai/gpt-4.1-mini",
+        "openai/gpt-4o-mini",
+        "openai/gpt-5",
+        "openai/gpt-5-mini",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-mini",
+        "openai/gpt-5.5",
+        "claude-fable-5",
+        "claude-fable-5.1",
+        "claude-fable-5.1@eu",
+        "claude-fable-5@eu",
+        "claude-haiku-4-5@eu",
+        "claude-opus-4-1",
+        "claude-opus-4-5",
+        "claude-opus-4-5@eu",
+        "claude-opus-4-6",
+        "claude-opus-4-6@eu",
+        "claude-opus-4-7@eu",
+        "claude-opus-4-8",
+        "claude-opus-4-8@eu",
+        "claude-opus-5",
+        "claude-opus-5@eu",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-5@eu",
+        "claude-sonnet-4-6@eu",
+        "claude-sonnet-4@eu",
+        "claude-sonnet-5",
+        "claude-sonnet-5@eu",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-flash-0731@eu",
+        "deepseek-v4-pro",
+        "deepseek-v4-pro-0813",
+        "deepseek-v4-pro-0813@eu",
+        "deepseek-v4-pro@eu",
+        "deepseek-v4.1-flash",
+        "devstral-latest",
+        "devstral-latest@eu",
+        "fugu-ultra",
+        "gemini-2.5-flash-lite@eu",
+        "gemini-2.5-flash@eu",
+        "gemini-2.5-pro@eu",
+        "gemini-3-pro-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-lite",
+        "gemini-3.1-flash-lite@eu",
+        "gemini-3.1-pro-preview",
+        "gemini-3.5-flash-lite",
+        "gemini-3.5-flash-lite@eu",
+        "gemini-3.5-flash@eu",
+        "gemini-3.6-flash",
+        "gemini-3.7-flash",
+        "gemini-3.7-flash@eu",
+        "gemini-3.8-flash",
+        "gemini-3.8-flash@eu",
+        "gemma-4-26b-a4b-it",
+        "gemma-4-31b-it",
+        "glm-5.1",
+        "glm-5.1@eu",
+        "glm-5.2",
+        "glm-5.2-fast",
+        "glm-5.2@eu",
+        "glm-5.3",
+        "glm-5.3-flash",
+        "glm-5.3-flash@eu",
+        "glm-5.3@eu",
+        "gpt-4.1-mini@eu",
+        "gpt-4.1-nano@eu",
+        "gpt-4.1@eu",
+        "gpt-4o-mini@eu",
+        "gpt-5-mini@eu",
+        "gpt-5-nano@eu",
+        "gpt-5.1@eu",
+        "gpt-5.3-codex",
+        "gpt-5.4-nano",
+        "gpt-5.4-pro",
+        "gpt-5.4@eu",
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "gpt-5.5@eu",
+        "gpt-5.6-luna",
+        "gpt-5.6-luna@eu",
+        "gpt-5.6-sol",
+        "gpt-5.6-sol@eu",
+        "gpt-5.6-terra",
+        "gpt-5.6-terra@eu",
+        "gpt-5@eu",
+        "gpt-6-astra",
+        "grok-4.2-beta",
+        "grok-4.3",
+        "grok-4.5",
+        "grok-4.6",
+        "grok-build-0.1",
+        "hy3",
+        "inkling",
+        "inkling-256k",
+        "kat-coder-pro",
+        "kimi-k2.6",
+        "kimi-k2.6@eu",
+        "kimi-k2.7-code",
+        "kimi-k2.7-code@eu",
+        "kimi-k3@eu",
+        "leanstral-1-5",
+        "leanstral-1-5@eu",
+        "ling-2.6-1t",
+        "ling-2.6-flash",
+        "ling-3.0-tiny",
+        "mimo-v2.5",
+        "mimo-v2.5-pro",
+        "minimax-m2.7",
+        "minimax-m2.7-highspeed",
+        "minimax-m3",
+        "minimax-m3@eu",
+        "mistral-medium-3-5",
+        "mistral-medium-3-5@eu",
+        "mistral-medium-latest",
+        "mistral-medium-latest@eu",
+        "mistral-small-2603",
+        "mistral-small-2603@eu",
+        "muse-glimmer-30b",
+        "nemotron-3-nano-omni",
+        "nemotron-3-nano-omni-30b-a3b-reasoning",
+        "nemotron-3-nano-omni@eu",
+        "nemotron-3-super-120b-a12b",
+        "nemotron-3-ultra-550b-a55b",
+        "nemotron-3-ultra-nvfp4",
+        "nemotron-3.5-lightning-30b-a3b",
+        "nemotron-lightning-3.5-30b-a3b",
+        "nvidia-nemotron-3-super-120b-a12b",
+        "o4-mini@eu",
+        "qwen3.5-27b",
+        "qwen3.5-2b",
+        "qwen3.5-35b-a3b",
+        "qwen3.6-plus",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.8-2.4T-A95B",
+        "qwen3.8-2.4T-A95B@eu",
+        "qwen3.8-flash",
+        "qwen3.8-flash-next",
+        "qwen3.8-flash-next@eu",
+        "qwen3.8-max",
+        "ring-2.6-1t",
+        "seed-1.8",
+        "seed-2.0-code",
+        "seed-2.0-mini",
+        "seed-2.0-pro",
+        "step-3.7-flash",
+        "thinkingcap-qwen3.6-27b",
+        "thinkingcap-qwen3.6-27b@eu"
+      ]
+    },
     "together": {
       "model_metadata": {
         "MiniMaxAI/MiniMax-M2.7": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1847,6 +1847,7 @@ def test_providers_command_lists_default_provider(
     assert " \topenai-codex\topenai-codex\tgpt-5.5" in result.stdout
     assert " \tanthropic\tanthropic\tclaude-sonnet-4-6" in result.stdout
     assert " \topenrouter\topenai-compatible\tqwen/qwen3.7-max" in result.stdout
+    assert " \trequesty\topenai-compatible\topenai/gpt-4o-mini" in result.stdout
     assert " \thuggingface\topenai-compatible\tmoonshotai/Kimi-K2.6" in result.stdout
 
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -63,6 +63,7 @@ def test_builtin_catalog_matches_expected_providers() -> None:
         "cerebras",
         "nvidia",
         "openrouter",
+        "requesty",
         "zai",
         "mistral",
         "minimax",
@@ -333,6 +334,60 @@ def test_builtin_catalog_golden_nvidia_entry() -> None:
     assert gpt_oss_metadata.reasoning is True
     assert gpt_oss_metadata.context_window == 128_000
     assert gpt_oss_metadata.max_tokens == 8_192
+
+
+def test_builtin_catalog_golden_requesty_entry() -> None:
+    entry = builtin_provider_entry("requesty")
+    assert entry is not None
+    assert entry.display_name == "Requesty"
+    assert entry.kind == "openai-compatible"
+    assert entry.base_url == "https://router.requesty.ai/v1"
+    assert entry.api_key_env == "REQUESTY_API_KEY"
+    assert entry.credential_name == "requesty"
+    # Vendor-prefixed catalog ids and short managed policy ids are both valid
+    # Requesty model names; the built-in entry ships a starter set of each.
+    assert {
+        "openai/gpt-4o-mini",
+        "openai/gpt-5-mini",
+        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-haiku-4-5",
+        "google/gemini-2.5-flash",
+        "deepseek/deepseek-chat",
+        "claude-sonnet-4-6",
+        "gpt-5.4",
+    } <= set(entry.models)
+    assert entry.default_model == "openai/gpt-4o-mini"
+    assert entry.docs_url == "https://docs.requesty.ai"
+    assert entry.api == "openai-completions"
+    assert entry.context_windows is not None
+    assert entry.context_windows["openai/gpt-4o-mini"] == 128_000
+    assert entry.context_windows["claude-sonnet-4-6"] == 1_000_000
+    assert entry.thinking_levels == ("off", "minimal", "low", "medium", "high", "xhigh")
+    assert entry.thinking_models == ()
+    assert entry.thinking_default == "medium"
+    assert entry.thinking_parameter == "reasoning_effort"
+
+    default_metadata = entry.model_metadata[entry.default_model]
+    assert default_metadata.name == "OpenAI: GPT-4o-mini"
+    assert default_metadata.reasoning is False
+    assert default_metadata.input == ("text", "image")
+    assert default_metadata.context_window == 128_000
+    assert default_metadata.max_tokens == 16_384
+    assert default_metadata.cost == {
+        "input": 0.15,
+        "output": 0.6,
+        "cacheRead": 0.075,
+        "cacheWrite": 0,
+    }
+
+    # Managed policy rows come from the generated models.dev snapshot.
+    managed_metadata = entry.model_metadata["claude-sonnet-4-6"]
+    assert managed_metadata.reasoning is True
+    assert managed_metadata.context_window == 1_000_000
+    assert managed_metadata.thinking_level_map["off"] == "none"
+    assert managed_metadata.thinking_level_map["max"] == "max"
+    eu_models = [model for model in entry.models if model.endswith("@eu")]
+    assert eu_models
 
 
 def test_builtin_catalog_huggingface_model_expansion() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -105,6 +105,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
         "cerebras",
         "nvidia",
         "openrouter",
+        "requesty",
         "zai",
         "mistral",
         "minimax",
@@ -127,6 +128,7 @@ def test_load_provider_settings_missing_file_uses_openai_default(tmp_path: Path)
     assert settings.providers[0].default_model == DEFAULT_MODEL
     assert settings.get_provider("anthropic").api_key_env == "ANTHROPIC_API_KEY"
     assert settings.get_provider("openrouter").api_key_env == "OPENROUTER_API_KEY"
+    assert settings.get_provider("requesty").api_key_env == "REQUESTY_API_KEY"
     assert settings.get_provider("huggingface").api_key_env == "HF_TOKEN"
 
 

--- a/tests/test_tau_ai.py
+++ b/tests/test_tau_ai.py
@@ -575,6 +575,42 @@ async def test_openai_compatible_provider_includes_openrouter_provider_routing()
 
 
 @pytest.mark.anyio
+async def test_openai_compatible_provider_includes_requesty_options() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text='data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = OpenAICompatibleProvider(
+            OpenAICompatibleConfig(
+                api_key="test-key",
+                base_url="https://router.requesty.ai/v1",
+                compat={"requestyOptions": {"tags": ["tau"], "auto_cache": True}},
+            ),
+            client=client,
+        )
+
+        await _collect(
+            provider.stream_response(
+                model="openai/gpt-4o-mini",
+                system="You are Tau.",
+                messages=[UserMessage(content="Say ok")],
+                tools=[],
+            )
+        )
+
+    payload = loads(requests[0].content)
+    assert payload["requesty"] == {"tags": ["tau"], "auto_cache": True}
+    assert "provider" not in payload
+
+
+@pytest.mark.anyio
 async def test_openai_compatible_provider_supports_nested_reasoning_effort_parameter() -> None:
     requests: list[httpx.Request] = []
 

--- a/website/content/concepts.md
+++ b/website/content/concepts.md
@@ -18,7 +18,7 @@ model has nothing left to do. That loop is the heart of every coding agent.
 ## Providers and models
 
 A **provider** is the service that hosts AI models (OpenAI, Anthropic, OpenAI
-Codex, OpenRouter, Hugging Face, or any OpenAI-compatible endpoint). A **model**
+Codex, OpenRouter, Requesty, Hugging Face, or any OpenAI-compatible endpoint). A **model**
 is the specific brain you're talking to (e.g. `gpt-5.5`, `claude-sonnet-4-6`).
 You pick a provider + model; you can switch either mid-session.
 → [Providers & models]({{< relref "./guides/providers-and-models.md" >}})

--- a/website/content/guides/providers-and-models.md
+++ b/website/content/guides/providers-and-models.md
@@ -25,13 +25,14 @@ tau
 /login github-copilot # authenticate GitHub Copilot with a device code
 /login opencode-go  # save an OpenCode Go API key
 /login nvidia       # save an NVIDIA NIM API key
+/login requesty     # save a Requesty API key
 /login custom       # add an OpenAI-compatible custom provider
 ```
 
 Built-in providers include **OpenAI**, **Anthropic**, **OpenAI Codex**
 (subscription), **GitHub Copilot**, **OpenCode Go**, **OpenCode Zen**,
-**Moonshot AI (Kimi)**, **Kimi Code** (subscription), **OpenRouter**, **Hugging Face**,
-and **NVIDIA NIM**.
+**Moonshot AI (Kimi)**, **Kimi Code** (subscription), **OpenRouter**, **Requesty**,
+**Hugging Face**, and **NVIDIA NIM**.
 
 ### OAuth subscriptions
 
@@ -182,6 +183,57 @@ continue to omit it. See the [Z.AI deep-thinking
 reference](https://docs.z.ai/guides/capabilities/thinking) and [chat-completion
 schema](https://docs.z.ai/api-reference/llm/chat-completion) for the authoritative
 wire contract.
+
+### Requesty
+
+Log in with `/login requesty` or set `REQUESTY_API_KEY`. Requesty is an LLM
+gateway that exposes one OpenAI-compatible API across many upstream providers
+at `https://router.requesty.ai/v1`. Tau treats it as a standard
+`openai-compatible` provider and sends the OpenAI `reasoning_effort` field for
+thinking levels.
+
+Two kinds of model ids are valid:
+
+- Catalog ids use the `<vendor>/<model>` form, for example `openai/gpt-4o-mini`,
+  `anthropic/claude-sonnet-4-6`, or `google/gemini-2.5-flash`. Get the full list
+  from `GET https://router.requesty.ai/v1/models` (with your key it returns only
+  the models your organization has approved).
+- Managed policy ids are short names such as `claude-sonnet-4-6`, `gpt-5.4`, or
+  `kimi-k3`. Each is a Requesty-maintained routing chain across several
+  upstream providers for one model. Ids ending in `@eu` route only through EU
+  providers. The list comes from `GET https://router.requesty.ai/v1/models/managed`
+  and is what [models.dev](https://models.dev) publishes for Requesty, so Tau's
+  generated snapshot and `tau update --models` refresh it automatically.
+
+The built-in entry ships a starter set of both, with `openai/gpt-4o-mini` as the
+default model. Use `/model` to search the generated list.
+
+Requesty also serves regional endpoints with the same key: `https://router.eu.requesty.ai/v1`
+(EU, Frankfurt), `https://router.us.requesty.ai/v1`, and
+`https://router.ap.requesty.ai/v1`. To pin Tau to one of them, override the
+`base_url` in `~/.tau/catalog.toml`:
+
+```toml
+schema_version = 1
+[[providers]]
+name = "requesty"
+base_url = "https://router.eu.requesty.ai/v1"
+```
+
+Requesty-specific request options (tags, `user_id`, `trace_id`, `auto_cache`) can
+be sent through the `requestyOptions` compat key at the provider or model level.
+Tau forwards the mapping as the request's `requesty` body field:
+
+```toml
+schema_version = 1
+[[providers]]
+name = "requesty"
+compat = { requestyOptions = { tags = ["tau"], auto_cache = true } }
+```
+
+Keys are created at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys);
+see the [Requesty docs](https://docs.requesty.ai) for the current model list,
+pricing, and routing behavior.
 
 ### Hugging Face Inference Providers
 

--- a/website/content/quickstart.md
+++ b/website/content/quickstart.md
@@ -86,7 +86,7 @@ Then run one of these inside Tau:
 ```
 
 Tau ships with built-in entries for OpenAI, Anthropic, OpenAI Codex,
-OpenRouter, and Hugging Face. See [Providers & models]({{< relref "./guides/providers-and-models.md" >}})
+OpenRouter, Requesty, and Hugging Face. See [Providers & models]({{< relref "./guides/providers-and-models.md" >}})
 for switching models or adding a custom/local OpenAI-compatible endpoint.
 
 ## 3. Start a session

--- a/website/content/what-is-tau.md
+++ b/website/content/what-is-tau.md
@@ -29,7 +29,7 @@ The name is a small joke about picking the *right* foundation. See
   **running shell commands** in your project.
 - Work in an **interactive TUI** or as a **one-shot command** for scripts and
   pipes.
-- Talk to **OpenAI, Anthropic, OpenAI Codex, OpenRouter, Hugging Face**, or any
+- Talk to **OpenAI, Anthropic, OpenAI Codex, OpenRouter, Requesty, Hugging Face**, or any
   OpenAI-compatible endpoint (including local models).
 - **Remember** every session, let you **resume** it later, and **branch** from
   any earlier point to explore a different path.


### PR DESCRIPTION
## Summary

Adds Requesty (`https://router.requesty.ai/v1`) as a built in `openai-compatible` provider, mirroring the existing OpenRouter entry. One `REQUESTY_API_KEY` (or `/login requesty`) reaches 700+ models under `<vendor>/<model>` ids plus Requesty's managed routing policies, which have short ids such as `claude-sonnet-4-6` or `gpt-5.4-mini`.

## Changes

- `src/tau_coding/data/catalog.toml`: `[[providers]] name = "requesty"` right after OpenRouter, with `default_model = "openai/gpt-4o-mini"`, `reasoning_effort` thinking levels, and a starter set of 26 models: 18 vendor ids from `GET /v1/models` and 8 managed policy ids from `GET /v1/models/managed`, each with context windows and model metadata. Managed rows are named `<Model> (managed policy)` so they are distinguishable in the picker.
- `src/tau_coding/data/models-dev-catalog.json`: additive `providers.requesty` key in sort order between `openrouter` and `together`, produced with the repo's own `models_dev_catalog_document()` for the requesty entry only; `generated_at` and every other provider are untouched. A maintainer regenerate with `scripts/generate_models.py` reproduces it. models.dev publishes the managed policy list for Requesty, so `tau update --models` and the `/model` refresh already keep it current without a bespoke fetcher.
- `src/tau_ai/openai_compatible.py`: `compat.requestyOptions` is forwarded as the request's `requesty` body field (tags, `user_id`, `trace_id`, `auto_cache`), next to the existing OpenRouter `provider` passthrough.
- Docs: `/login requesty` line and a Requesty section in `website/content/guides/providers-and-models.md` (model id kinds, the two listing endpoints, `@eu` ids, regional endpoints via a `base_url` override in `~/.tau/catalog.toml`, the compat option); provider lists in `README.md`, `concepts.md`, `quickstart.md`, `what-is-tau.md`.
- Tests: golden catalog entry and provider order in `test_provider_catalog.py`, default catalog list and `REQUESTY_API_KEY` in `test_provider_config.py`, `tau providers` row in `test_cli.py`, payload passthrough in `test_tau_ai.py`.

No `provider_config.py` changes: the OpenRouter branches there (`reasoning: {effort}` format, `x-session-id` affinity) are OpenRouter protocol quirks; Requesty takes the standard `reasoning_effort` field and was verified live with `store: false` and `max_completion_tokens`. Requesty is not added to any automatic preference or fallback list.

## Validation

- `ruff check src tests` and `ruff format --check` pass.
- `mypy` reports only the three `redundant-cast` errors already present on `main` (`openai_codex.py`, `provider_config.py`, `local_backends.py`), none in touched files.
- Full pytest suite: 1954 passed, 2 skipped (Windows only).
- Live, through `load_provider_settings` then `provider_runtime.create_model_provider` and `OpenAICompatibleProvider.stream_response`: a chat completion with `openai/gpt-4o-mini` and one with the managed id `gpt-5.4-mini` at thinking level `low` (reasoning tokens reported) both returned the expected reply. All 26 catalog ids were confirmed present in the live `/v1/models` and `/v1/models/managed` listings.

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.
