### PR TITLE
Add Ctrl-Z process suspension to the TUI

### DIFF
--- a/src/tau_coding/commands.py
+++ b/src/tau_coding/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -521,6 +522,8 @@ def _hotkeys_command(context: CommandContext) -> CommandResult:
         "- Ctrl+C: clear prompt input",
         "- Ctrl+D: quit",
     ]
+    if sys.platform != "win32":
+        lines.append("- Ctrl+Z: suspend to the shell; resume with fg")
     return CommandResult(handled=True, message="\n".join(lines))
 
 

--- a/src/tau_coding/data/docs/tui.md
+++ b/src/tau_coding/data/docs/tui.md
@@ -23,6 +23,15 @@ refresh failures leave the existing list usable. Use `tau update --models` for
 forced public-catalog revalidation or `TAU_OFFLINE=1` to disable catalog network
 access.
 
+## Suspending to the shell
+
+On Unix-like systems, press Ctrl+Z to suspend Tau and return to the shell. Run
+`fg` to resume the same interactive session. Tau relies on Textual to restore
+normal terminal mode before suspension and redraw the TUI after resumption.
+Native Windows leaves this action unbound because it does not provide Unix job
+control. Set the `suspend` keybinding to `null` in `~/.tau/tui.json` to disable
+it on another platform.
+
 ## `/sidebar`
 
 Use `/sidebar` to toggle the detailed session sidebar for the current TUI

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -3155,7 +3155,8 @@ class OAuthLoginScreen(ModalScreen[OAuthCredential | _LoginFlowAction | None]):
 #: brick the TUI. Deliberately minimal — only the always-available escape
 #: hatches: ``ctrl+d`` (the ``quit`` action, exits the app) and ``ctrl+c``
 #: (Tau binds it to ``clear_prompt``, but it is the terminal-standard
-#: SIGINT/interrupt reflex users hit to bail). NOT reserved: escape/enter/
+#: SIGINT/interrupt reflex users hit to bail). The configured process-suspend
+#: key is reserved dynamically by :meth:`TauTuiApp.on_event`. NOT reserved: escape/enter/
 #: arrows/tab/left/right — those are load-bearing for the tau-subagents
 #: extension and must stay interceptable. This is Tau's counterpart to Pi's
 #: ``RESERVED_KEYBINDINGS_FOR_EXTENSION_CONFLICTS`` (runner.ts:69), applied
@@ -4211,6 +4212,7 @@ class TauTuiApp(App[None]):
             isinstance(event, events.Key)
             and not event.is_forwarded
             and event.key not in RESERVED_EXTENSION_INTERCEPTOR_KEYS
+            and event.key != self.tui_settings.keybindings.suspend
             and self._extension_key_interceptors
             and len(self.screen_stack) <= 1
             and self._run_extension_key_interceptors(event, self._current_prompt_text())
@@ -7423,7 +7425,7 @@ def _key_hint(key: str) -> str:
 
 
 def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
-    return [
+    bindings = [
         Binding(keybindings.cancel, "cancel", "Cancel"),
         Binding(keybindings.command_palette, "open_command_palette", "Commands"),
         Binding(keybindings.session_picker, "open_session_picker", "Sessions"),
@@ -7464,6 +7466,16 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
         Binding(keybindings.copy_message, "clear_prompt", "Clear input"),
         Binding(keybindings.quit, "quit", "Quit"),
     ]
+    if keybindings.suspend is not None:
+        bindings.append(
+            Binding(
+                keybindings.suspend,
+                "suspend_process",
+                "Suspend",
+                priority=True,
+            )
+        )
+    return bindings
 
 
 def _prompt_bindings(
@@ -7563,11 +7575,12 @@ def _hidden_prompt_bindings(
         (keybindings.completion_next, "completion_next"),
         (keybindings.completion_previous, "completion_previous"),
         (keybindings.quit, "quit"),
+        (keybindings.suspend, "suspend_process"),
     )
     return [
         Binding(key, action, show=False, priority=True)
         for key, action in candidates
-        if key not in visible_keys
+        if key is not None and key not in visible_keys
     ]
 
 

--- a/src/tau_coding/tui/config.py
+++ b/src/tau_coding/tui/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from json import dumps, loads
 from pathlib import Path
@@ -46,6 +47,11 @@ class TuiConfigError(ValueError):
     """Raised when Tau TUI configuration is invalid."""
 
 
+def _default_suspend_key() -> str | None:
+    """Return the platform-appropriate process suspension shortcut."""
+    return None if sys.platform == "win32" else "ctrl+z"
+
+
 @dataclass(frozen=True, slots=True)
 class TuiKeybindings:
     """Configurable keys for Tau's built-in Textual frontend."""
@@ -65,8 +71,9 @@ class TuiKeybindings:
     toggle_tool_results: str = "ctrl+o"
     copy_message: str = "ctrl+c"
     quit: str = "ctrl+d"
+    suspend: str | None = field(default_factory=_default_suspend_key)
 
-    def to_json(self) -> dict[str, str]:
+    def to_json(self) -> dict[str, str | None]:
         """Serialize these keybindings to JSON-compatible data."""
         return {
             "cancel": self.cancel,
@@ -84,6 +91,7 @@ class TuiKeybindings:
             "toggle_tool_results": self.toggle_tool_results,
             "copy_message": self.copy_message,
             "quit": self.quit,
+            "suspend": self.suspend,
         }
 
 
@@ -178,14 +186,17 @@ def _bool_setting(value: object, field_name: str) -> bool:
 
 def _keybindings_from_json(data: dict[str, Any]) -> TuiKeybindings:
     defaults = TuiKeybindings()
+    serialized_defaults = defaults.to_json()
+    suspend_default = serialized_defaults.pop("suspend")
     # Future versions may add actions to this nested object. Read only actions
     # this version understands, just as the top-level settings parser does.
     values = {
         field_name: _key_string(data.get(field_name, default_value), field_name)
-        for field_name, default_value in defaults.to_json().items()
+        for field_name, default_value in serialized_defaults.items()
     }
-    _reject_duplicate_keys(values)
-    return TuiKeybindings(**values)
+    suspend = _optional_key_string(data.get("suspend", suspend_default), "suspend")
+    _reject_duplicate_keys({**values, "suspend": suspend})
+    return TuiKeybindings(**values, suspend=suspend)
 
 
 def _key_string(value: object, field_name: str) -> str:
@@ -194,15 +205,23 @@ def _key_string(value: object, field_name: str) -> str:
     return value.strip()
 
 
+def _optional_key_string(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _key_string(value, field_name)
+
+
 def _theme_name(value: object) -> TuiThemeName:
     if not isinstance(value, str) or not value.strip():
         raise TuiConfigError("TUI theme must be a non-empty string")
     return value.strip()
 
 
-def _reject_duplicate_keys(values: dict[str, str]) -> None:
+def _reject_duplicate_keys(values: dict[str, str | None]) -> None:
     key_to_action: dict[str, str] = {}
     for action, key in values.items():
+        if key is None:
+            continue
         previous_action = key_to_action.get(key)
         if previous_action is not None:
             raise TuiConfigError(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from tau_coding.commands import CommandRegistry, SlashCommand, create_default_command_registry
@@ -330,6 +331,8 @@ def test_hotkeys_command_lists_common_tui_shortcuts(tmp_path: Path) -> None:
     assert "Ctrl+R: open session picker" in result.message
     assert "Ctrl+P / Shift+Ctrl+P: cycle scoped models forward / backward" in result.message
     assert "Shift+Tab: cycle thinking mode" in result.message
+    if sys.platform != "win32":
+        assert "Ctrl+Z: suspend to the shell; resume with fg" in result.message
 
 
 def test_model_command_requests_picker_and_switches_models(tmp_path: Path) -> None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7201,6 +7201,58 @@ async def test_tui_app_quits_from_focused_prompt_with_default_keybinding() -> No
 
 
 @pytest.mark.anyio
+async def test_tui_app_suspends_from_focused_prompt_before_editor_undo() -> None:
+    app = TauTuiApp(FakeSession())
+    suspensions: list[int] = []
+    app.action_suspend_process = lambda: suspensions.append(1)  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "keep this text"
+
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+
+        assert suspensions == [1]
+        assert prompt.value == "keep this text"
+
+
+@pytest.mark.anyio
+async def test_tui_app_uses_configured_suspend_keybinding() -> None:
+    app = TauTuiApp(
+        FakeSession(),
+        tui_settings=TuiSettings(keybindings=TuiKeybindings(suspend="f8")),
+    )
+    suspensions: list[int] = []
+    app.action_suspend_process = lambda: suspensions.append(1)  # type: ignore[method-assign]
+
+    async with app.run_test() as pilot:
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+        assert suspensions == []
+
+        await pilot.press("f8")
+        await pilot.pause()
+        assert suspensions == [1]
+
+
+@pytest.mark.anyio
+async def test_tui_app_allows_suspend_keybinding_to_be_unbound() -> None:
+    app = TauTuiApp(
+        FakeSession(),
+        tui_settings=TuiSettings(keybindings=TuiKeybindings(suspend=None)),
+    )
+
+    async with app.run_test():
+        prompt = app.query_one("#prompt")
+        assert not any(
+            binding.action == "suspend_process"
+            for binding in prompt._bindings.get_bindings_for_key("ctrl+z")
+        )
+        assert "ctrl+z" not in app._bindings.key_to_bindings
+
+
+@pytest.mark.anyio
 async def test_tui_app_uses_configured_completion_keybinding() -> None:
     app = TauTuiApp(
         FakeSession(),
@@ -10608,11 +10660,13 @@ async def test_component_interceptor_never_consumes_reserved_interrupt_keys() ->
         bridge = _component_bridge(app)
         seen: list[str] = []
         quits: list[int] = []
+        suspensions: list[int] = []
 
         async def fake_quit() -> None:  # don't actually tear down the pilot
             quits.append(1)
 
         app.action_quit = fake_quit  # type: ignore[method-assign]
+        app.action_suspend_process = lambda: suspensions.append(1)  # type: ignore[method-assign]
 
         # Greedy interceptor: consumes literally every key it is consulted for.
         bridge.register_key_interceptor(lambda event, text: (seen.append(event.key), True)[1])
@@ -10628,6 +10682,12 @@ async def test_component_interceptor_never_consumes_reserved_interrupt_keys() ->
         await pilot.pause()
         assert "ctrl+c" not in seen
         assert prompt.text == ""
+
+        # ctrl+z (process suspend): never consulted, and suspend still fires.
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+        assert "ctrl+z" not in seen
+        assert suspensions == [1]
 
         # ctrl+d (quit / hard exit): never consulted, and quit still fires.
         await pilot.press("ctrl+d")

--- a/tests/test_tui_config.py
+++ b/tests/test_tui_config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+import tau_coding.tui.config as tui_config
 from tau_coding.paths import TauPaths
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
@@ -28,6 +29,8 @@ def test_load_tui_settings_returns_defaults_when_file_is_missing(tmp_path: Path)
     assert load_tui_settings(paths) == TuiSettings()
     assert load_tui_settings(paths).keybindings.model_cycle_reverse == "ctrl+shift+p"
     assert load_tui_settings(paths).keybindings.quit == "ctrl+d"
+    expected_suspend = None if tui_config.sys.platform == "win32" else "ctrl+z"
+    assert load_tui_settings(paths).keybindings.suspend == expected_suspend
 
 
 def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
@@ -47,7 +50,8 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
             "model_cycle": "f6",
             "model_cycle_reverse": "shift+f6",
             "toggle_thinking": "f4",
-            "copy_message": "ctrl+b"
+            "copy_message": "ctrl+b",
+            "suspend": "f8"
           },
           "theme": "high-contrast"
         }
@@ -69,6 +73,7 @@ def test_load_tui_settings_reads_keybindings(tmp_path: Path) -> None:
     assert settings.keybindings.model_cycle_reverse == "shift+f6"
     assert settings.keybindings.copy_message == "ctrl+b"
     assert settings.keybindings.cancel == "escape"
+    assert settings.keybindings.suspend == "f8"
     assert settings.theme == "high-contrast"
     assert settings.resolved_theme == HIGH_CONTRAST_THEME
 
@@ -117,6 +122,33 @@ def test_tui_keybindings_ignore_unknown_actions() -> None:
     )
 
     assert settings.keybindings.quit == "f12"
+
+
+def test_tui_suspend_keybinding_can_be_unbound() -> None:
+    settings = tui_settings_from_json({"keybindings": {"suspend": None}})
+
+    assert settings.keybindings.suspend is None
+    assert settings.to_json()["keybindings"]["suspend"] is None
+
+
+@pytest.mark.parametrize("value", ["", "  ", 7, False])
+def test_tui_suspend_keybinding_rejects_invalid_values(value: object) -> None:
+    with pytest.raises(TuiConfigError, match="suspend"):
+        tui_settings_from_json({"keybindings": {"suspend": value}})
+
+
+def test_tui_suspend_keybinding_participates_in_duplicate_validation() -> None:
+    with pytest.raises(TuiConfigError, match="assigned to both"):
+        tui_settings_from_json({"keybindings": {"command_palette": "ctrl+z", "suspend": "ctrl+z"}})
+
+
+def test_tui_suspend_keybinding_defaults_to_unbound_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tui_config.sys, "platform", "win32")
+
+    assert TuiKeybindings().suspend is None
+    assert tui_settings_from_json({}).keybindings.suspend is None
 
 
 def test_tui_keybindings_reject_duplicate_keys() -> None:
@@ -178,6 +210,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
             model_cycle_reverse="shift+f6",
             toggle_thinking="f4",
             copy_message="ctrl+b",
+            suspend="f8",
         ),
         theme="high-contrast",
     )
@@ -193,6 +226,7 @@ def test_tui_keybindings_serialize_to_json() -> None:
     assert settings.to_json()["keybindings"]["model_cycle"] == "f6"
     assert settings.to_json()["keybindings"]["model_cycle_reverse"] == "shift+f6"
     assert settings.to_json()["keybindings"]["copy_message"] == "ctrl+b"
+    assert settings.to_json()["keybindings"]["suspend"] == "f8"
     assert settings.to_json()["theme"] == "high-contrast"
     assert settings.to_json()["auto_copy_selection"] is False
 

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -55,6 +55,9 @@ While the agent is working you don't have to wait:
   applied to the current run.
 - **Alt+Enter** queues a **follow-up** — a prompt that waits until the current
   run would otherwise finish.
+- **Ctrl+Z** suspends Tau to the shell on Unix-like systems. Run `fg` to resume
+  the same TUI session. Native Windows leaves suspension unbound because it does
+  not provide Unix job control.
 - Press **Up** on an empty prompt while running to pull the most recently queued
   follow-up back into the prompt for editing.
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -398,7 +398,8 @@ The built-in frontend reads optional settings from `~/.tau/tui.json`:
     "toggle_thinking": "ctrl+t",
     "toggle_tool_results": "ctrl+o",
     "copy_message": "ctrl+c",
-    "quit": "ctrl+d"
+    "quit": "ctrl+d",
+    "suspend": "ctrl+z"
   }
 }
 ```
@@ -412,7 +413,10 @@ to `tau-dark` with a startup notice, without overwriting the setting. Keys use
 Textual syntax; omitted keys keep their defaults. Tau ignores unrecognized
 settings and keybinding names so a `tui.json` written by a newer Tau version does
 not prevent an older version from starting. Recognized settings remain strict:
-Tau rejects invalid values, empty keys, and duplicate assignments.
+Tau rejects invalid values, empty keys, and duplicate assignments. The `suspend`
+action defaults to `"ctrl+z"` on Unix-like systems and `null` on native Windows,
+where Unix job control is unavailable. Set it to `null` on any platform to leave
+the action unbound.
 
 - `sidebar_position`: `"right"` (default), `"left"`, or `"off"`. Controls
   placement of the session metadata sidebar. `"off"` hides the sidebar entirely;

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -45,11 +45,14 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 | `Ctrl+O` | Toggle exact tool commands and full output (vs. compact previews) |
 | `Ctrl+C` | Clear the prompt input |
 | `Ctrl+D` | Quit |
+| `Ctrl+Z` | Suspend to the shell; resume with `fg` (Unix-like systems) |
 
 {{% note title="Remapping" %}}
 Keys use Textual's syntax (`ctrl+k`, `shift+tab`, `down`, `f2`, …). Tau rejects
 unknown names, empty keys, and duplicate assignments so mistakes fail early. Any
-key you don't set keeps its default. If your terminal cannot distinguish
+key you don't set keeps its default. Set `suspend` to `null` to leave process
+suspension unbound; this is the default on native Windows, which does not support
+Unix job control. If your terminal cannot distinguish
 `Shift+Enter` from `Enter`, choose a key it can report separately:
 
 ```json


### PR DESCRIPTION
## Summary

- bind `Ctrl+Z` to Textual's process-suspension action on Unix-like systems
- restore the same TUI session with the shell's `fg` command
- make the `suspend` keybinding configurable and allow `null` to leave it unbound
- default suspension to unbound on native Windows, where Unix job control is unavailable

## User experience

Users can temporarily return to their shell without quitting Tau or losing their interactive session. The priority binding overrides the prompt editor's undo shortcut, and extension key interceptors cannot accidentally swallow the configured suspend key.

No linked issue.

## Manual validation

1. Run `uv run tau` on Linux or macOS.
2. Enter text in the prompt and press `Ctrl+Z`.
3. Confirm the shell prompt returns and the terminal is in normal mode.
4. Run `fg`.
5. Confirm Tau redraws and preserves the prompt/session.
6. Set `"suspend": null` under `keybindings` in `~/.tau/tui.json`, restart Tau, and confirm `Ctrl+Z` is no longer handled by Tau.

## Checks

- `uv run pytest` (1961 passed, 3 platform-specific skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build --out-dir /tmp/tau-ctrl-z-dist`

The optional Hugo documentation build was not run locally because `hugo` is not installed.
