### PR TITLE
TUI: accept non-file completions with Enter

### DIFF
--- a/dev-notes/architecture/phase-17-tui-autocomplete.md
+++ b/dev-notes/architecture/phase-17-tui-autocomplete.md
@@ -60,8 +60,10 @@ Accepting a skill completion preserves the rest of the request:
 
 The prompt input handles:
 
-- `Tab` to accept the selected completion (Enter always submits the prompt as
-  typed, without applying a highlighted completion)
+- `Tab` to accept any selected completion
+- `Enter` to accept selected slash-command, skill, prompt-template, argument,
+  and shell-path completions; for `@` file references, Enter instead submits
+  the raw prompt text without applying the suggestion
 - `Down` to select the next completion
 - `Up` to select the previous completion
 
@@ -98,4 +100,5 @@ The tests verify:
 - `/skill:` suggestions
 - preserving request text after skill completion
 - completion selection wrapping
-- TUI completion acceptance
+- context-dependent Enter acceptance versus raw `@` file-reference submission
+- Tab acceptance for every completion kind

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -144,6 +144,7 @@ from tau_coding.thinking import ThinkingLevel
 from tau_coding.tui.adapter import TuiEventAdapter
 from tau_coding.tui.autocomplete import (
     CompletionItem,
+    CompletionKind,
     CompletionOption,
     CompletionState,
     build_completion_state,
@@ -547,12 +548,15 @@ class PromptInput(TextArea):
         super().__init__(**kwargs)
         self.tui_keybindings = tui_keybindings or TuiKeybindings()
         self._base_bindings = self._bindings.copy()
-        self._footer_mode: Literal["normal", "completion", "running"] = "normal"
+        self._footer_mode: Literal["normal", "completion", "file_completion", "running"] = "normal"
         self._pending_pastes: list[tuple[str, str]] = []
         self._paste_placeholder_counter = 0
         self._apply_prompt_bindings()
 
-    def set_footer_mode(self, mode: Literal["normal", "completion", "running"]) -> None:
+    def set_footer_mode(
+        self,
+        mode: Literal["normal", "completion", "file_completion", "running"],
+    ) -> None:
         """Switch the prompt bindings shown by Textual's built-in footer."""
         if mode == self._footer_mode:
             return
@@ -4301,7 +4305,11 @@ class TauTuiApp(App[None]):
         self._refresh_completions()
 
     async def action_submit_prompt(self) -> None:
-        """Submit the current prompt text or slash command."""
+        """Accept a non-file completion, or submit the current prompt text."""
+        selected = self._completion_state.selected
+        if selected is not None and selected.kind is not CompletionKind.FILE_REFERENCE:
+            self.action_accept_completion()
+            return
         await self._submit_prompt_from_editor(streaming_behavior="steer")
 
     async def action_submit_follow_up(self) -> None:
@@ -4313,9 +4321,6 @@ class TauTuiApp(App[None]):
         *,
         streaming_behavior: Literal["steer", "follow_up"],
     ) -> None:
-        # Enter always submits the prompt text as typed; accepting the
-        # selected completion is reserved for the accept-completion key
-        # (Tab by default).
         prompt = self.query_one("#prompt", PromptInput)
         raw_text = prompt.text_for_submission()
 
@@ -7410,8 +7415,11 @@ def _prompt_footer_mode(
     completion_state: CompletionState,
     *,
     working: bool,
-) -> Literal["normal", "completion", "running"]:
-    if completion_state.items:
+) -> Literal["normal", "completion", "file_completion", "running"]:
+    selected = completion_state.selected
+    if selected is not None:
+        if selected.kind is CompletionKind.FILE_REFERENCE:
+            return "file_completion"
         return "completion"
     if working:
         return "running"
@@ -7469,15 +7477,19 @@ def _app_bindings(keybindings: TuiKeybindings) -> list[Binding]:
 def _prompt_bindings(
     keybindings: TuiKeybindings,
     *,
-    mode: Literal["normal", "completion", "running"],
+    mode: Literal["normal", "completion", "file_completion", "running"],
 ) -> list[Binding]:
-    if mode == "completion":
+    if mode in {"completion", "file_completion"}:
         bindings = [
             Binding(
                 keybindings.accept_completion,
                 "accept_completion",
                 "Complete",
-                key_display=_key_hint(keybindings.accept_completion),
+                key_display=(
+                    _key_hint(keybindings.accept_completion)
+                    if mode == "file_completion"
+                    else f"{_key_hint(keybindings.accept_completion)}/Enter"
+                ),
                 priority=True,
             ),
             Binding(
@@ -7492,6 +7504,8 @@ def _prompt_bindings(
             ),
             Binding(keybindings.cancel, "cancel", "Close", priority=True),
         ]
+        if mode == "file_completion":
+            bindings.insert(1, Binding("enter", "submit_prompt", "Submit raw", priority=True))
         return bindings + _hidden_prompt_bindings(keybindings, visible_bindings=bindings)
     if mode == "running":
         bindings = [

--- a/src/tau_coding/tui/app.py
+++ b/src/tau_coding/tui/app.py
@@ -4305,11 +4305,14 @@ class TauTuiApp(App[None]):
         self._refresh_completions()
 
     async def action_submit_prompt(self) -> None:
-        """Accept a non-file completion, or submit the current prompt text."""
+        """Accept a changing non-file completion, or submit the current prompt text."""
         selected = self._completion_state.selected
         if selected is not None and selected.kind is not CompletionKind.FILE_REFERENCE:
+            prompt = self.query_one("#prompt", PromptInput)
+            text_before_completion = prompt.text
             self.action_accept_completion()
-            return
+            if prompt.text != text_before_completion:
+                return
         await self._submit_prompt_from_editor(streaming_behavior="steer")
 
     async def action_submit_follow_up(self) -> None:

--- a/src/tau_coding/tui/autocomplete.py
+++ b/src/tau_coding/tui/autocomplete.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from tau_coding.commands import CommandRegistry, SlashCommand
@@ -37,6 +38,17 @@ class CompletionOption:
     description: str | None = None
 
 
+class CompletionKind(StrEnum):
+    """Source of a prompt completion and its Enter-key behavior."""
+
+    COMMAND = "command"
+    PROMPT_TEMPLATE = "prompt_template"
+    SKILL = "skill"
+    ARGUMENT = "argument"
+    FILE_REFERENCE = "file_reference"
+    SHELL_PATH = "shell_path"
+
+
 @dataclass(frozen=True, slots=True)
 class CompletionItem:
     """One selectable prompt completion."""
@@ -45,6 +57,7 @@ class CompletionItem:
     replacement: str
     start: int
     end: int
+    kind: CompletionKind
     description: str | None = None
     category: str | None = None
 
@@ -181,6 +194,7 @@ def _file_reference_completions(*, text: str, cwd: Path) -> tuple[CompletionItem
                 replacement=display,
                 start=start,
                 end=end,
+                kind=CompletionKind.FILE_REFERENCE,
                 description="File reference",
             )
         )
@@ -203,6 +217,7 @@ def _external_file_reference_completions(
                 replacement=display,
                 start=start,
                 end=end,
+                kind=CompletionKind.FILE_REFERENCE,
                 description="File reference",
             ),
         )
@@ -237,6 +252,7 @@ def _external_file_reference_completions(
                 replacement=display,
                 start=start,
                 end=end,
+                kind=CompletionKind.FILE_REFERENCE,
                 description="File reference",
             )
         )
@@ -324,6 +340,7 @@ def _shell_path_completions(*, text: str, cwd: Path) -> tuple[CompletionItem, ..
                 replacement=replacement,
                 start=start,
                 end=end,
+                kind=CompletionKind.SHELL_PATH,
                 description="Directory" if child.is_dir() else "File",
             )
         )
@@ -417,6 +434,7 @@ def _command_completions(
             replacement=f"/{template.name}",
             start=0,
             end=token_end,
+            kind=CompletionKind.PROMPT_TEMPLATE,
             description=template.description or "Prompt template",
             category="Custom prompts",
         )
@@ -463,6 +481,7 @@ def _command_alias_completions(
                 replacement=replacement,
                 start=0,
                 end=token_end,
+                kind=CompletionKind.COMMAND,
                 description=command.description,
                 category="Commands",
             )
@@ -480,6 +499,7 @@ def _skill_completions(
             replacement=f"/skill:{skill.name}",
             start=0,
             end=token_end,
+            kind=CompletionKind.SKILL,
             description=skill.description,
         )
         for skill in sorted(skills, key=lambda item: item.name)
@@ -554,6 +574,7 @@ def _value_completions(
             replacement=option.value,
             start=start,
             end=end,
+            kind=CompletionKind.ARGUMENT,
             description=option.description,
         )
         for option in ordered_options

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -5842,7 +5842,7 @@ async def test_tui_app_completes_registered_slash_command() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_enter_accepts_slash_completion_without_submitting() -> None:
+async def test_tui_app_enter_completes_slash_then_second_enter_submits() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5856,6 +5856,99 @@ async def test_tui_app_enter_accepts_slash_completion_without_submitting() -> No
 
         assert prompt.value == "/session"
         assert app.session.prompt_texts == []
+        assert not isinstance(app.screen, CommandOutputScreen)
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert prompt.value == ""
+        assert isinstance(app.screen, CommandOutputScreen)
+        assert app.screen.message == "Session info"
+
+
+@pytest.mark.anyio
+async def test_tui_app_enter_submits_directly_typed_exact_slash_command() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/session"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        selected = app._completion_state.selected
+        assert selected is not None
+        assert selected.replacement == prompt.value
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert prompt.value == ""
+        assert isinstance(app.screen, CommandOutputScreen)
+        assert app.screen.message == "Session info"
+
+
+@pytest.mark.anyio
+async def test_tui_app_tab_completion_then_enter_submits() -> None:
+    app = TauTuiApp(FakeSession())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = "/se"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        await pilot.press("tab")
+        assert prompt.value == "/session"
+        assert app.session.prompt_texts == []
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert prompt.value == ""
+        assert isinstance(app.screen, CommandOutputScreen)
+        assert app.screen.message == "Session info"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("raw_text", "expected_kind"),
+    (
+        ("/skill:review", CompletionKind.SKILL),
+        ("/example", CompletionKind.PROMPT_TEMPLATE),
+        ("/model fake-model", CompletionKind.ARGUMENT),
+    ),
+)
+async def test_tui_app_enter_submits_exact_non_file_completion_kinds(
+    raw_text: str,
+    expected_kind: CompletionKind,
+) -> None:
+    session = FakeSession()
+    session.prompt_templates = (
+        PromptTemplate(
+            name="example",
+            path=Path("example.md"),
+            content="Example prompt.",
+        ),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = raw_text
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        selected = app._completion_state.selected
+        assert selected is not None
+        assert selected.kind is expected_kind
+        assert app._apply_selected_completion(raw_text) == raw_text
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert prompt.value == ""
+        assert session.prompt_texts == [raw_text]
 
 
 @pytest.mark.anyio

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -125,7 +125,7 @@ from tau_coding.tui.app import (
     _TuiExtensionUiBridge,
     _visible_completion_state,
 )
-from tau_coding.tui.autocomplete import CompletionItem, CompletionState
+from tau_coding.tui.autocomplete import CompletionItem, CompletionKind, CompletionState
 from tau_coding.tui.config import (
     HIGH_CONTRAST_THEME,
     TAU_DARK_THEME,
@@ -3185,7 +3185,30 @@ async def test_tui_app_footer_hints_update_for_completions() -> None:
 
         assert _visible_footer_bindings(app) == {
             "Choose": "Up/Down",
+            "Complete": "Tab/Enter",
+            "Close": "escape",
+        }
+
+
+@pytest.mark.anyio
+async def test_tui_app_footer_hints_explain_file_reference_enter_behavior(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+    session = FakeSession()
+    session.cwd = tmp_path
+    app = TauTuiApp(session)
+
+    async with app.run_test(size=(120, 30)):
+        prompt = app.query_one("#prompt")
+        prompt.value = "inspect @READ"
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        assert _visible_footer_bindings(app) == {
+            "Choose": "Up/Down",
             "Complete": "Tab",
+            "Submit raw": "enter",
             "Close": "escape",
         }
 
@@ -5819,7 +5842,7 @@ async def test_tui_app_completes_registered_slash_command() -> None:
 
 
 @pytest.mark.anyio
-async def test_tui_app_enter_submits_without_accepting_completion() -> None:
+async def test_tui_app_enter_accepts_slash_completion_without_submitting() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5831,12 +5854,12 @@ async def test_tui_app_enter_submits_without_accepting_completion() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
-        assert prompt.value == ""
-        assert app.session.prompt_texts == ["/se"]
+        assert prompt.value == "/session"
+        assert app.session.prompt_texts == []
 
 
 @pytest.mark.anyio
-async def test_tui_app_enter_ignores_arrow_selected_completion() -> None:
+async def test_tui_app_enter_accepts_arrow_selected_non_file_completion() -> None:
     app = TauTuiApp(FakeSession())
 
     async with app.run_test() as pilot:
@@ -5851,8 +5874,51 @@ async def test_tui_app_enter_ignores_arrow_selected_completion() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
+        assert prompt.value == selected.replacement
+        assert app.session.prompt_texts == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "raw_text",
+    (
+        "inspect @main",
+        "/skill:review inspect @main",
+        "/example inspect @main",
+    ),
+)
+async def test_tui_app_enter_submits_raw_file_reference_text(
+    tmp_path: Path,
+    raw_text: str,
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+
+    session = FakeSession()
+    session.cwd = tmp_path
+    session.prompt_templates = (
+        PromptTemplate(
+            name="example",
+            path=tmp_path / "example.md",
+            content="Example prompt.",
+        ),
+    )
+    app = TauTuiApp(session)
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt")
+        prompt.value = raw_text
+        app._completion_state = app._build_completion_state(prompt.value)
+        app._refresh_completions()
+
+        selected = app._completion_state.selected
+        assert selected is not None
+        assert selected.kind is CompletionKind.FILE_REFERENCE
+        await pilot.press("enter")
+        await pilot.pause()
+
         assert prompt.value == ""
-        assert app.session.prompt_texts == ["/s"]
+        assert session.prompt_texts == [raw_text]
 
 
 @pytest.mark.anyio
@@ -6472,6 +6538,7 @@ def test_completion_selected_render_line_accounts_for_group_headers() -> None:
                 replacement="/session",
                 start=0,
                 end=2,
+                kind=CompletionKind.COMMAND,
                 category="Commands",
             ),
             CompletionItem(
@@ -6479,6 +6546,7 @@ def test_completion_selected_render_line_accounts_for_group_headers() -> None:
                 replacement="/example",
                 start=0,
                 end=2,
+                kind=CompletionKind.PROMPT_TEMPLATE,
                 category="Custom prompts",
             ),
         ),
@@ -6496,6 +6564,7 @@ def test_visible_completion_state_keeps_selected_item_in_render_window() -> None
             replacement=f"/prompt-{index:02d}",
             start=0,
             end=1,
+            kind=CompletionKind.PROMPT_TEMPLATE,
             category="Custom prompts",
         )
         for index in range(30)
@@ -6518,6 +6587,7 @@ def test_visible_completion_state_accounts_for_wrapped_descriptions() -> None:
             replacement=f"/prompt-{index:02d}",
             start=0,
             end=1,
+            kind=CompletionKind.PROMPT_TEMPLATE,
             description=(
                 "This prompt has a long description that wraps across multiple lines "
                 "inside the completion table."
@@ -6543,6 +6613,7 @@ def test_visible_completion_state_keeps_selected_item_above_bottom_edge() -> Non
             replacement=f"/prompt-{index:02d}",
             start=0,
             end=1,
+            kind=CompletionKind.PROMPT_TEMPLATE,
             category="Custom prompts",
         )
         for index in range(30)

--- a/website/content/guides/tui.md
+++ b/website/content/guides/tui.md
@@ -74,6 +74,10 @@ to search and run them. Common ones:
 - `/local` — choose and manage a registered local backend
 - `/sidebar` — show or hide the sidebar for this session
 
+When slash-command autocomplete is open, **Enter** applies the highlighted
+suggestion without submitting it; use the arrow keys first to choose a different
+suggestion. **Tab** also applies the highlighted suggestion.
+
 The full list is in the [Slash commands reference]({{< relref "../reference/slash-commands.md" >}}). For local inference, see the [local backends guide]({{< relref "./local-inference.md" >}}).
 
 ### Local backends
@@ -136,7 +140,9 @@ complete files and directories outside the project root. External completion
 follows only the path you type instead of scanning the surrounding filesystem.
 Dot-prefixed content such as `.env` and `.agents/` is included. Tau still skips
 known metadata and generated directories such as `.git`, `.venv`, `node_modules`,
-`__pycache__`, `build`, and `dist`.
+`__pycache__`, `build`, and `dist`. Press **Tab** to insert the highlighted file;
+press **Enter** to submit exactly what you typed without inserting it. The same
+rule applies to `@` suggestions in skill and custom-prompt argument text.
 
 ## Dropping files into the prompt
 

--- a/website/content/reference/keybindings.md
+++ b/website/content/reference/keybindings.md
@@ -11,7 +11,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 
 | Key | Action |
 | --- | --- |
-| `Enter` | Submit the prompt |
+| `Enter` | Accept a highlighted non-file completion; otherwise submit the prompt exactly as typed (including `@` file-reference text) |
 | `Shift+Enter` | Insert a newline |
 | `Esc` | Cancel the active run |
 | `Enter` (while running) | Queue text as steering for the current run |
@@ -24,7 +24,7 @@ These are the default keys in the interactive [TUI]({{< relref "../guides/tui.md
 | --- | --- |
 | `Ctrl+K` | Open the command palette |
 | `Ctrl+R` | Open the session picker |
-| `Tab` | Accept the highlighted completion |
+| `Tab` | Accept any highlighted completion, including `@` file references |
 | `Down` / `Up` | Move through completions |
 | `Ctrl+E` (in `/prompts`) | Edit the selected prompt template |
 | `Ctrl+S` (while editing a prompt template) | Save and reload resources |


### PR DESCRIPTION
## Description

Restore context-dependent Enter behavior for TUI autocomplete. Enter now applies highlighted non-file completions, including slash commands and arrow-selected suggestions, without submitting. Highlighted `@` file-reference suggestions remain excluded through an explicit completion kind, so Enter submits the raw typed text. Tab continues to accept every completion kind.

Footer hints, the TUI guide, keybinding reference, and autocomplete architecture note now describe the distinction.

## UX improvement

Slash-command users can press Enter once to expand the highlighted command instead of accidentally submitting a partial command. Users writing `@` file references can still send exactly what they typed with Enter, including inside skill and custom-prompt arguments, while Tab remains the explicit way to insert the suggested path.

## Issue addressed

Direct user request dated 2026-09-12; no GitHub issue.

## Manual validation

1. Type `/se`; press Enter; verify `/session` is inserted and not submitted.
2. Type `/s`; use Down to select another suggestion; press Enter; verify that selected suggestion is inserted and not submitted.
3. Type `inspect @main` while `@src/main.py` is highlighted; press Enter; verify `inspect @main` is submitted unchanged.
4. Repeat the `@` check in `/skill:review inspect @main` and custom-prompt argument text.
5. Verify Tab inserts both slash-command and `@` file-reference suggestions.
6. Verify the completion footer shows `Tab/Enter` for non-file suggestions and `Complete Tab` plus `Submit raw Enter` for `@` suggestions.

## Verification

- `uv run pytest` (1960 passed, 3 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Hugo 0.152.2: `hugo --minify`
- `npx --yes pagefind@latest --site public`

