### PR TITLE
Prepare Tau 0.4.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tau-ai"
-version = "0.4.2"
+version = "0.4.3"
 description = "A Python implementation of a minimalist Pi-style coding-agent harness."
 readme = "README.md"
 license = "MIT"

--- a/src/tau_coding/data/release-notes/releases.json
+++ b/src/tau_coding/data/release-notes/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.4.3",
+    "date": "2026-09-12",
+    "sections": {
+      "New": [
+        "Resume sessions from other projects directly from /resume, with current-directory sessions first and other directories grouped separately."
+      ],
+      "Changed": [
+        "Accept highlighted non-file autocomplete suggestions with Enter while preserving raw @ file references; Tab continues to accept every completion kind."
+      ]
+    }
+  },
+  {
     "version": "0.4.2",
     "date": "2026-09-10",
     "sections": {

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -870,7 +870,7 @@ def test_session_sidebar_brand_includes_current_version() -> None:
 
     console.print(_sidebar_brand(theme=TAU_DARK_THEME))
 
-    assert "τ = 2π  0.4.2" in console.export_text()
+    assert "τ = 2π  0.4.3" in console.export_text()
 
 
 def test_session_sidebar_uses_prominent_title_and_accented_section_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "tau-ai"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump `tau-ai` from 0.4.2 to 0.4.3
- add bundled release notes for cross-directory session resume and autocomplete Enter behavior
- update the sidebar version assertion and lockfile

## Checks

- `uv run mypy`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` (1969 passed, 2 skipped)
- `hugo --minify`
- `npx --yes pagefind@latest --site public`
